### PR TITLE
LPS-147613 Fix XSS vulnerability in Management Toolbar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LabelTag.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
@@ -124,16 +125,15 @@ public class LabelTag extends BaseContainerTag {
 
 			jspWriter.write("<span class=\"label-item label-item-expand\">");
 
+			String labelValue = _label;
+
 			if (_translated) {
-				jspWriter.write(
-					LanguageUtil.get(
-						TagResourceBundleUtil.getResourceBundle(pageContext),
-						_label));
-			}
-			else {
-				jspWriter.write(_label);
+				labelValue = LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_label);
 			}
 
+			jspWriter.write(HtmlUtil.escape(labelValue));
 			jspWriter.write("</span>");
 
 			if (_dismissible) {


### PR DESCRIPTION
### References

- [LPS-147613 Reflected XSS with filterType param in search](https://issues.liferay.com/browse/LPS-147613)

### What is the goal?

To prevent XSS attack, we need to escape label before writing to JSP.

### What does it look like?
#### Before PR
![before](https://user-images.githubusercontent.com/5435511/156557535-94e9a544-8327-42c8-89e6-756e5ea0f0c9.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/156557548-6937f982-64d7-47ea-9fd9-1239004fc27c.gif)

### How to replicate

See steps to reproduce in the JIRA ticket.