### PR TITLE
LRQA-66243  Create Automated tests for Clay Card

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
@@ -37,6 +37,26 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CHECKBOX_SELECTABLE_IMAGE_CARD</td>
+	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@id,'image-card-icon-block')]//input[contains(@type,'checkbox')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CARD_ACTIVE</td>
+	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@class,'active file-card')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>KEBAB_DROPDOWN_CARD_OPTION</td>
+	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@id,'image-card-icon-block')]//button[contains(@class, 'dropdown-toggle')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TITLE_CARD</td>
+	<td>//h4[contains(text(), '${key_header}')]//following::a[contains(text(),'${key_title}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>SELECTOR</td>
 	<td>//label[normalize-space(text())='${key_label}']/following-sibling::select</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCards.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCards.testcase
@@ -1,0 +1,110 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Clay";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Sample Test Page");
+
+		JSONLayout.updateLayoutTemplateOfPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Sample Test Page",
+			layoutTemplate = "1 Column");
+
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Sample Test Page",
+			widgetName = "Clay Sample");
+
+		Navigator.gotoPage(pageName = "Clay Sample Test Page");
+
+		task ("Change for Card tab") {
+			Navigator.gotoNavTab(navTab = "Cards");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+	@description = "LRQA-66243: Assert active state of Selectable Image Card when checkbox was clicked"
+	@priority = "3"
+	test ActiveStateSelectableImageCard {
+		task ("Click at checkbok for active Card") {
+			Check.checkNotVisible(
+				key_header = "Selectable Image Card",
+				locator1 = "ClaySamplePortlet#CHECKBOX_SELECTABLE_IMAGE_CARD");
+		}
+
+		task ("Check default state of Selectable Image Card") {
+			AssertChecked.assertCheckedNotVisible(
+				key_header = "Selectable Image Card",
+				locator1 = "ClaySamplePortlet#CHECKBOX_SELECTABLE_IMAGE_CARD");
+
+			AssertElementPresent(
+				key_header = "Selectable Image Card",
+				locator1 = "ClaySamplePortlet#CARD_ACTIVE");
+		}
+	}
+
+	@description = "LRQA-66243: Assert that appends the href value to current URL: #image-card-href when click on Card Title"
+	@priority = "5"
+	test ChangingURLWhenClickCardTitle {
+		task ("Click on card title") {
+			ClickNoError(
+				key_header = "Selectable Image Card",
+				key_title = "Beetle",
+				locator1 = "ClaySamplePortlet#TITLE_CARD");
+		}
+
+		task ("Assert that appends the href value to current URL: #image-card-href") {
+			AssertLocation.assertPartialLocation(value1 = "#image-card-href");
+		}
+	}
+
+	@description = "LRQA-66243: Assert that appends the href value to current URL: #1 when add on Group 1 - Option 1"
+	@priority = "5"
+	test ChangingURLWhenSelectCardGroup {
+		task ("Select the Group 1 - Option 1") {
+			Click(
+				key_header = "Selectable Image Card",
+				locator1 = "ClaySamplePortlet#KEBAB_DROPDOWN_CARD_OPTION");
+
+			MenuItem.clickNoError(menuItem = "Group 1 - Option 1");
+		}
+
+		task ("Assert that appends the href value to current URL: #1") {
+			AssertLocation.assertPartialLocation(value1 = "#1");
+		}
+	}
+
+	@description = "LRQA-66243: Assert default state (not checked) of Selectable Image Card"
+	@priority = "3"
+	test CheckDefaultStateSelectableImageCard {
+		task ("Check default state of Selectable Image Card") {
+			AssertNotChecked.assertNotCheckedNotVisible(
+				key_header = "Selectable Image Card",
+				locator1 = "ClaySamplePortlet#CHECKBOX_SELECTABLE_IMAGE_CARD");
+		}
+	}
+
+}


### PR DESCRIPTION
Background
Create Automated tests for Clay Card

Test Plan
1. Given Test Page with Clay Sample Portlet added
When view Cards tab
And When viewing default state (not checked) of Selectable Image Card
Then it should not be active state

2. Given Test Page with Clay Sample Portlet added
When view Cards tab
And When click a default state of Selectable Image Card
Then it should check the checkbox
And Then it should make the card active

3. Given Test Page with Clay Sample Portlet added
When view Cards tab
And When click the title of Selectable Image Card
Then it appends the href value to current URL: #image-card-href

4. Given Test Page with Clay Sample Portlet added
When view Cards tab
And When click the elipsis of Selectable Image Card
And When click the Group 1 - Option 1
Then it appends the href value to current URL: # 1

JIRA Ticket:
[LRQA-66243](https://issues.liferay.com/browse/LRQA-66243)