### PR TITLE
LPS-147849 Assert Filter and Order buttons render individual dropdown menus

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -77,6 +77,16 @@
 </tr>
 <!--FEATURE FLAG CONFIGURATIONS-->
 <tr>
+	<td>ACTIVE_DROPDOWN_ITEM</td>
+	<td>//div[contains(@class,'dropdown-menu show')]//li//*[contains(@class,'dropdown-item') and contains(.,'${key_item}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_OR_ORDER</td>
+	<td>//nav[contains(@class,'management-bar')]//*[*[contains(@title,'${key_filter}')]]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>ICON_AND_TEXT_ACTION_BUTTON</td>
 	<td>//nav[contains(@class,'management-bar')]//*[*[name()='svg'][contains(@class,'icon-${key_icon}')]]//following-sibling::span[text()='${key_action}']</td>
 	<td></td>
@@ -94,11 +104,6 @@
 <tr>
 	<td>NEW_BUTTON_MOBILE</td>
 	<td>//nav[contains(@class,'management-bar')]//button[contains(@aria-label, 'New')]//*[contains(@class,'icon-plus')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>QUICK_ACTION_DROPDOWN_ITEM</td>
-	<td>//div[contains(@class,'dropdown-menu show')]//li//*[contains(@class,'dropdown-item') and contains(., '${key_action}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -15,7 +15,7 @@ definition {
 
 		User.firstLoginPG();
 
