### PR TITLE
LPS-147499 & LPS-147612 | Default languageIs available and views no other languages options | Translation results displayed side by side

### DIFF
--- a/modules/apps/translation/translation-test/src/testFunctional/macros/TranslationManager.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/TranslationManager.macro
@@ -1,0 +1,34 @@
+definition {
+
+	macro openSelectTranslationLanguageDropdownMenu {
+		Portlet.waitForForm();
+
+		Click.clickNoMouseOver(
+			key_currentLocale = "${key_currentLocale}",
+			key_title = "${key_title}",
+			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_MENU");
+	}
+
+	macro useDifferentLanguageInputText {
+		Portlet.waitForForm();
+
+		Type.type(
+			key_title = "${key_title}",
+			locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+			value1 = "${languagefirst}");
+
+		Click.clickNoMouseOver(
+			key_currentLocale = "${key_currentLocale}",
+			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_ADMINMENU");
+
+		Click(
+			key_locale = "${key_locale}",
+			locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+		Type.type(
+			key_title = "${key_title}",
+			locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+			value1 = "${languagesecond}");
+	}
+
+}

--- a/modules/apps/translation/translation-test/src/testFunctional/macros/TranslationManager.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/TranslationManager.macro
@@ -1,5 +1,42 @@
 definition {
 
+	macro deleteLanguageFromDialogList {
+		Portlet.waitForForm();
+
+		TranslationManager.openSelectTranslationLanguageDropdownMenu(
+			key_currentLocale = "${key_currentLocale}",
+			key_title = "${key_title}");
+
+		Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS");
+
+		if ("${key_locale}" == "ca-es") {
+			var key_index = "2";
+
+			AssertElementPresent(
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_LIST",
+				value1 = "ca-es");
+
+			Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_DELETE");
+
+			AssertElementNotPresent(
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_LIST",
+				value1 = "ca-es");
+		}
+		else if ("${key_locale}" == "fr-fr") {
+			var key_index = "3";
+
+			AssertElementPresent(
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_LIST",
+				value1 = "fr-fr");
+
+			Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_DELETE");
+
+			AssertElementNotPresent(
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_LIST",
+				value1 = "fr-fr");
+		}
+	}
+
 	macro openSelectTranslationLanguageDropdownMenu {
 		Portlet.waitForForm();
 

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
@@ -76,4 +76,33 @@ definition {
 		}
 	}
 
+	@description = "LPS-147612. Verifies translation results displayed by different language."
+	@priority = "3"
+	test TranslationResultsDisplayedByDifferentLanguage {
+		task ("Input different languages with the same word") {
+			TranslationManager.useDifferentLanguageInputText(
+				key_currentLocale = "en-us",
+				key_locale = "fr-FR",
+				key_title = "Admin",
+				languagefirst = "Welcome to Liferay",
+				languagesecond = "Bienvenue sur Liferay");
+		}
+
+		task ("View translation results displayed by different language and the language selector is changed to the selected language") {
+			AssertElementPresent(
+				key_currentLocale = "fr-fr",
+				locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_ADMINMENU");
+
+			AssertElementPresent(
+				key_title = "Admin",
+				locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+				value1 = "Bienvenue sur Liferay");
+
+			AssertElementPresent(
+				key_title = "Admin",
+				locator1 = "TranslationManager#AUI_TAG_DEFAULT_LANGUAGE_TEXT",
+				value1 = "Welcome to Liferay");
+		}
+	}
+
 }

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
@@ -1,0 +1,79 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-js-components-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Translation Manager";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "JS Components Sample Page");
+
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "JS Components Sample Page",
+			widgetName = "JS Components Sample");
+
+		Navigator.gotoPage(pageName = "JS Components Sample Page");
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			User.logoutPG();
+
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "JS Components Sample Page");
+		}
+	}
+
+	@description = "LPS-147499. Verifies default options are present in translation manager language menu."
+	@priority = "3"
+	test DefaultLanguageIsAvailableAndViewsNoOtherLanguagesOptions {
+		task ("Select translation language menu") {
+			TranslationManager.openSelectTranslationLanguageDropdownMenu(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("Assert only default language options are available") {
+			AssertElementPresent(
+				key_locale = "en-US",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementPresent(
+				key_locale = "ca-ES",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementPresent(
+				key_locale = "fr-FR",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+
+			AssertElementPresent(locator1 = "TranslationManager#MANAGE_TRANSLATIONS");
+
+			AssertElementNotPresent(
+				key_index = "6",
+				locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_MENU_ITEM_INDEX");
+		}
+
+		task ("Assert link to Manage Translations is available") {
+			Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS");
+
+			AssertElementPresent(locator1 = "Portlet#MODAL_TITLE");
+		}
+	}
+
+}

--- a/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
+++ b/modules/apps/translation/translation-test/src/testFunctional/tests/TranslationsManager.testcase
@@ -76,6 +76,43 @@ definition {
 		}
 	}
 
+	@description = "LPS-147946. Verifies the list will filter the results and the language will be deleted from the Manage Translation list."
+	@priority = "3"
+	test SearchAndDeleteLanguageOnManageTranslationModal {
+		task ("Select translation language menu") {
+			TranslationManager.openSelectTranslationLanguageDropdownMenu(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("Click Manage Translations and type text in search field") {
+			Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS");
+
+			Type.type(
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_SEARCH_FIELD",
+				value1 = "English");
+		}
+
+		task ("View the list will filter the results using Code and Language fields") {
+			AssertElementPresent(
+				key_text = "Code",
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_SEARCH_RESULTS_TITLE");
+
+			AssertElementPresent(
+				key_text = "Language",
+				locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_SEARCH_RESULTS_TITLE");
+
+			Click(locator1 = "Modal#CLOSE_BUTTON");
+		}
+
+		task ("Delete language in Manage Translations dialog") {
+			TranslationManager.deleteLanguageFromDialogList(
+				key_currentLocale = "en-us",
+				key_locale = "ca-es",
+				key_title = "Admin");
+		}
+	}
+
 	@description = "LPS-147612. Verifies translation results displayed by different language."
 	@priority = "3"
 	test TranslationResultsDisplayedByDifferentLanguage {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layout/JSONLayoutUtil.macro
@@ -101,6 +101,9 @@ definition {
 		else if ("${widgetName}" == "JS Clay Sample") {
 			var portletId = "com_liferay_frontend_js_clay_sample_web_internal_portlet_FrontendJSClaySampleWebPortlet";
 		}
+		else if ("${widgetName}" == "JS Components Sample") {
+			var portletId = "com_liferay_frontend_js_components_sample_web_portlet_FrontendJSComponentsSampleWebPortlet";
+		}
 		else if ("${widgetName}" == "Knowledge Base Article") {
 			var portletId = "com_liferay_knowledge_base_web_portlet_ArticlePortlet";
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TranslationManager.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TranslationManager.path
@@ -1,0 +1,46 @@
+<html>
+<head>
+<title>TranslationManager</title>
+</head>
+
+<body>
+<table border="1" cellpadding="1" cellspacing="1">
+<thead>
+<tr><td rowspan="1" colspan="3">TranslationManager</td></tr>
+</thead>
+
+<tbody>
+<tr>
+	<td>SELECT_TRANSLATION_LANGUAGE_MENU</td>
+	<td>//div[h3='${key_title}']//button[contains(@title,'select-translation-language')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SELECT_TRANSLATION_LANGUAGE_AUI_TAG_ADMINMENU</td>
+	<td>//button[contains(@id,'aui_2d_2Menu')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SELECT_TRANSLATION_LANGUAGE_MENU_ITEM_INDEX</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//ul[contains(@class,'list-unstyled')]//li[${key_index}]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>MANAGE_TRANSLATIONS</td>
+	<td>//button[contains(@class,'dropdown-item')]//div[contains(@class,'autofit-section')and text()='Manage Translations']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>AUI_TAG_INPUT_TEXT_FIELD</td>
+	<td>//div[contains(@class,'col') and h3='${key_title}']//input[contains(@class,'language-value field')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>AUI_TAG_BELOW_INPUT_TEXT_FIELD</td>
+	<td>//div[contains(@class,'col') and h3='${key_title}']//div[contains(@class,'form-group')]//div[contains(@class,'form-text')]</td>
+	<td></td>
+</tr>
+</tbody>
+</table>
+</body>
+</html>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TranslationManager.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TranslationManager.path
@@ -31,6 +31,26 @@
 	<td></td>
 </tr>
 <tr>
+	<td>MANAGE_TRANSLATIONS_DIALOG_SEARCH_FIELD</td>
+	<td>//div[contains(@class,'modal-dialog')]//input[contains(@placeholder,'Search')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>MANAGE_TRANSLATIONS_DIALOG_SEARCH_RESULTS_TITLE</td>
+	<td>//th[contains(text(),'${key_text}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_LIST</td>
+	<td>//tr[${key_index}]//*[name()='svg'][contains(@class,'lexicon-icon-${key_locale}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_DELETE</td>
+	<td>//tr[${key_index}]//*[name()='svg'][contains(@class,'lexicon-icon-trash')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>AUI_TAG_INPUT_TEXT_FIELD</td>
 	<td>//div[contains(@class,'col') and h3='${key_title}']//input[contains(@class,'language-value field')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TranslationManager.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/TranslationManager.path
@@ -56,7 +56,7 @@
 	<td></td>
 </tr>
 <tr>
-	<td>AUI_TAG_BELOW_INPUT_TEXT_FIELD</td>
+	<td>AUI_TAG_DEFAULT_LANGUAGE_TEXT</td>
 	<td>//div[contains(@class,'col') and h3='${key_title}']//div[contains(@class,'form-group')]//div[contains(@class,'form-text')]</td>
 	<td></td>
 </tr>


### PR DESCRIPTION
**Background**
Create automation tests for Translation Manager

**Test Plan**

Create a page with the widget JS Components Sample
Click and view select translation language menu
Assert the default language is available and no other languages options
Click Manage Translations
Assert the link to Manage Translations is available

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147499

**Background**
Create automation tests for Translation Manager

**Test Plan**

Create a page with the widget JS Components Sample
Click AUI Tag translation selector of Admin mode
Input different languages with the same word
View translation results displayed side by side

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147612

**Background**
Create automation tests for Translation Manager

**Test Plan**

Create a page with the widget JS Components Sample
Click translation selector of Admin mode
Search language and the list will filter the results using Code and Language fields
Delete language  and the language will be deleted from the Manage Translation list

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147946