### PR TITLE
LPS-147262 - Escape special characters in TM filter regexp

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.js
@@ -47,7 +47,10 @@ const TranslationAdminContent = ({
 
 	const activeLanguageIds = useMemo(() => {
 		return initialAvailableLocales.filter((availableLocale) => {
-			const regExp = new RegExp(searchValue, 'i');
+			const regExp = new RegExp(
+				searchValue.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&'),
+				'i'
+			);
 
 			return (
 				initialActiveLanguageIds.includes(availableLocale.id) &&


### PR DESCRIPTION
### References

- [LPS-147262](https://issues.liferay.com/browse/LPS-147262)

### What is the goal?

* Escape special characters in TM filter regexp to prevent modal closing after exception

### What does it look like?

https://user-images.githubusercontent.com/6642927/154929314-f184b6ff-b5d1-4349-899c-5857f245cbf6.mov



### How to replicate
* Go to `Content & Data > Web Content > Structures`
* Click on `+` icon to add new structure
* Click on flag icon
* Click on `Manage Translations`
* Write something in input including special regex characters, see that the modal doesn't close
