### PR TITLE
LPS-148142 | Validates Manage Translations cancel add language by different ways

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/ManageTranslations.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/ManageTranslations.macro
@@ -1,5 +1,13 @@
 definition {
 
+	macro addLanguage {
+		Click(locator1 = "Modal#PLUS");
+
+		Click(
+			key_locale = "${key_locale}",
+			locator1 = "Translation#DROPDOWN_MENU_ITEM");
+	}
+
 	macro deleteLanguage {
 		Click(locator1 = "ManageTranslations#LIST_ITEM_DELETE_LANGUAGE_BUTTON");
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/TranslationManager.path
@@ -40,6 +40,11 @@
 	<td>//div[contains(@class,'col') and h3='${key_title}']//div[contains(@class,'form-group')]//div[contains(@class,'form-text')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>AUI_TAG</td>
+	<td>//div[contains(@class,'col') and h2='AUI Tag']</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -92,6 +92,64 @@ definition {
 		}
 	}
 
+	@description = "LPS-148142. Validates Manage Translations cancel add language by click cancel button."
+	@priority = "3"
+	test CancelAddLanguageByClickCancelButton {
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToManageTranslationsModal(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("When add language in Manage Translations table list") {
+			ManageTranslations.addLanguage(key_locale = "zh-CN");
+		}
+
+		task ("Then cancel add a language with cancel button") {
+			Click(locator1 = "Button#CANCEL");
+		}
+
+		task ("Then view language not active in selector menu") {
+			TranslationManagerPortlet.clickSelectTranslation(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+
+			AssertElementNotPresent(
+				key_locale = "zh-CN",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+		}
+	}
+
+	@description = "LPS-148142. Validates Manage Translations cancel add language by click somewhere outside the modal."
+	@priority = "3"
+	test CancelAddLanguageByClickSomewhereOutsideModal {
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToManageTranslationsModal(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("When add language in Manage Translations table list") {
+			ManageTranslations.addLanguage(key_locale = "zh-CN");
+		}
+
+		task ("Then cancel add a language with click somewhere outside the modal") {
+			Click.mouseDownMouseUp(locator1 = "TranslationManager#AUI_TAG");
+
+			AssertElementNotPresent(locator1 = "Modal#MODAL");
+		}
+
+		task ("Then view language not active in selector menu") {
+			TranslationManagerPortlet.clickSelectTranslation(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+
+			AssertElementNotPresent(
+				key_locale = "zh-CN",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+		}
+	}
+
 	@description = "LPS-147946. Validates language can be deleted from the Manage Translation list."
 	@priority = "3"
 	test CanDeleteLanguageFromManageTranslationsList {


### PR DESCRIPTION
**Background**
Create automation tests for Manage Translations

**Test Plan**
Create a page with the widget JS Components Sample
Given Manage Translations modal is open
Add a language from the dropdown list
Click the Cancel button or Click somewhere outside the modal
Assert Manage Translations modal is closed
Click the language selector
Assert the language is not active

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-148142