### PR TITLE
LRQA-73996 Fix widget category locator

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenuAddPanel.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/controlmenu/ControlMenuAddPanel.path
@@ -47,6 +47,12 @@
 	<td>//div[contains(@class,'item-body')]//div[contains(@class,'title')][normalize-space(text())='${key_entryTitle}']</td>
 	<td></td>
 </tr>
+<!--WIDGETS-->
+<tr>
+	<td>WIDGET_CATEGORY</td>
+	<td>//div[contains(@class,'panel-group')]//*[contains(@class,'subtitle') and *[normalize-space(text())='${key_category}']]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -71,8 +71,8 @@ definition {
 				value1 = "Test Remote App");
 
 			AssertElementPresent(
-				key_assetItem = "Collaboration",
-				locator1 = "ControlMenuAddPanel#ASSET_ITEM");
+				key_category = "Collaboration",
+				locator1 = "ControlMenuAddPanel#WIDGET_CATEGORY");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Previous path that was used was [modified](https://github.com/brianchandotcom/liferay-portal/commit/9172008c7e895816d922adb64d2637918ce9bcb1) and no longer works for this test. Created a better path to target just the category subtitle.  

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-73996