### PR TITLE
LPS-148020 Fix for increasing CI coverage for frontend-theme module

### DIFF
--- a/modules/apps/frontend-theme/test.properties
+++ b/modules/apps/frontend-theme/test.properties
@@ -26,4 +26,3 @@
 ##
 
     testray.main.component.name=Theme
-    testray.main.component.name=Navigation


### PR DESCRIPTION
Small fix for https://github.com/liferay-frontend/liferay-portal/pull/1960 to edit the test.properties file of [frontend-theme module](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-theme/test.properties) to remove one line as the component is not owned by FI team, so the frontend-theme module only shows FI components.

JIRA issue: [LPS-148020](https://issues.liferay.com/browse/LPS-148020)