### PR TITLE
LPS-147872 Date picker in web content doesn't have correct styles

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_portal.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_portal.scss
@@ -3,6 +3,7 @@
 @import './portal/asset_column';
 @import './portal/aui';
 @import './portal/auto_row';
+@import './portal/date_picker';
 @import './portal/dropdowns';
 @import './portal/edit_layout';
 @import './portal/forms';

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_date_picker.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_date_picker.scss
@@ -1,0 +1,3 @@
+.datepicker-popover-content .popover-content {
+	padding: 0.75rem 1rem;
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -296,7 +296,3 @@ $productMenuWidth: 320px;
 		}
 	}
 }
-
-.datepicker-popover-content .popover-content {
-	padding: 0.75rem 1rem;
-}


### PR DESCRIPTION
This feedback was given to me to a bug that I opened in Clay
https://github.com/liferay/clay/issues/4715#issuecomment-1058500049

Per Patrick`s comment, I decided to add this code to frontend-theme-styled module, since the component is been used in several other modules. Let me know if I should put this code in another place. Thanks!

## Problem's describe
The date picker in Web Content does not have the correct styles:
<img width="222" alt="Screenshot 2022-03-03 at 15 07 53" src="https://user-images.githubusercontent.com/91208451/156580743-1db61e0e-5267-4553-8a18-dd6e015e0c0d.png">
## What are the steps to reproduce?
1. Create a Web content
2. Open the "schedule" section in the sidebar
3. Click in the date field
## What is the expected result? 
![Screenshot 2022-03-03 at 15 01 13](https://user-images.githubusercontent.com/91208451/156579656-16942aca-d85f-4d70-8a9a-25b9653998e4.png)
This is how looks like in 7.3 version (expected result), which has the following CSS:
_.popover-body, .popover-content {
      border-bottom-right-radius: calc(0.25rem - 1px);
      border-bottom-left-radius: calc(0.25rem - 1px);
      color: #6b6c7e;
      padding: 0.75rem 1rem;
}_





