### PR TITLE
LPS-149496 Move Headless tests owned by FI team to Frontend Infra

### DIFF
--- a/modules/apps/headless/headless-admin-content/test.properties
+++ b/modules/apps/headless/headless-admin-content/test.properties
@@ -1,0 +1,19 @@
+##
+## Test Batch
+##
+
+#
+# Relevant
+#
+
+test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.main.component.name ~ "Headless FI") \
+        )
+
+##
+## Testray
+##
+
+testray.main.component.name=Headless FI

--- a/modules/apps/headless/headless-admin-content/test.properties
+++ b/modules/apps/headless/headless-admin-content/test.properties
@@ -7,7 +7,7 @@
 #
 
 test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (portal.acceptance == true) AND \
+    (portal.acceptance == true) AND \
         (\
             (testray.main.component.name ~ "Headless FI") \
         )

--- a/modules/apps/headless/headless-admin-taxonomy/test.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/test.properties
@@ -1,0 +1,19 @@
+##
+## Test Batch
+##
+
+#
+# Relevant
+#
+
+test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.main.component.name ~ "Headless FI") \
+        )
+
+##
+## Testray
+##
+
+testray.main.component.name=Headless FI

--- a/modules/apps/headless/headless-admin-taxonomy/test.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/test.properties
@@ -7,7 +7,7 @@
 #
 
 test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (portal.acceptance == true) AND \
+    (portal.acceptance == true) AND \
         (\
             (testray.main.component.name ~ "Headless FI") \
         )

--- a/modules/apps/headless/headless-delivery/test.properties
+++ b/modules/apps/headless/headless-delivery/test.properties
@@ -1,0 +1,19 @@
+##
+## Test Batch
+##
+
+#
+# Relevant
+#
+
+test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.main.component.name ~ "Headless FI") \
+        )
+
+##
+## Testray
+##
+
+testray.main.component.name=Headless FI

--- a/modules/apps/headless/headless-delivery/test.properties
+++ b/modules/apps/headless/headless-delivery/test.properties
@@ -7,7 +7,7 @@
 #
 
 test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (portal.acceptance == true) AND \
+    (portal.acceptance == true) AND \
         (\
             (testray.main.component.name ~ "Headless FI") \
         )

--- a/modules/apps/headless/headless-discovery/test.properties
+++ b/modules/apps/headless/headless-discovery/test.properties
@@ -1,0 +1,19 @@
+##
+## Test Batch
+##
+
+#
+# Relevant
+#
+
+test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.main.component.name ~ "Headless FI") \
+        )
+
+##
+## Testray
+##
+
+testray.main.component.name=Headless FI

--- a/modules/apps/headless/headless-discovery/test.properties
+++ b/modules/apps/headless/headless-discovery/test.properties
@@ -7,7 +7,7 @@
 #
 
 test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
-        (portal.acceptance == true) AND \
+    (portal.acceptance == true) AND \
         (\
             (testray.main.component.name ~ "Headless FI") \
         )

--- a/modules/apps/portal-vulcan/test.properties
+++ b/modules/apps/portal-vulcan/test.properties
@@ -10,11 +10,10 @@
 ##
 
     modules.includes.required.test.batch.class.names.includes[relevant]=\
-        **/apps/portal-workflow/**/*Test.java,\
         apps/portal-vulcan/**/*Test.java
 
 ##
 ## Testray
 ##
 
-    testray.main.component.name=Headless
+    testray.main.component.name=Headless FI

--- a/test.properties
+++ b/test.properties
@@ -3703,7 +3703,7 @@
         **/frontend-token/**/*Test.java,\
         **/headless/headless-admin-content/**/*Test.java,\
         **/headless/headless-admin-taxonomy/**/*Test.java,\
-        **/headless/headless-delivery-resource/**/*Test.java,\
+        **/headless/headless-delivery/**/*Test.java,\
         **/portal-portlet-bridge/**/*Test.java,\
         **/portal-template-react-renderer-api/**/*Test.java,\
         **/portal-template-react-renderer-impl/**/*Test.java,\

--- a/test.properties
+++ b/test.properties
@@ -3701,6 +3701,9 @@
         **/frontend-taglib/**/*Test.java,\
         **/frontend-theme/**/*Test.java,\
         **/frontend-token/**/*Test.java,\
+        **/headless/headless-admin-content/**/*Test.java,\
+        **/headless/headless-admin-taxonomy/**/*Test.java,\
+        **/headless/headless-delivery-resource/**/*Test.java,\
         **/portal-portlet-bridge/**/*Test.java,\
         **/portal-template-react-renderer-api/**/*Test.java,\
         **/portal-template-react-renderer-impl/**/*Test.java,\
