### PR TITLE
LPS-XXXXX Create a PoC for new prompt API

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -39,6 +39,7 @@ import {
 import {showTab} from './portal/tabs.es';
 import {showTooltip} from './portal/tooltip.es';
 import portlet, {minimizePortlet} from './portlet/portlet.es';
+import {promptAsync} from './prompt';
 import SideNavigation from './side_navigation.es';
 import addParams from './util/add_params';
 import getCountries from './util/address/get_countries.es';
@@ -144,6 +145,8 @@ Liferay.Portlet.openWindow = (...args) => {
 Liferay.SideNavigation = SideNavigation;
 
 Liferay.Util = Liferay.Util || {};
+
+Liferay.Util.prompt = promptAsync;
 
 Liferay.Util.MAP_HTML_CHARS_ESCAPED = MAP_HTML_CHARS_ESCAPED;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -39,7 +39,6 @@ import {
 import {showTab} from './portal/tabs.es';
 import {showTooltip} from './portal/tooltip.es';
 import portlet, {minimizePortlet} from './portlet/portlet.es';
-import {promptAsync} from './prompt';
 import SideNavigation from './side_navigation.es';
 import addParams from './util/add_params';
 import getCountries from './util/address/get_countries.es';
@@ -146,7 +145,13 @@ Liferay.SideNavigation = SideNavigation;
 
 Liferay.Util = Liferay.Util || {};
 
-Liferay.Util.prompt = promptAsync;
+Liferay.Util.prompt = (...args) => {
+	Liferay.Loader.require('frontend-js-web/liferay/prompt', (commands) => {
+		commands.promptAsync(...args);
+	});
+};
+
+Liferay.Util.confirm = confirmAsync;
 
 Liferay.Util.MAP_HTML_CHARS_ESCAPED = MAP_HTML_CHARS_ESCAPED;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/prompt.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/prompt.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+// It throw an error during build time where @liferay/frontend-js-react-web module was not found :shrug:
+// import {openModal} from './modal/Modal';
+
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import ClayModal, {useModal} from '@clayui/modal';
+import {render} from '@liferay/frontend-js-react-web';
+import React, {useCallback, useState} from 'react';
+
+function PromptDialog({defaultPlaceholder, message, onClose}) {
+	const [value, setValue] = useState(() => defaultPlaceholder);
+	const [visible, setVisible] = useState(true);
+
+	const {observer} = useModal({
+		onClose: () => processClose(),
+	});
+
+	const processClose = useCallback(() => {
+		setVisible(false);
+
+		// TODO - Is this really necessary?? REFLITAO
+
+		document.body.classList.remove('modal-open');
+
+		if (onClose) {
+			onClose(value);
+		}
+	}, [onClose, value]);
+
+	if (!visible) {
+		return null;
+	}
+
+	return (
+		<ClayModal
+			className="liferay-modal"
+			observer={observer}
+			role="dialog"
+			size="sm"
+		>
+			<ClayModal.Body>
+				<ClayForm.Group>
+					<label htmlFor="promptInputText">{message}</label>
+
+					<ClayInput
+						id="promptInputText"
+						onChange={setValue}
+						type="text"
+					/>
+				</ClayForm.Group>
+			</ClayModal.Body>
+
+			<ClayModal.Footer
+				last={
+					<>
+						<ClayButton
+							aria-label={Liferay.Language.get('cancel')}
+							displayType="secondary"
+							onClick={() => onClose(null)}
+							type="button"
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+						<ClayButton
+							aria-label={Liferay.Language.get('ok')}
+							displayType="primary"
+							onClick={processClose}
+							type="button"
+						>
+							{Liferay.Language.get('ok')}
+						</ClayButton>
+					</>
+				}
+			/>
+		</ClayModal>
+	);
+}
+
+/**
+ * Display a dialog with an optional message prompting the user to input some text,
+ * and to wait until the user either submits the text or cancels the dialog.
+ * @param {string} message
+ * @param {string?} [defaultPlaceholder=""] - Optional placeholder
+ * @returns {Promise} Promise object wrapping the result of the user input
+ */
+export function promptAsync(message, defaultPlaceholder) {
+	return new Promise((resolve, _) => {
+
+		// Mount in detached node; Clay will take care of appending to `document.body`.
+		// See: https://github.com/liferay/clay/blob/master/packages/clay-shared/src/Portal.tsx
+
+		render(
+			PromptDialog,
+			{
+				defaultPlaceholder,
+				message,
+				onClose: (returnValue) => resolve(returnValue),
+			},
+			document.createElement('div')
+		);
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/prompt.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/prompt.js
@@ -18,11 +18,11 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {render} from '@liferay/frontend-js-react-web';
+import {render, useEventListener} from '@liferay/frontend-js-react-web';
 import React, {useCallback, useState} from 'react';
 
 function PromptDialog({defaultPlaceholder, message, onClose}) {
-	const [value, setValue] = useState(() => defaultPlaceholder);
+	const [value, setValue] = useState(defaultPlaceholder);
 	const [visible, setVisible] = useState(true);
 
 	const {observer} = useModal({
@@ -32,14 +32,22 @@ function PromptDialog({defaultPlaceholder, message, onClose}) {
 	const processClose = useCallback(() => {
 		setVisible(false);
 
-		// TODO - Is this really necessary?? REFLITAO
-
-		document.body.classList.remove('modal-open');
 
 		if (onClose) {
 			onClose(value);
 		}
 	}, [onClose, value]);
+
+	useEventListener(
+		'keydown',
+		(event) => {
+			if (visible && event.key === 'Enter') {
+				processClose();
+			}
+		},
+		true,
+		document
+	);
 
 	if (!visible) {
 		return null;
@@ -58,7 +66,8 @@ function PromptDialog({defaultPlaceholder, message, onClose}) {
 
 					<ClayInput
 						id="promptInputText"
-						onChange={setValue}
+						onChange={(event) => setValue(event.target.value)}
+						placeholder={defaultPlaceholder}
 						type="text"
 					/>
 				</ClayForm.Group>
@@ -66,15 +75,20 @@ function PromptDialog({defaultPlaceholder, message, onClose}) {
 
 			<ClayModal.Footer
 				last={
-					<>
+					<ClayButton.Group spaced>
 						<ClayButton
 							aria-label={Liferay.Language.get('cancel')}
 							displayType="secondary"
-							onClick={() => onClose(null)}
+							onClick={() => {
+								onClose(null);
+
+								processClose();
+							}}
 							type="button"
 						>
 							{Liferay.Language.get('cancel')}
 						</ClayButton>
+
 						<ClayButton
 							aria-label={Liferay.Language.get('ok')}
 							displayType="primary"
@@ -83,7 +97,7 @@ function PromptDialog({defaultPlaceholder, message, onClose}) {
 						>
 							{Liferay.Language.get('ok')}
 						</ClayButton>
-					</>
+					</ClayButton.Group>
 				}
 			/>
 		</ClayModal>


### PR DESCRIPTION
> ~~This PR will not work, we should solve [this issue](https://liferay.slack.com/archives/C3JBR21HA/p1646341572015229) first~~ Solved partially, with Liferay.Loader.require call on globals the promise design will not work :/

## What `window.prompt` does and what we should achieve with this code

Basically, `window.prompt` shows an input where the user can enter his string there and it will return this string when clicking on **"Ok"**.

but it can have some special cases when providing the other argument for placeholder.

We should provide a way to handle this input since it has the following behaviors:

1. Considering native implementation, it can accept another argument and we can use it as a placeholder. When clicking on **"Ok"**, the received placeholder text will be returned if we don't change it

2. When changing it and clicking on **"Ok"**, it will return the new value

3. When cleaning the input value and clicking on **"Ok"**, it will return an empty string('')

4. When clicking on **"Cancel"**, it returns `null`

## `openModal` design vs. `window.prompt` usages

### Possible implementations

1. openModal with string tpl with an input as a `bodyHTML`

2. openModal with a new API called input(?) and we can control it inside

3. **Don't use openModal**, Create a React component as we already been doing on openModal command but we could make things easier inside it without hacking using openModal

~~4. OVERKILL *DO NOT CONSIDER, my eyes will hurt* - Create a new JSP page using actionURL with a `aui:input`, control it using vanilla and use openModal passing this URL as an iframe~~

**I decided go with 3) since it is less hacky but I'm open for suggestions** 