### PR TITLE
LPS-147835 Assert action buttons are displayed as icon buttons in responsive mode

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -139,7 +139,7 @@ definition {
 
 	@description = "LPS-147835. Assert the action buttons are displayed as icon buttons in responsive mode"
 	@priority = "3"
-	test ResponsiveModeActionsAsIconButtons {
+	test ResponsiveModeActionButtonsShouldDisplayAsIcons {
 		task ("Given window size set to tablet size") {
 			SetWindowSize(value1 = "800,1024");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -137,6 +137,40 @@ definition {
 		}
 	}
 
+	@description = "LPS-147835. Assert the action buttons are displayed as icon buttons in responsive mode"
+	@priority = "3"
+	test ResponsiveModeActionsAsIconButtons {
+		task ("Set window size to tablet size") {
+			SetWindowSize(value1 = "800,1024");
+		}
+
+		task ("Navigate to Management Toolbars tab") {
+			Navigator.gotoNavTab(navTab = "Management Toolbars");
+		}
+
+		task ("Assert action buttons are not displayed as icon and text buttons") {
+			AssertNotVisible(
+				key_action = "Download",
+				key_icon = "download",
+				locator1 = "ManagementBar#ICON_AND_TEXT_ACTION_BUTTON");
+
+			AssertNotVisible(
+				key_action = "Delete",
+				key_icon = "trash",
+				locator1 = "ManagementBar#ICON_AND_TEXT_ACTION_BUTTON");
+		}
+
+		task ("Assert action buttons are displayed as icon buttons") {
+			AssertElementPresent(
+				key_text = "download",
+				locator1 = "ManagementBar#ANY_ICON");
+
+			AssertElementPresent(
+				key_text = "trash",
+				locator1 = "ManagementBar#ANY_ICON");
+		}
+	}
+
 	@description = "LPS-147865. Assert the new button is displayed as an icon button in responsive mode"
 	@priority = "5"
 	test ResponsiveModeNewButtonAsIconButton {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -140,15 +140,11 @@ definition {
 	@description = "LPS-147835. Assert the action buttons are displayed as icon buttons in responsive mode"
 	@priority = "3"
 	test ResponsiveModeActionsAsIconButtons {
-		task ("Set window size to tablet size") {
+		task ("Given window size set to tablet size") {
 			SetWindowSize(value1 = "800,1024");
 		}
 
-		task ("Navigate to Management Toolbars tab") {
-			Navigator.gotoNavTab(navTab = "Management Toolbars");
-		}
-
-		task ("Assert action buttons are not displayed as icon and text buttons") {
+		task ("Then action buttons are not displayed as icon and text buttons") {
 			AssertNotVisible(
 				key_action = "Download",
 				key_icon = "download",
@@ -160,7 +156,7 @@ definition {
 				locator1 = "ManagementBar#ICON_AND_TEXT_ACTION_BUTTON");
 		}
 
-		task ("Assert action buttons are displayed as icon buttons") {
+		task ("Then action buttons are displayed as icon buttons") {
 			AssertElementPresent(
 				key_text = "download",
 				locator1 = "ManagementBar#ANY_ICON");


### PR DESCRIPTION
**Background**
Create automated tests for management toolbar.

**Test Plan**
Given a user of the portal on responsive mode
When the user opens any section with the management toolbar
Then the actions of the MT will be displayed as icon buttons

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147835
