### PR TITLE
LPS-148658 Use `Util.openAlertModal` on JS files

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
@@ -29,7 +29,8 @@ export default function propsTransformer({
 					Liferay.Util.openAlertModal({
 						message: `${greeting} ${itemData.title}!`,
 					});
-				} else {
+				}
+				else {
 					alert(`${greeting} ${itemData.title}!`);
 				}
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {openAlertModal} from 'frontend-js-web';
+
 import SampleCustomDataRenderer from './SampleCustomDataRenderer';
 
 export default function propsTransformer({
@@ -25,13 +27,15 @@ export default function propsTransformer({
 		},
 		onActionDropdownItemClick({action, itemData}) {
 			if (action.data.id === 'sampleMessage') {
+				const alertMessage = `${greeting} ${itemData.title}!`;
+
 				if (Liferay.__FF__.enableCustomDialogs) {
-					Liferay.Util.openAlertModal({
-						message: `${greeting} ${itemData.title}!`,
+					openAlertModal({
+						message: alertMessage,
 					});
 				}
 				else {
-					alert(`${greeting} ${itemData.title}!`);
+					alert(alertMessage);
 				}
 			}
 		},

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
@@ -29,7 +29,7 @@ export default function propsTransformer({
 			if (action.data.id === 'sampleMessage') {
 				const alertMessage = `${greeting} ${itemData.title}!`;
 
-				if (Liferay.__FF__.enableCustomDialogs) {
+				if (Liferay.__FF__.customDialogsEnabled) {
 					openAlertModal({
 						message: alertMessage,
 					});

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
@@ -25,7 +25,13 @@ export default function propsTransformer({
 		},
 		onActionDropdownItemClick({action, itemData}) {
 			if (action.data.id === 'sampleMessage') {
-				alert(`${greeting} ${itemData.title}!`);
+				if (Liferay.__FF__.enableCustomDialogs) {
+					Liferay.Util.openAlertModal({
+						message: `${greeting} ${itemData.title}!`,
+					});
+				} else {
+					alert(`${greeting} ${itemData.title}!`);
+				}
 			}
 		},
 	};

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
@@ -63,9 +63,9 @@ public class FrontendComponentsTopHeadDynamicInclude
 				_ffFrontendJSComponentsConfiguration.enableClayTreeView()));
 		sb.append(
 			_buildFeatureFlagJSGlobalVariable(
-				"enableCustomDialogs",
+				"customDialogsEnabled",
 				GetterUtil.getBoolean(
-					PropsUtil.get("feature.flag.enableCustomDialogs"))));
+					PropsUtil.get("feature.flag.customDialogsEnabled"))));
 		sb.append("</script>");
 
 		printWriter.println(sb);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
@@ -15,7 +15,7 @@
 import {openAlertModal} from 'frontend-js-web';
 
 function openAlert(message) {
-	if (Liferay.__FF__.enableCustomDialogs) {
+	if (Liferay.__FF__.customDialogsEnabled) {
 		openAlertModal({message});
 	}
 	else {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
@@ -12,64 +12,37 @@
  * details.
  */
 
+import {openAlertModal} from 'frontend-js-web';
+
+function openAlert(message) {
+	if (Liferay.__FF__.enableCustomDialogs) {
+		openAlertModal({message});
+	}
+	else {
+		alert(message);
+	}
+}
+
 export default function propsTransformer(props) {
 	return {
 		...props,
 		onActionButtonClick: () => {
-			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'Action button clicked'});
-			}
-			else {
-				alert('Action button clicked');
-			}
+			openAlert('Action button clicked');
 		},
 		onCheckboxChange: () => {
-			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({
-					message: 'Select all checkbox changed',
-				});
-			}
-			else {
-				alert('Select all checkbox changed');
-			}
+			openAlert('Select all checkbox changed');
 		},
 		onClearSelectionButtonClick: () => {
-			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({
-					message: 'Clear selection button clicked',
-				});
-			}
-			else {
-				alert('Clear selection button clicked');
-			}
+			openAlert('Clear selection button clicked');
 		},
 		onInfoButtonClick: () => {
-			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'Info button clicked'});
-			}
-			else {
-				alert('Info button clicked');
-			}
+			openAlert('Info button clicked');
 		},
 		onSelectAllButtonClick: () => {
-			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({
-					message: 'Select all button clicked',
-				});
-			}
-			else {
-				alert('Select all button click');
-			}
+			openAlert('Select all button clicked');
 		},
 		onShowMoreButtonClick: () => {
-			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({
-					message: 'Show more button clicked',
-				});
-			}
-			else {
-				alert('Show more button clicked');
-			}
+			openAlert('Show more button clicked');
 		},
 	};
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
@@ -18,7 +18,8 @@ export default function propsTransformer(props) {
 		onActionButtonClick: () => {
 			if (Liferay.__FF__.enableCustomDialogs) {
 				Liferay.Util.openAlertModal({message: 'Action button clicked'});
-			} else {
+			}
+			else {
 				alert('Action button clicked');
 			}
 		},
@@ -27,7 +28,8 @@ export default function propsTransformer(props) {
 				Liferay.Util.openAlertModal({
 					message: 'Select all checkbox changed',
 				});
-			} else {
+			}
+			else {
 				alert('Select all checkbox changed');
 			}
 		},
