### PR TITLE
[TS] LPS-148147 remove filter mappings for deleted servlet

### DIFF
--- a/portal-web/docroot/WEB-INF/liferay-web.xml
+++ b/portal-web/docroot/WEB-INF/liferay-web.xml
@@ -540,10 +540,6 @@
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>Header Filter</filter-name>
-		<url-pattern>/o/js_loader_config</url-pattern>
-	</filter-mapping>
-	<filter-mapping>
-		<filter-name>Header Filter</filter-name>
 		<url-pattern>*.css</url-pattern>
 	</filter-mapping>
 	<filter-mapping>
@@ -613,10 +609,6 @@
 	<filter-mapping>
 		<filter-name>ETag Filter</filter-name>
 		<url-pattern>/o/js_bundle_config</url-pattern>
-	</filter-mapping>
-	<filter-mapping>
-		<filter-name>ETag Filter</filter-name>
-		<url-pattern>/o/js_loader_config</url-pattern>
 	</filter-mapping>
 	<filter-mapping>
 		<filter-name>ETag Filter</filter-name>
@@ -785,11 +777,6 @@
 	<filter-mapping>
 		<filter-name>GZip Filter</filter-name>
 		<url-pattern>/o/js_bundle_config</url-pattern>
-		<dispatcher>REQUEST</dispatcher>
-	</filter-mapping>
-	<filter-mapping>
-		<filter-name>GZip Filter</filter-name>
-		<url-pattern>/o/js_loader_config</url-pattern>
 		<dispatcher>REQUEST</dispatcher>
 	</filter-mapping>
 	<filter-mapping>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-148147

`/o/js_loader_config` was the JSLoaderConfigServlet's path, that servlet was deleted and the JS code that it generated was moved to an embedded script in the html, the logic is done in `com.liferay.frontend.js.loader.modules.extender.internal.servlet.taglib.JSLoaderTopHeadDynamicInclude`

Now that the servlet does not exist the path `/o/js_loader_config` will be not used anymore and we can delete the filter mappings.