### PR TITLE
LPS-148425 Use MT UX improvements in Clay sample

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleManagementToolbarsDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleManagementToolbarsDisplayContext.java
@@ -136,48 +136,55 @@ public class ClaySampleManagementToolbarsDisplayContext
 	}
 
 	@Override
-	public List<DropdownItem> getFilterDropdownItems() {
+	public List<DropdownItem> getFilterNavigationDropdownItems() {
 		if (_filterDropdownItems != null) {
 			return _filterDropdownItems;
 		}
 
-		_filterDropdownItems = DropdownItemListBuilder.addGroup(
-			dropdownGroupItem -> {
-				dropdownGroupItem.setDropdownItems(
-					DropdownItemListBuilder.add(
-						dropdownItem -> {
-							dropdownItem.setHref("#1");
-							dropdownItem.setLabel("Filter 1");
-						}
-					).add(
-						dropdownItem -> {
-							dropdownItem.setHref("#2");
-							dropdownItem.setLabel("Filter 2");
-						}
-					).build());
-
-				dropdownGroupItem.setLabel("Filter By");
+		_filterDropdownItems = DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.setHref("#1");
+				dropdownItem.setLabel("Filter 1");
 			}
-		).addGroup(
-			dropdownGroupItem -> {
-				dropdownGroupItem.setDropdownItems(
-					DropdownItemListBuilder.add(
-						dropdownItem -> {
-							dropdownItem.setHref("#3");
-							dropdownItem.setLabel("Order 1");
-						}
-					).add(
-						dropdownItem -> {
-							dropdownItem.setHref("#4");
-							dropdownItem.setLabel("Order 2");
-						}
-					).build());
-
-				dropdownGroupItem.setLabel("Order By");
+		).add(
+			dropdownItem -> {
+				dropdownItem.setHref("#2");
+				dropdownItem.setLabel("Filter 2");
 			}
 		).build();
 
 		return _filterDropdownItems;
+	}
+
+	@Override
+	public String getFilterNavigationDropdownItemsLabel() {
+		return "Filter By";
+	}
+
+	@Override
+	public List<DropdownItem> getOrderByDropdownItems() {
+		if (_orderDropdownItems != null) {
+			return _orderDropdownItems;
+		}
+
+		_orderDropdownItems = DropdownItemListBuilder.add(
+			dropdownItem -> {
+				dropdownItem.setHref("#3");
+				dropdownItem.setLabel("Order 1");
+			}
+		).add(
+			dropdownItem -> {
+				dropdownItem.setHref("#4");
+				dropdownItem.setLabel("Order 2");
+			}
+		).build();
+
+		return _orderDropdownItems;
+	}
+
+	@Override
+	public String getOrderByDropdownItemsLabel() {
+		return "Order By";
 	}
 
 	@Override
@@ -223,6 +230,7 @@ public class ClaySampleManagementToolbarsDisplayContext
 	private List<DropdownItem> _actionDropdownItems;
 	private CreationMenu _creationMenu;
 	private List<DropdownItem> _filterDropdownItems;
+	private List<DropdownItem> _orderDropdownItems;
 	private List<ViewTypeItem> _viewTypeItems;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
@@ -29,6 +29,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 <clay:management-toolbar
 	creationMenu="<%= managementToolbarsDisplayContext.getCreationMenu() %>"
 	filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
+	orderDropdownItems="<%= managementToolbarsDisplayContext.getOrderDropdownItems() %>"
 	searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
 	searchFormName="mySearchName"
 	searchInputAutoFocus="<%= true %>"
@@ -56,6 +57,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
 	filterLabelItems="<%= managementToolbarsDisplayContext.getFilterLabelItems() %>"
 	itemsTotal="<%= 42 %>"
+	orderDropdownItems="<%= managementToolbarsDisplayContext.getOrderDropdownItems() %>"
 	searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
 	searchFormName="mySearchName"
 	searchInputName="mySearchInputName"


### PR DESCRIPTION
### References

- [LPS-148425](https://issues.liferay.com/browse/LPS-148425)

### What is the goal?

* Update Clay sample to display MT UX improvements epic changes when FF is enabled  

### What does it look like?
#### FF disabled

https://user-images.githubusercontent.com/6642927/156340901-4781c5e4-5ba0-43af-81c8-63039280edda.mov



#### FF enabled

https://user-images.githubusercontent.com/6642927/156340926-d1996505-1a94-4215-94be-0c3905f59a5b.mov


### How to replicate
* Launch portal
* Run `cd ${PORTAL_ROOT}/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web && gradlew deploy -a`
* Go to `Site Builder > Pages`
* Click on the `+` button next to `Public Pages`, then click on `Add Page`
* Select widget page, name it `Clay sample test`, click on `Add`
* Click `Home` on the left sidebar
* Select the widget page you created in the navigation bar by clicking on `Clay sample test`
* Click on the `+` icon on the right sidebar, the sidebar should extend with the list of available widgets
* Search for `Clay Sample` or click on the `Sample` accordion and see `Clay sample`
* Drag that element to the center of your screen, it should show a tab bar with multiple sections
* Select the `Management Toolbar` section
* Done!

