### PR TITLE
LPS-147859 Assert clear button is displayed as an icon button in responsive mode

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -82,6 +82,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CLEAR_BUTTON</td>
+	<td>//nav[contains(@class,'management-bar')]//*[contains(@aria-label, 'Clear')]//*[contains(.,'Clear')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>CLEAR_BUTTON_MOBILE</td>
+	<td>//nav[contains(@class,'management-bar')]//*[contains(@aria-label, 'Clear')]//*[contains(@class,'icon-times-circle')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FILTER_OR_ORDER</td>
 	<td>//nav[contains(@class,'management-bar')]//*[*[contains(@title,'${key_filter}')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -169,7 +169,7 @@ definition {
 
 	@description = "LPS-147859. Assert the clear button will be displayed as an icon button in responsive mode"
 	@priority = "4"
-	test ResponsiveModeClearAsAButton {
+	test ResponsiveModeClearButtonShouldDisplayAsIcon {
 		task ("Given a window size set to phone size") {
 			SetWindowSize(value1 = "360,720");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -167,6 +167,22 @@ definition {
 		}
 	}
 
+	@description = "LPS-147859. Assert the clear button will be displayed as an icon button in responsive mode"
+	@priority = "4"
+	test ResponsiveModeClearAsAButton {
+		task ("Given a window size set to phone size") {
+			SetWindowSize(value1 = "360,720");
+		}
+
+		task ("Then clear button is not displayed as a text button") {
+			AssertNotVisible(locator1 = "ManagementBar#CLEAR_BUTTON");
+		}
+
+		task ("Then clear button is displayed as an icon button") {
+			AssertElementPresent(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
+		}
+	}
+
 	@description = "LPS-147865. Assert the new button is displayed as an icon button in responsive mode"
 	@priority = "5"
 	test ResponsiveModeNewButtonAsIconButton {


### PR DESCRIPTION
**Background**
Create automated tests for Management Toolbar.

**Test Plan**
Given a user of the portal on responsive mode
When the user opens any section with the management toolbar
Then the 'clear' button will be displayed as an icon button

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147859