### PR TITLE
[TS] LPS-147457 Accessibility errors caused by the use of 'content: normal' from style sheets

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
@@ -20,12 +20,12 @@ html#{$cadmin-selector} {
 
 .dropdown-toggle:after {
 	border-width: 0;
-	content: normal;
+	content: '';
 }
 
 .dropup .dropdown-toggle:after {
 	border-width: 0;
-	content: normal;
+	content: '';
 }
 
 .dropdown > .dropdown-menu {

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
@@ -9,25 +9,3 @@ html#{$cadmin-selector} {
 .overlay-content .open > .dropdown-menu {
 	display: block;
 }
-
-.dropdown-menu {
-	border: 1px solid $dropdown-border-color;
-
-	.dropdown-item.active {
-		pointer-events: initial;
-	}
-}
-
-.dropdown-toggle:after {
-	border-width: 0;
-	content: '';
-}
-
-.dropup .dropdown-toggle:after {
-	border-width: 0;
-	content: '';
-}
-
-.dropdown > .dropdown-menu {
-	position: absolute;
-}


### PR DESCRIPTION
Hi team,

Can we change `content: normal` to `content: ''` to avoid the errors reported by some accessibility tools?

More info in [LPS-147457](https://issues.liferay.com/browse/LPS-147457).

Thanks

cc/ @georgel-pop-lr @pat270 @marcoscv-work 