### PR TITLE
LPS-XXXXX Create a PoC for new confirm API

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/js/BlogImagesManagementToolbarPropsTransformer.js
@@ -17,13 +17,17 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		...otherProps,
 		onActionButtonClick: (event, {item}) => {
 			if (item?.data?.action === 'deleteImages') {
-				if (
-					confirm(
-						Liferay.Language.get(
-							'are-you-sure-you-want-to-delete-the-selected-images'
-						)
+				let confirmDeleteImages = false;
+
+				Liferay.Util.confirm(
+					Liferay.Language.get(
+						'are-you-sure-you-want-to-delete-the-selected-images'
 					)
-				) {
+				).then((confirmResult) => {
+					confirmDeleteImages = confirmResult;
+				});
+
+				if (confirmDeleteImages) {
 					const form = document.getElementById(
 						`${portletNamespace}fm`
 					);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/confirm.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/confirm.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+// It throw an error during build time where @liferay/frontend-js-react-web module was not found :shrug:
+// import {openModal} from './modal/Modal';
+
+export function confirmAsync(message) {
+	return new Promise((resolve, _) => {
+		Liferay.Util.openModal({
+			bodyHTML: message,
+			buttons: [
+				{
+					displayType: 'secondary',
+					label: Liferay.Language.get('cancel'),
+					type: 'cancel',
+				},
+				{
+					label: Liferay.Language.get('ok'),
+					onClick: ({processClose}) => {
+						resolve(true);
+
+						processClose();
+					},
+				},
+			],
+			id: `confirmCommand`,
+			onClose: () => 
+				resolve(false)
+			,
+		});
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -28,6 +28,7 @@ import {
 	getComponentCache,
 	initComponentCache,
 } from './component.es';
+import {confirmAsync} from './confirm';
 import {
 	getLayoutIcons,
 	hideLayoutPane,
@@ -144,6 +145,8 @@ Liferay.Portlet.openWindow = (...args) => {
 Liferay.SideNavigation = SideNavigation;
 
 Liferay.Util = Liferay.Util || {};
+
+Liferay.Util.confirm = confirmAsync;
 
 Liferay.Util.MAP_HTML_CHARS_ESCAPED = MAP_HTML_CHARS_ESCAPED;
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/configuration/icon/export_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/configuration/icon/export_users.jsp
@@ -27,7 +27,12 @@ int status = GetterUtil.getInteger(request.getAttribute(UsersAdminWebKeys.STATUS
 <liferay-util:buffer
 	var="onClickFn"
 >
-	if (confirm('<liferay-ui:message key="warning-this-csv-file-contains-user-supplied-inputs" unicode="<%= true %>" />')) {
+	let confirmed = false;
+
+	Liferay.Util.confirm('<liferay-ui:message key="warning-this-csv-file-contains-user-supplied-inputs" unicode="<%= true %>" />')
+		.then(confirmResult => confirmed = confirmResult);
+
+	if (confirmed) {
 		submitForm(document.hrefFm, '<%= exportURL + "&compress=0&etag=0&strip=0" %>');
 	}
 </liferay-util:buffer>


### PR DESCRIPTION
I created a small poc where I migrated an use case of `confirm` with our new `Util.confirm` command:

## For reproducing JSP usage

1. Open global menu -> Control Panel -> Users and Organizations
2. Click on ellipsis icon located in right side of widget name("Users and Organizations")
3. Click on "Export Users"

See it in action.

Observations:

It worked well inside the conditional but it required a refactor for instead of inlining `confirm` call on the conditional, it requires a local variable to assign the return value(`true`|`false`) and then using this local variable on the conditional.

## For reproducing JS usage

1. Go to Blogs -> Add a new blog entry -> place an image on blog post body -> publish it
2. Go to Blogs again -> Images tab
3. Click on select all checkbox
4. Click on delete button

## Pics >>> my poor explanation

<img width="841" alt="Screen Shot 2022-03-02 at 20 01 31" src="https://user-images.githubusercontent.com/7663513/156467158-f5c551ea-43fa-4cf0-ab8b-456c864b867f.png">

## Questions

> Please, consider https://liferay.atlassian.net/wiki/spaces/~73202423/pages/1985775828/Provide+alternative+for+browser+native+dialogs+when+Liferay+is+rendered+in+cross-domain+iframes docs before going thru this

I used openModal API and considering we would use DXP built-in features aswell React it worked well.

My worry was about the `message` argument which allows only strings in native implementation but on our side we're allowing htmlstrings too. Is this something that can invalidate using `openModal` command?

/cc @markocikos @dsanz 