### PR TITLE
[TS] LPS-149967 Number of elements dropdown of the search pagination has a wrong role="button"

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/lexicon/start.jsp
@@ -87,7 +87,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 	<div class="pagination-bar" data-qa-id="paginator" id="<%= namespace + id %>">
 		<c:if test="<%= deltaConfigurable %>">
 			<div class="dropdown pagination-items-per-page">
-				<a class="dropdown-toggle page-link" data-toggle="liferay-dropdown" href="javascript:;" role="button"><liferay-ui:message arguments="<%= delta %>" key="x-entries" />
+				<a class="dropdown-toggle page-link" data-toggle="liferay-dropdown" href="javascript:;"><liferay-ui:message arguments="<%= delta %>" key="x-entries" />
 					<span class="sr-only"><liferay-ui:message key="per-page" /></span>
 
 					<aui:icon image="caret-double-l" markupView="lexicon" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-149967

Number of elements dropdown of the search pagination has a wrong role="button".

_This issue has been reported by a blind association that is a Liferay customer, for more information see: https://issues.liferay.com/browse/LPS-148048?focusedCommentId=2626115&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2626115_

This dropdown is a link that can be unfolded to display more link options, one for each number of elements, so it shouldn't have this button role as screen reader will treat in a different way the button and the links of the page. (For example if you install the NVDA reader and press INS+F7, you will see the link lists and the button lists in different sections, and it makes no sense having them separated.)

This is a request from a blind association that is a Liferay customer and after doing some tests using both NVDA and JAWS readers for me it makes sense.

For more information you can also read the following word file from our customer attached word file https://issues.liferay.com/secure/attachment/445905/LIFERAY_Soporte60801.docx (it is in Spanish)
