### PR TITLE
LPS-113529 Modernize the `getLexiconIcon()` AUI utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -454,16 +454,6 @@
 			}
 		},
 
-		getLexiconIcon(icon, cssClass) {
-			var instance = this;
-
-			const tempElement = document.createElement('div');
-
-			tempElement.innerHTML = instance.getLexiconIconTpl(icon, cssClass);
-
-			return tempElement.firstChild;
-		},
-
 		getLexiconIconTpl(icon, cssClass) {
 			return Liferay.Util.sub(TPL_LEXICON_ICON, icon, cssClass || '');
 		},

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -54,6 +54,7 @@ import formatXML from './util/format_xml.es';
 import getCropRegion from './util/get_crop_region.es';
 import getDOM from './util/get_dom';
 import getElement from './util/get_element';
+import getLexiconIcon from './util/get_lexicon_icon';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
 import {
@@ -185,6 +186,7 @@ Liferay.Util.getDOM = getDOM;
 Liferay.Util.getElement = getElement;
 
 Liferay.Util.getFormElement = getFormElement;
+Liferay.Util.getLexiconIcon = getLexiconIcon;
 
 /**
  * @deprecated As of Athanasius (7.3.x), replaced by `import {getPortletId} from 'frontend-js-web'`

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -117,6 +117,11 @@ declare module Liferay {
 			elementName: string
 		): Element | NodeList | null;
 
+		export function getLexiconIcon(
+			icon: string,
+			cssClass?: string
+		): HTMLElement;
+
 		export function getOpener(): any;
 
 		/**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function getLexiconIcon(icon, cssClass = '') {
+	if (!icon) {
+		throw new TypeError('Parameter icon must be provided');
+	}
+
+	function getLexiconIconTemplate(iconName, cssClass) {
+		return `<svg
+				aria-hidden="true"
+				class="lexicon-icon lexicon-icon-${iconName} ${cssClass}"
+				focusable="false"
+				role="presentation"
+			>
+				<use href="${themeDisplay.getPathThemeImages()}/clay/icons.svg#${iconName}" />
+			</svg>`;
+	}
+
+	const lexiconIconTemplate = getLexiconIconTemplate(icon, cssClass);
+	const tempElement = document.createElement('div');
+
+	tempElement.innerHTML = lexiconIconTemplate;
+
+	return tempElement.firstChild;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon.js
@@ -17,7 +17,7 @@ export default function getLexiconIcon(icon, cssClass = '') {
 		throw new TypeError('Parameter icon must be provided');
 	}
 
-	function getLexiconIconTemplate(iconName, cssClass) {
+	function getLexiconIconHTML(iconName, cssClass) {
 		return `<svg
 				aria-hidden="true"
 				class="lexicon-icon lexicon-icon-${iconName} ${cssClass}"
@@ -28,7 +28,7 @@ export default function getLexiconIcon(icon, cssClass = '') {
 			</svg>`;
 	}
 
-	const lexiconIconTemplate = getLexiconIconTemplate(icon, cssClass);
+	const lexiconIconTemplate = getLexiconIconHTML(icon, cssClass);
 	const tempElement = document.createElement('div');
 
 	tempElement.innerHTML = lexiconIconTemplate;

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_lexicon_icon.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_lexicon_icon.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getLexiconIcon from '../../../src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon';
+
+describe('Liferay.Util.getLexiconIcon', () => {
+	it('returns an svg element', () => {
+		const icon = getLexiconIcon('close');
+
+		expect(icon.nodeName).toBe('svg');
+	});
+
+	it('returns an element with the class determining the icon', () => {
+		const icon = getLexiconIcon('close');
+
+		expect(icon.classList.contains('lexicon-icon-close')).toBe(true);
+	});
+
+	it('returns an element pointing to the icon within the svg spritemap', () => {
+		const icon = getLexiconIcon('close');
+
+		const svgHref = icon.children[0].getAttribute('href');
+
+		expect(svgHref).toContain('close');
+	});
+
+	it('returns an element containing the provided css class', () => {
+		const icon = getLexiconIcon('close', 'test-class');
+
+		expect(icon.classList.contains('test-class')).toBe(true);
+	});
+
+	it("throws an error if the icon string isn't provided", () => {
+		expect(() => getLexiconIcon()).toThrow();
+	});
+});


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-113529

The utility itself wasn't old in the sense that it had any AUI code, but I still went with moving it to `frontend-js-web` so that we can add types to the TS definition file, tests, and improve the code slightly.

The biggest change was removing the reliance on `Liferay.Util.getLexiconIconTpl()` and `Liferay.Util.sub` (by extension) by adding a new function inside the new util that handles what those 2 utils did, in this case.