@@ -36,28 +38,36 @@ export default function propsTransformer(props) {
 				Liferay.Util.openAlertModal({
 					message: 'Clear selection button clicked',
 				});
-			} else {
+			}
+			else {
 				alert('Clear selection button clicked');
 			}
 		},
 		onInfoButtonClick: () => {
 			if (Liferay.__FF__.enableCustomDialogs) {
 				Liferay.Util.openAlertModal({message: 'Info button clicked'});
-			} else {
+			}
+			else {
 				alert('Info button clicked');
 			}
 		},
 		onSelectAllButtonClick: () => {
 			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'Select all button clicked'});
-			} else {
+				Liferay.Util.openAlertModal({
+					message: 'Select all button clicked',
+				});
+			}
+			else {
 				alert('Select all button click');
 			}
 		},
 		onShowMoreButtonClick: () => {
 			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'Show more button clicked'});
-			} else {
+				Liferay.Util.openAlertModal({
+					message: 'Show more button clicked',
+				});
+			}
+			else {
 				alert('Show more button clicked');
 			}
 		},

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleManagementToolbarPropsTransformer.js
@@ -16,22 +16,50 @@ export default function propsTransformer(props) {
 	return {
 		...props,
 		onActionButtonClick: () => {
-			alert('Action button clicked');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Action button clicked'});
+			} else {
+				alert('Action button clicked');
+			}
 		},
 		onCheckboxChange: () => {
-			alert('Select all checkbox changed');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({
+					message: 'Select all checkbox changed',
+				});
+			} else {
+				alert('Select all checkbox changed');
+			}
 		},
 		onClearSelectionButtonClick: () => {
-			alert('Clear selection button clicked');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({
+					message: 'Clear selection button clicked',
+				});
+			} else {
+				alert('Clear selection button clicked');
+			}
 		},
 		onInfoButtonClick: () => {
-			alert('Info button clicked');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Info button clicked'});
+			} else {
+				alert('Info button clicked');
+			}
 		},
 		onSelectAllButtonClick: () => {
-			alert('Select all button clicked');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Select all button clicked'});
+			} else {
+				alert('Select all button click');
+			}
 		},
 		onShowMoreButtonClick: () => {
-			alert('Show more button clicked');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Show more button clicked'});
+			} else {
+				alert('Show more button clicked');
+			}
 		},
 	};
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
@@ -12,12 +12,16 @@
  * details.
  */
 
