### PR TITLE
LPS-144537 - Prevent MT separator from shrinking

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -3,6 +3,7 @@
 .management-bar-separator-left::before {
 	background-color: $gray-500;
 	content: '';
+	flex-shrink: 0;
 	height: 16px;
 	margin: 0 10px;
 	width: 1px;


### PR DESCRIPTION
### References

- [LPS-144537](https://issues.liferay.com/browse/LPS-144537)

### What is the goal?

* Prevent MT info button separator from shrinking and not showing in specific browsers
   * The separator width was fixed to 1px, but because it's inside a flex container it was shrinking to ~0.5px, which is not visible in some screens
   * Tested in Chrome, Firefox and Safari

### What does it look like?
#### Before fix
<img width="1328" alt="Captura de pantalla 2022-02-15 a las 12 05 33" src="https://user-images.githubusercontent.com/6642927/154050062-ba85b29a-8a6f-4e79-bece-b3ccdca4d67d.png">

#### After changes
<img width="1330" alt="Captura de pantalla 2022-02-15 a las 12 05 25" src="https://user-images.githubusercontent.com/6642927/154050186-3901d3db-83d2-42d5-931a-bb29c4ec315c.png">


### How to replicate
* Enable feature flag
   * Download [this flag](https://issues.liferay.com/secure/attachment/436739/com.liferay.frontend.taglib.clay.internal.configuration.FFManagementToolbarConfiguration.config)
   * Move it to `bundles/osgi/config`
   * Restart portal
* Go to `Content & Data > Documents and Media`
* Create at least one document and select it
* See that there's a vertical bar to the left of the info button at the end of the MT
* Check that it's visible in all browsers
