### PR TITLE
LPS-149398 Support adding icons in dropdown menu tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/normalize_dropdown_items.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/normalize_dropdown_items.js
@@ -57,19 +57,20 @@ function filterEmptyGroups(items) {
 		);
 }
 
-function spreadDataAttributes(item) {
+function updateItemProps(item) {
 	const {data, ...rest} = item;
 
 	const dataAttributes = getDataAttributes(data);
 
 	const items = Array.isArray(item.items)
-		? item.items.map(spreadDataAttributes)
+		? item.items.map(updateItemProps)
 		: item.items;
 
 	return {
 		...dataAttributes,
 		...rest,
 		items,
+		symbolLeft: item.icon,
 	};
 }
 
@@ -84,5 +85,5 @@ export default function normalizeDropdownItems(items) {
 		return null;
 	}
 
-	return addSeparators(filteredItems.map(spreadDataAttributes));
+	return addSeparators(filteredItems.map(updateItemProps));
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -78,7 +78,7 @@
 <!--FEATURE FLAG CONFIGURATIONS-->
 <tr>
 	<td>ACTIVE_DROPDOWN_ITEM</td>
-	<td>//div[contains(@class,'dropdown-menu show')]//li//*[contains(@class,'dropdown-item') and contains(.,'${key_item}')]</td>
+	<td>//div[contains(@class,'show')]//li//*[contains(@class,'dropdown-item') and contains(.,'${key_item}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Hello, this is a PR related to the story https://issues.liferay.com/browse/LPS-14529, which calls for adding icons to dropdowns (for example: in documents and media). 

For this request, I have created another subtask (LPS-149398) which supports adding icons to the dropdown menu tag.
In the beginning, if you set an icon in the dropdown menu object, it was not rendering the react component. So I have added the property **"symbolLeft"** to the function _normalize_dropdown_items.spreadDataAttributes_. And then, I have changed the name of the function to **"updateItemProps"**. I only have added the property **"symbolLeft"** because for this case we only need the icon to be on the left side. If in the future we need to add a **"symbolRight"**, we can change the function, but we do not need it yet.

Tell me if I have to change something else. 

Thanks!.