### PR TITLE
LPS-113528 Move `getGeolocation` to frontend-js-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -435,25 +435,6 @@
 			return columnId;
 		},
 
-		getGeolocation(success, fallback, options) {
-			if (success && navigator.geolocation) {
-				navigator.geolocation.getCurrentPosition(
-					(position) => {
-						success(
-							position.coords.latitude,
-							position.coords.longitude,
-							position
-						);
-					},
-					fallback,
-					options
-				);
-			}
-			else if (fallback) {
-				fallback();
-			}
-		},
-
 		getLexiconIconTpl(icon, cssClass) {
 			return Liferay.Util.sub(TPL_LEXICON_ICON, icon, cssClass || '');
 		},

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -54,6 +54,7 @@ import formatXML from './util/format_xml.es';
 import getCropRegion from './util/get_crop_region.es';
 import getDOM from './util/get_dom';
 import getElement from './util/get_element';
+import getGeolocation from './util/get_geolocation';
 import getLexiconIcon from './util/get_lexicon_icon';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
@@ -194,6 +195,7 @@ Liferay.Util.getDOM = getDOM;
  */
 Liferay.Util.getElement = getElement;
 
+Liferay.Util.getGeolocation = getGeolocation;
 Liferay.Util.getFormElement = getFormElement;
 Liferay.Util.getLexiconIcon = getLexiconIcon;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_geolocation.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_geolocation.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function getGeolocation(success, fallback, options) {
+	if (success && navigator.geolocation) {
+		navigator.geolocation.getCurrentPosition(
+			(position) => {
+				success(
+					position.coords.latitude,
+					position.coords.longitude,
+					position
+				);
+			},
+			fallback,
+			options
+		);
+	}
+	else if (fallback) {
+		fallback();
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_geolocation.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_geolocation.js
@@ -14,7 +14,7 @@
 
 import getGeolocation from '../../../src/main/resources/META-INF/resources/liferay/util/get_geolocation';
 
-describe('Liferay.Util.getCropRegion', () => {
+describe('Liferay.Util.getGeolocation', () => {
 	it('calls navigator.geolocation.getCurrentPosition if location is enabled', () => {
 		const success = jest.fn();
 		const fallback = jest.fn();

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_geolocation.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_geolocation.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getGeolocation from '../../../src/main/resources/META-INF/resources/liferay/util/get_geolocation';
+
+describe('Liferay.Util.getCropRegion', () => {
+	it('calls navigator.geolocation.getCurrentPosition if location is enabled', () => {
+		const success = jest.fn();
+		const fallback = jest.fn();
+
+		const mockGeolocation = {
+			getCurrentPosition: jest.fn(),
+			watchPosition: jest.fn(),
+		};
+
+		global.navigator.geolocation = mockGeolocation;
+
+		getGeolocation(success, fallback);
+
+		expect(navigator.geolocation.getCurrentPosition).toHaveBeenCalled();
+	});
+
+	it('returns a null island location if location is disabled', () => {
+		const success = jest.fn();
+		const fallback = jest.fn();
+
+		global.navigator.geolocation = null;
+
+		getGeolocation(success, fallback);
+
+		expect(fallback).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Alternative to #1992 

With us finally deciding what to do with these kinda things, here's the wanted approach - moving `getGeolocation` to `frontend-js-web`, and removing it from `frontend-js-aui-web`.