### PR TITLE
LPS-147404, LPS-147832 | Assert 'more actions' and quick actions are displayed 

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -97,6 +97,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>QUICK_ACTION_DROPDOWN_ITEM</td>
+	<td>//div[contains(@class,'dropdown-menu show')]//li//*[contains(@class,'dropdown-item') and contains(., '${key_action}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>VIEW_BUTTON</td>
 	<td>//nav[contains(@class,'management-bar')]//*[(@title="Show View Options")][*[name()='svg'][contains(@class,'icon-${key_text}')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -75,9 +75,15 @@
 	<td>//nav[contains(@class,'subnav-tbar')]//span[@class='text-truncate']</td>
 	<td></td>
 </tr>
+<!--FEATURE FLAG CONFIGURATIONS-->
 <tr>
-	<td>VIEW_BUTTON</td>
-	<td>//nav[contains(@class,'management-bar')]//*[(@title="Show View Options")][*[name()='svg'][contains(@class,'icon-${key_text}')]]</td>
+	<td>ICON_AND_TEXT_ACTION_BUTTON</td>
+	<td>//nav[contains(@class,'management-bar')]//*[*[name()='svg'][contains(@class,'icon-${key_icon}')]]//following-sibling::span[text()='${key_action}']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>MORE_ACTIONS_ELLIPSIS</td>
+	<td>//nav[contains(@class,'management-bar')]//button[contains(@class, 'dropdown-toggle')][*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
 	<td></td>
 </tr>
 <tr>
@@ -88,6 +94,11 @@
 <tr>
 	<td>NEW_BUTTON_MOBILE</td>
 	<td>//nav[contains(@class,'management-bar')]//button[contains(@aria-label, 'New')]//*[contains(@class,'icon-plus')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>VIEW_BUTTON</td>
+	<td>//nav[contains(@class,'management-bar')]//*[(@title="Show View Options")][*[name()='svg'][contains(@class,'icon-${key_text}')]]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -47,6 +47,30 @@ definition {
 		}
 	}
 
+	@description = "LPS-147404. Assert the more actions button is displayed"
+	@priority = "5"
+	test MoreActionsButtonCanRender {
+		task ("Navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
+		}
+
+		task ("Assert the 'more actions' button is displayed") {
+			AssertElementPresent(locator1 = "ManagementBar#MORE_ACTIONS_ELLIPSIS");
+		}
+
+		task ("Assert all the actions are displayed as icon and text buttons") {
+			AssertElementPresent(
+				key_action = "Download",
+				key_icon = "download",
+				locator1 = "ManagementBar#ICON_AND_TEXT_ACTION_BUTTON");
+
+			AssertElementPresent(
+				key_action = "Delete",
+				key_icon = "trash",
+				locator1 = "ManagementBar#ICON_AND_TEXT_ACTION_BUTTON");
+		}
+	}
+
 	@description = "LPS-147864. Assert the New button is displayed as a text button"
 	@priority = "5"
 	test NewButtonRender {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -71,6 +71,32 @@ definition {
 		}
 	}
 
+	@description = "LPS-147832. Assert the more actions button can display quick actions"
+	@priority = "5"
+	test MoreActionsButtonRenderQuickActions {
+		task ("Navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
+		}
+
+		task ("Click on 'more actions' button") {
+			Click(locator1 = "ManagementBar#MORE_ACTIONS_ELLIPSIS");
+		}
+
+		task ("Assert quick actions are displayed") {
+			AssertElementPresent(
+				key_action = "Edit",
+				locator1 = "ManagementBar#QUICK_ACTION_DROPDOWN_ITEM");
+
+			AssertElementPresent(
+				key_action = "Download",
+				locator1 = "ManagementBar#QUICK_ACTION_DROPDOWN_ITEM");
+
+			AssertElementPresent(
+				key_action = "Delete",
+				locator1 = "ManagementBar#QUICK_ACTION_DROPDOWN_ITEM");
+		}
+	}
+
 	@description = "LPS-147864. Assert the New button is displayed as a text button"
 	@priority = "5"
 	test NewButtonRender {


### PR DESCRIPTION
**Background**
Create automated tests for Management Toolbar.

**Test Plan**
- Given a user of the portal
- When the user opens any section with the management toolbar
- Then the 'more actions' button will be displayed
- And all the actions of the MT will be displayed as icon plus text buttons
-
- Given a user of the portal
- When the user opens any section with the management toolbar
- And clicks on the 'more actions' button
- Then the quick actions will be displayed 

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147404
https://issues.liferay.com/browse/LPS-147832

*Side Note: 'more actions' button isn't actually a button, just referring to the vertical ellipsis