### PR TITLE
LPS-147202 | Add test to verify admin can receive request to approve remote app

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsWorkflow.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsWorkflow.testcase
@@ -49,6 +49,51 @@ definition {
 		}
 	}
 
+	@description = "LPS-147202. Verify admin can receive notification request to approve remote app"
+	@priority = "4"
+	test CanSendWorkflowNotification {
+		property portal.acceptance = "true";
+
+		task ("Apply workflow approval process to remote apps") {
+			RemoteAppsWorkflow.applyWorkflow();
+		}
+
+		task ("Add user with permissions to create remote app") {
+			Permissions.setUpRegRoleLoginUserCP(
+				roleTitle = "New Regular Role",
+				userEmailAddress = "userea@liferay.com",
+				userFirstName = "userfn",
+				userLastName = "userln",
+				userScreenName = "usersn");
+
+			RemoteAppsWorkflow.addUserPermissions();
+		}
+
+		task ("Create remote app as user with permissions") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "userea@liferay.com",
+				userLoginFullName = "userfn userln");
+
+			RemoteApps.goToRemoteAppsPortlet();
+
+			RemoteAppsWorkflow.addApp(
+				entryName = "Test Remote App",
+				entryURL = "http://www.liferay.com");
+		}
+
+		task ("Assert admin received notification to approve remote app") {
+			User.logoutAndLoginPG(
+				userLoginEmailAddress = "test@liferay.com",
+				userLoginFullName = "Test Test");
+
+			Notifications.gotoNotifications();
+
+			AssertElementPresent(
+				locator1 = "Notifications#NOTIFICATIONS_WORKFLOW_TITLE",
+				value1 = "userfn userln sent you a Remote App Entry for review in the workflow.");
+		}
+	}
+
 	@description = "LPS-147200. Verify pending remote app portlet cannot be added to page"
 	@priority = "4"
 	test PendingRemoteAppCannotBeAddedToPage {


### PR DESCRIPTION
Background
Create automated tests for remote apps workflow

Test Plan

- apply workflow process to remote apps
- add a user with permissions to create remote apps
- create remote app as user with permissions
- assert admin received notification to approve remote app

JIRA Ticket:
https://issues.liferay.com/browse/LPS-147202