### PR TITLE
LPS-147499 | Translation Manager default language is available with no other languages options

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
@@ -742,6 +742,15 @@ definition {
 			locator1 = "ContentRow#ENTRY_CONTENT_ENTRY_NAME");
 	}
 
+	macro viewSelectTranslationLanguageMenu {
+		Portlet.waitForForm();
+
+		Click.clickNoMouseOver(
+			key_currentLocale = StringUtil.lowerCase("${key_currentLocale}"),
+			key_title = "${key_title}",
+			locator1 = "Button#SELECT_TRANSLATION_LANGUAGE");
+	}
+
 	macro viewTargetFields {
 		if (isSet(contentPageName)) {
 			AssertElementPresent(

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
@@ -1,0 +1,83 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-js-components-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Translation Manager";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "JS Components Sample Page");
+
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "JS Components Sample Page",
+			widgetName = "JS Components Sample");
+
+		Navigator.gotoPage(pageName = "JS Components Sample Page");
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			User.logoutPG();
+
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "JS Components Sample Page");
+		}
+	}
+
+	@description = "LPS-147499. Verifies default language is available and views no other languages options."
+	@priority = "3"
+	test DefaultLanguageIsAvailableAndViewsNoOtherLanguagesOptions {
+		task ("Select translation language menu") {
+			Translations.viewSelectTranslationLanguageMenu(
+				key_currentLocale = "en-US",
+				key_title = "Admin");
+		}
+
+		task ("Check if element exists ") {
+			AssertElementPresent(
+				key_locale = "en-US",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementPresent(
+				key_locale = "ca-ES",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementPresent(
+				key_locale = "fr-FR",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementNotPresent(
+				key_locale = "zh-CN",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementNotPresent(
+				key_locale = "es-ES",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementPresent(locator1 = "Button#MANAGE_TRANSLATIONS");
+		}
+
+		task ("Assert link to Manage Translations is available") {
+			Click(locator1 = "Button#MANAGE_TRANSLATIONS");
+
+			AssertElementPresent(locator1 = "Portlet#MODAL_TITLE");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
@@ -101,6 +101,9 @@ definition {
 		else if ("${widgetName}" == "JS Clay Sample") {
 			var portletId = "com_liferay_frontend_js_clay_sample_web_internal_portlet_FrontendJSClaySampleWebPortlet";
 		}
+		else if ("${widgetName}" == "JS Components Sample") {
+			var portletId = "com_liferay_frontend_js_components_sample_web_portlet_FrontendJSComponentsSampleWebPortlet";
+		}
 		else if ("${widgetName}" == "Knowledge Base Article") {
 			var portletId = "com_liferay_knowledge_base_web_portlet_ArticlePortlet";
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -786,6 +786,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SELECT_TRANSLATION_LANGUAGE</td>
+	<td>//div[contains(@class,'col') and h3='${key_title}']//button[contains(@class,'dropdown-toggle')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>MANAGE_TRANSLATIONS</td>
+	<td>//button[contains(@class,'dropdown-item')]//div[contains(@class,'autofit-section')and text()='Manage Translations']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TRANSLATIONS_LOCALIZATION</td>
 	<td>//div[contains(@class,'dropdown')]//button[contains(@class,'dropdown-toggle')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
 	<td></td>


### PR DESCRIPTION
**Background**
Create automation tests for Translation Manager

**Test Plan**

Create a page with the widget JS Components Sample
Click and view select translation language menu
Assert the default language is available and no other languages options
Click Manage Translations
Assert the link to Manage Translations is available

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147499