### PR TITLE
LPS-144832 - Add selectedLanguageIdAtom and use in input_localized and samples

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -446,21 +446,19 @@ AUI.add(
 				_onSelectFlag(event) {
 					var instance = this;
 
+					var languageId = event.item.getAttribute('data-value');
+
+					instance._State.writeAtom(
+						instance._selectedLanguageIdAtom,
+						languageId
+					);
+
 					if (!event.domEvent) {
 						Liferay.fire('inputLocalized:localeChanged', {
 							item: event.item,
 							source: instance,
 						});
 					}
-
-					var State = instance._State;
-
-					var languageId = event.item.getAttribute('data-value');
-
-					State.writeAtom(
-						instance._selectedLanguageIdAtom,
-						languageId
-					);
 				},
 
 				_onSelectedLanguageIdChange(languageId) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -443,12 +443,6 @@ AUI.add(
 						);
 				},
 
-				_onSelectedLanguageIdChange(languageId) {
-					var instance = this;
-
-					instance.selectFlag(languageId);
-				},
-
 				_onSelectFlag(event) {
 					var instance = this;
 
@@ -463,7 +457,16 @@ AUI.add(
 
 					var languageId = event.item.getAttribute('data-value');
 
-					State.writeAtom(instance._selectedLanguageIdAtom, languageId);
+					State.writeAtom(
+						instance._selectedLanguageIdAtom,
+						languageId
+					);
+				},
+
+				_onSelectedLanguageIdChange(languageId) {
+					var instance = this;
+
+					instance.selectFlag(languageId);
 				},
 
 				_onSubmit(event, input) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -443,6 +443,12 @@ AUI.add(
 						);
 				},
 
+				_onSelectedLanguageIdChange(languageId) {
+					var instance = this;
+
+					instance.selectFlag(languageId);
+				},
+
 				_onSelectFlag(event) {
 					var instance = this;
 
@@ -452,6 +458,12 @@ AUI.add(
 							source: instance,
 						});
 					}
+
+					var State = instance._State;
+
+					var languageId = event.item.getAttribute('data-value');
+
+					State.writeAtom(instance._selectedLanguageIdAtom, languageId);
 				},
 
 				_onSubmit(event, input) {
@@ -541,6 +553,10 @@ AUI.add(
 						instance._bindManageTranslationsButton();
 					}
 				},
