### PR TITLE
LPS-147712 - Migrate Clay MT to frontend-js-components-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/ManagementToolbarSamples.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/ManagementToolbarSamples.js
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import {ClayCheckbox, ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import {ManagementToolbar} from 'frontend-js-components-web';
+import React, {useState} from 'react';
+
+const filterItems = [
+	{label: 'Filter Action 1', onClick: () => alert('Filter clicked')},
+	{label: 'Filter Action 2', onClick: () => alert('Filter clicked')},
+];
+
+const viewTypes = [
+	{
+		label: 'List',
+		onClick: () => alert('Show view list'),
+		symbolLeft: 'list',
+	},
+	{
+		active: true,
+		label: 'Table',
+		onClick: () => alert('Show view talbe'),
+		symbolLeft: 'table',
+	},
+	{
+		label: 'Card',
+		onClick: () => alert('Show view card'),
+		symbolLeft: 'cards2',
+	},
+];
+
+export default function ManagementToolbarSamples() {
+	const [searchMobile, setSearchMobile] = useState(false);
+	const viewTypeActive = viewTypes.find((type) => type.active);
+
+	return (
+		<>
+			<ManagementToolbar.Container aria-label="Management toolbar">
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item>
+						<ClayCheckbox checked={false} onChange={() => {}} />
+					</ManagementToolbar.Item>
+
+					<ManagementToolbar.Item>
+						<ClayDropDownWithItems
+							items={filterItems}
+							trigger={
+								<ClayButton
+									aria-label="Filter items"
+									className="nav-link"
+									displayType="link"
+								>
+									<span className="navbar-breakpoint-down-d-none">
+										<span className="navbar-text-truncate">
+											Filter and Order
+										</span>
+
+										<ClayIcon
+											className="inline-item inline-item-after"
+											symbol="caret-bottom"
+										/>
+									</span>
+
+									<span className="navbar-breakpoint-d-none">
+										<ClayIcon symbol="filter" />
+									</span>
+								</ClayButton>
+							}
+						/>
+					</ManagementToolbar.Item>
+
+					<ManagementToolbar.Item>
+						<ClayButton
+							aria-label="Order items"
+							className="nav-link nav-link-monospaced"
+							displayType="link"
+							onClick={() => {}}
+						>
+							<ClayIcon symbol="order-list-up" />
+						</ClayButton>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
+
+				<ManagementToolbar.Search showMobile={searchMobile}>
+					<ClayInput.Group>
+						<ClayInput.GroupItem>
+							<ClayInput
+								aria-label="Search"
+								className="form-control input-group-inset input-group-inset-after"
+								defaultValue="Red"
+								type="text"
+							/>
+
+							<ClayInput.GroupInsetItem after tag="span">
+								<ClayButtonWithIcon
+									aria-label="Clear search button"
+									className="navbar-breakpoint-d-none"
+									displayType="unstyled"
+									onClick={() => setSearchMobile(false)}
+									symbol="times"
+								/>
+
+								<ClayButtonWithIcon
+									aria-label="Search button"
+									displayType="unstyled"
+									symbol="search"
+									type="submit"
+								/>
+							</ClayInput.GroupInsetItem>
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</ManagementToolbar.Search>
+
+				<ManagementToolbar.ItemList>
+					<ManagementToolbar.Item className="navbar-breakpoint-d-none">
+						<ClayButton
+							aria-label="Search button mobile"
+							className="nav-link nav-link-monospaced"
+							displayType="unstyled"
+							onClick={() => setSearchMobile(true)}
+						>
+							<ClayIcon symbol="search" />
+						</ClayButton>
+					</ManagementToolbar.Item>
+
+					<ManagementToolbar.Item>
+						<ClayButton
+							aria-label="Information"
+							className="nav-link nav-link-monospaced"
+							displayType="link"
+							onClick={() => {}}
+						>
+							<ClayIcon symbol="info-circle-open" />
+						</ClayButton>
+					</ManagementToolbar.Item>
+
+					<ClayDropDownWithItems
+						containerElement={ManagementToolbar.Item}
+						items={viewTypes}
+						trigger={
+							<ClayButton
+								aria-label="Display type"
+								className="nav-link nav-link-monospaced"
+								displayType="link"
+							>
+								<ClayIcon
+									symbol={
+										viewTypeActive
+											? viewTypeActive.symbolLeft
+											: ''
+									}
+								/>
+							</ClayButton>
+						}
+					/>
+
+					<ManagementToolbar.Item>
+						<ClayButtonWithIcon
+							aria-label="Add new"
+							className="nav-btn nav-btn-monospaced"
+							symbol="plus"
+						/>
+					</ManagementToolbar.Item>
+				</ManagementToolbar.ItemList>
+			</ManagementToolbar.Container>
+
+			<ManagementToolbar.ResultsBar>
+				<ManagementToolbar.ResultsBarItem>
+					<span className="component-text text-truncate-inline">
+						<span className="text-truncate">
+							2 results for <strong>Red</strong>
+						</span>
+					</span>
+				</ManagementToolbar.ResultsBarItem>
+
+				<ManagementToolbar.ResultsBarItem expand>
+					<ClayLabel
+						className="component-label tbar-label"
+						displayType="unstyled"
+					>
+						Filter
+					</ClayLabel>
+				</ManagementToolbar.ResultsBarItem>
+
+				<ManagementToolbar.ResultsBarItem>
+					<ClayButton
+						className="component-link tbar-link"
+						displayType="link"
+					>
+						Clear
+					</ClayButton>
+				</ManagementToolbar.ResultsBarItem>
+			</ManagementToolbar.ResultsBar>
+		</>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/partials/management_toolbar.jsp
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/partials/management_toolbar.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -11,15 +12,18 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+--%>
 
-export {default as Treeview} from './treeview/Treeview';
+<%@ include file="/init.jsp" %>
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+<clay:container-fluid>
+	<clay:row>
+		<clay:col>
+			<h2>React Component</h2>
+		</clay:col>
+	</clay:row>
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
-
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+	<react:component
+		module="js/ManagementToolbarSamples"
+	/>
+</clay:container-fluid>

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,11 +18,15 @@
 
 <div class="frontend-js-components-sample-web">
 	<liferay-ui:tabs
-		names="Translation Manager"
+		names="Translation Manager, Management Toolbar"
 		refresh="<%= false %>"
 	>
 		<liferay-ui:section>
 			<liferay-util:include page="/partials/translation_manager.jsp" servletContext="<%= application %>" />
+		</liferay-ui:section>
+
+		<liferay-ui:section>
+			<liferay-util:include page="/partials/management_toolbar.jsp" servletContext="<%= application %>" />
 		</liferay-ui:section>
 	</liferay-ui:tabs>
 </div>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts
@@ -18,6 +18,10 @@ import type {Atom} from '@liferay/frontend-js-state-web';
 
 export const activeLanguageIdsAtom: Atom<any>;
 
+export function ResultsBar(
+	children: React.ReactElement | Array<React.ReactElement>
+): ReactElement;
+
 export function Treeview(
 	NodeComponent: () => void,
 	filter: string | (() => void),

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Container.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Container.js
@@ -12,14 +12,24 @@
  * details.
  */
 
-export {default as Treeview} from './treeview/Treeview';
+import ClayLayout from '@clayui/layout';
+import classNames from 'classnames';
+import React from 'react';
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+const Container = ({active = false, children, className, ...otherProps}) => (
+	<nav
+		{...otherProps}
+		className={classNames(
+			'management-toolbar-container navbar navbar-expand-md',
+			className,
+			{
+				'management-toolbar-container-light': !active,
+				'management-toolbar-container-primary navbar-nowrap': active,
+			}
+		)}
+	>
+		<ClayLayout.ContainerFluid>{children}</ClayLayout.ContainerFluid>
+	</nav>
+);
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
-
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export default Container;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Item.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Item.js
@@ -12,14 +12,13 @@
  * details.
  */
 
-export {default as Treeview} from './treeview/Treeview';
+import classNames from 'classnames';
+import React from 'react';
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+const Item = ({children, className, ...otherProps}) => (
+	<li {...otherProps} className={classNames('nav-item', className)}>
+		{children}
+	</li>
+);
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
-
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export default Item;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ItemList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ItemList.js
@@ -12,14 +12,21 @@
  * details.
  */
 
-export {default as Treeview} from './treeview/Treeview';
+import classNames from 'classnames';
+import React from 'react';
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+const ItemList = ({children, expand}) => (
+	<ul
+		className={classNames('navbar-nav', {
+			'navbar-nav-expand': expand,
+		})}
+	>
+		{children}
+	</ul>
+);
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
+ItemList.propTypes = {
+	expand: Boolean,
+};
 
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export default ItemList;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -12,14 +12,22 @@
  * details.
  */
 
-export {default as Treeview} from './treeview/Treeview';
+import Container from './Container';
+import Item from './Item';
+import ItemList from './ItemList';
+import ResultsBar from './ResultsBar';
+import ResultsBarItem from './ResultsBarItem';
+import Search from './Search';
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+import './ManagementToolbar.scss';
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
+const ManagementToolbar = {};
 
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+ManagementToolbar.Container = Container;
+ManagementToolbar.Item = Item;
+ManagementToolbar.ItemList = ItemList;
+ManagementToolbar.ResultsBar = ResultsBar;
+ManagementToolbar.ResultsBarItem = ResultsBarItem;
+ManagementToolbar.Search = Search;
+
+export default ManagementToolbar;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.scss
@@ -1,0 +1,123 @@
+@import 'atlas-variables';
+
+$management-toolbar-container-base: (
+	border-color: transparent,
+	border-style: solid,
+	media-breakpoint-down: (),
+	media-breakpoint-up: (),
+	navbar-nav: (
+		nav-link: (
+			border-radius: $border-radius,
+			outline: 0,
+			transition: box-shadow 0.15s ease-in-out,
+			focus: (
+				box-shadow: $btn-focus-box-shadow,
+			),
+			disabled: (
+				box-shadow: none,
+			),
+		),
+	),
+);
+
+$management-toolbar-container-size: (
+	scaling-navbar: true,
+	border-bottom-width: 0.0625rem,
+	font-size: $navbar-font-size,
+	height: 4rem,
+	min-height: 4rem,
+	padding-x: 0,
+	padding-y: 0,
+	height-mobile: 3rem,
+	min-height-mobile: 3rem,
+	btn-monospaced-font-size: 1rem,
+	link-height: 2rem,
+	link-height-mobile: 2rem,
+	link-margin-x: 0.5rem,
+	link-margin-x-mobile: 0.25rem,
+	link-padding-x-mobile: 0.25rem,
+	form-control-height-mobile: 2rem,
+	toggler-margin-x: 0.875rem,
+	active-border-bottom-width: 0.25rem,
+	nav-item-dropdown-margin-top: 0,
+);
+
+$management-toolbar-container-light: (
+	background-color: $white,
+	navbar-nav: (
+		nav-link: (
+			color: $navbar-light-color,
+			font-weight: $font-weight-semi-bold,
+			hover: (
+				background-color: rgba($gray-900, 0.03),
+				color: $gray-900,
+			),
+			focus: (
+				background-color: rgba($gray-900, 0.03),
+				color: $gray-900,
+			),
+			active: (
+				background-color: rgba($gray-900, 0.06),
+				color: $navbar-light-active-color,
+			),
+			disabled: (
+				background-color: transparent,
+				color: $navbar-light-disabled-color,
+				opacity: 1,
+			),
+		),
+	),
+	media-breakpoint-down: (),
+	media-breakpoint-up: (),
+);
+
+$management-toolbar-container-primary: (
+	background-color: $primary-l3,
+	border-color: $primary,
+	color: $navbar-light-color,
+	navbar-nav: (
+		nav-link: (
+			border-radius: $border-radius,
+			font-weight: $font-weight-semi-bold,
+			color: $navbar-light-color,
+			hover: (
+				background-color: rgba($gray-900, 0.03),
+				color: $gray-900,
+			),
+			focus: (
+				background-color: rgba($gray-900, 0.03),
+				color: $gray-900,
+			),
+			active: (
+				background-color: rgba($gray-900, 0.06),
+			),
+			disabled: (
+				background-color: transparent,
+				disabled-color: $navbar-light-disabled-color,
+				disabled-opacity: 1,
+			),
+		),
+	),
+	media-breakpoint-down: (),
+	media-breakpoint-up: (),
+);
+
+.management-toolbar-container {
+	@include clay-navbar-size($management-toolbar-container-size);
+	@include clay-navbar-variant($management-toolbar-container-base);
+
+	&.navbar-nowrap {
+		.navbar-text {
+			white-space: normal;
+			word-wrap: break-word;
+		}
+	}
+}
+
+.management-toolbar-container-light {
+	@include clay-navbar-variant($management-toolbar-container-light);
+}
+
+.management-toolbar-container-primary {
+	@include clay-navbar-variant($management-toolbar-container-primary);
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -12,14 +12,18 @@
  * details.
  */
 
-export {default as Treeview} from './treeview/Treeview';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+const ResultsBar = ({children, ...otherProps}) => (
+	<nav
+		{...otherProps}
+		className="subnav-tbar subnav-tbar-primary tbar tbar-inline-xs-down"
+	>
+		<ClayLayout.ContainerFluid>
+			<ul className="tbar-nav tbar-nav-wrap">{children}</ul>
+		</ClayLayout.ContainerFluid>
+	</nav>
+);
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
-
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export default ResultsBar;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBarItem.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBarItem.js
@@ -12,14 +12,27 @@
  * details.
  */
 
-export {default as Treeview} from './treeview/Treeview';
+import classNames from 'classnames';
+import React from 'react';
 
-export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';
+const ResultsBarItem = ({
+	children,
+	className,
+	expand = false,
+	...otherProps
+}) => (
+	<li
+		{...otherProps}
+		className={classNames('tbar-item', className, {
+			'tbar-item-expand': expand,
+		})}
+	>
+		<div className="tbar-section">{children}</div>
+	</li>
+);
 
-export {
-	activeLanguageIdsAtom,
-	selectedLanguageIdAtom,
-} from './translation_manager/state';
+ResultsBarItem.propTypes = {
+	expand: Boolean,
+};
 
-export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
-export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export default ResultsBarItem;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Search.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Search.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayLayout from '@clayui/layout';
+import classNames from 'classnames';
+import React from 'react';
+
+const Search = ({children, onlySearch, showMobile, ...otherProps}) => {
+	const content = (
+		<form {...otherProps} role="search">
+			{children}
+		</form>
+	);
+
+	return (
+		<div
+			className={classNames('navbar-form navbar-form-autofit', {
+				'navbar-overlay navbar-overlay-sm-down': !onlySearch,
+				'show': showMobile,
+			})}
+		>
+			{onlySearch ? (
+				content
+			) : (
+				<ClayLayout.ContainerFluid>{content}</ClayLayout.ContainerFluid>
+			)}
+		</div>
+	);
+};
+
+Search.propTypes = {
+	onlySearch: Boolean,
+	showMobile: Boolean,
+};
+
+export default Search;


### PR DESCRIPTION
### References

- [LPS-147712](https://issues.liferay.com/browse/LPS-147712)

### What is the goal?

* Migrate `ClayManagementToolbar` from Clay repo to `frontend-js-components-web`
   * Changed the root class name to `management-toolbar` (used to be `management-bar`) to ensure all required stylesheets are migrated.
* Add sample to `frontend-js-components-sample-web`
   * I have used the existing Storybook sample for this, but considering how simple this component is I don't know if we should simplify it

### What does it look like?
<img width="1306" alt="imagen" src="https://user-images.githubusercontent.com/6642927/155958124-246769aa-f506-465b-aee5-b6c5e5f1ea38.png">



### How to replicate
* Launch portal
* Run `cd ${PORTAL_ROOT}/modules/apps/frontend-js/frontend-js-components-sample-web && gradlew deploy -a`
* Go to `Site Builder > Pages`
* Click on the `+` button next to `Public Pages`, then click on `Add Page`
* Select widget page, name it `Frontend JS components sample`, click on `Add`
* Click `Home` on the left sidebar
* Select the widget page you created in the navigation bar by clicking on `Frontend JS components sample`
* Click on the `+` icon on the right sidebar, the sidebar should extend with the list of available widgets
* Search for `JS Components Sample` or click on the `Sample` accordion and see `JS Components Sample`
* Drag that element to the center of your screen, it should show a tab bar with two sections
* Select the `Management Toolbar` section
* Done!
