### PR TITLE
LPS-147612 | Validates translation can be synced in selector and text field

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/ManageTranslations.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/ManageTranslations.macro
@@ -8,7 +8,7 @@ definition {
 
 	macro searchLanguage {
 		Type.type(
-			locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_SEARCH_FIELD",
+			locator1 = "ManageTranslations#SEARCH_FIELD",
 			value1 = "${key_language}");
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
@@ -19,4 +19,44 @@ definition {
 		Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS");
 	}
 
+	macro inputTextInAuiTagField {
+		Type(
+			key_title = "${key_leftTitle}",
+			locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+			value1 = "${languagefirst}");
+
+		Type(
+			key_title = "${key_rightTitle}",
+			locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+			value1 = "${languagefirst}");
+
+		TranslationManagerPortlet.selectLanguageInAuiTagSelector(
+			key_currentLocale = "${key_currentLocale}",
+			key_locale = "${key_locale}",
+			key_number = "${key_number}",
+			key_title = "${key_leftTitle}");
+
+		Type(
+			key_title = "${key_leftTitle}",
+			locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+			value1 = "${languagesecond}");
+
+		Type(
+			key_title = "${key_rightTitle}",
+			locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+			value1 = "${languagesecond}");
+	}
+
+	macro selectLanguageInAuiTagSelector {
+		Click.clickNoMouseOver(
+			key_currentLocale = "${key_currentLocale}",
+			key_number = "${key_number}",
+			key_title = "${key_leftTitle}",
+			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
+
+		Click(
+			key_locale = "${key_locale}",
+			locator1 = "Translation#DROPDOWN_MENU_ITEM");
+	}
+
 }

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
@@ -7,10 +7,6 @@ definition {
 			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_MENU");
 	}
 
-	macro deleteLanguage {
-		Click(locator1 = "TranslationManager#MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_DELETE");
-	}
-
 	macro goToManageTranslationsModal {
 		TranslationManagerPortlet.clickSelectTranslation(
 			key_currentLocale = "${key_currentLocale}",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
@@ -29,7 +29,6 @@ definition {
 		TranslationManagerPortlet.selectLanguageInAuiTagSelector(
 			key_currentLocale = "${key_currentLocale}",
 			key_locale = "${key_locale}",
-			key_number = "${key_number}",
 			key_title = "${key_leftTitle}");
 
 		Type(
@@ -46,7 +45,6 @@ definition {
 	macro selectLanguageInAuiTagSelector {
 		Click.clickNoMouseOver(
 			key_currentLocale = "${key_currentLocale}",
-			key_number = "${key_number}",
 			key_title = "${key_leftTitle}",
 			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/ManageTranslations.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/ManageTranslations.path
@@ -22,6 +22,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SEARCH_FIELD</td>
+	<td>//div[contains(@class,'modal-dialog')]//input[contains(@placeholder,'Search')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TABLE_BODY_ROW_INDEX</td>
 	<td>//tbody//tr[${key_index}]</td>
 	<td></td>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 	<td>SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU</td>
-	<td>//div[h3='${key_title}']//button[contains(@id,'aui_2d_${key_number}Menu')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
+	<td>//div[h3='${key_title}']//button[contains(@id,'aui_2d')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
@@ -31,26 +31,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>MANAGE_TRANSLATIONS_DIALOG_SEARCH_FIELD</td>
-	<td>//div[contains(@class,'modal-dialog')]//input[contains(@placeholder,'Search')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>MANAGE_TRANSLATIONS_DIALOG_SEARCH_RESULTS_TITLE</td>
-	<td>//th[contains(text(),'${key_text}')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_LIST</td>
-	<td>//tr[${key_index}]//*[name()='svg'][contains(@class,'lexicon-icon-${key_locale}')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>MANAGE_TRANSLATIONS_DIALOG_LANGUAGE_DELETE</td>
-	<td>//tr[${key_index}]//*[name()='svg'][contains(@class,'lexicon-icon-trash')]</td>
-	<td></td>
-</tr>
-<tr>
 	<td>AUI_TAG_INPUT_TEXT_FIELD</td>
 	<td>//div[contains(@class,'col') and h3='${key_title}']//input[contains(@class,'language-value field')]</td>
 	<td></td>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
@@ -12,12 +12,12 @@
 <tbody>
 <tr>
 	<td>SELECT_TRANSLATION_LANGUAGE_MENU</td>
-	<td>//div[h3='${key_title}']//button[contains(@title,'select-translation-language')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
+	<td>//div[h3='${key_title}']//button[@*='select-translation-language']//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
 	<td></td>
 </tr>
 <tr>
-	<td>SELECT_TRANSLATION_LANGUAGE_AUI_TAG_ADMINMENU</td>
-	<td>//button[contains(@id,'aui_2d_2Menu')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
+	<td>SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU</td>
+	<td>//div[h3='${key_title}']//button[contains(@id,'aui_2d_${key_number}Menu')]//*[name()='svg'][contains(@class,'lexicon-icon-${key_currentLocale}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -48,7 +48,6 @@ definition {
 				key_currentLocale = "en-us",
 				key_leftTitle = "Default",
 				key_locale = "fr-FR",
-				key_number = "1",
 				key_rightTitle = "Admin",
 				languagefirst = "Welcome to Liferay",
 				languagesecond = "Bienvenue sur Liferay");
@@ -58,28 +57,24 @@ definition {
 			TranslationManagerPortlet.selectLanguageInAuiTagSelector(
 				key_currentLocale = "fr-fr",
 				key_leftTitle = "Default",
-				key_locale = "en-US",
-				key_number = "1");
+				key_locale = "en-US");
 		}
 
 		task ("Then translated language is available to select") {
 			TranslationManagerPortlet.selectLanguageInAuiTagSelector(
 				key_currentLocale = "en-us",
 				key_leftTitle = "Default",
-				key_locale = "fr-FR",
-				key_number = "1");
+				key_locale = "fr-FR");
 		}
 
 		task ("Then assert language selector is changed to the selected language") {
 			AssertElementPresent(
 				key_currentLocale = "fr-fr",
-				key_number = "1",
 				key_title = "Default",
 				locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
 
 			AssertElementPresent(
 				key_currentLocale = "fr-fr",
-				key_number = "2",
 				key_title = "Admin",
 				locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
 		}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -40,6 +40,63 @@ definition {
 		}
 	}
 
+	@description = "LPS-147612. Validates translation can be synced in selector and text field."
+	@priority = "3"
+	test CanBeSyncedOnSelectedAndTranslatedLanguages {
+		task ("When input different language text in aui tag field") {
+			TranslationManagerPortlet.inputTextInAuiTagField(
+				key_currentLocale = "en-us",
+				key_leftTitle = "Default",
+				key_locale = "fr-FR",
+				key_number = "1",
+				key_rightTitle = "Admin",
+				languagefirst = "Welcome to Liferay",
+				languagesecond = "Bienvenue sur Liferay");
+		}
+
+		task ("When select language in aui tag selector") {
+			TranslationManagerPortlet.selectLanguageInAuiTagSelector(
+				key_currentLocale = "fr-fr",
+				key_leftTitle = "Default",
+				key_locale = "en-US",
+				key_number = "1");
+		}
+
+		task ("Then translated language is available to select") {
+			TranslationManagerPortlet.selectLanguageInAuiTagSelector(
+				key_currentLocale = "en-us",
+				key_leftTitle = "Default",
+				key_locale = "fr-FR",
+				key_number = "1");
+		}
+
+		task ("Then assert language selector is changed to the selected language") {
+			AssertElementPresent(
+				key_currentLocale = "fr-fr",
+				key_number = "1",
+				key_title = "Default",
+				locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
+
+			AssertElementPresent(
+				key_currentLocale = "fr-fr",
+				key_number = "2",
+				key_title = "Admin",
+				locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
+		}
+
+		task ("Then assert translation results displayed by the selected language") {
+			AssertElementPresent(
+				key_title = "Default",
+				locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+				value1 = "Bienvenue sur Liferay");
+
+			AssertElementPresent(
+				key_title = "Admin",
+				locator1 = "TranslationManager#AUI_TAG_INPUT_TEXT_FIELD",
+				value1 = "Bienvenue sur Liferay");
+		}
+	}
+
 	@description = "LPS-147946. Validates language can be deleted from the Manage Translation list."
 	@priority = "3"
 	test CanDeleteLanguageFromManageTranslationsList {


### PR DESCRIPTION
**Background**
Create automation tests for Translation Manager

**Test Plan**

Create a page with the widget JS Components Sample
Click AUI Tag translation language menu
Input different language text in AuI Tag field
Select language in AuI Tag selector
Assert translated language is available to select
Assert language selector is changed to the selected language
Assert translation results displayed by the selected language

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147612