-		task ("Add Clay Sample Portlet") {
+		task ("Given a Clay Sample Portlet") {
 			JSONLayout.addPublicLayout(
 				groupName = "Guest",
 				layoutName = "Clay Sample Test Page");
@@ -32,6 +32,11 @@ definition {
 
 			Navigator.gotoPage(pageName = "Clay Sample Test Page");
 		}
+
+		task ("When navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
+		}
+
 	}
 
 	tearDown {
@@ -49,16 +54,12 @@ definition {
 
 	@description = "LPS-147849. Assert the filter and order buttons are independent dropdowns"
 	@priority = "5"
-	test FilterAndOrderButtonsRenderIndependent {
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
-		task ("Assert 'filter' and 'order' button is not rendered together") {
+	test RendersIndependentFilterAndOrderButtons {
+		task ("Then 'filter' and 'order' button is not rendered together") {
 			AssertElementNotPresent(locator1 = "ManagementBar#FILTER_AND_ORDER");
 		}
 
-		task ("Assert 'filter' button is an independent dropdown") {
+		task ("Then 'filter' button is an independent dropdown") {
 			AssertClick(
 				key_filter = "Show Filter Options",
 				locator1 = "ManagementBar#FILTER_OR_ORDER",
@@ -69,7 +70,7 @@ definition {
 				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 		}
 
-		task ("Assert 'order' button is an independent dropdown") {
+		task ("Then 'order' button is an independent dropdown") {
 			AssertClick(
 				key_filter = "Show Order Options",
 				locator1 = "ManagementBar#FILTER_OR_ORDER",
@@ -88,10 +89,6 @@ definition {
 	@description = "LPS-147404. Assert the more actions button is displayed"
 	@priority = "5"
 	test MoreActionsButtonCanRender {
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
 		task ("Assert the 'more actions' button is displayed") {
 			AssertElementPresent(locator1 = "ManagementBar#MORE_ACTIONS_ELLIPSIS");
 		}
@@ -112,10 +109,6 @@ definition {
 	@description = "LPS-147832. Assert the more actions button can display quick actions"
 	@priority = "5"
 	test MoreActionsButtonRenderQuickActions {
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
 		task ("Click on 'more actions' button") {
 			Click(locator1 = "ManagementBar#MORE_ACTIONS_ELLIPSIS");
 		}
@@ -138,10 +131,6 @@ definition {
 	@description = "LPS-147864. Assert the New button is displayed as a text button"
 	@priority = "5"
 	test NewButtonRender {
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
 		task ("Assert the new button is displayed as a text button") {
 			AssertTextEquals(
 				locator1 = "ManagementBar#NEW_BUTTON",
@@ -154,10 +143,6 @@ definition {
 	test ResponsiveModeNewButtonAsIconButton {
 		task ("Set window size to phone size") {
 			SetWindowSize(value1 = "360,720");
-		}
-
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
 		}
 
 		task ("Assert the new button is displayed as an icon button") {
@@ -180,10 +165,6 @@ definition {
 			SetWindowSize(value1 = "360,720");
 		}
 
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
 		task ("Hover over the new button") {
 			ScrollWebElementIntoView(locator1 = "ManagementBar#NEW_BUTTON_MOBILE");
 
@@ -202,10 +183,6 @@ definition {
 	@description = "LPS-147844. Assert the tooltip message is displayed when hovered over the view button"
 	@priority = "3"
 	test ViewButtonCanDisplayTooltip {
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
 		task ("Hover over the view button") {
 			MouseOver(
 				key_text = "caret-double",
@@ -222,10 +199,6 @@ definition {
 	@description = "LPS-147839. Assert the view button displays a double caret icon"
 	@priority = "5"
 	test ViewButtonCanRenderDoubleCaret {
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
 		task ("Assert the view button also has a double caret icon") {
 			AssertElementPresent(
 				key_text = "cards",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -47,6 +47,44 @@ definition {
 		}
 	}
 
+	@description = "LPS-147849. Assert the filter and order buttons are independent dropdowns"
+	@priority = "5"
+	test FilterAndOrderButtonsRenderIndependent {
+		task ("Navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
+		}
+
+		task ("Assert 'filter' and 'order' button is not rendered together") {
+			AssertElementNotPresent(locator1 = "ManagementBar#FILTER_AND_ORDER");
+		}
+
+		task ("Assert 'filter' button is an independent dropdown") {
+			AssertClick(
+				key_filter = "Show Filter Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER",
+				value1 = "Filter");
+
+			AssertElementPresent(
+				key_item = "Filter",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+		}
+
+		task ("Assert 'order' button is an independent dropdown") {
+			AssertClick(
+				key_filter = "Show Order Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER",
+				value1 = "Order");
+
+			AssertElementPresent(
+				key_item = "Order",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+
+			AssertElementPresent(
+				key_item = "Ascending",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+		}
+	}
+
 	@description = "LPS-147404. Assert the more actions button is displayed"
 	@priority = "5"
 	test MoreActionsButtonCanRender {
@@ -84,16 +122,16 @@ definition {
 
 		task ("Assert quick actions are displayed") {
 			AssertElementPresent(
-				key_action = "Edit",
-				locator1 = "ManagementBar#QUICK_ACTION_DROPDOWN_ITEM");
+				key_item = "Edit",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 
 			AssertElementPresent(
-				key_action = "Download",
-				locator1 = "ManagementBar#QUICK_ACTION_DROPDOWN_ITEM");
+				key_item = "Download",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 
 			AssertElementPresent(
-				key_action = "Delete",
-				locator1 = "ManagementBar#QUICK_ACTION_DROPDOWN_ITEM");
+				key_item = "Delete",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -36,7 +36,6 @@ definition {
 		task ("When navigate to Management Toolbars tab") {
 			Navigator.gotoNavTab(navTab = "Management Toolbars");
 		}
-
 	}
 
 	tearDown {
@@ -49,40 +48,6 @@ definition {
 			JSONLayout.deletePublicLayout(
 				groupName = "Guest",
 				layoutName = "Clay Sample Test Page");
-		}
-	}
-
-	@description = "LPS-147849. Assert the filter and order buttons are independent dropdowns"
-	@priority = "5"
-	test RendersIndependentFilterAndOrderButtons {
-		task ("Then 'filter' and 'order' button is not rendered together") {
-			AssertElementNotPresent(locator1 = "ManagementBar#FILTER_AND_ORDER");
-		}
-
-		task ("Then 'filter' button is an independent dropdown") {
-			AssertClick(
-				key_filter = "Show Filter Options",
-				locator1 = "ManagementBar#FILTER_OR_ORDER",
-				value1 = "Filter");
-
-			AssertElementPresent(
-				key_item = "Filter",
-				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
-		}
-
-		task ("Then 'order' button is an independent dropdown") {
-			AssertClick(
-				key_filter = "Show Order Options",
-				locator1 = "ManagementBar#FILTER_OR_ORDER",
-				value1 = "Order");
-
-			AssertElementPresent(
-				key_item = "Order",
-				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
-
-			AssertElementPresent(
-				key_item = "Ascending",
-				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 		}
 	}
 
@@ -135,6 +100,40 @@ definition {
 			AssertTextEquals(
 				locator1 = "ManagementBar#NEW_BUTTON",
 				value1 = "New");
+		}
+	}
+
+	@description = "LPS-147849. Assert the filter and order buttons are independent dropdowns"
+	@priority = "5"
+	test RendersIndependentFilterAndOrderButtons {
+		task ("Then 'filter' and 'order' button is not rendered together") {
+			AssertElementNotPresent(locator1 = "ManagementBar#FILTER_AND_ORDER");
+		}
+
+		task ("Then 'filter' button is an independent dropdown") {
+			AssertClick(
+				key_filter = "Show Filter Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER",
+				value1 = "Filter");
+
+			AssertElementPresent(
+				key_item = "Filter",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+		}
+
+		task ("Then 'order' button is an independent dropdown") {
+			AssertClick(
+				key_filter = "Show Order Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER",
+				value1 = "Order");
+
+			AssertElementPresent(
+				key_item = "Order",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+
+			AssertElementPresent(
+				key_item = "Ascending",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automated tests for management toolbar. 

**Test Plan**
Given a user of the portal
When the user opens any section with the management toolbar
Then 'filter' and 'order' buttons will be independent dropdowns

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147849