### PR TITLE
LPS-113524 Deprecate AUI `checkTab` and `processTab` utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -253,6 +253,9 @@
 			return totalOn;
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		checkTab(box) {
 			if (document.all && Number(window.event.keyCode) === 9) {
 				box.selection = document.selection.createRange();
@@ -683,6 +686,9 @@
 			topUtil._openWindowProvider(config, callback);
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		processTab(id) {
 			document.all[id].selection.text = String.fromCharCode(9);
 			document.all[id].focus();

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -160,7 +160,7 @@ sb.append("\n");
 					<aui:input name="preferences--width--" type="text" value="<%= iFramePortletInstanceConfiguration.width() %>" />
 				</div>
 
-				<aui:input cssClass="lfr-textarea-container" name="preferences--htmlAttributes--" onKeyDown="Liferay.Util.checkTab(this); Liferay.Util.disableEsc();" type="textarea" value="<%= sb.toString() %>" wrap="soft" />
+				<aui:input cssClass="lfr-textarea-container" name="preferences--htmlAttributes--" onKeyDown="Liferay.Util.disableEsc();" type="textarea" value="<%= sb.toString() %>" wrap="soft" />
 			</liferay-frontend:fieldset>
 		</liferay-frontend:fieldset-group>
 	</liferay-frontend:edit-form-body>

--- a/portal-web/docroot/html/taglib/ui/input_field/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_field/page.jsp
@@ -529,7 +529,7 @@ if (hints != null) {
 								languagesDropdownDirection="<%= languagesDropdownDirection %>"
 								maxLength="<%= maxLength %>"
 								name="<%= fieldParam %>"
-								onKeyDown='<%= (checkTab ? "Liferay.Util.checkTab(this); " : StringPool.BLANK) + "Liferay.Util.disableEsc();" %>'
+								onKeyDown='<%= "Liferay.Util.disableEsc();" %>'
 								placeholder="<%= placeholder %>"
 								style='<%= !autoSize ? "height: " + displayHeight + (Validator.isDigit(displayHeight) ? "px" : StringPool.BLANK) + ";" : StringPool.BLANK %>'
 								type="textarea"
@@ -538,7 +538,7 @@ if (hints != null) {
 							/>
 						</c:when>
 						<c:otherwise>
-							<textarea class="<%= cssClass %> lfr-textarea" <%= disabled ? "disabled=\"disabled\"" : StringPool.BLANK %> id="<%= namespace %><%= id %>" name="<%= namespace %><%= fieldParam %>" onKeyDown="<%= checkTab ? "Liferay.Util.checkTab(this); " : StringPool.BLANK %> Liferay.Util.disableEsc();" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> style="<%= !autoSize ? "height: " + displayHeight + (Validator.isDigit(displayHeight) ? "px" : StringPool.BLANK) + ";" : StringPool.BLANK %>" wrap="soft"><%= autoEscape ? HtmlUtil.escape(value) : value %></textarea>
+							<textarea class="<%= cssClass %> lfr-textarea" <%= disabled ? "disabled=\"disabled\"" : StringPool.BLANK %> id="<%= namespace %><%= id %>" name="<%= namespace %><%= fieldParam %>" onKeyDown="Liferay.Util.disableEsc();" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> style="<%= !autoSize ? "height: " + displayHeight + (Validator.isDigit(displayHeight) ? "px" : StringPool.BLANK) + ";" : StringPool.BLANK %>" wrap="soft"><%= autoEscape ? HtmlUtil.escape(value) : value %></textarea>
 						</c:otherwise>
 					</c:choose>
 


### PR DESCRIPTION
Hey folks, it's ya boi here with a PR.

This one deprecates and removes any usages not found under `archived/` of the `checkTab` AUI utility found under `frontend-js-aui-web/util.js`.

I've tested the functionality with and without my changes and it is exactly the same, it seems that the utility was circumventing a functionality that is now in browsers by default. 

One note is that the code (found in `processTab`) suggests that it looks for the textbox and forces focus on it, but the functionality wasn't as such. It is also manipulating with the `selection` which I do not know why but it certainly doesn't work as it once might have, because the browsers don't support them anymore (`createRange()` I'm looking at you).