### PR TITLE
[TS] LPS-146513

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -452,8 +452,7 @@ AUI.add(
 				links.set(ARIA_ATTR_ROLE, ariaLinksAttr);
 
 				trigger.attr({
-					'aria-haspopup': true,
-					'role': 'button',
+					'aria-haspopup': true
 				});
 
 				listNode.setAttribute('aria-labelledby', trigger.guid());

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
@@ -52,7 +52,7 @@ html#{$cadmin-selector} {
 
 			> a,
 			> span > a,
-			.lfr-icon-menu > a {
+			.lfr-icon-menu > .component-action {
 				color: $portlet-topper-link-color;
 			}
 
@@ -253,7 +253,7 @@ html#{$cadmin-selector} {
 
 	> a,
 	> span > a,
-	.lfr-icon-menu > a {
+	.lfr-icon-menu > .component-action {
 		color: $portlet-topper-link-color;
 	}
 

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -45,9 +45,9 @@ if (Validator.isNull(icon)) {
 			</button>
 		</c:when>
 		<c:otherwise>
-			<a class="component-action direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" title="<%= message %>">
+			<button aria-expanded="false" aria-haspopup="true" class="component-action direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" id="<%= id %>" <%= ((message != null) && !message.isEmpty()) ? "title=\"" + message + "\"" : StringPool.BLANK %> type="button">
 				<aui:icon image="<%= icon %>" markupView="lexicon" />
-			</a>
+			</button>
 		</c:otherwise>
 	</c:choose>
 


### PR DESCRIPTION
As discussed in https://issues.liferay.com/browse/PTR-2875, this change was suggested in order to improve accessibility and fix the case described in https://issues.liferay.com/browse/LPS-146513:

Steps to reproduce:

1. Enable Jaws screen reader.
2. Go to home page.
3. Use the tab key to reach, for example, the Navigation icon menu. 
4. Press the space tab: check the menu is open and navigate through the options with up and down keys.
5. Press escape key to exit the menu.
6. Navigate to the icon menu again. Jaws says 'Press space tab to open the options'.
7. Press the space tab.

**Expected result**: menu is open

**Current result:** menu is not open

Notes: 

After refreshing the page menu steps 1-7 can be reproduced again. i.e, Space tab opens the menu only the first time after loading the page. This may be because when you click on the icon-menu, a
role="button"
is added to the html element.

Jaws does not inform about the space tab the first time the icon is reached.
Reproduced with Jaws screen reader (default config).
Not reproduced with Window's 11 default screen reader 'Narrator'.

cc/ @pat270 