### PR TITLE
LPS-113526 - Deprecate AUI util `getAttributes`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -374,6 +374,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		getAttributes(element, attributeGetter) {
 			var result = null;
 


### PR DESCRIPTION
<img src="https://media1.giphy.com/media/54JLdulN5BOwM/giphy.gif"/>

This util is only used inside the already deprecated `selectEntityHandler`, and is replaced by the vanilla JS `getAttribute` method which is why I decided against modernizing it.