### PR TITLE
LPS-148559 Include asset priority in StructuredContent in Headless Admin Content API

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
+import com.liferay.portal.odata.entity.DoubleEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.entity.IntegerEntityField;
@@ -52,6 +53,9 @@ public class StructuredContentEntityModel implements EntityModel {
 				"datePublished",
 				locale -> Field.getSortableFieldName(Field.DISPLAY_DATE),
 				locale -> Field.DISPLAY_DATE),
+			new DoubleEntityField(
+				"priority",
+				locale -> Field.getSortableFieldName(Field.PRIORITY)),
 			new IntegerEntityField(
 				"contentStructureId", locale -> Field.CLASS_TYPE_ID),
 			new IntegerEntityField("creatorId", locale -> Field.USER_ID),

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -90,6 +90,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.ws.rs.BadRequestException;
@@ -304,6 +305,12 @@ public class StructuredContentResourceImpl
 				_getExpandoBridgeAttributes(structuredContent), siteId,
 				contextHttpServletRequest,
 				structuredContent.getViewableByAsString());
+
+		Optional.ofNullable(
+			structuredContent.getPriority()
+		).ifPresent(
+			serviceContext::setAssetPriority
+		);
 
 		serviceContext.setWorkflowAction(WorkflowConstants.ACTION_SAVE_DRAFT);
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -184,7 +184,7 @@ public class StructuredContentResourceTest
 
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
-		return new String[] {"title"};
+		return new String[] {"priority", "title"};
 	}
 
 	@Override
@@ -241,7 +241,7 @@ public class StructuredContentResourceTest
 				StructuredContent structuredContent)
 		throws Exception {
 
-		return _postSiteStructuredContent(
+		return _postSiteStructuredContentDraft(
 			testGroup.getGroupId(), structuredContent);
 	}
 
@@ -299,6 +299,14 @@ public class StructuredContentResourceTest
 				}));
 	}
 
+	private StructuredContent _postSiteStructuredContentDraft(
+			Long siteId, StructuredContent structuredContent)
+		throws Exception {
+
+		return structuredContentResource.postSiteStructuredContentDraft(
+			siteId, structuredContent);
+	}
+
 	private String _read(String fileName) throws Exception {
 		Class<?> clazz = getClass();
 
@@ -334,6 +342,7 @@ public class StructuredContentResourceTest
 				setDateCreated(structuredContent.getDateCreated());
 				setDateModified(structuredContent.getDateModified());
 				setId(structuredContent.getId());
+				setPriority(structuredContent.getPriority());
 				setSiteId(structuredContent.getSiteId());
 				setTitle(structuredContent.getTitle());
 			}


### PR DESCRIPTION
Related ticket: [LPS-148559](https://issues.liferay.com/browse/LPS-148559)

This PR contains the code to expose the asset priority field for StructuredContent in the Headless Admin Content API.

The field was already exposed in the Headless Delivery API (rest-openapi.yaml) as it is not necessary in this case for using the same source file.

It may be tested by invoking the /headless-admin-content/v1.0/sites/{siteId}/structured-contents/draft endpoint; see the following example with siteId 20123 and contentStructureId 39901:
```
curl \
    -H "accept: application/json" \
    -H "Content-Type: application/json" \
    -X 'POST' "http://localhost:8080/o/headless-admin-content/v1.0/sites/20123/structured-contents/draft" \
    -u "test@liferay.com:test" \
    -d '{
            "contentFields": [
                {
                "contentFieldValue": {
                    "data": "<p>My content</p>"
                },
                "dataType": "string",
                "label": "content",
                "name": "content",
                "nestedContentFields": [],
                "repeatable": false
                }
            ],
            "contentStructureId" : "39901",
            "title" : "Able",
            "priority": 1.3
        }'
```
getting the following response:
```
{
  "actions": {},
  "availableLanguages": [
    "en-US"
  ],
  "contentFields": [
    {
      "contentFieldValue": {
        "data": "<p>My content</p>"
      },
      "dataType": "string",
      "label": "content",
      "name": "content",
      "nestedContentFields": [],
      "repeatable": false
    }
  ],
  "contentStructureId": 39901,
  "creator": {
    "additionalName": "",
    "contentType": "UserAccount",
    "familyName": "Test",
    "givenName": "Test",
    "id": 20127,
    "name": "Test Test"
  },
  "customFields": [],
  "dateCreated": "2022-03-03T19:09:14Z",
  "dateModified": "2022-03-03T19:09:14Z",
  "datePublished": "2022-03-03T19:09:00Z",
  "description": "",
  "externalReferenceCode": "84841",
  "friendlyUrlPath": "able",
  "id": 84843,
  "key": "84841",
  "keywords": [],
  "numberOfComments": 0,
  "priority": 1.3,
  "relatedContents": [],
  "renderedContents": [
    {
      "contentTemplateId": "BASIC-WEB-CONTENT",
      "contentTemplateName": "Basic Web Content",
      "markedAsDefault": true,
      "renderedContentURL": "http://localhost:8080/o/headless-delivery/v1.0/structured-contents/84843/rendered-content/BASIC-WEB-CONTENT"
    }
  ],
  "siteId": 20123,
  "subscribed": false,
  "taxonomyCategoryBriefs": [],
  "title": "Able",
  "uuid": "ca8302a1-3959-51da-5a5a-a0278d5a5265",
  "version": {
    "number": 1,
    "status": {
      "code": 2,
      "label": "draft"
    }
  }
}
```
