### PR TITLE
[TS] LPS-148762 Remove buildNumber from the static resources URLs, timestamp should be enough to invalidate browser's cache in a upgrade of version

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -532,7 +532,7 @@ public class ComboServlet extends HttpServlet {
 			PortalCacheManagerNames.SINGLE_VM, FileContentBag.class.getName());
 
 	private final Set<String> _protectedParameters = SetUtil.fromArray(
-		"b", "browserId", "minifierType", "languageId", "t", "themeId", "zx");
+		"browserId", "minifierType", "languageId", "t", "themeId", "zx");
 
 	private static class FileContentBag implements Serializable {
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -190,7 +190,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletCategoryKeys;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.StringComparator;
@@ -5202,7 +5201,7 @@ public class PortalImpl implements Portal {
 			parameterMap = HttpUtil.getParameterMap(queryString);
 		}
 
-		StringBundler sb = new StringBundler(17);
+		StringBundler sb = new StringBundler(15);
 
 		// URI
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5321,11 +5321,6 @@ public class PortalImpl implements Portal {
 
 		sb.append(themeDisplay.getLanguageId());
 
-		// Build number
-
-		sb.append("&b=");
-		sb.append(ReleaseInfo.getBuildNumber());
-
 		// Timestamp
 
 		if (((parameterMap == null) || !parameterMap.containsKey("t")) &&


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-148762

buildNumber was introduced in https://issues.liferay.com/browse/LPS-13514 to control the browser cache in a upgrade, but having the timestamp it should not be necessary the buildNumber and also it is a security weakness that users are reporting