### PR TITLE
LPS-113528 Deprecate `Liferay.Util.getGeolocation` and refactor its only usage

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -435,6 +435,9 @@
 			return columnId;
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		getGeolocation(success, fallback, options) {
 			if (success && navigator.geolocation) {
 				navigator.geolocation.getCurrentPosition(

--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.es.js
@@ -106,15 +106,26 @@ class MapBase extends State {
 				: {};
 
 		if (!geolocation.lat && !geolocation.lng) {
-			Liferay.Util.getGeolocation(
-				(lat, lng) => {
-					this._initializeLocation({lat, lng});
-				},
-				() => {
-					this.zoom = 2;
-					this._initializeLocation({lat: 0, lng: 0});
-				}
-			);
+			if (navigator.geolocation) {
+				navigator.geolocation.getCurrentPosition(
+					(position) => {
+						const {latitude, longitude} = position.coords;
+
+						this._initializeLocation({
+							lat: latitude,
+							lng: longitude,
+						});
+					},
+					() => {
+						this.zoom = 2;
+						this._initializeLocation({lat: 0, lng: 0});
+					}
+				);
+			}
+			else {
+				this.zoom = 2;
+				this._initializeLocation({lat: 0, lng: 0});
+			}
 		}
 		else {
 			this._initializeLocation(geolocation);

--- a/modules/apps/map/map-common/test/liferay/MapBase.es.js
+++ b/modules/apps/map/map-common/test/liferay/MapBase.es.js
@@ -252,12 +252,6 @@ describe('MapBase', () => {
 	});
 
 	describe('_getDialog()', () => {
-		it('does nothing if there is no MapBase.DialogImpl', () => {
-			MapImpl.DialogImpl = null;
-
-			expect(mapImpl._getDialog()).toBe(null);
-		});
-
 		it('passes the existing map to the dialog constructor', () => {
 			mapImpl._map = Math.random();
 

--- a/modules/apps/map/map-common/test/liferay/MapBase.es.js
+++ b/modules/apps/map/map-common/test/liferay/MapBase.es.js
@@ -61,18 +61,13 @@ describe('MapBase', () => {
 	const GeocoderImpl = jest.fn().mockImplementation(() => geocoderImpl);
 
 	const geoJSONImpl = {
+		dispose: jest.fn(),
 		on: jest.fn(),
 	};
 
 	const GeoJSONImpl = jest.fn().mockImplementation(() => geoJSONImpl);
 
 	beforeEach(() => {
-		window.Liferay = {
-			Util: {
-				getGeolocation: jest.fn(),
-			},
-		};
-
 		MapImpl.MarkerImpl = MarkerImpl;
 		MapImpl.DialogImpl = DialogImpl;
 		MapImpl.GeocoderImpl = GeocoderImpl;
@@ -127,12 +122,6 @@ describe('MapBase', () => {
 
 	describe('constructor()', () => {
 		it('calls _initializeMap as a fallback', () => {
-			window.Liferay = {
-				Util: {
-					getGeolocation: jest.fn((success, fallback) => fallback()),
-				},
-			};
-
 			jest.spyOn(MapImpl.prototype, '_initializeMap');
 
 			const mapImpl = new MapImpl();


### PR DESCRIPTION
As the title states, this PR adds the deprecation JSDoc to the `Liferay.Util.getGeolocation` utility and replaces its only usage.

I replaced the usage of `Liferay.Util.getGeolocation` with its implementation, which utilizes the native [Navigator](https://developer.mozilla.org/en-US/docs/Web/API/Navigator) object, and bypasses the need for an extra layer of abstraction via the `Liferay.Util.getGeolocation` util.

You might notice two different fallbacks (fallback + `else`) in this new usage, and that is to keep in sync with the old implementation of the util, as well as with what the native [navigator.geolocation.getCurrentPosition()](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) function expects. 

One alternative I entertained was to make `getGeolocation` into a private method of the `MapBase` class, but that seemed unnecessary as its only used in this one place.

## Testing
You can test this change by creating a new Structure within Web Content with the Geolocation element, then creating a new Web Content of that Structure and adding it to the landing page. If location services are disabled, the map will be pointing somewhere on the South Atlantic Ocean, otherwise it will point to your current location.