### PR TITLE
LPS-146496 Reflected XSS in CKEditor through GetEditorStrutsAction

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -105,7 +105,7 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 	var="editor"
 >
 	<c:if test="<%= Validator.isNotNull(placeholder) %>">
-		<label class="control-label" for="<%= name %>">
+		<label class="control-label" for="<%= HtmlUtil.escapeAttribute(name) %>">
 			<liferay-ui:message key="<%= placeholder %>" />
 		</label>
 	</c:if>


### PR DESCRIPTION
### References

- [LPS-146496 Reflected XSS in CKEditor through GetEditorStrutsAction](https://issues.liferay.com/browse/LPS-146496)

### What is the goal?

Prevent XSS attack, by escaping the `name` attribute. `namespace` is covered by this fix, because it is [included in name](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp#L62).

### What does it look like?
#### Before PR
![before](https://user-images.githubusercontent.com/5435511/155566325-8d0eb122-4da4-409e-8a79-6f46212851d6.png)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/155566324-f0b6af33-a781-4746-9caa-82a695632365.png)

### How to replicate

See steps to reproduce in [LPS-146496](https://issues.liferay.com/browse/LPS-146496)