### PR TITLE
LPS-147945 Allow dropdown to receive clicks

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
@@ -9,3 +9,7 @@ html#{$cadmin-selector} {
 .overlay-content .open > .dropdown-menu {
 	display: block;
 }
+
+.dropdown-menu .dropdown-item.active {
+	pointer-events: initial;
+}


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-147945

This is caused by https://github.com/liferay-frontend/liferay-portal/pull/1918

This PR fixes a problem in which the menu display don't navigate to a child page when clicking in it.

Clay sets `pointer-events: none` to dropdown items with the active property. In the portal there is an ancient logic that when some element is focused the `active` class is added to that element. What happened is that when the click event is started, the dropdown item already had the active class and didn't receive any click event. This PR makes sure to not block this event with the pointers-none style.

@pat270 Not sure if we can move this to clay, but it was faster to add it here for now instead of waiting for a new clay release to be created. 

### How to reproduce it
- Add a new page
- Add a child page to the page
- Go to the child page through the menu display (the portlet that it included in the theme by default)
