### PR TITLE
LRQA-66242 Remove all comments of CanRenderUI tescase.

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySmoke.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClaySmoke.testcase
@@ -63,15 +63,6 @@ definition {
 			ClaySamplePortlet.assertNavTabVisualContent(tab = "Progress Bars");
 
 			ClaySamplePortlet.assertNavTabVisualContent(tab = "Stickers");
-
-			// They are commented because ocular not working for full page screenshots
-
-			//ClaySamplePortlet.assertNavTabVisualContent(tab = "Alerts");
-			//ClaySamplePortlet.assertNavTabVisualContent(tab = "Cards");
-			//ClaySamplePortlet.assertNavTabVisualContent(tab = "Form Elements");
-			//ClaySamplePortlet.assertNavTabVisualContent(tab = "Icons");
-			//ClaySamplePortlet.assertNavTabVisualContent(tab = "Management Toolbars");
-
 		}
 	}
 


### PR DESCRIPTION
Background
Remove all comments of CanRenderUI testcase

Test Plan
Given: clay sample portlet deployed on page
When: navigate to each page
And when: viewing each screenshot
Then: each nav section of clay sample portlet looks normal

JIRA Ticket:
[LRQA-66242](https://issues.liferay.com/browse/LRQA-66242)