### PR TITLE
LPS-148928 | Add scroll and pause to stabilize tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -73,6 +73,10 @@ definition {
 		}
 
 		task ("Assert the new button is displayed as an icon button") {
+			ScrollWebElementIntoView(locator1 = "ManagementBar#NEW_BUTTON_MOBILE");
+
+			Pause(locator1 = "3000");
+
 			AssertElementPresent(locator1 = "ManagementBar#NEW_BUTTON_MOBILE");
 
 			AssertTextNotEquals(
@@ -93,6 +97,10 @@ definition {
 		}
 
 		task ("Hover over the new button") {
+			ScrollWebElementIntoView(locator1 = "ManagementBar#NEW_BUTTON_MOBILE");
+
+			Pause(locator1 = "3000");
+
 			MouseOver(locator1 = "ManagementBar#NEW_BUTTON_MOBILE");
 		}
 


### PR DESCRIPTION
**Background**
ManagementToolbar#ResponsiveModeNewButtonTooltip is failing inconsistently because the tooltip isn't being shown. Hopefully this will stabilize it. 

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-148928