### PR TITLE
LPS-147968 Add the path context to the url

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -46,7 +46,11 @@
 	};
 
 	window.YUI_config = {
-		base: Liferay.ThemeDisplay.getCDNBaseURL() + Liferay.ThemeDisplay.getPathContext() + PATH_JAVASCRIPT + '/aui/',
+		base:
+			Liferay.ThemeDisplay.getCDNBaseURL() +
+			Liferay.ThemeDisplay.getPathContext() +
+			PATH_JAVASCRIPT +
+			'/aui/',
 		combine: COMBINE,
 		comboBase: LiferayAUI.getComboPath(),
 		filter: process.env.NODE_ENV === 'development' ? 'raw' : 'min',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -46,7 +46,7 @@
 	};
 
 	window.YUI_config = {
-		base: Liferay.ThemeDisplay.getCDNBaseURL() + PATH_JAVASCRIPT + '/aui/',
+		base: Liferay.ThemeDisplay.getCDNBaseURL() + Liferay.ThemeDisplay.getPathContext() + PATH_JAVASCRIPT + '/aui/',
 		combine: COMBINE,
 		comboBase: LiferayAUI.getComboPath(),
 		filter: process.env.NODE_ENV === 'development' ? 'raw' : 'min',
@@ -65,6 +65,7 @@
 			liferay: {
 				base:
 					Liferay.ThemeDisplay.getCDNBaseURL() +
+					Liferay.ThemeDisplay.getPathContext() +
 					PATH_JAVASCRIPT +
 					'/liferay/',
 				combine: COMBINE,

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/taglib/JSLoaderTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/servlet/taglib/JSLoaderTopHeadDynamicInclude.java
@@ -140,7 +140,7 @@ public class JSLoaderTopHeadDynamicInclude extends BaseDynamicInclude {
 			return url + StringPool.AMPERSAND;
 		}
 
-		return themeDisplay.getCDNBaseURL();
+		return themeDisplay.getCDNBaseURL() + themeDisplay.getPathContext();
 	}
 
 	@Reference

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/fragments/customer/fragments/select-user/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/fragments/customer/fragments/select-user/index.js
@@ -37,6 +37,7 @@ const userName = fragmentElement.querySelector(
 				userIconWrapper.innerHTML = `<svg class="lexicon-icon lexicon-icon-user" focusable="false" role="presentation">
 			<use xlink:href="${
 				Liferay.ThemeDisplay.getCDNBaseURL() +
+				Liferay.ThemeDisplay.getPathContext() +
 				'/o/admin-theme/images/clay/icons.svg'
 			}#user" />
 		</svg>`;


### PR DESCRIPTION
Reproduce this issue is very easy, just follow the steps explained in jira, restart and clean the browser cache.

You'll se a ton of errors related with 'frontend-js-aui-web'

To solve it I introduced some changes in the modules.js, where the 'basic' url for this modules is been created.

I found that the pathContext (that could be retrieved using Liferay.ThemeDisplay.getPathContext()) was not used in this base url.

I've also check that in a lot of parts of the portal, we are using similar methods to add the path context, so it seems to be the right solution.

In the second commit I added it to other places I found with a similar problem.