+import {openAlertModal} from 'frontend-js-web';
+
 export default function propsTransformer(props) {
 	return {
 		...props,
 		onClick: () => {
+			const message = 'click!';
+
 			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'click!'});
+				openAlertModal({message});
 			}
 			else {
 				alert('click!');

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
@@ -18,7 +18,8 @@ export default function propsTransformer(props) {
 		onClick: () => {
 			if (Liferay.__FF__.enableCustomDialogs) {
 				Liferay.Util.openAlertModal({message: 'click!'});
-			} else {
+			}
+			else {
 				alert('click!');
 			}
 		},

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
@@ -20,7 +20,7 @@ export default function propsTransformer(props) {
 		onClick: () => {
 			const message = 'click!';
 
-			if (Liferay.__FF__.enableCustomDialogs) {
+			if (Liferay.__FF__.customDialogsEnabled) {
 				openAlertModal({message});
 			}
 			else {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleNavigationCardPropsTransformer.js
@@ -16,7 +16,11 @@ export default function propsTransformer(props) {
 	return {
 		...props,
 		onClick: () => {
-			alert('click!');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'click!'});
+			} else {
+				alert('click!');
+			}
 		},
 	};
 }

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
@@ -99,9 +99,7 @@ const DropArea = ({
 				const messageAlreadyExists = `File ${fileName} already exists!`;
 
 				if (Liferay.__FF__.customDialogsEnabled) {
-					Liferay.Util.openAlertModal(
-						messageAlreadyExists
-					);
+					Liferay.Util.openAlertModal(messageAlreadyExists);
 				}
 				else {
 					alert(messageAlreadyExists);

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
@@ -96,24 +96,28 @@ const DropArea = ({
 			);
 
 			if (currentFileExist) {
+				const messageAlreadyExists = `File ${fileName} already exists!`;
+
 				if (Liferay.__FF__.enableCustomDialogs) {
 					Liferay.Util.openAlertModal(
-						`File ${fileName} already exists!`
+						messageAlreadyExists
 					);
 				}
 				else {
-					alert(`File ${fileName} already exists!`);
+					alert(messageAlreadyExists);
 				}
 
 				continue;
 			}
 
 			if (!validateExtensions(fileType, type)) {
+				const messageInvalidFile = `Invalid file ${fileName}!`;
+
 				if (Liferay.__FF__.enableCustomDialogs) {
-					Liferay.Util.openAlertModal(`Invalid file ${fileName}!`);
+					Liferay.Util.openAlertModal(messageInvalidFile);
 				}
 				else {
-					alert(`Invalid file ${fileName}!`);
+					alert(messageInvalidFile);
 				}
 
 				continue;

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
@@ -98,7 +98,7 @@ const DropArea = ({
 			if (currentFileExist) {
 				const messageAlreadyExists = `File ${fileName} already exists!`;
 
-				if (Liferay.__FF__.enableCustomDialogs) {
+				if (Liferay.__FF__.customDialogsEnabled) {
 					Liferay.Util.openAlertModal(
 						messageAlreadyExists
 					);
@@ -113,7 +113,7 @@ const DropArea = ({
 			if (!validateExtensions(fileType, type)) {
 				const messageInvalidFile = `Invalid file ${fileName}!`;
 
-				if (Liferay.__FF__.enableCustomDialogs) {
+				if (Liferay.__FF__.customDialogsEnabled) {
 					Liferay.Util.openAlertModal(messageInvalidFile);
 				}
 				else {

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
@@ -97,8 +97,11 @@ const DropArea = ({
 
 			if (currentFileExist) {
 				if (Liferay.__FF__.enableCustomDialogs) {
-					Liferay.Util.openAlertModal(`File ${fileName} already exists!`);
-				} else {
+					Liferay.Util.openAlertModal(
+						`File ${fileName} already exists!`
+					);
+				}
+				else {
 					alert(`File ${fileName} already exists!`);
 				}
 
@@ -108,7 +111,8 @@ const DropArea = ({
 			if (!validateExtensions(fileType, type)) {
 				if (Liferay.__FF__.enableCustomDialogs) {
 					Liferay.Util.openAlertModal(`Invalid file ${fileName}!`);
-				} else {
+				}
+				else {
 					alert(`Invalid file ${fileName}!`);
 				}
 

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/extra/remote-app/src/routes/selected-quote/components/DropArea/index.js
@@ -96,13 +96,21 @@ const DropArea = ({
 			);
 
 			if (currentFileExist) {
-				alert(`File ${fileName} already exists!`);
+				if (Liferay.__FF__.enableCustomDialogs) {
+					Liferay.Util.openAlertModal(`File ${fileName} already exists!`);
+				} else {
+					alert(`File ${fileName} already exists!`);
+				}
 
 				continue;
 			}
 
 			if (!validateExtensions(fileType, type)) {
-				alert(`Invalid file ${fileName}!`);
+				if (Liferay.__FF__.enableCustomDialogs) {
+					Liferay.Util.openAlertModal(`Invalid file ${fileName}!`);
+				} else {
+					alert(`Invalid file ${fileName}!`);
+				}
 
 				continue;
 			}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
@@ -233,7 +233,8 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
-					var messageOrderCompleted = 'Order completed! you will be redirected to your dashboard';
+					var messageOrderCompleted =
+						'Order completed! you will be redirected to your dashboard';
 
 					if (Liferay.__FF__.customDialogsEnabled) {
 						Liferay.Util.openAlertModal({
@@ -241,9 +242,7 @@ function createOrder(
 						});
 					}
 					else {
-						alert(
-							messageOrderCompleted
-						);
+						alert(messageOrderCompleted);
 					}
 
 					window.location.href = url;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
@@ -233,9 +233,13 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
-					alert(
-						'Order completed! you will be redirected to your dashboard'
-					);
+					if (Liferay.__FF__.enableCustomDialogs) {
+						Liferay.Util.openAlertModal({
+							message: 'Order completed! you will be redirected to your dashboard'
+						});
+					} else {
+						alert('Order completed! you will be redirected to your dashboard');
+					}
 
 					window.location.href = url;
 				});

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
@@ -233,15 +233,16 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
+					var messageOrderCompleted = 'Order completed! you will be redirected to your dashboard';
+
 					if (Liferay.__FF__.enableCustomDialogs) {
 						Liferay.Util.openAlertModal({
-							message:
-								'Order completed! you will be redirected to your dashboard',
+							message: messageOrderCompleted,
 						});
 					}
 					else {
 						alert(
-							'Order completed! you will be redirected to your dashboard'
+							messageOrderCompleted
 						);
 					}
 

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
@@ -235,10 +235,14 @@ function createOrder(
 
 					if (Liferay.__FF__.enableCustomDialogs) {
 						Liferay.Util.openAlertModal({
-							message: 'Order completed! you will be redirected to your dashboard'
+							message:
+								'Order completed! you will be redirected to your dashboard',
 						});
-					} else {
-						alert('Order completed! you will be redirected to your dashboard');
+					}
+					else {
+						alert(
+							'Order completed! you will be redirected to your dashboard'
+						);
 					}
 
 					window.location.href = url;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/private/js.js
@@ -235,7 +235,7 @@ function createOrder(
 
 					var messageOrderCompleted = 'Order completed! you will be redirected to your dashboard';
 
-					if (Liferay.__FF__.enableCustomDialogs) {
+					if (Liferay.__FF__.customDialogsEnabled) {
 						Liferay.Util.openAlertModal({
 							message: messageOrderCompleted,
 						});

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
@@ -233,12 +233,12 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
-					var messageOrderCompleted = 'Order completed! you will be redirected to your dashboard';
+					var messageOrderCompleted =
+						'Order completed! you will be redirected to your dashboard';
 
 					if (Liferay.__FF__.customDialogsEnabled) {
 						Liferay.Util.openAlertModal({
-							message:
-								messageOrderCompleted,
+							message: messageOrderCompleted,
 						});
 					}
 					else {

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
@@ -233,13 +233,16 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
-
 					if (Liferay.__FF__.enableCustomDialogs) {
 						Liferay.Util.openAlertModal({
-							message: 'Order completed! you will be redirected to your dashboard'
+							message:
+								'Order completed! you will be redirected to your dashboard',
 						});
-					} else {
-						alert('Order completed! you will be redirected to your dashboard');
+					}
+					else {
+						alert(
+							'Order completed! you will be redirected to your dashboard'
+						);
 					}
 
 					window.location.href = url;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
@@ -233,16 +233,16 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
+					var messageOrderCompleted = 'Order completed! you will be redirected to your dashboard';
+
 					if (Liferay.__FF__.enableCustomDialogs) {
 						Liferay.Util.openAlertModal({
 							message:
-								'Order completed! you will be redirected to your dashboard',
+								messageOrderCompleted,
 						});
 					}
 					else {
-						alert(
-							'Order completed! you will be redirected to your dashboard'
-						);
+						alert(messageOrderCompleted);
 					}
 
 					window.location.href = url;

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
@@ -235,7 +235,7 @@ function createOrder(
 
 					var messageOrderCompleted = 'Order completed! you will be redirected to your dashboard';
 
-					if (Liferay.__FF__.enableCustomDialogs) {
+					if (Liferay.__FF__.customDialogsEnabled) {
 						Liferay.Util.openAlertModal({
 							message:
 								messageOrderCompleted,

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-liferay-online/src/main/resources/site-initializer/layout-set/public/js.js
@@ -233,9 +233,14 @@ function createOrder(
 						'&nextStep=' +
 						redirectURL;
 
-					alert(
-						'Order completed! you will be redirected to your dashboard'
-					);
+
+					if (Liferay.__FF__.enableCustomDialogs) {
+						Liferay.Util.openAlertModal({
+							message: 'Order completed! you will be redirected to your dashboard'
+						});
+					} else {
+						alert('Order completed! you will be redirected to your dashboard');
+					}
 
 					window.location.href = url;
 				});

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/fragment-collection.zip/fragment-collection/collection-name/fragments/button/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/fragment-collection.zip/fragment-collection/collection-name/fragments/button/index.js
@@ -1,6 +1,8 @@
 {
 	const form = document.querySelector('.fragment-button:not(.parsed)');
 
+	const MESSAGE_FORM_SUBMITTED = 'Form submitted';
+
 	form.classList.add('parsed');
 
 	form.addEventListener(
@@ -9,9 +11,9 @@
 			event.preventDefault();
 
 			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'Form submitted'});
+				Liferay.Util.openAlertModal({message: MESSAGE_FORM_SUBMITTED});
 			} else {
-				alert('Form submitted');
+				alert(MESSAGE_FORM_SUBMITTED);
 			}
 		});
 }

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/fragment-collection.zip/fragment-collection/collection-name/fragments/button/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/fragment-collection.zip/fragment-collection/collection-name/fragments/button/index.js
@@ -8,6 +8,10 @@
 		(event) => {
 			event.preventDefault();
 
-			alert('Form submitted');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Form submitted'});
+			} else {
+				alert('Form submitted');
+			}
 		});
 }

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/fragment-collection.zip/fragment-collection/collection-name/fragments/button/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/fragment-collection.zip/fragment-collection/collection-name/fragments/button/index.js
@@ -10,7 +10,7 @@
 		(event) => {
 			event.preventDefault();
 
-			if (Liferay.__FF__.enableCustomDialogs) {
+			if (Liferay.__FF__.customDialogsEnabled) {
 				Liferay.Util.openAlertModal({message: MESSAGE_FORM_SUBMITTED});
 			} else {
 				alert(MESSAGE_FORM_SUBMITTED);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/collections-HTMLCSSJSJSON-replace.zip/collection-name/fragments/fragment-name/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/collections-HTMLCSSJSJSON-replace.zip/collection-name/fragments/fragment-name/index.js
@@ -10,7 +10,7 @@
 		(event) => {
 			event.preventDefault();
 
-			if (Liferay.__FF__.enableCustomDialogs) {
+			if (Liferay.__FF__.customDialogsEnabled) {
 				Liferay.Util.openAlertModal({message: MESSAGE});
 			} else {
 				alert(MESSAGE);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/collections-HTMLCSSJSJSON-replace.zip/collection-name/fragments/fragment-name/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/collections-HTMLCSSJSJSON-replace.zip/collection-name/fragments/fragment-name/index.js
@@ -1,6 +1,8 @@
 {
 	const form = document.querySelector('.fragment-configuration:not(.parsed)');
 
+	const MESSAGE = 'Here we go';
+
 	form.classList.add('parsed');
 
 	form.addEventListener(
@@ -9,9 +11,9 @@
 			event.preventDefault();
 
 			if (Liferay.__FF__.enableCustomDialogs) {
-				Liferay.Util.openAlertModal({message: 'Here we go'});
+				Liferay.Util.openAlertModal({message: MESSAGE});
 			} else {
-				alert('Here we go');
+				alert(MESSAGE);
 			}
 		});
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/collections-HTMLCSSJSJSON-replace.zip/collection-name/fragments/fragment-name/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/collections-HTMLCSSJSJSON-replace.zip/collection-name/fragments/fragment-name/index.js
@@ -8,6 +8,10 @@
 		(event) => {
 			event.preventDefault();
 
-			alert('Here we go');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Here we go'});
+			} else {
+				alert('Here we go');
+			}
 		});
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js
@@ -8,7 +8,7 @@
 		(event) => {
 			event.preventDefault();
 
-			if (Liferay.__FF__.enableCustomDialogs) {
+			if (Liferay.__FF__.customDialogsEnabled) {
 				Liferay.Util.openAlertModal({message: 'Form submitted'});
 			} else {
 				alert('Form submitted');

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/dependencies/fragment_button.js
@@ -8,6 +8,10 @@
 		(event) => {
 			event.preventDefault();
 
-			alert('Form submitted');
+			if (Liferay.__FF__.enableCustomDialogs) {
+				Liferay.Util.openAlertModal({message: 'Form submitted'});
+			} else {
+				alert('Form submitted');
+			}
 		});
 }


### PR DESCRIPTION
> Depends on: https://github.com/liferay-frontend/liferay-portal/pull/1990, https://github.com/liferay-frontend/liferay-portal/pull/2072

#### What's this PR do?

Replace existing window.alert usages on JavaScript files with the new `Util.openAlertModal`

**These changes are under `Liferay.__FF__.enableCustomDialogs` feature flag and it should be enabled by product teams gradually and they should prioritize it** /cc @dsanz @markocikos   

#### How should this be manually tested?

##### For -sample modules:

0. Fetch my changes
1. Enable the feature flag by setting `feature.flag.enableCustomDialogs=true` on portal-ext.properties file
2. Deploy frontend-taglib-clay-sample module
3. Drop clay sample module using page editor
4. Go to Management Toolbar tab
5. On Display Context section, click on Info button or check the checkbox of the management toolbar


#### Screenshots (if appropriate)

![Peek 2022-03-15 18-12](https://user-images.githubusercontent.com/7663513/158473570-19c71134-b29a-4c68-9aff-7ef69d82725a.gif)

#### What gif best describes this PR or how it makes you feel?

![run](https://media.giphy.com/media/vvA65Wcq6xkfIcxAkr/giphy.gif)

#### Tasks:

- [x] Migrate on -sample modules
- [x] Migrate site-initalizer-raylife usages
- [x] Migrate osb-site-initializer-liferay-online usages
- [x] Migrate test related things 