+
+				_selectedLanguageIdAtom: null,
+
+				_selectedLanguageIdSubscription: null,
 
 				_updateHelpMessage(languageId) {
 					var instance = this;
@@ -676,6 +692,10 @@ AUI.add(
 					if (instance._availableLanguagesSubscription) {
 						instance._availableLanguagesSubscription.dispose();
 					}
+
+					if (instance._selectedLanguageIdSubscription) {
+						instance._selectedLanguageIdSubscription.dispose();
+					}
 				},
 
 				getSelectedLanguageId() {
@@ -756,6 +776,24 @@ AUI.add(
 					);
 					instance._flags = boundingBox.one('.palette-container');
 
+					instance._State = instance.get(
+						'frontendJsStateWebModule'
+					).State;
+
+					var State = instance._State;
+
+					instance._selectedLanguageIdAtom = instance.get(
+						'frontendJsComponentsWebModule'
+					).selectedLanguageIdAtom;
+
+					var selectedLanguageIdAtom =
+						instance._selectedLanguageIdAtom;
+
+					instance._selectedLanguageIdSubscription = State.subscribe(
+						selectedLanguageIdAtom,
+						A.bind('_onSelectedLanguageIdChange', instance)
+					);
+
 					var activeLanguageIds = instance.get('activeLanguageIds');
 
 					if (activeLanguageIds) {
@@ -763,17 +801,12 @@ AUI.add(
 							'frontendJsComponentsWebModule'
 						).activeLanguageIdsAtom;
 
-						instance._State = instance.get(
-							'frontendJsStateWebModule'
-						).State;
-
 						instance._flagsInitialContent = instance._flags.cloneNode(
 							true
 						);
 
 						instance._renderActiveLanguageIds();
 
-						var State = instance._State;
 						var activeLanguageIdsAtom =
 							instance._activeLanguageIdsAtom;
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -781,8 +781,6 @@ AUI.add(
 						'frontendJsStateWebModule'
 					).State;
 
-					var State = instance._State;
-
 					instance._selectedLanguageIdAtom = instance.get(
 						'frontendJsComponentsWebModule'
 					).selectedLanguageIdAtom;
@@ -790,7 +788,7 @@ AUI.add(
 					var selectedLanguageIdAtom =
 						instance._selectedLanguageIdAtom;
 
-					instance._selectedLanguageIdSubscription = State.subscribe(
+					instance._selectedLanguageIdSubscription = instance._State.subscribe(
 						selectedLanguageIdAtom,
 						A.bind('_onSelectedLanguageIdChange', instance)
 					);
@@ -812,13 +810,13 @@ AUI.add(
 							instance._activeLanguageIdsAtom;
 
 						if (instance.get('adminMode')) {
-							State.writeAtom(
+							instance._State.writeAtom(
 								activeLanguageIdsAtom,
 								activeLanguageIds
 							);
 						}
 
-						instance._availableLanguagesSubscription = State.subscribe(
+						instance._availableLanguagesSubscription = instance._State.subscribe(
 							activeLanguageIdsAtom,
 							A.bind('_onActiveLanguageIdsChange', instance)
 						);

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TranslationManagerSamples.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TranslationManagerSamples.js
@@ -17,6 +17,7 @@ import {State} from '@liferay/frontend-js-state-web';
 import {
 	TranslationAdminSelector,
 	activeLanguageIdsAtom,
+	selectedLanguageIdAtom,
 } from 'frontend-js-components-web';
 import React, {useEffect, useState} from 'react';
 
@@ -33,11 +34,16 @@ export default function TranslationManagerSamples({
 
 	useEffect(() => {
 		State.subscribe(activeLanguageIdsAtom, setActiveLanguageIds);
+		State.subscribe(selectedLanguageIdAtom, setSelectedLanguageId);
 	}, []);
 
 	useEffect(() => {
 		State.writeAtom(activeLanguageIdsAtom, activeLanguageIds);
 	}, [activeLanguageIds]);
+
+	useEffect(() => {
+		State.writeAtom(selectedLanguageIdAtom, selectedLanguageId);
+	}, [selectedLanguageId]);
 
 	return (
 		<>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/state.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/state.js
@@ -15,3 +15,4 @@
 import {State} from '@liferay/frontend-js-state-web';
 
 export const activeLanguageIdsAtom = State.atom('activeLocaleIds', []);
+export const selectedLanguageIdAtom = State.atom('selectedLocaleId', []);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/Kaleodesigner.testcase
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-test/src/testFunctional/tests/Kaleodesigner.testcase
@@ -725,6 +725,7 @@ definition {
 	@description = "This is a use case for LPS-71924."
 	@priority = "5"
 	test PublishDefaultWorkflowDefinition {
+		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "Kaleodesigner#PublishDefaultWorkflowDefinition";
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/edit_kaleo_definition_version.jsp
@@ -663,18 +663,18 @@ String successMessageKey = KaleoDesignerPortletKeys.KALEO_DESIGNER + "requestPro
 
 									<c:choose>
 										<c:when test="<%= kaleoDefinitionVersion == null %>">
-											var titleComponent = Liferay.component('<portlet:namespace />title');
+											Liferay.componentReady('<portlet:namespace />title').then((titleComponent) => {
+												var titlePlaceholderInput = titleComponent.get('inputPlaceholder');
 
-											var titlePlaceholderInput = titleComponent.get('inputPlaceholder');
-
-											if (titlePlaceholderInput) {
-												titlePlaceholderInput.after('change', (event) => {
-													<portlet:namespace />kaleoDesigner.set(
-														'definitionName',
-														titleComponent.getValue()
-													);
-												});
-											}
+												if (titlePlaceholderInput) {
+													titlePlaceholderInput.after('change', (event) => {
+														<portlet:namespace />kaleoDesigner.set(
+															'definitionName',
+															titleComponent.getValue()
+														);
+													});
+												}
+											});
 										</c:when>
 									</c:choose>
 

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -354,10 +354,22 @@
 					});
 				</c:when>
 				<c:otherwise>
-					Liferay.InputLocalized.register(
-						'<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>',
-						inputLocalizedProps
-					);
+					Liferay.Loader.require(
+					[
+						A.config.groups.components.mainModule,
+						A.config.groups.state.mainModule,
+					],
+					(frontendJsComponentsWebModule, frontendJsStateWebModule) => {
+
+						Liferay.InputLocalized.register(
+							'<%= namespace + id + HtmlUtil.getAUICompatibleId(fieldSuffix) %>',
+							{
+								frontendJsComponentsWebModule,
+								frontendJsStateWebModule,
+								...inputLocalizedProps
+							}
+						);
+					});
 				</c:otherwise>
 			</c:choose>
 


### PR DESCRIPTION
This PR was reverted a second time due to [this bug](https://issues.liferay.com/browse/LPS-149392). After analyzing it, the cause is a race condition: the workflow team is using `Liferay.component` in an inline script to get the `input_localized` instance, which now takes longer to initialize due to the atom. Getting the instance asynchronously using `Liferay.componentReady` fixes the bug.

### References

- [LPS-144832](https://issues.liferay.com/browse/LPS-144832)
- [LPS-148305](https://issues.liferay.com/browse/LPS-148305)
- [LPS-149392](https://issues.liferay.com/browse/LPS-149392)

### What is the goal?

* Add `selectedLanguageIdAtom` to share the currently selected language between `input_localized` and any React component. 

### What does it look like?

https://user-images.githubusercontent.com/6642927/156166334-1f342c33-fd83-42d0-ac86-c5a41de61469.mov



### How to replicate
* Go to `Content & Data > Web Content`
* Click on `+` button and select `Basic Web Content` in the dropdown
* Type something in the input at the top
* Click on the flag next to that input, select a different flag
* See that the input has the same value as before (might change alignment in different locales)
* See that if you click on the flag next to the input, the currently selected language still shows as `Not translated`

### Notes
* I'm not convinced by this solution: having two different "events" for this makes it flaky, and maybe the opposite could happen in the future (someone using the atom having the changes to the atom overridden because of the event). Maybe we should remove `inputLocalized:localeChanged` and use the atom instead, or remove the atom and use that event in React components. 

