### PR TITLE
LPS-149497 Generate methods to get non included fields in the API model but included in the URI path

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-test/src/testIntegration/java/com/liferay/headless/commerce/admin/account/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -222,7 +222,16 @@ public abstract class BaseAccountResourceTestCase {
 			204,
 			accountResource.
 				deleteAccountGroupByExternalReferenceCodeAccountHttpResponse(
-					null, account.getExternalReferenceCode()));
+					testDeleteAccountGroupByExternalReferenceCodeAccount_getAccountExternalReferenceCode(),
+					account.getExternalReferenceCode()));
+	}
+
+	protected String
+			testDeleteAccountGroupByExternalReferenceCodeAccount_getAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseDiagramResourceTestCase.java
@@ -207,10 +207,19 @@ public abstract class BaseDiagramResourceTestCase {
 			testGetProductByExternalReferenceCodeDiagram_addDiagram();
 
 		Diagram getDiagram =
-			diagramResource.getProductByExternalReferenceCodeDiagram(null);
+			diagramResource.getProductByExternalReferenceCodeDiagram(
+				testGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode());
 
 		assertEquals(postDiagram, getDiagram);
 		assertValid(getDiagram);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Diagram testGetProductByExternalReferenceCodeDiagram_addDiagram()
@@ -236,12 +245,22 @@ public abstract class BaseDiagramResourceTestCase {
 								"productByExternalReferenceCodeDiagram",
 								new HashMap<String, Object>() {
 									{
-										put("externalReferenceCode", null);
+										put(
+											"externalReferenceCode",
+											testGraphQLGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeDiagram"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeDiagram_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseMappedProductResourceTestCase.java
@@ -562,10 +562,19 @@ public abstract class BaseMappedProductResourceTestCase {
 		MappedProduct getMappedProduct =
 			mappedProductResource.
 				getProductByExternalReferenceCodeMappedProductBySequence(
-					null, postMappedProduct.getSequence());
+					testGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode(),
+					postMappedProduct.getSequence());
 
 		assertEquals(postMappedProduct, getMappedProduct);
 		assertValid(getMappedProduct);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected MappedProduct
@@ -593,7 +602,9 @@ public abstract class BaseMappedProductResourceTestCase {
 								"productByExternalReferenceCodeMappedProductBySequence",
 								new HashMap<String, Object>() {
 									{
-										put("externalReferenceCode", null);
+										put(
+											"externalReferenceCode",
+											testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode());
 										put(
 											"sequence",
 											"\"" + mappedProduct.getSequence() +
@@ -603,6 +614,14 @@ public abstract class BaseMappedProductResourceTestCase {
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeMappedProductBySequence"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeMappedProductBySequence_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/test/BaseProductTaxConfigurationResourceTestCase.java
@@ -205,10 +205,19 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 
 		ProductTaxConfiguration getProductTaxConfiguration =
 			productTaxConfigurationResource.
-				getProductByExternalReferenceCodeTaxConfiguration(null);
+				getProductByExternalReferenceCodeTaxConfiguration(
+					testGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode());
 
 		assertEquals(postProductTaxConfiguration, getProductTaxConfiguration);
 		assertValid(getProductTaxConfiguration);
+	}
+
+	protected String
+			testGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ProductTaxConfiguration
@@ -236,12 +245,22 @@ public abstract class BaseProductTaxConfigurationResourceTestCase {
 								"productByExternalReferenceCodeTaxConfiguration",
 								new HashMap<String, Object>() {
 									{
-										put("externalReferenceCode", null);
+										put(
+											"externalReferenceCode",
+											testGraphQLGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/productByExternalReferenceCodeTaxConfiguration"))));
+	}
+
+	protected String
+			testGraphQLGetProductByExternalReferenceCodeTaxConfiguration_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -191,10 +191,19 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetPaymentMethodGroupRelOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getPaymentMethodGroupRelOrderTypeOrderType(null);
+			orderTypeResource.getPaymentMethodGroupRelOrderTypeOrderType(
+				testGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long
+			testGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType
@@ -223,12 +232,20 @@ public abstract class BaseOrderTypeResourceTestCase {
 									{
 										put(
 											"paymentMethodGroupRelOrderTypeId",
-											null);
+											testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/paymentMethodGroupRelOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetPaymentMethodGroupRelOrderTypeOrderType_getPaymentMethodGroupRelOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -264,10 +281,19 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetShippingFixedOptionOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getShippingFixedOptionOrderTypeOrderType(null);
+			orderTypeResource.getShippingFixedOptionOrderTypeOrderType(
+				testGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long
+			testGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType
@@ -296,12 +322,20 @@ public abstract class BaseOrderTypeResourceTestCase {
 									{
 										put(
 											"shippingFixedOptionOrderTypeId",
-											null);
+											testGraphQLGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/shippingFixedOptionOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetShippingFixedOptionOrderTypeOrderType_getShippingFixedOptionOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-test/src/testIntegration/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/test/BaseTermResourceTestCase.java
@@ -192,10 +192,19 @@ public abstract class BaseTermResourceTestCase {
 	public void testGetPaymentMethodGroupRelTermTerm() throws Exception {
 		Term postTerm = testGetPaymentMethodGroupRelTermTerm_addTerm();
 
-		Term getTerm = termResource.getPaymentMethodGroupRelTermTerm(null);
+		Term getTerm = termResource.getPaymentMethodGroupRelTermTerm(
+			testGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId());
 
 		assertEquals(postTerm, getTerm);
 		assertValid(getTerm);
+	}
+
+	protected Long
+			testGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Term testGetPaymentMethodGroupRelTermTerm_addTerm()
@@ -221,12 +230,20 @@ public abstract class BaseTermResourceTestCase {
 									{
 										put(
 											"paymentMethodGroupRelTermId",
-											null);
+											testGraphQLGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/paymentMethodGroupRelTermTerm"))));
+	}
+
+	protected Long
+			testGraphQLGetPaymentMethodGroupRelTermTerm_getPaymentMethodGroupRelTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -258,10 +275,19 @@ public abstract class BaseTermResourceTestCase {
 	public void testGetShippingFixedOptionTermTerm() throws Exception {
 		Term postTerm = testGetShippingFixedOptionTermTerm_addTerm();
 
-		Term getTerm = termResource.getShippingFixedOptionTermTerm(null);
+		Term getTerm = termResource.getShippingFixedOptionTermTerm(
+			testGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId());
 
 		assertEquals(postTerm, getTerm);
 		assertValid(getTerm);
+	}
+
+	protected Long
+			testGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Term testGetShippingFixedOptionTermTerm_addTerm()
@@ -285,12 +311,22 @@ public abstract class BaseTermResourceTestCase {
 								"shippingFixedOptionTermTerm",
 								new HashMap<String, Object>() {
 									{
-										put("shippingFixedOptionTermId", null);
+										put(
+											"shippingFixedOptionTermId",
+											testGraphQLGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/shippingFixedOptionTermTerm"))));
+	}
+
+	protected Long
+			testGraphQLGetShippingFixedOptionTermTerm_getShippingFixedOptionTermId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-openapi.yaml
@@ -1304,7 +1304,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.18'."
+        artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.19'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Order API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.order.client', and version '4.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Order API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountGroupResourceTestCase.java
@@ -194,10 +194,19 @@ public abstract class BaseAccountGroupResourceTestCase {
 			testGetOrderRuleAccountGroupAccountGroup_addAccountGroup();
 
 		AccountGroup getAccountGroup =
-			accountGroupResource.getOrderRuleAccountGroupAccountGroup(null);
+			accountGroupResource.getOrderRuleAccountGroupAccountGroup(
+				testGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId());
 
 		assertEquals(postAccountGroup, getAccountGroup);
 		assertValid(getAccountGroup);
+	}
+
+	protected Long
+			testGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountGroup
@@ -224,12 +233,22 @@ public abstract class BaseAccountGroupResourceTestCase {
 								"orderRuleAccountGroupAccountGroup",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleAccountGroupId", null);
+										put(
+											"orderRuleAccountGroupId",
+											testGraphQLGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderRuleAccountGroupAccountGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetOrderRuleAccountGroupAccountGroup_getOrderRuleAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -198,10 +198,18 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGetOrderRuleAccountAccount() throws Exception {
 		Account postAccount = testGetOrderRuleAccountAccount_addAccount();
 
-		Account getAccount = accountResource.getOrderRuleAccountAccount(null);
+		Account getAccount = accountResource.getOrderRuleAccountAccount(
+			testGetOrderRuleAccountAccount_getOrderRuleAccountId());
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetOrderRuleAccountAccount_getOrderRuleAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testGetOrderRuleAccountAccount_addAccount()
@@ -225,11 +233,20 @@ public abstract class BaseAccountResourceTestCase {
 								"orderRuleAccountAccount",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleAccountId", null);
+										put(
+											"orderRuleAccountId",
+											testGraphQLGetOrderRuleAccountAccount_getOrderRuleAccountId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderRuleAccountAccount"))));
+	}
+
+	protected Long testGraphQLGetOrderRuleAccountAccount_getOrderRuleAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseChannelResourceTestCase.java
@@ -198,10 +198,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetOrderRuleChannelChannel() throws Exception {
 		Channel postChannel = testGetOrderRuleChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getOrderRuleChannelChannel(null);
+		Channel getChannel = channelResource.getOrderRuleChannelChannel(
+			testGetOrderRuleChannelChannel_getOrderRuleChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetOrderRuleChannelChannel_getOrderRuleChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetOrderRuleChannelChannel_addChannel()
@@ -225,11 +233,20 @@ public abstract class BaseChannelResourceTestCase {
 								"orderRuleChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleChannelId", null);
+										put(
+											"orderRuleChannelId",
+											testGraphQLGetOrderRuleChannelChannel_getOrderRuleChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderRuleChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetOrderRuleChannelChannel_getOrderRuleChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -260,10 +277,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetOrderTypeChannelChannel() throws Exception {
 		Channel postChannel = testGetOrderTypeChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getOrderTypeChannelChannel(null);
+		Channel getChannel = channelResource.getOrderTypeChannelChannel(
+			testGetOrderTypeChannelChannel_getOrderTypeChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetOrderTypeChannelChannel_getOrderTypeChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetOrderTypeChannelChannel_addChannel()
@@ -287,11 +312,20 @@ public abstract class BaseChannelResourceTestCase {
 								"orderTypeChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("orderTypeChannelId", null);
+										put(
+											"orderTypeChannelId",
+											testGraphQLGetOrderTypeChannelChannel_getOrderTypeChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/orderTypeChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetOrderTypeChannelChannel_getOrderTypeChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/BaseOrderTypeResourceTestCase.java
@@ -203,10 +203,18 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetOrderRuleOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getOrderRuleOrderTypeOrderType(null);
+			orderTypeResource.getOrderRuleOrderTypeOrderType(
+				testGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetOrderRuleOrderTypeOrderType_addOrderType()
@@ -230,12 +238,22 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"orderRuleOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("orderRuleOrderTypeId", null);
+										put(
+											"orderRuleOrderTypeId",
+											testGraphQLGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/orderRuleOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -878,10 +896,17 @@ public abstract class BaseOrderTypeResourceTestCase {
 		OrderType postOrderType = testGetTermOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType = orderTypeResource.getTermOrderTypeOrderType(
-			null);
+			testGetTermOrderTypeOrderType_getTermOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetTermOrderTypeOrderType_getTermOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetTermOrderTypeOrderType_addOrderType()
@@ -905,11 +930,20 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"termOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("termOrderTypeId", null);
+										put(
+											"termOrderTypeId",
+											testGraphQLGetTermOrderTypeOrderType_getTermOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/termOrderTypeOrderType"))));
+	}
+
+	protected Long testGraphQLGetTermOrderTypeOrderType_getTermOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/OrderTypeResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-test/src/testIntegration/java/com/liferay/headless/commerce/admin/order/resource/v1_0/test/OrderTypeResourceTest.java
@@ -26,18 +26,15 @@ import com.liferay.commerce.term.model.CommerceTermEntryRel;
 import com.liferay.commerce.term.service.CommerceTermEntryLocalService;
 import com.liferay.commerce.term.service.CommerceTermEntryRelLocalService;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderType;
-import com.liferay.headless.commerce.admin.order.client.serdes.v1_0.OrderTypeSerDes;
 import com.liferay.headless.commerce.core.util.DateConfig;
 import com.liferay.headless.commerce.core.util.LanguageUtils;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.ArrayList;
@@ -45,7 +42,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,21 +89,6 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 
 	@Override
 	@Test
-	public void testGetOrderRuleOrderTypeOrderType() throws Exception {
-		OrderType postOrderType = _addOrderType(randomOrderType());
-
-		COREntryRel corEntryRel = _getCOREntryRel(postOrderType);
-
-		OrderType getOrderType =
-			orderTypeResource.getOrderRuleOrderTypeOrderType(
-				corEntryRel.getCOREntryRelId());
-
-		assertEquals(postOrderType, getOrderType);
-		assertValid(getOrderType);
-	}
-
-	@Override
-	@Test
 	public void testGetTermOrderTypeOrderType() throws Exception {
 		OrderType postOrderType = _addOrderType(randomOrderType());
 
@@ -123,56 +104,7 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 
 	@Override
 	@Test
-	public void testGraphQLGetOrderRuleOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
-
-		COREntryRel corEntryRel = _getCOREntryRel(orderType);
-
-		Assert.assertTrue(
-			equals(
-				orderType,
-				OrderTypeSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"orderRuleOrderTypeOrderType",
-								HashMapBuilder.<String, Object>put(
-									"orderRuleOrderTypeId",
-									corEntryRel.getCOREntryRelId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data",
-						"Object/orderRuleOrderTypeOrderType"))));
-	}
-
-	@Override
-	@Test
 	public void testGraphQLGetOrderTypeNotFound() throws Exception {
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetTermOrderTypeOrderType() throws Exception {
-		OrderType orderType = testGraphQLOrderType_addOrderType();
-
-		CommerceTermEntryRel commerceTermEntryRel = _getCommerceTermEntryRel(
-			orderType);
-
-		Assert.assertTrue(
-			equals(
-				orderType,
-				OrderTypeSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"termOrderTypeOrderType",
-								HashMapBuilder.<String, Object>put(
-									"termOrderTypeId",
-									commerceTermEntryRel.
-										getCommerceTermEntryRelId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data", "Object/termOrderTypeOrderType"))));
 	}
 
 	@Override
@@ -217,6 +149,24 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 	}
 
 	@Override
+	protected OrderType testGetOrderRuleOrderTypeOrderType_addOrderType()
+		throws Exception {
+
+		OrderType orderType = _addOrderType(randomOrderType());
+
+		_corEntryRel = _getCOREntryRel(orderType);
+
+		return orderType;
+	}
+
+	@Override
+	protected Long testGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		return _corEntryRel.getCOREntryRelId();
+	}
+
+	@Override
 	protected OrderType testGetOrderType_addOrderType() throws Exception {
 		return _addOrderType(randomOrderType());
 	}
@@ -236,8 +186,28 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 	}
 
 	@Override
+	protected Long
+			testGraphQLGetOrderRuleOrderTypeOrderType_getOrderRuleOrderTypeId()
+		throws Exception {
+
+		return _corEntryRel.getCOREntryRelId();
+	}
+
+	@Override
+	protected Long testGraphQLGetTermOrderTypeOrderType_getTermOrderTypeId()
+		throws Exception {
+
+		return _commerceTermEntryRel.getCommerceTermEntryRelId();
+	}
+
+	@Override
 	protected OrderType testGraphQLOrderType_addOrderType() throws Exception {
-		return _addOrderType(randomOrderType());
+		OrderType orderType = _addOrderType(randomOrderType());
+
+		_commerceTermEntryRel = _getCommerceTermEntryRel(orderType);
+		_corEntryRel = _getCOREntryRel(orderType);
+
+		return orderType;
 	}
 
 	@Override
@@ -364,11 +334,15 @@ public class OrderTypeResourceTest extends BaseOrderTypeResourceTestCase {
 	@Inject
 	private CommerceTermEntryLocalService _commerceTermEntryLocalService;
 
+	private CommerceTermEntryRel _commerceTermEntryRel;
+
 	@Inject
 	private CommerceTermEntryRelLocalService _commerceTermEntryRelLocalService;
 
 	@Inject
 	private COREntryLocalService _corEntryLocalService;
+
+	private COREntryRel _corEntryRel;
 
 	@Inject
 	private COREntryRelLocalService _corEntryRelLocalService;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountGroupResourceTestCase.java
@@ -194,10 +194,19 @@ public abstract class BaseAccountGroupResourceTestCase {
 			testGetDiscountAccountGroupAccountGroup_addAccountGroup();
 
 		AccountGroup getAccountGroup =
-			accountGroupResource.getDiscountAccountGroupAccountGroup(null);
+			accountGroupResource.getDiscountAccountGroupAccountGroup(
+				testGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId());
 
 		assertEquals(postAccountGroup, getAccountGroup);
 		assertValid(getAccountGroup);
+	}
+
+	protected Long
+			testGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountGroup
@@ -224,12 +233,22 @@ public abstract class BaseAccountGroupResourceTestCase {
 								"discountAccountGroupAccountGroup",
 								new HashMap<String, Object>() {
 									{
-										put("discountAccountGroupId", null);
+										put(
+											"discountAccountGroupId",
+											testGraphQLGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountAccountGroupAccountGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountAccountGroupAccountGroup_getDiscountAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -262,10 +281,19 @@ public abstract class BaseAccountGroupResourceTestCase {
 			testGetPriceListAccountGroupAccountGroup_addAccountGroup();
 
 		AccountGroup getAccountGroup =
-			accountGroupResource.getPriceListAccountGroupAccountGroup(null);
+			accountGroupResource.getPriceListAccountGroupAccountGroup(
+				testGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId());
 
 		assertEquals(postAccountGroup, getAccountGroup);
 		assertValid(getAccountGroup);
+	}
+
+	protected Long
+			testGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountGroup
@@ -292,12 +320,22 @@ public abstract class BaseAccountGroupResourceTestCase {
 								"priceListAccountGroupAccountGroup",
 								new HashMap<String, Object>() {
 									{
-										put("priceListAccountGroupId", null);
+										put(
+											"priceListAccountGroupId",
+											testGraphQLGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceListAccountGroupAccountGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceListAccountGroupAccountGroup_getPriceListAccountGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseAccountResourceTestCase.java
@@ -192,10 +192,18 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGetDiscountAccountAccount() throws Exception {
 		Account postAccount = testGetDiscountAccountAccount_addAccount();
 
-		Account getAccount = accountResource.getDiscountAccountAccount(null);
+		Account getAccount = accountResource.getDiscountAccountAccount(
+			testGetDiscountAccountAccount_getDiscountAccountId());
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetDiscountAccountAccount_getDiscountAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testGetDiscountAccountAccount_addAccount()
@@ -219,11 +227,20 @@ public abstract class BaseAccountResourceTestCase {
 								"discountAccountAccount",
 								new HashMap<String, Object>() {
 									{
-										put("discountAccountId", null);
+										put(
+											"discountAccountId",
+											testGraphQLGetDiscountAccountAccount_getDiscountAccountId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountAccountAccount"))));
+	}
+
+	protected Long testGraphQLGetDiscountAccountAccount_getDiscountAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -254,10 +271,18 @@ public abstract class BaseAccountResourceTestCase {
 	public void testGetPriceListAccountAccount() throws Exception {
 		Account postAccount = testGetPriceListAccountAccount_addAccount();
 
-		Account getAccount = accountResource.getPriceListAccountAccount(null);
+		Account getAccount = accountResource.getPriceListAccountAccount(
+			testGetPriceListAccountAccount_getPriceListAccountId());
 
 		assertEquals(postAccount, getAccount);
 		assertValid(getAccount);
+	}
+
+	protected Long testGetPriceListAccountAccount_getPriceListAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testGetPriceListAccountAccount_addAccount()
@@ -281,11 +306,20 @@ public abstract class BaseAccountResourceTestCase {
 								"priceListAccountAccount",
 								new HashMap<String, Object>() {
 									{
-										put("priceListAccountId", null);
+										put(
+											"priceListAccountId",
+											testGraphQLGetPriceListAccountAccount_getPriceListAccountId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceListAccountAccount"))));
+	}
+
+	protected Long testGraphQLGetPriceListAccountAccount_getPriceListAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseCategoryResourceTestCase.java
@@ -197,10 +197,17 @@ public abstract class BaseCategoryResourceTestCase {
 		Category postCategory = testGetDiscountCategoryCategory_addCategory();
 
 		Category getCategory = categoryResource.getDiscountCategoryCategory(
-			null);
+			testGetDiscountCategoryCategory_getDiscountCategoryId());
 
 		assertEquals(postCategory, getCategory);
 		assertValid(getCategory);
+	}
+
+	protected Long testGetDiscountCategoryCategory_getDiscountCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Category testGetDiscountCategoryCategory_addCategory()
@@ -224,12 +231,22 @@ public abstract class BaseCategoryResourceTestCase {
 								"discountCategoryCategory",
 								new HashMap<String, Object>() {
 									{
-										put("discountCategoryId", null);
+										put(
+											"discountCategoryId",
+											testGraphQLGetDiscountCategoryCategory_getDiscountCategoryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountCategoryCategory"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountCategoryCategory_getDiscountCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -262,10 +279,19 @@ public abstract class BaseCategoryResourceTestCase {
 			testGetPriceModifierCategoryCategory_addCategory();
 
 		Category getCategory =
-			categoryResource.getPriceModifierCategoryCategory(null);
+			categoryResource.getPriceModifierCategoryCategory(
+				testGetPriceModifierCategoryCategory_getPriceModifierCategoryId());
 
 		assertEquals(postCategory, getCategory);
 		assertValid(getCategory);
+	}
+
+	protected Long
+			testGetPriceModifierCategoryCategory_getPriceModifierCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Category testGetPriceModifierCategoryCategory_addCategory()
@@ -289,12 +315,22 @@ public abstract class BaseCategoryResourceTestCase {
 								"priceModifierCategoryCategory",
 								new HashMap<String, Object>() {
 									{
-										put("priceModifierCategoryId", null);
+										put(
+											"priceModifierCategoryId",
+											testGraphQLGetPriceModifierCategoryCategory_getPriceModifierCategoryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceModifierCategoryCategory"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceModifierCategoryCategory_getPriceModifierCategoryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseChannelResourceTestCase.java
@@ -198,10 +198,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetDiscountChannelChannel() throws Exception {
 		Channel postChannel = testGetDiscountChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getDiscountChannelChannel(null);
+		Channel getChannel = channelResource.getDiscountChannelChannel(
+			testGetDiscountChannelChannel_getDiscountChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetDiscountChannelChannel_getDiscountChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetDiscountChannelChannel_addChannel()
@@ -225,11 +233,20 @@ public abstract class BaseChannelResourceTestCase {
 								"discountChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("discountChannelId", null);
+										put(
+											"discountChannelId",
+											testGraphQLGetDiscountChannelChannel_getDiscountChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetDiscountChannelChannel_getDiscountChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -260,10 +277,18 @@ public abstract class BaseChannelResourceTestCase {
 	public void testGetPriceListChannelChannel() throws Exception {
 		Channel postChannel = testGetPriceListChannelChannel_addChannel();
 
-		Channel getChannel = channelResource.getPriceListChannelChannel(null);
+		Channel getChannel = channelResource.getPriceListChannelChannel(
+			testGetPriceListChannelChannel_getPriceListChannelId());
 
 		assertEquals(postChannel, getChannel);
 		assertValid(getChannel);
+	}
+
+	protected Long testGetPriceListChannelChannel_getPriceListChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Channel testGetPriceListChannelChannel_addChannel()
@@ -287,11 +312,20 @@ public abstract class BaseChannelResourceTestCase {
 								"priceListChannelChannel",
 								new HashMap<String, Object>() {
 									{
-										put("priceListChannelId", null);
+										put(
+											"priceListChannelId",
+											testGraphQLGetPriceListChannelChannel_getPriceListChannelId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceListChannelChannel"))));
+	}
+
+	protected Long testGraphQLGetPriceListChannelChannel_getPriceListChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseOrderTypeResourceTestCase.java
@@ -189,10 +189,18 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetDiscountOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getDiscountOrderTypeOrderType(null);
+			orderTypeResource.getDiscountOrderTypeOrderType(
+				testGetDiscountOrderTypeOrderType_getDiscountOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetDiscountOrderTypeOrderType_getDiscountOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetDiscountOrderTypeOrderType_addOrderType()
@@ -216,12 +224,22 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"discountOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("discountOrderTypeId", null);
+										put(
+											"discountOrderTypeId",
+											testGraphQLGetDiscountOrderTypeOrderType_getDiscountOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountOrderTypeOrderType_getDiscountOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -254,10 +272,18 @@ public abstract class BaseOrderTypeResourceTestCase {
 			testGetPriceListOrderTypeOrderType_addOrderType();
 
 		OrderType getOrderType =
-			orderTypeResource.getPriceListOrderTypeOrderType(null);
+			orderTypeResource.getPriceListOrderTypeOrderType(
+				testGetPriceListOrderTypeOrderType_getPriceListOrderTypeId());
 
 		assertEquals(postOrderType, getOrderType);
 		assertValid(getOrderType);
+	}
+
+	protected Long testGetPriceListOrderTypeOrderType_getPriceListOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected OrderType testGetPriceListOrderTypeOrderType_addOrderType()
@@ -281,12 +307,22 @@ public abstract class BaseOrderTypeResourceTestCase {
 								"priceListOrderTypeOrderType",
 								new HashMap<String, Object>() {
 									{
-										put("priceListOrderTypeId", null);
+										put(
+											"priceListOrderTypeId",
+											testGraphQLGetPriceListOrderTypeOrderType_getPriceListOrderTypeId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceListOrderTypeOrderType"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceListOrderTypeOrderType_getPriceListOrderTypeId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductGroupResourceTestCase.java
@@ -189,10 +189,19 @@ public abstract class BaseProductGroupResourceTestCase {
 			testGetDiscountProductGroupProductGroup_addProductGroup();
 
 		ProductGroup getProductGroup =
-			productGroupResource.getDiscountProductGroupProductGroup(null);
+			productGroupResource.getDiscountProductGroupProductGroup(
+				testGetDiscountProductGroupProductGroup_getDiscountProductGroupId());
 
 		assertEquals(postProductGroup, getProductGroup);
 		assertValid(getProductGroup);
+	}
+
+	protected Long
+			testGetDiscountProductGroupProductGroup_getDiscountProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ProductGroup
@@ -219,12 +228,22 @@ public abstract class BaseProductGroupResourceTestCase {
 								"discountProductGroupProductGroup",
 								new HashMap<String, Object>() {
 									{
-										put("discountProductGroupId", null);
+										put(
+											"discountProductGroupId",
+											testGraphQLGetDiscountProductGroupProductGroup_getDiscountProductGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/discountProductGroupProductGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetDiscountProductGroupProductGroup_getDiscountProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -259,10 +278,19 @@ public abstract class BaseProductGroupResourceTestCase {
 			testGetPriceModifierProductGroupProductGroup_addProductGroup();
 
 		ProductGroup getProductGroup =
-			productGroupResource.getPriceModifierProductGroupProductGroup(null);
+			productGroupResource.getPriceModifierProductGroupProductGroup(
+				testGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId());
 
 		assertEquals(postProductGroup, getProductGroup);
 		assertValid(getProductGroup);
+	}
+
+	protected Long
+			testGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ProductGroup
@@ -291,12 +319,20 @@ public abstract class BaseProductGroupResourceTestCase {
 									{
 										put(
 											"priceModifierProductGroupId",
-											null);
+											testGraphQLGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceModifierProductGroupProductGroup"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceModifierProductGroupProductGroup_getPriceModifierProductGroupId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseProductResourceTestCase.java
@@ -194,10 +194,18 @@ public abstract class BaseProductResourceTestCase {
 	public void testGetDiscountProductProduct() throws Exception {
 		Product postProduct = testGetDiscountProductProduct_addProduct();
 
-		Product getProduct = productResource.getDiscountProductProduct(null);
+		Product getProduct = productResource.getDiscountProductProduct(
+			testGetDiscountProductProduct_getDiscountProductId());
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long testGetDiscountProductProduct_getDiscountProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetDiscountProductProduct_addProduct()
@@ -221,11 +229,20 @@ public abstract class BaseProductResourceTestCase {
 								"discountProductProduct",
 								new HashMap<String, Object>() {
 									{
-										put("discountProductId", null);
+										put(
+											"discountProductId",
+											testGraphQLGetDiscountProductProduct_getDiscountProductId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountProductProduct"))));
+	}
+
+	protected Long testGraphQLGetDiscountProductProduct_getDiscountProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -256,10 +273,18 @@ public abstract class BaseProductResourceTestCase {
 	public void testGetPriceEntryIdProduct() throws Exception {
 		Product postProduct = testGetPriceEntryIdProduct_addProduct();
 
-		Product getProduct = productResource.getPriceEntryIdProduct(null);
+		Product getProduct = productResource.getPriceEntryIdProduct(
+			testGetPriceEntryIdProduct_getPriceEntryId());
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long testGetPriceEntryIdProduct_getPriceEntryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetPriceEntryIdProduct_addProduct() throws Exception {
@@ -281,11 +306,20 @@ public abstract class BaseProductResourceTestCase {
 								"priceEntryIdProduct",
 								new HashMap<String, Object>() {
 									{
-										put("priceEntryId", null);
+										put(
+											"priceEntryId",
+											testGraphQLGetPriceEntryIdProduct_getPriceEntryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceEntryIdProduct"))));
+	}
+
+	protected Long testGraphQLGetPriceEntryIdProduct_getPriceEntryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -313,10 +347,18 @@ public abstract class BaseProductResourceTestCase {
 		Product postProduct = testGetPriceModifierProductProduct_addProduct();
 
 		Product getProduct = productResource.getPriceModifierProductProduct(
-			null);
+			testGetPriceModifierProductProduct_getPriceModifierProductId());
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long
+			testGetPriceModifierProductProduct_getPriceModifierProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetPriceModifierProductProduct_addProduct()
@@ -340,12 +382,22 @@ public abstract class BaseProductResourceTestCase {
 								"priceModifierProductProduct",
 								new HashMap<String, Object>() {
 									{
-										put("priceModifierProductId", null);
+										put(
+											"priceModifierProductId",
+											testGraphQLGetPriceModifierProductProduct_getPriceModifierProductId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/priceModifierProductProduct"))));
+	}
+
+	protected Long
+			testGraphQLGetPriceModifierProductProduct_getPriceModifierProductId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-test/src/testIntegration/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/test/BaseSkuResourceTestCase.java
@@ -196,10 +196,16 @@ public abstract class BaseSkuResourceTestCase {
 	public void testGetDiscountSkuSku() throws Exception {
 		Sku postSku = testGetDiscountSkuSku_addSku();
 
-		Sku getSku = skuResource.getDiscountSkuSku(null);
+		Sku getSku = skuResource.getDiscountSkuSku(
+			testGetDiscountSkuSku_getDiscountSkuId());
 
 		assertEquals(postSku, getSku);
 		assertValid(getSku);
+	}
+
+	protected Long testGetDiscountSkuSku_getDiscountSkuId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Sku testGetDiscountSkuSku_addSku() throws Exception {
@@ -221,11 +227,20 @@ public abstract class BaseSkuResourceTestCase {
 								"discountSkuSku",
 								new HashMap<String, Object>() {
 									{
-										put("discountSkuId", null);
+										put(
+											"discountSkuId",
+											testGraphQLGetDiscountSkuSku_getDiscountSkuId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/discountSkuSku"))));
+	}
+
+	protected Long testGraphQLGetDiscountSkuSku_getDiscountSkuId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -252,10 +267,16 @@ public abstract class BaseSkuResourceTestCase {
 	public void testGetPriceEntryIdSku() throws Exception {
 		Sku postSku = testGetPriceEntryIdSku_addSku();
 
-		Sku getSku = skuResource.getPriceEntryIdSku(null);
+		Sku getSku = skuResource.getPriceEntryIdSku(
+			testGetPriceEntryIdSku_getPriceEntryId());
 
 		assertEquals(postSku, getSku);
 		assertValid(getSku);
+	}
+
+	protected Long testGetPriceEntryIdSku_getPriceEntryId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Sku testGetPriceEntryIdSku_addSku() throws Exception {
@@ -277,11 +298,20 @@ public abstract class BaseSkuResourceTestCase {
 								"priceEntryIdSku",
 								new HashMap<String, Object>() {
 									{
-										put("priceEntryId", null);
+										put(
+											"priceEntryId",
+											testGraphQLGetPriceEntryIdSku_getPriceEntryId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/priceEntryIdSku"))));
+	}
+
+	protected Long testGraphQLGetPriceEntryIdSku_getPriceEntryId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/BaseShippingAddressResourceTestCase.java
@@ -334,10 +334,18 @@ public abstract class BaseShippingAddressResourceTestCase {
 			testGetShipmentShippingAddress_addShippingAddress();
 
 		ShippingAddress getShippingAddress =
-			shippingAddressResource.getShipmentShippingAddress(null);
+			shippingAddressResource.getShipmentShippingAddress(
+				testGetShipmentShippingAddress_getShipmentId());
 
 		assertEquals(postShippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
+	}
+
+	protected Long testGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected ShippingAddress
@@ -363,11 +371,20 @@ public abstract class BaseShippingAddressResourceTestCase {
 								"shipmentShippingAddress",
 								new HashMap<String, Object>() {
 									{
-										put("shipmentId", null);
+										put(
+											"shipmentId",
+											testGraphQLGetShipmentShippingAddress_getShipmentId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/shipmentShippingAddress"))));
+	}
+
+	protected Long testGraphQLGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/ShippingAddressResourceTest.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-test/src/testIntegration/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/test/ShippingAddressResourceTest.java
@@ -25,10 +25,8 @@ import com.liferay.commerce.service.CommerceShipmentLocalServiceUtil;
 import com.liferay.commerce.test.util.CommerceInventoryTestUtil;
 import com.liferay.commerce.test.util.CommerceTestUtil;
 import com.liferay.headless.commerce.admin.shipment.client.dto.v1_0.ShippingAddress;
-import com.liferay.headless.commerce.admin.shipment.client.serdes.v1_0.ShippingAddressSerDes;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Country;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
@@ -40,12 +38,10 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigDecimal;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,66 +114,6 @@ public class ShippingAddressResourceTest
 
 		assertEquals(shippingAddress, getShippingAddress);
 		assertValid(getShippingAddress);
-	}
-
-	@Override
-	@Test
-	public void testGetShipmentShippingAddress() throws Exception {
-		ShippingAddress shippingAddress = _toShippingAddress(
-			_commerceShipment.fetchCommerceAddress());
-
-		ShippingAddress getShippingAddress =
-			shippingAddressResource.getShipmentShippingAddress(
-				_commerceShipment.getCommerceShipmentId());
-
-		assertEquals(shippingAddress, getShippingAddress);
-		assertValid(getShippingAddress);
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetShipmentByExternalReferenceCodeShippingAddress()
-		throws Exception {
-
-		ShippingAddress shippingAddress = _toShippingAddress(
-			_commerceShipment.fetchCommerceAddress());
-
-		Assert.assertTrue(
-			equals(
-				shippingAddress,
-				ShippingAddressSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"shipmentShippingAddress",
-								HashMapBuilder.<String, Object>put(
-									"shipmentId",
-									_commerceShipment.getCommerceShipmentId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data", "Object/shipmentShippingAddress"))));
-	}
-
-	@Override
-	@Test
-	public void testGraphQLGetShipmentShippingAddress() throws Exception {
-		ShippingAddress shippingAddress = _toShippingAddress(
-			_commerceShipment.fetchCommerceAddress());
-
-		Assert.assertTrue(
-			equals(
-				shippingAddress,
-				ShippingAddressSerDes.toDTO(
-					JSONUtil.getValueAsString(
-						invokeGraphQLQuery(
-							new GraphQLField(
-								"shipmentShippingAddress",
-								HashMapBuilder.<String, Object>put(
-									"shipmentId",
-									_commerceShipment.getCommerceShipmentId()
-								).build(),
-								getGraphQLFields())),
-						"JSONObject/data", "Object/shipmentShippingAddress"))));
 	}
 
 	@Override
@@ -258,6 +194,35 @@ public class ShippingAddressResourceTest
 				zip = StringUtil.toLowerCase(RandomTestUtil.randomString());
 			}
 		};
+	}
+
+	@Override
+	protected ShippingAddress
+			testGetShipmentShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return _toShippingAddress(_commerceShipment.fetchCommerceAddress());
+	}
+
+	@Override
+	protected Long testGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		return _commerceShipment.getCommerceShipmentId();
+	}
+
+	@Override
+	protected Long testGraphQLGetShipmentShippingAddress_getShipmentId()
+		throws Exception {
+
+		return _commerceShipment.getCommerceShipmentId();
+	}
+
+	@Override
+	protected ShippingAddress testGraphQLShippingAddress_addShippingAddress()
+		throws Exception {
+
+		return _toShippingAddress(_commerceShipment.fetchCommerceAddress());
 	}
 
 	private String _getRegionISOCode(CommerceAddress commerceAddress)

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/test/BaseAddressResourceTestCase.java
@@ -218,10 +218,16 @@ public abstract class BaseAddressResourceTestCase {
 	public void testGetCartBillingAddres() throws Exception {
 		Address postAddress = testGetCartBillingAddres_addAddress();
 
-		Address getAddress = addressResource.getCartBillingAddres(null);
+		Address getAddress = addressResource.getCartBillingAddres(
+			testGetCartBillingAddres_getCartId());
 
 		assertEquals(postAddress, getAddress);
 		assertValid(getAddress);
+	}
+
+	protected Long testGetCartBillingAddres_getCartId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Address testGetCartBillingAddres_addAddress() throws Exception {
@@ -243,11 +249,20 @@ public abstract class BaseAddressResourceTestCase {
 								"cartBillingAddres",
 								new HashMap<String, Object>() {
 									{
-										put("cartId", null);
+										put(
+											"cartId",
+											testGraphQLGetCartBillingAddres_getCartId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/cartBillingAddres"))));
+	}
+
+	protected Long testGraphQLGetCartBillingAddres_getCartId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -274,10 +289,16 @@ public abstract class BaseAddressResourceTestCase {
 	public void testGetCartShippingAddres() throws Exception {
 		Address postAddress = testGetCartShippingAddres_addAddress();
 
-		Address getAddress = addressResource.getCartShippingAddres(null);
+		Address getAddress = addressResource.getCartShippingAddres(
+			testGetCartShippingAddres_getCartId());
 
 		assertEquals(postAddress, getAddress);
 		assertValid(getAddress);
+	}
+
+	protected Long testGetCartShippingAddres_getCartId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Address testGetCartShippingAddres_addAddress() throws Exception {
@@ -299,11 +320,20 @@ public abstract class BaseAddressResourceTestCase {
 								"cartShippingAddres",
 								new HashMap<String, Object>() {
 									{
-										put("cartId", null);
+										put(
+											"cartId",
+											testGraphQLGetCartShippingAddres_getCartId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/cartShippingAddres"))));
+	}
+
+	protected Long testGraphQLGetCartShippingAddres_getCartId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-test/src/testIntegration/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/test/BaseProductResourceTestCase.java
@@ -531,10 +531,15 @@ public abstract class BaseProductResourceTestCase {
 		Product postProduct = testGetChannelProduct_addProduct();
 
 		Product getProduct = productResource.getChannelProduct(
-			null, postProduct.getId(), null);
+			testGetChannelProduct_getChannelId(), postProduct.getId(), null);
 
 		assertEquals(postProduct, getProduct);
 		assertValid(getProduct);
+	}
+
+	protected Long testGetChannelProduct_getChannelId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Product testGetChannelProduct_addProduct() throws Exception {
@@ -556,12 +561,21 @@ public abstract class BaseProductResourceTestCase {
 								"channelProduct",
 								new HashMap<String, Object>() {
 									{
-										put("channelId", null);
+										put(
+											"channelId",
+											testGraphQLGetChannelProduct_getChannelId());
 										put("productId", product.getId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/channelProduct"))));
+	}
+
+	protected Long testGraphQLGetChannelProduct_getChannelId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/BaseStructuredContentResourceTestCase.java
@@ -650,17 +650,26 @@ public abstract class BaseStructuredContentResourceTestCase {
 			204,
 			structuredContentResource.
 				deleteStructuredContentByVersionHttpResponse(
-					structuredContent.getId(), null));
+					structuredContent.getId(),
+					testDeleteStructuredContentByVersion_getVersion()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.getStructuredContentByVersionHttpResponse(
-				structuredContent.getId(), null));
+				structuredContent.getId(),
+				testDeleteStructuredContentByVersion_getVersion()));
 
 		assertHttpResponseStatusCode(
 			404,
 			structuredContentResource.getStructuredContentByVersionHttpResponse(
-				0L, null));
+				0L, testDeleteStructuredContentByVersion_getVersion()));
+	}
+
+	protected Double testDeleteStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected StructuredContent
@@ -678,10 +687,18 @@ public abstract class BaseStructuredContentResourceTestCase {
 
 		StructuredContent getStructuredContent =
 			structuredContentResource.getStructuredContentByVersion(
-				postStructuredContent.getId(), null);
+				postStructuredContent.getId(),
+				testGetStructuredContentByVersion_getVersion());
 
 		assertEquals(postStructuredContent, getStructuredContent);
 		assertValid(getStructuredContent);
+	}
+
+	protected Double testGetStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected StructuredContent
@@ -710,12 +727,21 @@ public abstract class BaseStructuredContentResourceTestCase {
 										put(
 											"structuredContentId",
 											structuredContent.getId());
-										put("version", null);
+										put(
+											"version",
+											testGraphQLGetStructuredContentByVersion_getVersion());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data",
 						"Object/structuredContentByVersion"))));
+	}
+
+	protected Double testGraphQLGetStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-test/src/testIntegration/java/com/liferay/headless/admin/content/resource/v1_0/test/StructuredContentResourceTest.java
@@ -77,40 +77,6 @@ public class StructuredContentResourceTest
 
 	@Override
 	@Test
-	public void testDeleteStructuredContentByVersion() throws Exception {
-		StructuredContent structuredContent = _postSiteStructuredContent(
-			testGroup.getGroupId(), randomStructuredContent());
-
-		Page<StructuredContent> structuredContentsVersionsPage =
-			structuredContentResource.getStructuredContentsVersionsPage(
-				structuredContent.getId());
-
-		Assert.assertEquals(1L, structuredContentsVersionsPage.getTotalCount());
-
-		structuredContentResource.deleteStructuredContentByVersion(
-			structuredContent.getId(), 1.0D);
-
-		assertHttpResponseStatusCode(
-			404,
-			structuredContentResource.getStructuredContentByVersionHttpResponse(
-				structuredContent.getId(), 1.0D));
-	}
-
-	@Override
-	@Test
-	public void testGetStructuredContentByVersion() throws Exception {
-		StructuredContent structuredContent = _postSiteStructuredContent(
-			testGroup.getGroupId(), randomStructuredContent());
-
-		StructuredContent structuredContentVersion =
-			structuredContentResource.getStructuredContentByVersion(
-				structuredContent.getId(), 1.0D);
-
-		assertEquals(structuredContent, structuredContentVersion);
-	}
-
-	@Override
-	@Test
 	public void testGetStructuredContentsVersionsPage() throws Exception {
 		StructuredContent structuredContent = _postSiteStructuredContent(
 			testGroup.getGroupId(), randomStructuredContent());
@@ -219,11 +185,43 @@ public class StructuredContentResourceTest
 
 	@Override
 	protected StructuredContent
+			testDeleteStructuredContentByVersion_addStructuredContent()
+		throws Exception {
+
+		return _postSiteStructuredContent(
+			testGroup.getGroupId(), randomStructuredContent());
+	}
+
+	@Override
+	protected Double testDeleteStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		return 1.0D;
+	}
+
+	@Override
+	protected StructuredContent
 			testGetSiteStructuredContentsPage_addStructuredContent(
 				Long siteId, StructuredContent structuredContent)
 		throws Exception {
 
 		return _postSiteStructuredContent(siteId, structuredContent);
+	}
+
+	@Override
+	protected StructuredContent
+			testGetStructuredContentByVersion_addStructuredContent()
+		throws Exception {
+
+		return _postSiteStructuredContent(
+			testGroup.getGroupId(), randomStructuredContent());
+	}
+
+	@Override
+	protected Double testGetStructuredContentByVersion_getVersion()
+		throws Exception {
+
+		return 1.0D;
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1023,7 +1023,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.24'."
+        'com.liferay.headless.admin.user.client', and version '4.0.25'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/AccountRoleResourceTest.java
@@ -477,6 +477,22 @@ public class AccountRoleResourceTest extends BaseAccountRoleResourceTestCase {
 	}
 
 	@Override
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode()
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
 	protected AccountRole
 			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_addAccountRole()
 		throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountResourceTestCase.java
@@ -921,7 +921,15 @@ public abstract class BaseAccountResourceTestCase {
 
 		assertHttpResponseStatusCode(
 			204,
-			accountResource.deleteOrganizationAccountsHttpResponse(null, null));
+			accountResource.deleteOrganizationAccountsHttpResponse(
+				testDeleteOrganizationAccounts_getOrganizationId(), null));
+	}
+
+	protected Long testDeleteOrganizationAccounts_getOrganizationId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account testDeleteOrganizationAccounts_addAccount()
@@ -1310,7 +1318,16 @@ public abstract class BaseAccountResourceTestCase {
 			204,
 			accountResource.
 				deleteOrganizationAccountsByExternalReferenceCodeHttpResponse(
-					null, null));
+					testDeleteOrganizationAccountsByExternalReferenceCode_getOrganizationId(),
+					null));
+	}
+
+	protected Long
+			testDeleteOrganizationAccountsByExternalReferenceCode_getOrganizationId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Account

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseAccountRoleResourceTestCase.java
@@ -210,7 +210,25 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCodeHttpResponse(
-					null, accountRole.getId(), null));
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
+					accountRole.getId(),
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountRole
@@ -670,7 +688,25 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddressHttpResponse(
-					null, accountRole.getId(), null));
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode(),
+					accountRole.getId(),
+					testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeAccountRoleUserAccountByEmailAddress_getEmailAddress()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountRole
@@ -1095,7 +1131,16 @@ public abstract class BaseAccountRoleResourceTestCase {
 			204,
 			accountRoleResource.
 				deleteAccountAccountRoleUserAccountAssociationHttpResponse(
-					accountRole.getAccountId(), accountRole.getId(), null));
+					accountRole.getAccountId(), accountRole.getId(),
+					testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId()));
+	}
+
+	protected Long
+			testDeleteAccountAccountRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected AccountRole

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -1030,7 +1030,15 @@ public abstract class BaseOrganizationResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			organizationResource.deleteAccountOrganizationHttpResponse(
-				null, organization.getId()));
+				testDeleteAccountOrganization_getAccountId(),
+				organization.getId()));
+	}
+
+	protected Long testDeleteAccountOrganization_getAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Organization testDeleteAccountOrganization_addOrganization()
@@ -2210,7 +2218,15 @@ public abstract class BaseOrganizationResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			organizationResource.deleteUserAccountByEmailAddressHttpResponse(
-				organization.getId(), null));
+				organization.getId(),
+				testDeleteUserAccountByEmailAddress_getEmailAddress()));
+	}
+
+	protected String testDeleteUserAccountByEmailAddress_getEmailAddress()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Organization testDeleteUserAccountByEmailAddress_addOrganization()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseRoleResourceTestCase.java
@@ -358,7 +358,15 @@ public abstract class BaseRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			roleResource.deleteRoleUserAccountAssociationHttpResponse(
-				role.getId(), null));
+				role.getId(),
+				testDeleteRoleUserAccountAssociation_getUserAccountId()));
+	}
+
+	protected Long testDeleteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Role testDeleteRoleUserAccountAssociation_addRole()
@@ -401,7 +409,25 @@ public abstract class BaseRoleResourceTestCase {
 			204,
 			roleResource.
 				deleteOrganizationRoleUserAccountAssociationHttpResponse(
-					role.getId(), null, null));
+					role.getId(),
+					testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId(),
+					testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()));
+	}
+
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Role testDeleteOrganizationRoleUserAccountAssociation_addRole()
@@ -444,7 +470,23 @@ public abstract class BaseRoleResourceTestCase {
 		assertHttpResponseStatusCode(
 			204,
 			roleResource.deleteSiteRoleUserAccountAssociationHttpResponse(
-				role.getId(), null, null));
+				role.getId(),
+				testDeleteSiteRoleUserAccountAssociation_getUserAccountId(),
+				testDeleteSiteRoleUserAccountAssociation_getSiteId()));
+	}
+
+	protected Long testDeleteSiteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long testDeleteSiteRoleUserAccountAssociation_getSiteId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected Role testDeleteSiteRoleUserAccountAssociation_addRole()

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -235,7 +235,24 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCodeHttpResponse(
-					null, null));
+					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode(),
+					testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()));
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String
+			testDeleteAccountByExternalReferenceCodeUserAccountByExternalReferenceCode_getUserAccountExternalReferenceCode()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected UserAccount
@@ -1181,7 +1198,15 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountUserAccountsByEmailAddressHttpResponse(
-					null, null));
+					testDeleteAccountUserAccountsByEmailAddress_getAccountId(),
+					null));
+	}
+
+	protected Long testDeleteAccountUserAccountsByEmailAddress_getAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected UserAccount
@@ -1207,7 +1232,15 @@ public abstract class BaseUserAccountResourceTestCase {
 			204,
 			userAccountResource.
 				deleteAccountUserAccountByEmailAddressHttpResponse(
-					null, userAccount.getEmailAddress()));
+					testDeleteAccountUserAccountByEmailAddress_getAccountId(),
+					userAccount.getEmailAddress()));
+	}
+
+	protected Long testDeleteAccountUserAccountByEmailAddress_getAccountId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected UserAccount

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/OrganizationResourceTest.java
@@ -77,18 +77,6 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteAccountOrganization() throws Exception {
-		Organization organization =
-			testDeleteAccountOrganization_addOrganization();
-
-		assertHttpResponseStatusCode(
-			204,
-			organizationResource.deleteAccountOrganizationHttpResponse(
-				_accountEntry.getAccountEntryId(), organization.getId()));
-	}
-
-	@Override
-	@Test
 	public void testDeleteUserAccountByEmailAddress() throws Exception {
 		Organization organization = _toOrganization(
 			_addOrganization(randomOrganization(), "0"));
@@ -292,6 +280,13 @@ public class OrganizationResourceTest extends BaseOrganizationResourceTestCase {
 		return organizationResource.putOrganizationByExternalReferenceCode(
 			StringUtil.toLowerCase(RandomTestUtil.randomString()),
 			randomOrganization());
+	}
+
+	@Override
+	protected Long testDeleteAccountOrganization_getAccountId()
+		throws Exception {
+
+		return _accountEntry.getAccountEntryId();
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/RoleResourceTest.java
@@ -67,44 +67,6 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 
 	@Override
 	@Test
-	public void testDeleteOrganizationRoleUserAccountAssociation()
-		throws Exception {
-
-		Role role = testDeleteOrganizationRoleUserAccountAssociation_addRole();
-		Organization organization = OrganizationTestUtil.addOrganization();
-
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.
-				deleteOrganizationRoleUserAccountAssociationHttpResponse(
-					role.getId(), _user.getUserId(),
-					organization.getOrganizationId()));
-	}
-
-	@Override
-	@Test
-	public void testDeleteRoleUserAccountAssociation() throws Exception {
-		Role role = testDeleteRoleUserAccountAssociation_addRole();
-
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.deleteRoleUserAccountAssociationHttpResponse(
-				role.getId(), _user.getUserId()));
-	}
-
-	@Override
-	@Test
-	public void testDeleteSiteRoleUserAccountAssociation() throws Exception {
-		Role role = testDeleteSiteRoleUserAccountAssociation_addRole();
-
-		assertHttpResponseStatusCode(
-			204,
-			roleResource.deleteSiteRoleUserAccountAssociationHttpResponse(
-				role.getId(), _user.getUserId(), testGroup.getGroupId()));
-	}
-
-	@Override
-	@Test
 	public void testGetRolesPage() throws Exception {
 		Page<Role> page = roleResource.getRolesPage(
 			null, Pagination.of(1, 100));
@@ -292,6 +254,24 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	}
 
 	@Override
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getOrganizationId()
+		throws Exception {
+
+		Organization organization = OrganizationTestUtil.addOrganization();
+
+		return organization.getOrganizationId();
+	}
+
+	@Override
+	protected Long
+			testDeleteOrganizationRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		return _user.getUserId();
+	}
+
+	@Override
 	protected Role testDeleteRoleUserAccountAssociation_addRole()
 		throws Exception {
 
@@ -299,10 +279,31 @@ public class RoleResourceTest extends BaseRoleResourceTestCase {
 	}
 
 	@Override
+	protected Long testDeleteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		return _user.getUserId();
+	}
+
+	@Override
 	protected Role testDeleteSiteRoleUserAccountAssociation_addRole()
 		throws Exception {
 
 		return _addRole(RoleConstants.TYPE_SITE);
+	}
+
+	@Override
+	protected Long testDeleteSiteRoleUserAccountAssociation_getSiteId()
+		throws Exception {
+
+		return testGroup.getGroupId();
+	}
+
+	@Override
+	protected Long testDeleteSiteRoleUserAccountAssociation_getUserAccountId()
+		throws Exception {
+
+		return _user.getUserId();
 	}
 
 	@Override

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-test/src/testIntegration/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/test/BaseSLAResultResourceTestCase.java
@@ -194,10 +194,15 @@ public abstract class BaseSLAResultResourceTestCase {
 		SLAResult postSLAResult = testGetProcessLastSLAResult_addSLAResult();
 
 		SLAResult getSLAResult = slaResultResource.getProcessLastSLAResult(
-			null);
+			testGetProcessLastSLAResult_getProcessId());
 
 		assertEquals(postSLAResult, getSLAResult);
 		assertValid(getSLAResult);
+	}
+
+	protected Long testGetProcessLastSLAResult_getProcessId() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	protected SLAResult testGetProcessLastSLAResult_addSLAResult()
@@ -221,11 +226,20 @@ public abstract class BaseSLAResultResourceTestCase {
 								"processLastSLAResult",
 								new HashMap<String, Object>() {
 									{
-										put("processId", null);
+										put(
+											"processId",
+											testGraphQLGetProcessLastSLAResult_getProcessId());
 									}
 								},
 								getGraphQLFields())),
 						"JSONObject/data", "Object/processLastSLAResult"))));
+	}
+
+	protected Long testGraphQLGetProcessLastSLAResult_getProcessId()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -250,6 +250,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 		</#if>
 
 		<#if freeMarkerTool.hasHTTPMethod(javaMethodSignature, "delete")>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
@@ -269,7 +271,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 						<#else>
 							null
@@ -291,7 +294,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 
 							<#sep>, </#sep>
@@ -307,7 +311,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 
 							<#sep>, </#sep>
@@ -319,6 +324,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					Assert.assertTrue(false);
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="test"
+			/>
 
 			<#if properties?keys?seq_contains("id")>
 				protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_add${schemaName}() throws Exception {
@@ -1030,6 +1041,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#list>
 			</#if>
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?ends_with(schemaName)>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
@@ -1050,7 +1063,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
 								post${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
 							<#else>
-								null
+								<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+								test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 							</#if>
 						<#else>
 							null
@@ -1065,6 +1079,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					Assert.assertTrue(false);
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="test"
+			/>
 
 			<#if properties?keys?seq_contains("id")>
 				protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_add${schemaName}() throws Exception {
@@ -1307,6 +1327,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 			}
 		<#elseif freeMarkerTool.hasHTTPMethod(javaMethodSignature, "put") && javaMethodSignature.returnType?ends_with(schemaName)>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void test${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if !properties?keys?seq_contains("id")>
@@ -1376,6 +1398,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 						put${schemaName}.getExternalReferenceCode());
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="test"
+			/>
 
 			<#if javaMethodSignature.methodName?cap_first?ends_with("ByExternalReferenceCode")>
 				protected ${schemaName} test${javaMethodSignature.methodName?cap_first}_create${schemaName}() throws Exception {
@@ -1626,6 +1654,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				</#if>
 			}
 		<#elseif configYAML.generateGraphQL && freeMarkerTool.hasHTTPMethod(javaMethodSignature, "get") && javaMethodSignature.returnType?ends_with(schemaName)>
+			<#assign missingGetterJavaMethodParametersMap = {} />
+
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
@@ -1650,18 +1680,25 @@ public abstract class Base${schemaName}ResourceTestCase {
 																	${schemaVarName}.getId()
 																</#if>
 															);
-														<#elseif stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
-															put("siteKey", "\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\"");
 														<#elseif properties?keys?seq_contains(javaMethodParameter.parameterName)>
-															put("${javaMethodParameter.parameterName}",
-																<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
-																	"\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\""
-																<#else>
-																	${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
-																</#if>
-															);
+															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+																put("siteKey", "\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\"");
+															<#else>
+																put("${javaMethodParameter.parameterName}",
+																	<#if stringUtil.equals(javaMethodParameter.parameterType, "java.lang.String")>
+																		"\"" + ${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}() + "\""
+																	<#else>
+																		${schemaVarName}.get${javaMethodParameter.parameterName?cap_first}()
+																	</#if>
+																);
+															</#if>
 														<#else>
-															put("${javaMethodParameter.parameterName}", null);
+															<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+															<#if stringUtil.equals(javaMethodParameter.parameterName, "siteId")>
+																put("siteKey", testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}());
+															<#else>
+																put("${javaMethodParameter.parameterName}", testGraphQL${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}());
+															</#if>
 														</#if>
 													</#if>
 												</#list>
@@ -1674,6 +1711,12 @@ public abstract class Base${schemaName}ResourceTestCase {
 					Assert.assertTrue(true);
 				</#if>
 			}
+
+			<@getGetterParameterMethods
+				javaMethodSignature=javaMethodSignature
+				missingGetterJavaMethodParametersMap=missingGetterJavaMethodParametersMap
+				testNamePrefix="testGraphQL"
+			/>
 
 			@Test
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}NotFound() throws Exception {
@@ -2616,9 +2659,36 @@ public abstract class Base${schemaName}ResourceTestCase {
 			put${schemaName}.getId()
 		<#elseif freeMarkerTool.isPathParameter(javaMethodParameter, javaMethodSignature.operation) && properties?keys?seq_contains(javaMethodParameter.parameterName)>
 			put${schemaName}.get${javaMethodParameter.parameterName?cap_first}()
+		<#else>
+			<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+			test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 		</#if>
 
 		<#sep>, </#sep>
+	</#list>
+</#macro>
+
+<#macro getGetterParameterMethod
+	javaMethodParameter
+	javaMethodSignature
+	testNamePrefix
+>
+	protected ${javaMethodParameter.parameterType} ${testNamePrefix}${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}() throws Exception {
+		throw new UnsupportedOperationException("This method needs to be implemented");
+	}
+</#macro>
+
+<#macro getGetterParameterMethods
+	javaMethodSignature
+	missingGetterJavaMethodParametersMap
+	testNamePrefix
+>
+	<#list missingGetterJavaMethodParametersMap?values as javaMethodParameter>
+		<@getGetterParameterMethod
+			javaMethodParameter=javaMethodParameter
+			javaMethodSignature=javaMethodSignature
+			testNamePrefix=testNamePrefix
+		/>
 	</#list>
 </#macro>
 
@@ -2671,7 +2741,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 		<#elseif stringUtil.equals(javaMethodParameter.parameterName, "multipartBody") || stringUtil.equals(javaMethodParameter.parameterName, schemaVarName)>
 			${newSchemaVarNamePrefix}${schemaName}
 		<#else>
-			null
+			<#assign missingGetterJavaMethodParametersMap = missingGetterJavaMethodParametersMap + {javaMethodParameter.parameterName: javaMethodParameter} />
+			test${javaMethodSignature.methodName?cap_first}_get${javaMethodParameter.parameterName?cap_first}()
 		</#if>
 		<#sep>, </#sep>
 	</#list>


### PR DESCRIPTION
Related ticket: [LPS-149497](https://issues.liferay.com/browse/LPS-149497)

This PR contains an updated template for the `Base*ResourceTestCase` that includes the auto-generation of new protected methods to allow, from any extended Test, to modify the value of the attributes that are not included in the API model.

Before the PR:

The test should be completely overriden without calling the test from the parent because it was not possible to customize the value of any parameter included in the path of the URL but not in the requested API model.

```
@Test
public void testGetTermOrderTypeOrderType() throws Exception {
        OrderType postOrderType = testGetTermOrderTypeOrderType_addOrderType();
        
        OrderType getOrderType = orderTypeResource.getTermOrderTypeOrderType(null);
        
        assertEquals(postOrderType, getOrderType);
        assertValid(getOrderType);
}
```

After the PR:

It is possible to use the test from the Base class by implementing/overriding the required methods.

```
@Test
public void testGetTermOrderTypeOrderType() throws Exception {
	OrderType postOrderType = testGetTermOrderTypeOrderType_addOrderType();

	OrderType getOrderType = orderTypeResource.getTermOrderTypeOrderType(
		testGetTermOrderTypeOrderType_getTermOrderTypeId());

	assertEquals(postOrderType, getOrderType);
	assertValid(getOrderType);
}
```

```
protected Long testGetTermOrderTypeOrderType_getTermOrderTypeId()
	throws Exception {

	throw new UnsupportedOperationException(
		"This method needs to be implemented");
}
```
