### PR TITLE
LPS-148599 Screen readers read content below modal windows

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -25,6 +25,7 @@ const noop = () => {};
 
 function AssetTagsSelector({
 	addCallback,
+	autoFocus,
 	groupIds = [],
 	id,
 	inputName,
@@ -181,6 +182,7 @@ function AssetTagsSelector({
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
 						<ClayMultiSelect
+							autoFocus={autoFocus}
 							inputName={inputName}
 							inputValue={inputValue}
 							items={selectedItems}
@@ -221,6 +223,7 @@ function AssetTagsSelector({
 
 AssetTagsSelector.propTypes = {
 	addCallback: PropTypes.string,
+	autoFocus: PropTypes.bool,
 	groupIds: PropTypes.array,
 	id: PropTypes.string,
 	inputName: PropTypes.string,

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/tags/EditTagsModal.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/categorization/tags/EditTagsModal.es.js
@@ -250,6 +250,7 @@ const EditTagsModal = ({
 					)}
 
 					<AssetTagsSelector
+						autoFocus
 						groupIds={groupIds}
 						inputName={`${namespace}_hiddenInput`}
 						inputValue={inputValue}


### PR DESCRIPTION
### References

- [LPS-148599 Screen readers read content below modal windows](https://issues.liferay.com/browse/LPS-148599)
- [PTR-2921 Modals incorrect behaviour. AUI & Clay](https://issues.liferay.com/browse/PTR-2921)
- Slack discussion: https://liferay.slack.com/archives/C03CAD9EF/p1646392635353689

### What is the goal of this PR?

In this PR, we are adding support for autofocus in `AssetTagsSelector` input, and enabling it in edit tag modal.

On 7.2 the solution would be different, because we are using the old `ItemSelectorDialog`. But, if we agree on the principle for solution in this PR, this is not a problem to update. If PR is green to go, we can forward this to Lima team, as the change is in their domain.

There was some discussion that we should make this a general solution, for all modals. I don't think that is the best way to go, simply because we don't know what part of the modal should be focused. Something like the first input comes to my mind, but what is first can easily be changed by CSS. I think this should be handled on case-to-case usage bases, like in this PR, and in [the sign-in modal](https://github.com/liferay/liferay-portal/blob/master/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp#L172), mentioned in the ticket. Clay should support setting this prop, and it already does in the case of `ClayMultiSelect`.

One thing to note in this PR: we don't want to hardcode autofocus in `AssetTagsSelector`, because it can be both in and out of modal. We are adding support for it, but only enabling it in modal.

/cc @matuzalemsteles @marcoscv-work @crodriguezy @dsanz

### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/158815478-39aaa242-2d72-4aba-b948-9f6c9501ade5.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/158815470-c7bd3379-2158-4014-9bb2-a5a8e5f93220.gif)

### Steps to reproduce

See steps to reproduce in [LPS-148599 Screen readers read content below modal windows](https://issues.liferay.com/browse/LPS-148599)
