### PR TITLE
LPS-150162 Remove unused clickWaitForInlineCKEditorNoMouseOver function

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/functions/Click.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/Click.function
@@ -108,18 +108,6 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
-	function clickWaitForInlineCKEditorNoMouseOver {
-		WaitForSPARefresh();
-
-		if (selenium.isElementPresent("//div[contains(@class,'cke_editable_inline')]")) {
-			selenium.waitForElementPresent("//script[contains(@src,'http://localhost:8080/o/frontend-editors-web/ckeditor/plugins/wsc/lang/en.js')]");
-		}
-
-		selenium.waitForVisible();
-
-		selenium.click();
-	}
-
 	function javaScriptClick {
 		WaitForSPARefresh();
 


### PR DESCRIPTION
Full Context: https://github.com/liferay/liferay-ckeditor/pull/196

## Why?

wsc was deprecated on ckeditor@4.18.0 and this function it's unused around DXP