### PR TITLE
LPS-149682 `--container-max-*` CSS custom properties should apply to …

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/css/_clay_variables.scss
@@ -246,10 +246,10 @@ $grid-gutter-width: 24px !default;
 $grid-row-columns: 6 !default;
 
 $container-max-widths: (
-	sm: 540px,
-	md: 720px,
-	lg: 960px,
-	xl: 1248px,
+	sm: var(--container-max-sm, 540px),
+	md: var(--container-max-md, 720px),
+	lg: var(--container-max-lg, 960px),
+	xl: var(--container-max-xl, 1248px),
 ) !default;
 
 $container-form-lg: () !default;


### PR DESCRIPTION
…`.container` / `.container-fluid`

https://issues.liferay.com/browse/LPS-149682

We need to wait for https://github.com/liferay/clay/pull/4757 (next Clay release) to make it in liferay-portal for this PR. The mixins `_assert-ascending` and `_assert-starts-at-zero` were duplicated and the old ones were winning over the new ones in Portal for some reason.