### PR TITLE
LPS-149427 Updates components that use ClayTreeView to use the new default properties

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -50,8 +50,8 @@ const AssetCategoriesNavigationTreeView = ({
 
 	return (
 		<ClayTreeView
-			items={vocabularies}
-			selectedKeys={
+			defaultItems={vocabularies}
+			defaultSelectedKeys={
 				new Set(selectedCategoryId ? [selectedCategoryId] : [])
 			}
 		>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolder.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolder.es.js
@@ -19,8 +19,6 @@ import ClayLayout from '@clayui/layout';
 import {Treeview} from 'frontend-js-components-web';
 import React, {useMemo, useState} from 'react';
 
-const noop = () => {};
-
 const SelectFolder = ({itemSelectorSaveEvent, nodes}) => {
 	const [filterQuery, setFilterQuery] = useState('');
 
@@ -75,6 +73,8 @@ const SelectFolder = ({itemSelectorSaveEvent, nodes}) => {
 };
 
 function FolderTree({filterQuery, handleSelectionChange, items: initialItems}) {
+	const [items, setItems] = useState(initialItems);
+
 	const nodeByName = (items, name) => {
 		return items.reduce(function reducer(acc, item) {
 			if (item.name.match(new RegExp(name, 'i'))) {
@@ -91,16 +91,16 @@ function FolderTree({filterQuery, handleSelectionChange, items: initialItems}) {
 
 	const filteredItems = useMemo(() => {
 		if (!filterQuery) {
-			return initialItems;
+			return items;
 		}
 
-		return nodeByName(initialItems, filterQuery);
-	}, [initialItems, filterQuery]);
+		return nodeByName(items, filterQuery);
+	}, [items, filterQuery]);
 
 	return (
 		<ClayTreeView
 			items={filteredItems}
-			onItemsChange={noop}
+			onItemsChange={setItems}
 			showExpanderOnHover={false}
 		>
 			{(item) => (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/AllowedFragmentSelectorTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/AllowedFragmentSelectorTree.js
@@ -97,8 +97,6 @@ const nodeByName = (items, name) => {
 	}, []);
 };
 
-function noop() {}
-
 const AllowedFragmentSelectorTree = ({dropZoneConfig, onSelectedFragment}) => {
 	const fragments = useSelector((state) => state.fragments);
 
@@ -185,14 +183,14 @@ const AllowedFragmentSelectorTree = ({dropZoneConfig, onSelectedFragment}) => {
 
 				<div className="mb-2 page-editor__allowed-fragment__tree pl-2">
 					<ClayTreeView
-						expandedKeys={expandedKeys}
+						defaultExpandedKeys={expandedKeys}
 						expanderIcons={{
 							close: <ClayIcon symbol="hr" />,
 							open: <ClayIcon symbol="plus" />,
 						}}
 						items={items}
 						nestedKey="children"
-						onItemsChange={noop}
+						onItemsChange={setItems}
 						onSelectionChange={setSelectedKeys}
 						selectedKeys={selectedKeys}
 						selectionMode="multiple-recursive"

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuItemsTree.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuItemsTree.es.js
@@ -26,13 +26,13 @@ export default function NavigationMenuItemsTree({
 	return (
 		<div className="navigation-menu-items-tree">
 			<ClayTreeView
+				defaultExpandedKeys={selectedKeys}
+				defaultItems={siteNavigationMenuItems}
 				displayType="dark"
-				expandedKeys={selectedKeys}
 				expanderIcons={{
 					close: <ClayIcon symbol="hr" />,
 					open: <ClayIcon symbol="plus" />,
 				}}
-				items={siteNavigationMenuItems}
 				nestedKey="children"
 				showExpanderOnHover={false}
 			>


### PR DESCRIPTION
This change is due to the introduction of new `default` properties that was implemented in PR https://github.com/liferay/clay/pull/4727 according to feedback so it doesn't get confused when the property is operating as default and when it is operating as controlled.

I only needed to update in some use cases where the state of `items` was not being controlled, the other cases implement the controlled component.

To test these cases you need to add the feature flag:

- Create a new file named `com.liferay.frontend.js.components.web.internal.configuration.FFFrontendJSComponentsConfiguration.config` and with the content `enableClayTreeView="true"`
- Add to folder `osgi/configs`