### PR TITLE
LPS-113527 - Deprecate getColumnId() and simplify its usages

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
@@ -285,7 +285,12 @@ AUI.add(
 			},
 
 			saveIndex(portletNode, columnNode) {
-				var currentColumnId = Util.getColumnId(columnNode.get('id'));
+				var columnNodeId = columnNode.get('id');
+
+				var currentColumnId = columnNodeId.replace(
+					/layout-column_/,
+					''
+				);
 				var portletId = Util.getPortletId(portletNode.get('id'));
 				var position = Layout.findIndex(portletNode);
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -420,6 +420,9 @@
 			return result;
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		getColumnId(str) {
 			var columnId = str.replace(/layout-column_/, '');
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -208,7 +208,9 @@
 				return;
 			}
 
-			var currentColumnId = Util.getColumnId(container.attr('id'));
+			var containerId = container.attr('id');
+
+			var currentColumnId = containerId.replace(/layout-column_/, '');
 
 			var portletPosition = 0;
 


### PR DESCRIPTION
As discussed in [this Slack thread](https://liferay.slack.com/archives/C3JBR21HA/p1645606941803519), in this PR I'm deprecating the `getColumnId` method and replacing it's 2 usages with the action it is doing, which is a simple string replacement.

I've tested this by messing around with the drag and dropping modules onto the landing page on DXP making sure that my changes produce the same string as using the method.