### PR TITLE
LPS-147836 Assert tooltip message is displayed when hovered over an action button in responsive mode

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -167,6 +167,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-147836. Assert tooltip message will be displayed when hovered over an action button in responsive mode"
+	@priority = "3"
+	test ResponsiveModeActionsButtonsTooltips {
+		task ("Given a window size set to tablet size") {
+			SetWindowSize(value1 = "800,1024");
+		}
+
+		task ("And hovers over an action button") {
+			MouseOver(
+				key_text = "download",
+				locator1 = "ManagementBar#ANY_ICON");
+		}
+
+		task ("Then a tooltip message will be displayed") {
+			AssertTextEquals(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Download");
+		}
+	}
+
 	@description = "LPS-147865. Assert the new button is displayed as an icon button in responsive mode"
 	@priority = "5"
 	test ResponsiveModeNewButtonAsIconButton {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -169,7 +169,7 @@ definition {
 
 	@description = "LPS-147836. Assert tooltip message will be displayed when hovered over an action button in responsive mode"
 	@priority = "3"
-	test ResponsiveModeActionsButtonsTooltips {
+	test ResponsiveModeActionButtonsShouldDisplayTooltips {
 		task ("Given a window size set to tablet size") {
 			SetWindowSize(value1 = "800,1024");
 		}


### PR DESCRIPTION
**Background**
Create automated tests for Management Toolbar.

**Test Plan**
Given a user of the portal on responsive mode
When the user opens any section with the management toolbar
And hovers an action button
Then a tooltip message will be displayed

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147836