### PR TITLE
[TS] LPS-148048 Search result pagination should not contain a link to the same page to improve screen reader accessibility

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -143,7 +143,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					%>
 
 						<li class="page-item <%= (i == cur) ? "active" : StringPool.BLANK %>">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
+							<c:if test="<%= i == cur %>">
+								<a aria-current="page" class="page-link">
+							<% }
+							else { %>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
+							</c:if>
+
+								<span class="sr-only"><liferay-ui:message key="page" /></span><%= i %></a>
 						</li>
 
 					<%
@@ -153,7 +160,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				</c:when>
 				<c:when test="<%= cur == 1 %>">
 					<li class="active page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
+						<a aria-current="page" class="page-link"><span class="sr-only"><liferay-ui:message key="page" /></span>1</a>
 					</li>
 					<li class="page-item">
 						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span>2</a>
@@ -229,7 +236,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages - 1 %></a>
 					</li>
 					<li class="active page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
+						<a aria-current="page" class="page-link"><span class="sr-only"><liferay-ui:message key="page" /></span><%= pages %></a>
 					</li>
 				</c:when>
 				<c:otherwise>
@@ -274,7 +281,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					</c:if>
 
 					<li class="active page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur %></a>
+						<a aria-current="page" class="page-link"><span class="sr-only"><liferay-ui:message key="page" /></span><%= cur %></a>
 					</li>
 
 					<c:if test="<%= (cur + 1) < pages %>">

--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -126,7 +126,16 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 		<ul class="pagination">
 			<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
-				<a class="page-link" href="<%= (cur > 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur > 1) && forcePost) ? _getOnClick(namespace, curParam, cur -1) : "" %>">
+
+				<%
+				if (cur > 1) {
+				%>
+
+					<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>">
+				<%}
+				else { %>
+					<a class="page-link">
+				<%} %>
 					<liferay-ui:icon
 						icon='<%= PortalUtil.isRightToLeft(request) ? "angle-right" : "angle-left" %>'
 						markupView="lexicon"
@@ -329,7 +338,16 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 			</c:choose>
 
 			<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
-				<a class="page-link" href="<%= (cur < pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:;" %>" onclick="<%= ((cur < pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>">
+
+				<%
+				if (cur < pages) {
+				%>
+
+					<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>">
+				<%}
+				else { %>
+					<a class="page-link">
+				<%} %>
 					<liferay-ui:icon
 						icon='<%= PortalUtil.isRightToLeft(request) ? "angle-left" : "angle-right" %>'
 						markupView="lexicon"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-148048

_This issue has been reported by a blind association that is a Liferay customer, for more information see: https://issues.liferay.com/browse/LPS-148048?focusedCommentId=2626115&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2626115_

The search result pagination has a different visual style to highlight which is the current page:
![442718_pagination 1](https://user-images.githubusercontent.com/6472845/155528828-2b3f2179-148f-45f3-a00c-78f4329393ba.png)

But it also contains a link to itself, this link is processed by the screen readers, this is confusing for the final screen reader user as it is hard to notice that that link is a link to the current page.

To improve screen reader accessibility, this link should be removed.

After a quick research with several search engines:

- Google: https://www.google.com/search?q=search
- Bing: https://www.bing.com/search?q=search
- Yahoo: https://search.yahoo.com/search?p=search
- Amazon: https://www.amazon.com/s?k=search

All of them are not linking the current page, so it seems we should also remove the link.

I saw the same pattern in this example: https://weboverhauls.github.io/demos/pagination/

**Steps to reproduce**

1. Create 25 webcontent
2. Search "test"
3. Go to the pagination links and check the current page position:

   - **Expected behavior:** Current page doesn't have any link :heavy_check_mark:
   - **Wrong behavior:** Current page has a link :x:
