### PR TITLE
LPS-138620 Remove ClayButtons around loading indicators

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionsDropdownRenderer.js
@@ -219,9 +219,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 			/>
 
 			{loading ? (
-				<ClayButton disabled monospaced small>
-					<ClayLoadingIndicator small />
-				</ClayButton>
+				<ClayLoadingIndicator small />
 			) : (
 				<ClayButtonWithIcon
 					disabled={!itemChanges}
@@ -293,11 +291,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 		}
 
 		if (loading) {
-			return (
-				<ClayButton className="btn-sm" disabled monospaced>
-					<ClayLoadingIndicator small />
-				</ClayButton>
-			);
+			return <ClayLoadingIndicator small />;
 		}
 
 		const content = action.icon ? (
@@ -362,11 +356,7 @@ function ActionsDropdownRenderer({actions, itemData, itemId}) {
 	}
 
 	if (loading && !inlineEditingAlwaysOn) {
-		return (
-			<ClayButton disabled displayType="secondary" monospaced small>
-				<ClayLoadingIndicator small />
-			</ClayButton>
-		);
+		return <ClayLoadingIndicator small />;
 	}
 
 	const renderItems = (items) =>


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-138620

Hello, this solution aims to solve the position of the loading indicator in the Object tables, which today, it appears below the center of the button.

![ActualResult_Sep03](https://user-images.githubusercontent.com/46692326/154575379-e327d4a2-7db7-40cb-af30-17abf805c773.png)