### PR TITLE
LPS-148436 Errors in JS console when viewing a blog

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/ballooneditor/plugin.js
@@ -321,7 +321,7 @@
 					for (const editorName in CKEDITOR.instances) {
 						const editor = CKEDITOR.instances[editorName];
 
-						editor.balloonToolbars.hide();
+						editor.balloonToolbars?.hide();
 
 						const liferayToolbars = editor.liferayToolbars;
 


### PR DESCRIPTION
### References

- [LPS-148436 Errors in JS console when viewing a blog](https://issues.liferay.com/browse/LPS-148436)

### What is the goal?

The bug happens if there are multiple editors on one page, at least one balloon editor, and at least one classic editor:
-  A balloon editor is required for the code in this plugin to be executed.
- A classic editor is required for this bug, as it will not have `editor.balloonToolbars` defined.

A simple null-check in this PR fixes the issue.

### What does it look like?
#### Before PR
![before](https://user-images.githubusercontent.com/5435511/156370653-f0bcf893-2388-4114-9c33-bfd0e6b93ee0.gif)

#### After PR
The same as above, but no errors.

### How to replicate

1. Open a blog
2. Click anywhere, except on image caption


