### PR TITLE
LPS-146978 Update dateFormat in rest builder

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseLogResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BaseLogResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseLogResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
+++ b/modules/apps/batch-planner/batch-planner-rest-test/src/testIntegration/java/com/liferay/batch/planner/rest/resource/v1_0/test/BasePlanResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BasePlanResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseKeywordResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseSelectionResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseSelectionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseStatusResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/bulk/bulk-rest-test/src/testIntegration/java/com/liferay/bulk/rest/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Account.java
@@ -615,7 +615,7 @@ public class Account implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountAddresses != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/serdes/v1_0/AccountSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/serdes/v1_0/AccountSerDes.java
@@ -61,7 +61,7 @@ public class AccountSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account.getAccountAddresses() != null) {
 			if (sb.length() > 1) {
@@ -331,7 +331,7 @@ public class AccountSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account.getAccountAddresses() == null) {
 			map.put("accountAddresses", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountAddressResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseAccountAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountMemberResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountMemberResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseAccountMemberResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountOrganizationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountOrganizationResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseAccountOrganizationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseUserResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Attachment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Attachment.java
@@ -509,7 +509,7 @@ public class Attachment implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentBase64.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentBase64.java
@@ -453,7 +453,7 @@ public class AttachmentBase64 implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentUrl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentUrl.java
@@ -425,7 +425,7 @@ public class AttachmentUrl implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentType != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Product.java
@@ -1499,7 +1499,7 @@ public class Product implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Sku.java
@@ -840,7 +840,7 @@ public class Sku implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (cost != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/AttachmentBase64SerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/AttachmentBase64SerDes.java
@@ -61,7 +61,7 @@ public class AttachmentBase64SerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachmentBase64.getAttachment() != null) {
 			if (sb.length() > 1) {
@@ -254,7 +254,7 @@ public class AttachmentBase64SerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachmentBase64.getAttachment() == null) {
 			map.put("attachment", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/AttachmentSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/AttachmentSerDes.java
@@ -59,7 +59,7 @@ public class AttachmentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment.getAttachment() != null) {
 			if (sb.length() > 1) {
@@ -270,7 +270,7 @@ public class AttachmentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment.getAttachment() == null) {
 			map.put("attachment", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/AttachmentUrlSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/AttachmentUrlSerDes.java
@@ -61,7 +61,7 @@ public class AttachmentUrlSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachmentUrl.getContentType() != null) {
 			if (sb.length() > 1) {
@@ -236,7 +236,7 @@ public class AttachmentUrlSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachmentUrl.getContentType() == null) {
 			map.put("contentType", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/ProductSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/ProductSerDes.java
@@ -69,7 +69,7 @@ public class ProductSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (product.getActions() != null) {
 			if (sb.length() > 1) {
@@ -749,7 +749,7 @@ public class ProductSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (product.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/SkuSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/serdes/v1_0/SkuSerDes.java
@@ -59,7 +59,7 @@ public class SkuSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sku.getCost() != null) {
 			if (sb.length() > 1) {
@@ -377,7 +377,7 @@ public class SkuSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sku.getCost() == null) {
 			map.put("cost", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseAttachmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCatalogResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseCatalogResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseDiagramResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseMappedProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionCategoryResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseOptionCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseOptionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseOptionValueResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseOptionValueResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BasePinResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductAccountGroupResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseProductAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductChannelResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseProductChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductConfigurationResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseProductConfigurationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupProductResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseProductGroupProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductGroupResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseProductGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseProductOptionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductOptionValueResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseProductOptionValueResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductShippingConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductShippingConfigurationResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseProductShippingConfigurationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseProductSpecificationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductSubscriptionConfigurationResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseProductSubscriptionConfigurationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseSkuResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseSpecificationResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseSpecificationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-openapi.yaml
@@ -284,7 +284,7 @@ components:
 info:
     description:
         "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.10'."
+        artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.12'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.10'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Channel API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.channel.client', and version '4.0.12'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Channel API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelOrderTypeResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BasePaymentMethodGroupRelTermResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePaymentMethodGroupRelTermResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionOrderTypeResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseShippingFixedOptionTermResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseShippingFixedOptionTermResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseTermResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseItem.java
@@ -318,7 +318,7 @@ public class WarehouseItem implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (externalReferenceCode != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/resource/v1_0/WarehouseItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/resource/v1_0/WarehouseItemResource.java
@@ -1257,7 +1257,7 @@ public interface WarehouseItemResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (end != null) {
 				httpInvoker.parameter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/serdes/v1_0/WarehouseItemSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/serdes/v1_0/WarehouseItemSerDes.java
@@ -59,7 +59,7 @@ public class WarehouseItemSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (warehouseItem.getExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
@@ -180,7 +180,7 @@ public class WarehouseItemSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (warehouseItem.getExternalReferenceCode() == null) {
 			map.put("externalReferenceCode", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseItemResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseWarehouseItemResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-test/src/testIntegration/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseWarehouseResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Order.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Order.java
@@ -3241,7 +3241,7 @@ public class Order implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderItem.java
@@ -1244,7 +1244,7 @@ public class OrderItem implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (bookedQuantityId != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRule.java
@@ -635,7 +635,7 @@ public class OrderRule implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderType.java
@@ -467,7 +467,7 @@ public class OrderType implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Term.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Term.java
@@ -574,7 +574,7 @@ public class Term implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderItemSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderItemSerDes.java
@@ -59,7 +59,7 @@ public class OrderItemSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (orderItem.getBookedQuantityId() != null) {
 			if (sb.length() > 1) {
@@ -502,7 +502,7 @@ public class OrderItemSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (orderItem.getBookedQuantityId() == null) {
 			map.put("bookedQuantityId", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderRuleSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderRuleSerDes.java
@@ -62,7 +62,7 @@ public class OrderRuleSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (orderRule.getActions() != null) {
 			if (sb.length() > 1) {
@@ -355,7 +355,7 @@ public class OrderRuleSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (orderRule.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderSerDes.java
@@ -61,7 +61,7 @@ public class OrderSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (order.getAccount() != null) {
 			if (sb.length() > 1) {
@@ -1257,7 +1257,7 @@ public class OrderSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (order.getAccount() == null) {
 			map.put("account", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderTypeSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/OrderTypeSerDes.java
@@ -59,7 +59,7 @@ public class OrderTypeSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (orderType.getActions() != null) {
 			if (sb.length() > 1) {
@@ -234,7 +234,7 @@ public class OrderTypeSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (orderType.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/TermSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/serdes/v1_0/TermSerDes.java
@@ -59,7 +59,7 @@ public class TermSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (term.getActions() != null) {
 			if (sb.length() > 1) {
@@ -292,7 +292,7 @@ public class TermSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (term.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1304,7 +1304,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.15'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseBillingAddressResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseBillingAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderItemResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseOrderItemResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderNoteResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseOrderNoteResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseOrderResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountGroupResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseOrderRuleAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleAccountResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseOrderRuleAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleChannelResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseOrderRuleChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleOrderTypeResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseOrderRuleOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderRuleResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseOrderRuleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeChannelResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseOrderTypeChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermOrderTypeResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseTermOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseTermResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Discount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Discount.java
@@ -792,7 +792,7 @@ public class Discount implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (active != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceList.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceList.java
@@ -463,7 +463,7 @@ public class PriceList implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (active != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Discount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Discount.java
@@ -1068,7 +1068,7 @@ public class Discount implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceEntry.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceEntry.java
@@ -819,7 +819,7 @@ public class PriceEntry implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceList.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceList.java
@@ -884,7 +884,7 @@ public class PriceList implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifier.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifier.java
@@ -599,7 +599,7 @@ public class PriceModifier implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/TierPrice.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/TierPrice.java
@@ -618,7 +618,7 @@ public class TierPrice implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v1_0/DiscountSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v1_0/DiscountSerDes.java
@@ -64,7 +64,7 @@ public class DiscountSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (discount.getActive() != null) {
 			if (sb.length() > 1) {
@@ -398,7 +398,7 @@ public class DiscountSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (discount.getActive() == null) {
 			map.put("active", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v1_0/PriceListSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v1_0/PriceListSerDes.java
@@ -60,7 +60,7 @@ public class PriceListSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceList.getActive() != null) {
 			if (sb.length() > 1) {
@@ -256,7 +256,7 @@ public class PriceListSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceList.getActive() == null) {
 			map.put("active", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/DiscountSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/DiscountSerDes.java
@@ -68,7 +68,7 @@ public class DiscountSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (discount.getActions() != null) {
 			if (sb.length() > 1) {
@@ -543,7 +543,7 @@ public class DiscountSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (discount.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/PriceEntrySerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/PriceEntrySerDes.java
@@ -61,7 +61,7 @@ public class PriceEntrySerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceEntry.getActions() != null) {
 			if (sb.length() > 1) {
@@ -372,7 +372,7 @@ public class PriceEntrySerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceEntry.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/PriceListSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/PriceListSerDes.java
@@ -65,7 +65,7 @@ public class PriceListSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceList.getActions() != null) {
 			if (sb.length() > 1) {
@@ -471,7 +471,7 @@ public class PriceListSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceList.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/PriceModifierSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/PriceModifierSerDes.java
@@ -65,7 +65,7 @@ public class PriceModifierSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceModifier.getActions() != null) {
 			if (sb.length() > 1) {
@@ -336,7 +336,7 @@ public class PriceModifierSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (priceModifier.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/TierPriceSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/serdes/v2_0/TierPriceSerDes.java
@@ -59,7 +59,7 @@ public class TierPriceSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (tierPrice.getActions() != null) {
 			if (sb.length() > 1) {
@@ -282,7 +282,7 @@ public class TierPriceSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (tierPrice.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountProductResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseDiscountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseDiscountRuleResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceEntryResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BasePriceEntryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BasePriceListResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BasePriceListResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/test/BaseTierPriceResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseTierPriceResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountGroupResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountAccountResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountCategoryResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountChannelResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountOrderTypeResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductGroupResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountProductGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountProductResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseDiscountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountRuleResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseDiscountRuleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseDiscountSkuResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDiscountSkuResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceEntryResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceEntryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountGroupResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceListAccountGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListAccountResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceListAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListChannelResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceListChannelResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListDiscountResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BasePriceListDiscountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListOrderTypeResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BasePriceListOrderTypeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceListResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BasePriceListResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierCategoryResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceModifierCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductGroupResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceModifierProductGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierProductResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BasePriceModifierProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BasePriceModifierResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BasePriceModifierResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseProductGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseSkuResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseTierPriceResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseTierPriceResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Shipment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Shipment.java
@@ -579,7 +579,7 @@ public class Shipment implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountId != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShipmentItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShipmentItem.java
@@ -353,7 +353,7 @@ public class ShipmentItem implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/serdes/v1_0/ShipmentItemSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/serdes/v1_0/ShipmentItemSerDes.java
@@ -59,7 +59,7 @@ public class ShipmentItemSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (shipmentItem.getActions() != null) {
 			if (sb.length() > 1) {
@@ -185,7 +185,7 @@ public class ShipmentItemSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (shipmentItem.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/serdes/v1_0/ShipmentSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/serdes/v1_0/ShipmentSerDes.java
@@ -59,7 +59,7 @@ public class ShipmentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (shipment.getAccountId() != null) {
 			if (sb.length() > 1) {
@@ -295,7 +295,7 @@ public class ShipmentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (shipment.getAccountId() == null) {
 			map.put("accountId", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentItemResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseShipmentItemResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShipmentResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseShipmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseShippingAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseAvailabilityEstimateResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseAvailabilityEstimateResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseMeasurementUnitResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseMeasurementUnitResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseTaxCategoryResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseTaxCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-test/src/testIntegration/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/test/BaseWarehouseResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseWarehouseResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Cart.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Cart.java
@@ -1109,7 +1109,7 @@ public class Cart implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/serdes/v1_0/CartSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/serdes/v1_0/CartSerDes.java
@@ -60,7 +60,7 @@ public class CartSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (cart.getAccount() != null) {
 			if (sb.length() > 1) {
@@ -544,7 +544,7 @@ public class CartSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (cart.getAccount() == null) {
 			map.put("account", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartCommentResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseCartCommentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartItemResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseCartItemResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseCartResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseCartResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BasePaymentMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BasePaymentMethodResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BasePaymentMethodResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseShippingMethodResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseShippingMethodResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Attachment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Attachment.java
@@ -368,7 +368,7 @@ public class Attachment implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Product.java
@@ -803,7 +803,7 @@ public class Product implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachments != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Sku.java
@@ -625,7 +625,7 @@ public class Sku implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (allowedOrderQuantities != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/json/BaseJSONParser.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/serdes/v1_0/AttachmentSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/serdes/v1_0/AttachmentSerDes.java
@@ -57,7 +57,7 @@ public class AttachmentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment.getAttachment() != null) {
 			if (sb.length() > 1) {
@@ -200,7 +200,7 @@ public class AttachmentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (attachment.getAttachment() == null) {
 			map.put("attachment", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/serdes/v1_0/ProductSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/serdes/v1_0/ProductSerDes.java
@@ -64,7 +64,7 @@ public class ProductSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (product.getAttachments() != null) {
 			if (sb.length() > 1) {
@@ -467,7 +467,7 @@ public class ProductSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (product.getAttachments() == null) {
 			map.put("attachments", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/serdes/v1_0/SkuSerDes.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/serdes/v1_0/SkuSerDes.java
@@ -57,7 +57,7 @@ public class SkuSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sku.getAllowedOrderQuantities() != null) {
 			if (sb.length() > 1) {
@@ -302,7 +302,7 @@ public class SkuSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sku.getAllowedOrderQuantities() == null) {
 			map.put("allowedOrderQuantities", null);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseAttachmentResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseAttachmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseCategoryResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseMappedProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BasePinResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BasePinResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BasePinResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductOptionResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseProductOptionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductSpecificationResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseProductSpecificationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseRelatedProductResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseRelatedProductResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseSkuResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseSkuResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/DataDefinition.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/DataDefinition.java
@@ -521,7 +521,7 @@ public class DataDefinition implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (availableLanguageIds != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/DataLayout.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/DataLayout.java
@@ -488,7 +488,7 @@ public class DataLayout implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentType != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/DataListView.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/dto/v2_0/DataListView.java
@@ -371,7 +371,7 @@ public class DataListView implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (appliedFilters != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v2_0/DataDefinitionSerDes.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v2_0/DataDefinitionSerDes.java
@@ -62,7 +62,7 @@ public class DataDefinitionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dataDefinition.getAvailableLanguageIds() != null) {
 			if (sb.length() > 1) {
@@ -302,7 +302,7 @@ public class DataDefinitionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dataDefinition.getAvailableLanguageIds() == null) {
 			map.put("availableLanguageIds", null);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v2_0/DataLayoutSerDes.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v2_0/DataLayoutSerDes.java
@@ -60,7 +60,7 @@ public class DataLayoutSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dataLayout.getContentType() != null) {
 			if (sb.length() > 1) {
@@ -263,7 +263,7 @@ public class DataLayoutSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dataLayout.getContentType() == null) {
 			map.put("contentType", null);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v2_0/DataListViewSerDes.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/serdes/v2_0/DataListViewSerDes.java
@@ -59,7 +59,7 @@ public class DataListViewSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dataListView.getAppliedFilters() != null) {
 			if (sb.length() > 1) {
@@ -209,7 +209,7 @@ public class DataListViewSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dataListView.getAppliedFilters() == null) {
 			map.put("appliedFilters", null);

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionFieldLinkResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseDataDefinitionFieldLinkResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataDefinitionResourceTestCase.java
@@ -100,7 +100,7 @@ public abstract class BaseDataDefinitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataLayoutResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDataLayoutResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataListViewResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDataListViewResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordCollectionResourceTestCase.java
@@ -95,7 +95,7 @@ public abstract class BaseDataRecordCollectionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
+++ b/modules/apps/data-engine/data-engine-rest-test/src/testIntegration/java/com/liferay/data/engine/rest/resource/v2_0/test/BaseDataRecordResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseDataRecordResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/digital-signature/digital-signature-rest-api/src/main/java/com/liferay/digital/signature/rest/dto/v1_0/DSEnvelope.java
+++ b/modules/apps/digital-signature/digital-signature-rest-api/src/main/java/com/liferay/digital/signature/rest/dto/v1_0/DSEnvelope.java
@@ -396,7 +396,7 @@ public class DSEnvelope implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dateCreated != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/serdes/v1_0/DSEnvelopeSerDes.java
+++ b/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/serdes/v1_0/DSEnvelopeSerDes.java
@@ -60,7 +60,7 @@ public class DSEnvelopeSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dsEnvelope.getDateCreated() != null) {
 			if (sb.length() > 1) {
@@ -245,7 +245,7 @@ public class DSEnvelopeSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dsEnvelope.getDateCreated() == null) {
 			map.put("dateCreated", null);

--- a/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
+++ b/modules/apps/digital-signature/digital-signature-rest-test/src/testIntegration/java/com/liferay/digital/signature/rest/resource/v1_0/test/BaseDSEnvelopeResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseDSEnvelopeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/BaseActiveViewResourceTestCase.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-test/src/testIntegration/java/com/liferay/frontend/view/state/rest/resource/v1_0/test/BaseActiveViewResourceTestCase.java
@@ -78,7 +78,7 @@ public abstract class BaseActiveViewResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-api/src/main/java/com/liferay/headless/admin/content/dto/v1_0/DisplayPageTemplate.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-api/src/main/java/com/liferay/headless/admin/content/dto/v1_0/DisplayPageTemplate.java
@@ -501,7 +501,7 @@ public class DisplayPageTemplate implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/serdes/v1_0/DisplayPageTemplateSerDes.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/serdes/v1_0/DisplayPageTemplateSerDes.java
@@ -61,7 +61,7 @@ public class DisplayPageTemplateSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (displayPageTemplate.getActions() != null) {
 			if (sb.length() > 1) {
@@ -272,7 +272,7 @@ public class DisplayPageTemplateSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (displayPageTemplate.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/serdes/v1_0/StructuredContentSerDes.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/serdes/v1_0/StructuredContentSerDes.java
@@ -65,7 +65,7 @@ public class StructuredContentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (structuredContent.getActions() != null) {
 			if (sb.length() > 1) {
@@ -549,7 +549,7 @@ public class StructuredContentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (structuredContent.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseDisplayPageTemplateResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseDisplayPageTemplateResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BasePageDefinitionResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BasePageDefinitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/dto/v1_0/ListTypeDefinition.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/dto/v1_0/ListTypeDefinition.java
@@ -288,7 +288,7 @@ public class ListTypeDefinition implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/dto/v1_0/ListTypeEntry.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/dto/v1_0/ListTypeEntry.java
@@ -310,7 +310,7 @@ public class ListTypeEntry implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/serdes/v1_0/ListTypeDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/serdes/v1_0/ListTypeDefinitionSerDes.java
@@ -61,7 +61,7 @@ public class ListTypeDefinitionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (listTypeDefinition.getActions() != null) {
 			if (sb.length() > 1) {
@@ -184,7 +184,7 @@ public class ListTypeDefinitionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (listTypeDefinition.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/serdes/v1_0/ListTypeEntrySerDes.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/serdes/v1_0/ListTypeEntrySerDes.java
@@ -59,7 +59,7 @@ public class ListTypeEntrySerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (listTypeEntry.getActions() != null) {
 			if (sb.length() > 1) {
@@ -184,7 +184,7 @@ public class ListTypeEntrySerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (listTypeEntry.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeDefinitionResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseListTypeDefinitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-test/src/testIntegration/java/com/liferay/headless/admin/list/type/resource/v1_0/test/BaseListTypeEntryResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseListTypeEntryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Keyword.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Keyword.java
@@ -388,7 +388,7 @@ public class Keyword implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
@@ -692,7 +692,7 @@ public class TaxonomyCategory implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
@@ -589,7 +589,7 @@ public class TaxonomyVocabulary implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/KeywordSerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/KeywordSerDes.java
@@ -57,7 +57,7 @@ public class KeywordSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (keyword.getActions() != null) {
 			if (sb.length() > 1) {
@@ -195,7 +195,7 @@ public class KeywordSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (keyword.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -61,7 +61,7 @@ public class TaxonomyCategorySerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (taxonomyCategory.getActions() != null) {
 			if (sb.length() > 1) {
@@ -341,7 +341,7 @@ public class TaxonomyCategorySerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (taxonomyCategory.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
@@ -61,7 +61,7 @@ public class TaxonomyVocabularySerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (taxonomyVocabulary.getActions() != null) {
 			if (sb.length() > 1) {
@@ -309,7 +309,7 @@ public class TaxonomyVocabularySerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (taxonomyVocabulary.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -107,7 +107,7 @@ public abstract class BaseKeywordResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -102,7 +102,7 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -106,7 +106,7 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Organization.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Organization.java
@@ -671,7 +671,7 @@ public class Organization implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Role.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Role.java
@@ -416,7 +416,7 @@ public class Role implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Segment.java
@@ -354,7 +354,7 @@ public class Segment implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (active != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Subscription.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Subscription.java
@@ -286,7 +286,7 @@ public class Subscription implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentId != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/UserAccount.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/UserAccount.java
@@ -865,7 +865,7 @@ public class UserAccount implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountBriefs != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
@@ -64,7 +64,7 @@ public class OrganizationSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (organization.getActions() != null) {
 			if (sb.length() > 1) {
@@ -374,7 +374,7 @@ public class OrganizationSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (organization.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/RoleSerDes.java
@@ -57,7 +57,7 @@ public class RoleSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (role.getActions() != null) {
 			if (sb.length() > 1) {
@@ -222,7 +222,7 @@ public class RoleSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (role.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SegmentSerDes.java
@@ -57,7 +57,7 @@ public class SegmentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (segment.getActive() != null) {
 			if (sb.length() > 1) {
@@ -189,7 +189,7 @@ public class SegmentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (segment.getActive() == null) {
 			map.put("active", null);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SubscriptionSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/SubscriptionSerDes.java
@@ -59,7 +59,7 @@ public class SubscriptionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (subscription.getContentId() != null) {
 			if (sb.length() > 1) {
@@ -176,7 +176,7 @@ public class SubscriptionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (subscription.getContentId() == null) {
 			map.put("contentId", null);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/UserAccountSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/UserAccountSerDes.java
@@ -65,7 +65,7 @@ public class UserAccountSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (userAccount.getAccountBriefs() != null) {
 			if (sb.length() > 1) {
@@ -501,7 +501,7 @@ public class UserAccountSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (userAccount.getAccountBriefs() == null) {
 			map.put("accountBriefs", null);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1018,7 +1018,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.19'."
+        'com.liferay.headless.admin.user.client', and version '4.0.21'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.21'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseAccountRoleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseEmailAddressResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseEmailAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -100,7 +100,7 @@ public abstract class BaseOrganizationResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePhoneResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BasePhoneResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BasePostalAddressResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BasePostalAddressResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseRoleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseSegmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSegmentUserResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseSegmentUserResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseSiteResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseSubscriptionResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseSubscriptionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserGroupResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseUserGroupResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseWebUrlResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseWebUrlResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/Role.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/Role.java
@@ -382,7 +382,7 @@ public class Role implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (availableLanguages != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowDefinition.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowDefinition.java
@@ -400,7 +400,7 @@ public class WorkflowDefinition implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (active != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowInstance.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowInstance.java
@@ -330,7 +330,7 @@ public class WorkflowInstance implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (completed != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowLog.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowLog.java
@@ -472,7 +472,7 @@ public class WorkflowLog implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (auditPerson != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTask.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTask.java
@@ -522,7 +522,7 @@ public class WorkflowTask implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assigneePerson != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToMe.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToMe.java
@@ -185,7 +185,7 @@ public class WorkflowTaskAssignToMe implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (comment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToRole.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToRole.java
@@ -187,7 +187,7 @@ public class WorkflowTaskAssignToRole implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (comment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToUser.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTaskAssignToUser.java
@@ -215,7 +215,7 @@ public class WorkflowTaskAssignToUser implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assigneeId != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTasksBulkSelection.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-api/src/main/java/com/liferay/headless/admin/workflow/dto/v1_0/WorkflowTasksBulkSelection.java
@@ -456,7 +456,7 @@ public class WorkflowTasksBulkSelection implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (andOperator != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/RoleSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/RoleSerDes.java
@@ -57,7 +57,7 @@ public class RoleSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (role.getAvailableLanguages() != null) {
 			if (sb.length() > 1) {
@@ -212,7 +212,7 @@ public class RoleSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (role.getAvailableLanguages() == null) {
 			map.put("availableLanguages", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowDefinitionSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowDefinitionSerDes.java
@@ -62,7 +62,7 @@ public class WorkflowDefinitionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowDefinition.getActive() != null) {
 			if (sb.length() > 1) {
@@ -251,7 +251,7 @@ public class WorkflowDefinitionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowDefinition.getActive() == null) {
 			map.put("active", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowInstanceSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowInstanceSerDes.java
@@ -59,7 +59,7 @@ public class WorkflowInstanceSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowInstance.getCompleted() != null) {
 			if (sb.length() > 1) {
@@ -197,7 +197,7 @@ public class WorkflowInstanceSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowInstance.getCompleted() == null) {
 			map.put("completed", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowLogSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowLogSerDes.java
@@ -59,7 +59,7 @@ public class WorkflowLogSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowLog.getAuditPerson() != null) {
 			if (sb.length() > 1) {
@@ -236,7 +236,7 @@ public class WorkflowLogSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowLog.getAuditPerson() == null) {
 			map.put("auditPerson", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToMeSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToMeSerDes.java
@@ -59,7 +59,7 @@ public class WorkflowTaskAssignToMeSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTaskAssignToMe.getComment() != null) {
 			if (sb.length() > 1) {
@@ -123,7 +123,7 @@ public class WorkflowTaskAssignToMeSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTaskAssignToMe.getComment() == null) {
 			map.put("comment", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToRoleSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToRoleSerDes.java
@@ -61,7 +61,7 @@ public class WorkflowTaskAssignToRoleSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTaskAssignToRole.getComment() != null) {
 			if (sb.length() > 1) {
@@ -125,7 +125,7 @@ public class WorkflowTaskAssignToRoleSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTaskAssignToRole.getComment() == null) {
 			map.put("comment", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToUserSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskAssignToUserSerDes.java
@@ -61,7 +61,7 @@ public class WorkflowTaskAssignToUserSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTaskAssignToUser.getAssigneeId() != null) {
 			if (sb.length() > 1) {
@@ -135,7 +135,7 @@ public class WorkflowTaskAssignToUserSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTaskAssignToUser.getAssigneeId() == null) {
 			map.put("assigneeId", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTaskSerDes.java
@@ -61,7 +61,7 @@ public class WorkflowTaskSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTask.getAssigneePerson() != null) {
 			if (sb.length() > 1) {
@@ -279,7 +279,7 @@ public class WorkflowTaskSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTask.getAssigneePerson() == null) {
 			map.put("assigneePerson", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTasksBulkSelectionSerDes.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/serdes/v1_0/WorkflowTasksBulkSelectionSerDes.java
@@ -63,7 +63,7 @@ public class WorkflowTasksBulkSelectionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTasksBulkSelection.getAndOperator() != null) {
 			if (sb.length() > 1) {
@@ -321,7 +321,7 @@ public class WorkflowTasksBulkSelectionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (workflowTasksBulkSelection.getAndOperator() == null) {
 			map.put("andOperator", null);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseAssigneeResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseAssigneeResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseAssigneeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseTransitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseTransitionResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseTransitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowDefinitionResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseWorkflowDefinitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowInstanceResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseWorkflowInstanceResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowLogResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseWorkflowLogResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskAssignableUsersResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskAssignableUsersResourceTestCase.java
@@ -88,7 +88,7 @@ public abstract class BaseWorkflowTaskAssignableUsersResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseWorkflowTaskResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskTransitionsResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-test/src/testIntegration/java/com/liferay/headless/admin/workflow/resource/v1_0/test/BaseWorkflowTaskTransitionsResourceTestCase.java
@@ -88,7 +88,7 @@ public abstract class BaseWorkflowTaskTransitionsResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ExportTask.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ExportTask.java
@@ -370,7 +370,7 @@ public class ExportTask implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (className != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ImportTask.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ImportTask.java
@@ -480,7 +480,7 @@ public class ImportTask implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (className != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/serdes/v1_0/ExportTaskSerDes.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/serdes/v1_0/ExportTaskSerDes.java
@@ -57,7 +57,7 @@ public class ExportTaskSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (exportTask.getClassName() != null) {
 			if (sb.length() > 1) {
@@ -193,7 +193,7 @@ public class ExportTaskSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (exportTask.getClassName() == null) {
 			map.put("className", null);

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/serdes/v1_0/ImportTaskSerDes.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/serdes/v1_0/ImportTaskSerDes.java
@@ -59,7 +59,7 @@ public class ImportTaskSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (importTask.getClassName() != null) {
 			if (sb.length() > 1) {
@@ -243,7 +243,7 @@ public class ImportTaskSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (importTask.getClassName() == null) {
 			map.put("className", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BlogPosting.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BlogPosting.java
@@ -829,7 +829,7 @@ public class BlogPosting implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Comment.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Comment.java
@@ -320,7 +320,7 @@ public class Comment implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentStructure.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentStructure.java
@@ -452,7 +452,7 @@ public class ContentStructure implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assetLibraryKey != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentTemplate.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ContentTemplate.java
@@ -541,7 +541,7 @@ public class ContentTemplate implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/CreatorStatistics.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/CreatorStatistics.java
@@ -200,7 +200,7 @@ public class CreatorStatistics implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (joinDate != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Document.java
@@ -921,7 +921,7 @@ public class Document implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/DocumentFolder.java
@@ -555,7 +555,7 @@ public class DocumentFolder implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/KnowledgeBaseArticle.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/KnowledgeBaseArticle.java
@@ -875,7 +875,7 @@ public class KnowledgeBaseArticle implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/KnowledgeBaseFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/KnowledgeBaseFolder.java
@@ -579,7 +579,7 @@ public class KnowledgeBaseFolder implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardMessage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardMessage.java
@@ -900,7 +900,7 @@ public class MessageBoardMessage implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardSection.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardSection.java
@@ -540,7 +540,7 @@ public class MessageBoardSection implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardThread.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/MessageBoardThread.java
@@ -997,7 +997,7 @@ public class MessageBoardThread implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/NavigationMenu.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/NavigationMenu.java
@@ -376,7 +376,7 @@ public class NavigationMenu implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/NavigationMenuItem.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/NavigationMenuItem.java
@@ -524,7 +524,7 @@ public class NavigationMenuItem implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (availableLanguages != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageTemplate.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageTemplate.java
@@ -417,7 +417,7 @@ public class PageTemplate implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (creator != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageTemplateCollection.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageTemplateCollection.java
@@ -292,7 +292,7 @@ public class PageTemplateCollection implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (creator != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Rating.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/Rating.java
@@ -330,7 +330,7 @@ public class Rating implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/SitePage.java
@@ -810,7 +810,7 @@ public class SitePage implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/StructuredContent.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/StructuredContent.java
@@ -1056,7 +1056,7 @@ public class StructuredContent implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/StructuredContentFolder.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/StructuredContentFolder.java
@@ -578,7 +578,7 @@ public class StructuredContentFolder implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/WikiNode.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/WikiNode.java
@@ -462,7 +462,7 @@ public class WikiNode implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/WikiPage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/WikiPage.java
@@ -805,7 +805,7 @@ public class WikiPage implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
@@ -685,7 +685,7 @@ public interface MessageBoardThreadResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (dateCreated != null) {
 				httpInvoker.parameter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BlogPostingSerDes.java
@@ -64,7 +64,7 @@ public class BlogPostingSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (blogPosting.getActions() != null) {
 			if (sb.length() > 1) {
@@ -442,7 +442,7 @@ public class BlogPostingSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (blogPosting.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CommentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CommentSerDes.java
@@ -57,7 +57,7 @@ public class CommentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (comment.getActions() != null) {
 			if (sb.length() > 1) {
@@ -171,7 +171,7 @@ public class CommentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (comment.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentStructureSerDes.java
@@ -61,7 +61,7 @@ public class ContentStructureSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentStructure.getAssetLibraryKey() != null) {
 			if (sb.length() > 1) {
@@ -259,7 +259,7 @@ public class ContentStructureSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentStructure.getAssetLibraryKey() == null) {
 			map.put("assetLibraryKey", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentTemplateSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ContentTemplateSerDes.java
@@ -59,7 +59,7 @@ public class ContentTemplateSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentTemplate.getActions() != null) {
 			if (sb.length() > 1) {
@@ -283,7 +283,7 @@ public class ContentTemplateSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (contentTemplate.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CreatorStatisticsSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/CreatorStatisticsSerDes.java
@@ -59,7 +59,7 @@ public class CreatorStatisticsSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (creatorStatistics.getJoinDate() != null) {
 			if (sb.length() > 1) {
@@ -139,7 +139,7 @@ public class CreatorStatisticsSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (creatorStatistics.getJoinDate() == null) {
 			map.put("joinDate", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentFolderSerDes.java
@@ -61,7 +61,7 @@ public class DocumentFolderSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (documentFolder.getActions() != null) {
 			if (sb.length() > 1) {
@@ -271,7 +271,7 @@ public class DocumentFolderSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (documentFolder.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/DocumentSerDes.java
@@ -63,7 +63,7 @@ public class DocumentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (document.getActions() != null) {
 			if (sb.length() > 1) {
@@ -477,7 +477,7 @@ public class DocumentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (document.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseArticleSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseArticleSerDes.java
@@ -63,7 +63,7 @@ public class KnowledgeBaseArticleSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (knowledgeBaseArticle.getActions() != null) {
 			if (sb.length() > 1) {
@@ -458,7 +458,7 @@ public class KnowledgeBaseArticleSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (knowledgeBaseArticle.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/KnowledgeBaseFolderSerDes.java
@@ -61,7 +61,7 @@ public class KnowledgeBaseFolderSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (knowledgeBaseFolder.getActions() != null) {
 			if (sb.length() > 1) {
@@ -278,7 +278,7 @@ public class KnowledgeBaseFolderSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (knowledgeBaseFolder.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardMessageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardMessageSerDes.java
@@ -62,7 +62,7 @@ public class MessageBoardMessageSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (messageBoardMessage.getActions() != null) {
 			if (sb.length() > 1) {
@@ -428,7 +428,7 @@ public class MessageBoardMessageSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (messageBoardMessage.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardSectionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardSectionSerDes.java
@@ -61,7 +61,7 @@ public class MessageBoardSectionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (messageBoardSection.getActions() != null) {
 			if (sb.length() > 1) {
@@ -262,7 +262,7 @@ public class MessageBoardSectionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (messageBoardSection.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardThreadSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/MessageBoardThreadSerDes.java
@@ -63,7 +63,7 @@ public class MessageBoardThreadSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (messageBoardThread.getActions() != null) {
 			if (sb.length() > 1) {
@@ -489,7 +489,7 @@ public class MessageBoardThreadSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (messageBoardThread.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/NavigationMenuItemSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/NavigationMenuItemSerDes.java
@@ -60,7 +60,7 @@ public class NavigationMenuItemSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (navigationMenuItem.getAvailableLanguages() != null) {
 			if (sb.length() > 1) {
@@ -301,7 +301,7 @@ public class NavigationMenuItemSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (navigationMenuItem.getAvailableLanguages() == null) {
 			map.put("availableLanguages", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/NavigationMenuSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/NavigationMenuSerDes.java
@@ -61,7 +61,7 @@ public class NavigationMenuSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (navigationMenu.getActions() != null) {
 			if (sb.length() > 1) {
@@ -206,7 +206,7 @@ public class NavigationMenuSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (navigationMenu.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageTemplateCollectionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageTemplateCollectionSerDes.java
@@ -59,7 +59,7 @@ public class PageTemplateCollectionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (pageTemplateCollection.getCreator() != null) {
 			if (sb.length() > 1) {
@@ -177,7 +177,7 @@ public class PageTemplateCollectionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (pageTemplateCollection.getCreator() == null) {
 			map.put("creator", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageTemplateSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageTemplateSerDes.java
@@ -61,7 +61,7 @@ public class PageTemplateSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (pageTemplate.getCreator() != null) {
 			if (sb.length() > 1) {
@@ -251,7 +251,7 @@ public class PageTemplateSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (pageTemplate.getCreator() == null) {
 			map.put("creator", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/RatingSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/RatingSerDes.java
@@ -57,7 +57,7 @@ public class RatingSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (rating.getActions() != null) {
 			if (sb.length() > 1) {
@@ -166,7 +166,7 @@ public class RatingSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (rating.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SegmentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SegmentSerDes.java
@@ -57,7 +57,7 @@ public class SegmentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (segment.getActive() != null) {
 			if (sb.length() > 1) {
@@ -189,7 +189,7 @@ public class SegmentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (segment.getActive() == null) {
 			map.put("active", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SitePageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SitePageSerDes.java
@@ -60,7 +60,7 @@ public class SitePageSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sitePage.getActions() != null) {
 			if (sb.length() > 1) {
@@ -407,7 +407,7 @@ public class SitePageSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sitePage.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentFolderSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentFolderSerDes.java
@@ -63,7 +63,7 @@ public class StructuredContentFolderSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (structuredContentFolder.getActions() != null) {
 			if (sb.length() > 1) {
@@ -287,7 +287,7 @@ public class StructuredContentFolderSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (structuredContentFolder.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/StructuredContentSerDes.java
@@ -65,7 +65,7 @@ public class StructuredContentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (structuredContent.getActions() != null) {
 			if (sb.length() > 1) {
@@ -555,7 +555,7 @@ public class StructuredContentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (structuredContent.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/WikiNodeSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/WikiNodeSerDes.java
@@ -57,7 +57,7 @@ public class WikiNodeSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (wikiNode.getActions() != null) {
 			if (sb.length() > 1) {
@@ -224,7 +224,7 @@ public class WikiNodeSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (wikiNode.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/WikiPageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/WikiPageSerDes.java
@@ -61,7 +61,7 @@ public class WikiPageSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (wikiPage.getActions() != null) {
 			if (sb.length() > 1) {
@@ -403,7 +403,7 @@ public class WikiPageSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (wikiPage.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingImageResourceTestCase.java
@@ -102,7 +102,7 @@ public abstract class BaseBlogPostingImageResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseBlogPostingResourceTestCase.java
@@ -104,7 +104,7 @@ public abstract class BaseBlogPostingResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseCommentResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseCommentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentElementResourceTestCase.java
@@ -102,7 +102,7 @@ public abstract class BaseContentElementResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentSetElementResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseContentSetElementResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentStructureResourceTestCase.java
@@ -105,7 +105,7 @@ public abstract class BaseContentStructureResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseContentTemplateResourceTestCase.java
@@ -102,7 +102,7 @@ public abstract class BaseContentTemplateResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentFolderResourceTestCase.java
@@ -107,7 +107,7 @@ public abstract class BaseDocumentFolderResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseDocumentResourceTestCase.java
@@ -110,7 +110,7 @@ public abstract class BaseDocumentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseArticleResourceTestCase.java
@@ -104,7 +104,7 @@ public abstract class BaseKnowledgeBaseArticleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseAttachmentResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseKnowledgeBaseFolderResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseKnowledgeBaseFolderResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseLanguageResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseLanguageResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardAttachmentResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseMessageBoardAttachmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardMessageResourceTestCase.java
@@ -103,7 +103,7 @@ public abstract class BaseMessageBoardMessageResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardSectionResourceTestCase.java
@@ -103,7 +103,7 @@ public abstract class BaseMessageBoardSectionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseMessageBoardThreadResourceTestCase.java
@@ -105,7 +105,7 @@ public abstract class BaseMessageBoardThreadResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseNavigationMenuResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseNavigationMenuResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -98,7 +98,7 @@ public abstract class BaseSitePageResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentFolderResourceTestCase.java
@@ -107,7 +107,7 @@ public abstract class BaseStructuredContentFolderResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -108,7 +108,7 @@ public abstract class BaseStructuredContentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiNodeResourceTestCase.java
@@ -103,7 +103,7 @@ public abstract class BaseWikiNodeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageAttachmentResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseWikiPageAttachmentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseWikiPageResourceTestCase.java
@@ -102,7 +102,7 @@ public abstract class BaseWikiPageResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/dto/v1_0/Form.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/dto/v1_0/Form.java
@@ -541,7 +541,7 @@ public class Form implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (availableLanguages != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/dto/v1_0/FormRecord.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/dto/v1_0/FormRecord.java
@@ -317,7 +317,7 @@ public class FormRecord implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (creator != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/dto/v1_0/FormStructure.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/dto/v1_0/FormStructure.java
@@ -433,7 +433,7 @@ public class FormStructure implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (availableLanguages != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormRecordSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormRecordSerDes.java
@@ -59,7 +59,7 @@ public class FormRecordSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (formRecord.getCreator() != null) {
 			if (sb.length() > 1) {
@@ -185,7 +185,7 @@ public class FormRecordSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (formRecord.getCreator() == null) {
 			map.put("creator", null);

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormSerDes.java
@@ -59,7 +59,7 @@ public class FormSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (form.getAvailableLanguages() != null) {
 			if (sb.length() > 1) {
@@ -298,7 +298,7 @@ public class FormSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (form.getAvailableLanguages() == null) {
 			map.put("availableLanguages", null);

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormStructureSerDes.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/serdes/v1_0/FormStructureSerDes.java
@@ -61,7 +61,7 @@ public class FormStructureSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (formStructure.getAvailableLanguages() != null) {
 			if (sb.length() > 1) {
@@ -248,7 +248,7 @@ public class FormStructureSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (formStructure.getAvailableLanguages() == null) {
 			map.put("availableLanguages", null);

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormDocumentResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseFormDocumentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormRecordResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseFormRecordResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseFormResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
+++ b/modules/apps/headless/headless-form/headless-form-test/src/testIntegration/java/com/liferay/headless/form/resource/v1_0/test/BaseFormStructureResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseFormStructureResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/json/BaseJSONParser.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectAction.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectAction.java
@@ -344,7 +344,7 @@ public class ObjectAction implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectDefinition.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectDefinition.java
@@ -660,7 +660,7 @@ public class ObjectDefinition implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectLayout.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectLayout.java
@@ -317,7 +317,7 @@ public class ObjectLayout implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectView.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/dto/v1_0/ObjectView.java
@@ -317,7 +317,7 @@ public class ObjectView implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/json/BaseJSONParser.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectActionSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectActionSerDes.java
@@ -59,7 +59,7 @@ public class ObjectActionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectAction.getActions() != null) {
 			if (sb.length() > 1) {
@@ -193,7 +193,7 @@ public class ObjectActionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectAction.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectDefinitionSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectDefinitionSerDes.java
@@ -65,7 +65,7 @@ public class ObjectDefinitionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectDefinition.getActions() != null) {
 			if (sb.length() > 1) {
@@ -380,7 +380,7 @@ public class ObjectDefinitionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectDefinition.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectLayoutSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectLayoutSerDes.java
@@ -61,7 +61,7 @@ public class ObjectLayoutSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectLayout.getActions() != null) {
 			if (sb.length() > 1) {
@@ -186,7 +186,7 @@ public class ObjectLayoutSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectLayout.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectViewSerDes.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/serdes/v1_0/ObjectViewSerDes.java
@@ -59,7 +59,7 @@ public class ObjectViewSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectView.getActions() != null) {
 			if (sb.length() > 1) {
@@ -180,7 +180,7 @@ public class ObjectViewSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (objectView.getActions() == null) {
 			map.put("actions", null);

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectActionResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseObjectActionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectDefinitionResourceTestCase.java
@@ -99,7 +99,7 @@ public abstract class BaseObjectDefinitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseObjectFieldResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldSettingResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectFieldSettingResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseObjectFieldSettingResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectLayoutResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseObjectLayoutResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectRelationshipResourceTestCase.java
@@ -94,7 +94,7 @@ public abstract class BaseObjectRelationshipResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
+++ b/modules/apps/object/object-admin-rest-test/src/testIntegration/java/com/liferay/object/admin/rest/resource/v1_0/test/BaseObjectViewResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseObjectViewResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/ObjectEntry.java
@@ -352,7 +352,7 @@ public class ObjectEntry implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/param/converter/DateParamConverter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/param/converter/DateParamConverter.java
@@ -66,6 +66,6 @@ public class DateParamConverter implements ParamConverter<Date> {
 		"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
 
 	private static final String _PATTERN_DATE_TIME_WITHOUT_MILLIS =
-		"yyyy-MM-dd'T'HH:mm:ss'Z'";
+		"yyyy-MM-dd'T'HH:mm:ssXX";
 
 }

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/Cart.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/Cart.java
@@ -881,7 +881,7 @@ public class Cart implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/AccountCategoryForecast.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/AccountCategoryForecast.java
@@ -346,7 +346,7 @@ public class AccountCategoryForecast implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/AccountForecast.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/AccountForecast.java
@@ -288,7 +288,7 @@ public class AccountForecast implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (account != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/FrequentPatternRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/FrequentPatternRecommendation.java
@@ -261,7 +261,7 @@ public class FrequentPatternRecommendation implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (antecedentIds != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductContentRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductContentRecommendation.java
@@ -259,7 +259,7 @@ public class ProductContentRecommendation implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (createDate != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductInteractionRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductInteractionRecommendation.java
@@ -259,7 +259,7 @@ public class ProductInteractionRecommendation implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (createDate != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/SkuForecast.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/SkuForecast.java
@@ -286,7 +286,7 @@ public class SkuForecast implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actual != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/UserRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/UserRecommendation.java
@@ -283,7 +283,7 @@ public class UserRecommendation implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assetCategoryIds != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountCategoryForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountCategoryForecastResource.java
@@ -207,7 +207,7 @@ public interface AccountCategoryForecastResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (accountIds != null) {
 				for (int i = 0; i < accountIds.length; i++) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountForecastResource.java
@@ -205,7 +205,7 @@ public interface AccountForecastResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (accountIds != null) {
 				for (int i = 0; i < accountIds.length; i++) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/SkuForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/SkuForecastResource.java
@@ -200,7 +200,7 @@ public interface SkuForecastResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (forecastLength != null) {
 				httpInvoker.parameter(

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/AccountCategoryForecastSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/AccountCategoryForecastSerDes.java
@@ -61,7 +61,7 @@ public class AccountCategoryForecastSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountCategoryForecast.getAccount() != null) {
 			if (sb.length() > 1) {
@@ -189,7 +189,7 @@ public class AccountCategoryForecastSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountCategoryForecast.getAccount() == null) {
 			map.put("account", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/AccountForecastSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/AccountForecastSerDes.java
@@ -59,7 +59,7 @@ public class AccountForecastSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountForecast.getAccount() != null) {
 			if (sb.length() > 1) {
@@ -160,7 +160,7 @@ public class AccountForecastSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (accountForecast.getAccount() == null) {
 			map.put("account", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/FrequentPatternRecommendationSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/FrequentPatternRecommendationSerDes.java
@@ -63,7 +63,7 @@ public class FrequentPatternRecommendationSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (frequentPatternRecommendation.getAntecedentIds() != null) {
 			if (sb.length() > 1) {
@@ -174,7 +174,7 @@ public class FrequentPatternRecommendationSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (frequentPatternRecommendation.getAntecedentIds() == null) {
 			map.put("antecedentIds", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/ProductContentRecommendationSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/ProductContentRecommendationSerDes.java
@@ -63,7 +63,7 @@ public class ProductContentRecommendationSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (productContentRecommendation.getCreateDate() != null) {
 			if (sb.length() > 1) {
@@ -158,7 +158,7 @@ public class ProductContentRecommendationSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (productContentRecommendation.getCreateDate() == null) {
 			map.put("createDate", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/ProductInteractionRecommendationSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/ProductInteractionRecommendationSerDes.java
@@ -63,7 +63,7 @@ public class ProductInteractionRecommendationSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (productInteractionRecommendation.getCreateDate() != null) {
 			if (sb.length() > 1) {
@@ -161,7 +161,7 @@ public class ProductInteractionRecommendationSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (productInteractionRecommendation.getCreateDate() == null) {
 			map.put("createDate", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/SkuForecastSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/SkuForecastSerDes.java
@@ -59,7 +59,7 @@ public class SkuForecastSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (skuForecast.getActual() != null) {
 			if (sb.length() > 1) {
@@ -164,7 +164,7 @@ public class SkuForecastSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (skuForecast.getActual() == null) {
 			map.put("actual", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/UserRecommendationSerDes.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/serdes/v1_0/UserRecommendationSerDes.java
@@ -59,7 +59,7 @@ public class UserRecommendationSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (userRecommendation.getAssetCategoryIds() != null) {
 			if (sb.length() > 1) {
@@ -175,7 +175,7 @@ public class UserRecommendationSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (userRecommendation.getAssetCategoryIds() == null) {
 			map.put("assetCategoryIds", null);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountCategoryForecastResourceTestCase.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountCategoryForecastResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseAccountCategoryForecastResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountForecastResourceTestCase.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseAccountForecastResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseAccountForecastResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseSkuForecastResourceTestCase.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-test/src/testIntegration/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/test/BaseSkuForecastResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseSkuForecastResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/AssigneeMetricBulkSelection.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/AssigneeMetricBulkSelection.java
@@ -291,7 +291,7 @@ public class AssigneeMetricBulkSelection implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (completed != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Instance.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Instance.java
@@ -698,7 +698,7 @@ public class Instance implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (active != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Node.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Node.java
@@ -362,7 +362,7 @@ public class Node implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dateCreated != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Process.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Process.java
@@ -340,7 +340,7 @@ public class Process implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (active != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/SLA.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/SLA.java
@@ -397,7 +397,7 @@ public class SLA implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (calendarKey != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/SLAResult.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/SLAResult.java
@@ -294,7 +294,7 @@ public class SLAResult implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dateModified != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Task.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/Task.java
@@ -651,7 +651,7 @@ public class Task implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assetTitle != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/TimeRange.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/dto/v1_0/TimeRange.java
@@ -226,7 +226,7 @@ public class TimeRange implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dateEnd != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/HistogramMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/HistogramMetricResource.java
@@ -196,7 +196,7 @@ public interface HistogramMetricResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (dateEnd != null) {
 				httpInvoker.parameter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/InstanceResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/InstanceResource.java
@@ -251,7 +251,7 @@ public interface InstanceResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (assigneeIds != null) {
 				for (int i = 0; i < assigneeIds.length; i++) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/NodeMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/NodeMetricResource.java
@@ -202,7 +202,7 @@ public interface NodeMetricResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (completed != null) {
 				httpInvoker.parameter("completed", String.valueOf(completed));

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessMetricResource.java
@@ -302,7 +302,7 @@ public interface ProcessMetricResource {
 			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
 
 			DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-				"yyyy-MM-dd'T'HH:mm:ss'Z'");
+				"yyyy-MM-dd'T'HH:mm:ssXX");
 
 			if (completed != null) {
 				httpInvoker.parameter("completed", String.valueOf(completed));

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/AssigneeMetricBulkSelectionSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/AssigneeMetricBulkSelectionSerDes.java
@@ -63,7 +63,7 @@ public class AssigneeMetricBulkSelectionSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assigneeMetricBulkSelection.getCompleted() != null) {
 			if (sb.length() > 1) {
@@ -219,7 +219,7 @@ public class AssigneeMetricBulkSelectionSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (assigneeMetricBulkSelection.getCompleted() == null) {
 			map.put("completed", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/InstanceSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/InstanceSerDes.java
@@ -61,7 +61,7 @@ public class InstanceSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (instance.getActive() != null) {
 			if (sb.length() > 1) {
@@ -371,7 +371,7 @@ public class InstanceSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (instance.getActive() == null) {
 			map.put("active", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/NodeSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/NodeSerDes.java
@@ -57,7 +57,7 @@ public class NodeSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (node.getDateCreated() != null) {
 			if (sb.length() > 1) {
@@ -202,7 +202,7 @@ public class NodeSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (node.getDateCreated() == null) {
 			map.put("dateCreated", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/ProcessSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/ProcessSerDes.java
@@ -57,7 +57,7 @@ public class ProcessSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (process.getActive() != null) {
 			if (sb.length() > 1) {
@@ -193,7 +193,7 @@ public class ProcessSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (process.getActive() == null) {
 			map.put("active", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/SLAResultSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/SLAResultSerDes.java
@@ -57,7 +57,7 @@ public class SLAResultSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (slaResult.getDateModified() != null) {
 			if (sb.length() > 1) {
@@ -166,7 +166,7 @@ public class SLAResultSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (slaResult.getDateModified() == null) {
 			map.put("dateModified", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/SLASerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/SLASerDes.java
@@ -57,7 +57,7 @@ public class SLASerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sla.getCalendarKey() != null) {
 			if (sb.length() > 1) {
@@ -204,7 +204,7 @@ public class SLASerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sla.getCalendarKey() == null) {
 			map.put("calendarKey", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/TaskSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/TaskSerDes.java
@@ -57,7 +57,7 @@ public class TaskSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (task.getAssetTitle() != null) {
 			if (sb.length() > 1) {
@@ -314,7 +314,7 @@ public class TaskSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (task.getAssetTitle() == null) {
 			map.put("assetTitle", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/TimeRangeSerDes.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/serdes/v1_0/TimeRangeSerDes.java
@@ -57,7 +57,7 @@ public class TimeRangeSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (timeRange.getDateEnd() != null) {
 			if (sb.length() > 1) {
@@ -140,7 +140,7 @@ public class TimeRangeSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (timeRange.getDateEnd() == null) {
 			map.put("dateEnd", null);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeMetricResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseAssigneeMetricResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseAssigneeResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseAssigneeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseCalendarResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseCalendarResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseCalendarResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseHistogramMetricResourceTestCase.java
@@ -89,7 +89,7 @@ public abstract class BaseHistogramMetricResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseIndexResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseIndexResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseIndexResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseInstanceResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseInstanceResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeMetricResourceTestCase.java
@@ -96,7 +96,7 @@ public abstract class BaseNodeMetricResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseNodeResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseNodeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessMetricResourceTestCase.java
@@ -97,7 +97,7 @@ public abstract class BaseProcessMetricResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseProcessResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessVersionResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseProcessVersionResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseProcessVersionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseReindexStatusResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseReindexStatusResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseReindexStatusResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseRoleResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResourceTestCase.java
@@ -93,7 +93,7 @@ public abstract class BaseSLAResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseSLAResultResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTaskResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseTaskResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseTimeRangeResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseTimeRangeResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPBlueprint.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPBlueprint.java
@@ -433,7 +433,7 @@ public class SXPBlueprint implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPElement.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/dto/v1_0/SXPElement.java
@@ -486,7 +486,7 @@ public class SXPElement implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (actions != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPBlueprintSerDes.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPBlueprintSerDes.java
@@ -61,7 +61,7 @@ public class SXPBlueprintSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sxpBlueprint.getActions() != null) {
 			if (sb.length() > 1) {
@@ -242,7 +242,7 @@ public class SXPBlueprintSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sxpBlueprint.getActions() == null) {
 			map.put("actions", null);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPElementSerDes.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/serdes/v1_0/SXPElementSerDes.java
@@ -57,7 +57,7 @@ public class SXPElementSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sxpElement.getActions() != null) {
 			if (sb.length() > 1) {
@@ -244,7 +244,7 @@ public class SXPElementSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (sxpElement.getActions() == null) {
 			map.put("actions", null);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -513,7 +513,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '1.0.2'."
+        'com.liferay.search.experiences.rest.client', and version '1.0.3'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '1.0.2'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseFieldMappingInfoResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseFieldMappingInfoResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseFieldMappingInfoResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseKeywordQueryContributorResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseKeywordQueryContributorResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseKeywordQueryContributorResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseModelPrefilterContributorResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseModelPrefilterContributorResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseModelPrefilterContributorResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseQueryPrefilterContributorResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseQueryPrefilterContributorResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseQueryPrefilterContributorResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPBlueprintResourceTestCase.java
@@ -100,7 +100,7 @@ public abstract class BaseSXPBlueprintResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPElementResourceTestCase.java
@@ -100,7 +100,7 @@ public abstract class BaseSXPElementResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPParameterContributorDefinitionResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSXPParameterContributorDefinitionResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseSXPParameterContributorDefinitionResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchResponseResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchResponseResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseSearchResponseResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameDisplayResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameDisplayResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseSearchableAssetNameDisplayResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameResourceTestCase.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-test/src/testIntegration/java/com/liferay/search/experiences/rest/resource/v1_0/test/BaseSearchableAssetNameResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseSearchableAssetNameResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/Experiment.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/dto/v1_0/Experiment.java
@@ -308,7 +308,7 @@ public class Experiment implements Serializable {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (dateCreated != null) {
 			if (sb.length() > 1) {

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/json/BaseJSONParser.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/json/BaseJSONParser.java
@@ -289,7 +289,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/serdes/v1_0/ExperimentSerDes.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/serdes/v1_0/ExperimentSerDes.java
@@ -57,7 +57,7 @@ public class ExperimentSerDes {
 		sb.append("{");
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (experiment.getDateCreated() != null) {
 			if (sb.length() > 1) {
@@ -184,7 +184,7 @@ public class ExperimentSerDes {
 		Map<String, String> map = new TreeMap<>();
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 
 		if (experiment.getDateCreated() == null) {
 			map.put("dateCreated", null);

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentResourceTestCase.java
@@ -92,7 +92,7 @@ public abstract class BaseExperimentResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseExperimentRunResourceTestCase.java
@@ -90,7 +90,7 @@ public abstract class BaseExperimentRunResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-test/src/testIntegration/java/com/liferay/segments/asah/rest/resource/v1_0/test/BaseStatusResourceTestCase.java
@@ -91,7 +91,7 @@ public abstract class BaseStatusResourceTestCase {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+			"yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -118,7 +118,7 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = DateFormatFactoryUtil.getSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 	}
 
 	@Before

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_base_json_parser.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_base_json_parser.ftl
@@ -269,7 +269,7 @@ public abstract class BaseJSONParser<T> {
 
 	private void _init(String json) {
 		_captureStartStack = new Stack<>();
-		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		_dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 		_index = 0;
 		_json = json.trim();
 		_lastChar = 0;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
@@ -260,7 +260,7 @@ public interface ${schemaName}Resource {
 
 				<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
 					<#if stringUtil.equals(javaMethodParameter.parameterType, "java.util.Date")>
-						DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+						DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 
 						<#break>
 					</#if>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_serdes.ftl
@@ -66,7 +66,7 @@ public class ${schemaName}SerDes {
 			<#assign propertyType = properties[propertyName] />
 
 			<#if stringUtil.equals(propertyType, "Date") || stringUtil.equals(propertyType, "Date[]")>
-				DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+				DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 
 				<#break>
 			</#if>
@@ -184,7 +184,7 @@ public class ${schemaName}SerDes {
 			<#assign propertyType = properties[propertyName] />
 
 			<#if stringUtil.equals(propertyType, "Date") || stringUtil.equals(propertyType, "Date[]")>
-				DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+				DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 
 				<#break>
 			</#if>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -278,7 +278,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 			<#assign propertyType = properties[propertyName] />
 
 			<#if stringUtil.equals(propertyType, "Date") || stringUtil.equals(propertyType, "Date[]")>
-				DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+				DateFormat liferayToJSONDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXX");
 
 				<#break>
 			</#if>


### PR DESCRIPTION
Comes from [here](https://github.com/liferay-frontend/liferay-portal/pull/1900)
___ 
**Description**

- Our REST builder defines a [SimpleDateFormat](https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) object with the general pattern yyyy-MM-dd HH:mm:ss timezone
- But it seems there was a typo defining that pattern related to the timezone, maybe because of a quoted 'T' letter added between date and time: we did the same with 'Z' letter (it is quoted)
- So, the pattern is defined as yyyy-MM-dd'T'HH:mm:ss'Z' and then, the quoted 'Z' (timezone) is not interpreted during formatting.