### PR TITLE
LPS-146513 Pressing space should open liferay-ui:icon-menu and update…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -35,6 +35,8 @@ AUI.add(
 
 		var EVENT_CLICK = 'click';
 
+		var EVENT_KEYDOWN = 'keydown';
+
 		var PARENT_NODE = 'parentNode';
 
 		var STR_BOTTOM = 'b';
@@ -131,6 +133,10 @@ AUI.add(
 
 					instance._activeMenu = null;
 					instance._activeTrigger = null;
+
+					trigger.attr({
+						'aria-expanded': false,
+					});
 
 					if (trigger.hasClass(CSS_EXTENDED)) {
 						trigger.removeClass(CSS_BTN_PRIMARY);
@@ -453,7 +459,6 @@ AUI.add(
 
 				trigger.attr({
 					'aria-haspopup': true,
-					'role': 'button',
 				});
 
 				listNode.setAttribute('aria-labelledby', trigger.guid());
@@ -497,7 +502,10 @@ AUI.add(
 			if (buffer.length) {
 				var nodes = A.all(buffer);
 
-				nodes.on(EVENT_CLICK, A.bind('_registerMenu', Menu));
+				nodes.on(
+					[EVENT_CLICK, EVENT_KEYDOWN],
+					A.bind('_registerMenu', Menu)
+				);
 
 				buffer.length = 0;
 			}
@@ -629,6 +637,15 @@ AUI.add(
 			Menu,
 			'_registerMenu',
 			(event) => {
+				var key = event.key || event.keyCode;
+
+				if (
+					event.type === EVENT_KEYDOWN &&
+					key !== A.Event.KeyMap.SPACE
+				) {
+					return;
+				}
+
 				var menuInstance = Menu._INSTANCE;
 
 				var handles = menuInstance._handles;
@@ -661,6 +678,10 @@ AUI.add(
 
 					menuInstance._activeMenu = menu;
 					menuInstance._activeTrigger = trigger;
+
+					trigger.attr({
+						'aria-expanded': true,
+					});
 
 					if (!handles.length) {
 						var listContainer = trigger.getData(

--- a/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon_menu/lexicon/start.jsp
@@ -45,7 +45,7 @@ if (Validator.isNull(icon)) {
 			</button>
 		</c:when>
 		<c:otherwise>
-			<a class="component-action direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" title="<%= message %>">
+			<a aria-expanded="false" aria-haspopup="true" class="component-action direction-<%= direction %> dropdown-toggle <%= triggerCssClass %>" href="javascript:;" id="<%= id %>" role="button" <%= ((message != null) && !message.isEmpty()) ? "title=\"" + message + "\"" : StringPool.BLANK %>>
 				<aui:icon image="<%= icon %>" markupView="lexicon" />
 			</a>
 		</c:otherwise>


### PR DESCRIPTION
… aria attributes

 - Don't set `'role': 'button'` in menu.js. liferay-ui:icon-menu can be a `button` or `a` element, `role="button"` should be used when an element other than a `button` or `input` behaves like a button.
- The `aria-expanded` attribute should be true when the dropdown menu is open and false when closed

https://issues.liferay.com/browse/LPS-146513

/cc @crodriguezy @magjed4289