### PR TITLE
LPS-147839 | Assert the view button has a double caret icon and has a tooltip message when hovered over it

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -75,6 +75,11 @@
 	<td>//nav[contains(@class,'subnav-tbar')]//span[@class='text-truncate']</td>
 	<td></td>
 </tr>
+<tr>
+	<td>VIEW_BUTTON</td>
+	<td>//nav[contains(@class,'management-bar')]//*[(@title="Show View Options")][*[name()='svg'][contains(@class,'icon-${key_text}')]]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -1,0 +1,46 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.module.configuration.file.names = "com.liferay.document.library.web.internal.configuration.FFManagementToolbarConfiguration.config:com.liferay.frontend.taglib.clay.internal.configuration.FFManagementToolbarConfiguration.config";
+	property osgi.module.configurations = "enableDesignImprovements=&quot;true&quot;:showDesignImprovements=&quot;true&quot;";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Management Toolbar";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-147839. Assert the view button displays a double caret icon"
+	@priority = "5"
+	test ViewButtonCanRenderDoubleCaret {
+		task ("Open a section with the management toolbar") {
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+		}
+
+		task ("Assert the view button also has a double caret icon") {
+			AssertElementPresent(
+				key_text = "list",
+				locator1 = "ManagementBar#VIEW_BUTTON");
+
+			AssertElementPresent(
+				key_text = "caret-double",
+				locator1 = "ManagementBar#VIEW_BUTTON");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -23,6 +23,28 @@ definition {
 		}
 	}
 
+	@description = "LPS-147844. Assert the tooltip message is displayed when hovered over the view button"
+	@priority = "3"
+	test ViewButtonCanDisplayTooltip {
+		task ("Open a section with the management toolbar") {
+			ProductMenu.gotoPortlet(
+				category = "Content & Data",
+				portlet = "Web Content");
+		}
+
+		task ("Hover over the view button") {
+			MouseOver(
+				key_text = "caret-double",
+				locator1 = "ManagementBar#VIEW_BUTTON");
+		}
+
+		task ("Assert tooltip message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Show View Options");
+		}
+	}
+
 	@description = "LPS-147839. Assert the view button displays a double caret icon"
 	@priority = "5"
 	test ViewButtonCanRenderDoubleCaret {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -26,10 +26,26 @@ definition {
 	@description = "LPS-147844. Assert the tooltip message is displayed when hovered over the view button"
 	@priority = "3"
 	test ViewButtonCanDisplayTooltip {
-		task ("Open a section with the management toolbar") {
-			ProductMenu.gotoPortlet(
-				category = "Content & Data",
-				portlet = "Web Content");
+		task ("Add Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("Navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
 		}
 
 		task ("Hover over the view button") {
@@ -48,15 +64,31 @@ definition {
 	@description = "LPS-147839. Assert the view button displays a double caret icon"
 	@priority = "5"
 	test ViewButtonCanRenderDoubleCaret {
-		task ("Open a section with the management toolbar") {
-			ProductMenu.gotoPortlet(
-				category = "Content & Data",
-				portlet = "Web Content");
+		task ("Add Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+
+		task ("Navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
 		}
 
 		task ("Assert the view button also has a double caret icon") {
 			AssertElementPresent(
-				key_text = "list",
+				key_text = "cards",
 				locator1 = "ManagementBar#VIEW_BUTTON");
 
 			AssertElementPresent(

--- a/test.properties
+++ b/test.properties
@@ -6551,6 +6551,7 @@
         Cadmin,\
         Clay,\
         Frontend Dataset,\
+        Management Toolbar,\
         Maps,\
         Remote Apps,\
         Theme,\


### PR DESCRIPTION
**Background**
Create automated tests for the management toolbar

**Test Plan(s)**

- Product Menu > Content & Data > Web Content
- Assert the view button has a double caret icon
-
- Product Menu > Content & Data > Web Content
- Hover over the view button
- Assert the view button has 'Show View Options' tooltip message

**JIRA Ticket(s):**
https://issues.liferay.com/browse/LPS-147839
https://issues.liferay.com/browse/LPS-147844