@@ -3863,7 +3866,10 @@
         **/commerce/**/*Test.java
 
     test.batch.class.names.includes[headless]=\
-        **/headless/**/*Test.java,\
+        **/headless/headless-admin-list-type-resource/**/*Test.java,\
+        **/headless/headless-admin-user-resource/**/*Test.java,\
+        **/headless/headless-admin-workflow/**/*Test.java,\
+        **/headless/headless-form-resource/**/*Test.java,\
         **/portal-tools-rest-builder/**/*Test.java,\
         **/portal-vulcan/**/*Test.java
 
@@ -3888,7 +3894,10 @@
         **/commerce/**/*Test.java
 
     test.batch.class.names.includes[headless-acceptance]=\
-        **/headless/**/*Test.java,\
+        **/headless/headless-admin-list-type-resource/**/*Test.java,\
+        **/headless/headless-admin-user-resource/**/*Test.java,\
+        **/headless/headless-admin-workflow/**/*Test.java,\
+        **/headless/headless-form-resource/**/*Test.java,\
         **/portal-tools-rest-builder/**/*Test.java,\
 
     test.batch.dist.app.servers[headless-acceptance]=tomcat

--- a/test.properties
+++ b/test.properties
@@ -7252,8 +7252,8 @@
         ) AND \
         (\
             (testray.main.component.name == "Kaleo Designer") OR \
-            (testray.main.component.name == "Workflow") OR \
-            (testray.main.component.name == "Workflow Metrics")\
+            (testray.main.component.name == "Workflow Metrics") OR \
+            (testray.main.component.name == "Workflow")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][workflow-es7-remote]=\
@@ -7816,6 +7816,7 @@
         Cadmin,\
         Clay,\
         Frontend Dataset,\
+        Headless FI,\
         Management Toolbar,\
         Maps,\
         Remote Apps,\

--- a/test.properties
+++ b/test.properties
@@ -3711,7 +3711,9 @@
         **/portal-template-soy-impl/**/*Test.java,\
         **/portal-template-soy-renderer-api/**/*Test.java,\
         **/portal-template-soy-renderer-impl/**/*Test.java,\
+        **/portal-tools-rest-builder/**/*Test.java,\
         **/portal-url-builder/**/*Test.java,\
+        **/portal-vulcan/**/*Test.java,\
         **/remote-app/**/*Test.java,\
         /portal-web/docroot/html/**/*Test.java,\
         /util-taglib/**/*Test.java
@@ -3869,9 +3871,7 @@
         **/headless/headless-admin-list-type-resource/**/*Test.java,\
         **/headless/headless-admin-user-resource/**/*Test.java,\
         **/headless/headless-admin-workflow/**/*Test.java,\
-        **/headless/headless-form-resource/**/*Test.java,\
-        **/portal-tools-rest-builder/**/*Test.java,\
-        **/portal-vulcan/**/*Test.java
+        **/headless/headless-form-resource/**/*Test.java
 
     test.batch.dist.app.servers[headless]=tomcat
 
@@ -5916,10 +5916,11 @@
         functional-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][site-initializer-testray]=\
-        (portal.acceptance != quarantine AND portal.upstream != quarantine) AND \
         (\
-            (testray.main.component.name == "Testray 2")\
-        )
+            (portal.acceptance != quarantine) AND \
+            (portal.upstream != quarantine)\
+        ) AND \
+        (testray.main.component.name == "Testray 2")
 
     #
     # Redirect
@@ -7252,8 +7253,8 @@
         ) AND \
         (\
             (testray.main.component.name == "Kaleo Designer") OR \
-            (testray.main.component.name == "Workflow Metrics") OR \
-            (testray.main.component.name == "Workflow")\
+            (testray.main.component.name == "Workflow") OR \
+            (testray.main.component.name == "Workflow Metrics")\
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][workflow-es7-remote]=\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-149496
The purpose of these changes is to move all the Headless module integration tests into the Frontend Infra team tab in order to analyse release runs faster and report it in more organised way.

Headless Squad of Frontend Infra owns tests from the following modules:

- headless-admin-content
- headless-admin-taxonomy
- headless-delivery
- headless-discovery
- portal-vulcan

The goal is to move the tests in Testray into "Headless FI" component which would belong to Fronted Infra team. The rest of the tests from Headless Team/Headless component would be still available for other teams in order to analyse it from there or move it as well (according to what each team decides works for them best)


