### PR TITLE
LPS-147280 LPS-147278 Create an approved Layout instead of draft in integration tests

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsEntry;
@@ -228,7 +229,8 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 			Group group, boolean importPageDefinition, String title)
 		throws Exception {
 
-		Layout layout = LayoutTestUtil.addTypeContentLayout(group, title);
+		Layout layout = LayoutTestUtil.addTypeContentPublishedLayout(
+			group, WorkflowConstants.STATUS_APPROVED, title);
 
 		if (importPageDefinition) {
 			String name = PrincipalThreadLocal.getName();

--- a/modules/apps/layout/layout-test-util/bnd.bnd
+++ b/modules/apps/layout/layout-test-util/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Layout Test Utilities
 Bundle-SymbolicName: com.liferay.layout.test.util
-Bundle-Version: 8.0.1
+Bundle-Version: 8.1.0
 Export-Package: com.liferay.layout.test.util

--- a/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java
+++ b/modules/apps/layout/layout-test-util/src/main/java/com/liferay/layout/test/util/LayoutTestUtil.java
@@ -182,6 +182,35 @@ public class LayoutTestUtil {
 			StringPool.BLANK, serviceContext);
 	}
 
+	public static Layout addTypeContentPublishedLayout(
+			Group group, int status, String title)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getGroupId(), TestPropsValues.getUserId());
+
+		Layout layout = LayoutLocalServiceUtil.addLayout(
+			TestPropsValues.getUserId(), group.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, title, StringPool.BLANK,
+			StringPool.BLANK, LayoutConstants.TYPE_CONTENT, false,
+			StringPool.BLANK, serviceContext);
+
+		serviceContext.setAttribute("published", Boolean.TRUE);
+
+		Layout draftLayout = LayoutLocalServiceUtil.fetchDraftLayout(
+			layout.getPlid());
+
+		if (draftLayout != null) {
+			LayoutLocalServiceUtil.updateStatus(
+				draftLayout.getUserId(), draftLayout.getPlid(), status,
+				serviceContext);
+		}
+
+		return LayoutLocalServiceUtil.updateStatus(
+			layout.getUserId(), layout.getPlid(), status, serviceContext);
+	}
+
 	public static Layout addTypeLinkToLayoutLayout(
 			long groupId, long linkedToLayoutId)
 		throws Exception {

--- a/modules/apps/layout/layout-test-util/src/main/resources/com/liferay/layout/test/util/packageinfo
+++ b/modules/apps/layout/layout-test-util/src/main/resources/com/liferay/layout/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0


### PR DESCRIPTION
Related tickets:

[LPS-147278](https://issues.liferay.com/browse/LPS-147278)
[LPS-147280](https://issues.liferay.com/browse/LPS-147280)
This PR contains a change on the way of generating Layouts for Headless Delivery API tests to mark them as published.

It can be tested by launching the Integration Test

`SitePageResourceTest.testGetSiteSitePagesPageWithFilterDateTimeEquals`

**Before the PR:**

The searchUtil did not find any Layout as its status was 2 (STATUS_DRAFT) in the Elasticsearch entry.

**After the PR:**

The created Layout is marked as published so the status is updated to 0 (STATUS_APPROVED). Then, the API is working as expected.
