### PR TITLE
LPS-113532 Modernize `Liferay.Util.getTop()`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -459,54 +459,6 @@
 			return openingWindow || window.opener || window.parent;
 		},
 
-		getTop() {
-			var topWindow = Util._topWindow;
-
-			if (!topWindow) {
-				var parentWindow = window.parent;
-
-				var parentThemeDisplay;
-
-				while (parentWindow !== window) {
-					try {
-						if (typeof parentWindow.location.href === 'undefined') {
-							break;
-						}
-
-						parentThemeDisplay = parentWindow.themeDisplay;
-					}
-					catch (error) {
-						break;
-					}
-
-					if (
-						!parentThemeDisplay ||
-						window.name === 'simulationDeviceIframe'
-					) {
-						break;
-					}
-					else if (
-						!parentThemeDisplay.isStatePopUp() ||
-						parentWindow === parentWindow.parent
-					) {
-						topWindow = parentWindow;
-
-						break;
-					}
-
-					parentWindow = parentWindow.parent;
-				}
-
-				if (!topWindow) {
-					topWindow = window;
-				}
-
-				Util._topWindow = topWindow;
-			}
-
-			return topWindow;
-		},
-
 		getWindow(id) {
 			if (!id) {
 				id = Util.getWindowName();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -58,6 +58,7 @@ import getGeolocation from './util/get_geolocation';
 import getLexiconIcon from './util/get_lexicon_icon';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
+import getTop from './util/get_top';
 import getURLWithSessionId from './util/get_url_with_session_id';
 import {
 	MAP_HTML_CHARS_ESCAPED,
@@ -209,6 +210,7 @@ Liferay.Util.getLexiconIcon = getLexiconIcon;
 Liferay.Util.getPortletId = getPortletId;
 
 Liferay.Util.getPortletNamespace = getPortletNamespace;
+Liferay.Util.getTop = getTop;
 Liferay.Util.getURLWithSessionId = getURLWithSessionId;
 Liferay.Util.groupBy = groupBy;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -122,6 +122,8 @@ declare module Liferay {
 			cssClass?: string
 		): HTMLElement;
 
+		export function getTop(): Window;
+
 		export function getOpener(): any;
 
 		/**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_top.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_top.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const SIMULATION_DEVICE_IFRAME = 'simulationDeviceIframe';
+let _topWindow;
+
+export default function getTop() {
+	let topWindow = _topWindow;
+
+	if (!topWindow) {
+		let parentWindow = window.parent;
+
+		let parentThemeDisplay;
+
+		while (parentWindow !== window) {
+			try {
+				if (typeof parentWindow.location.href === 'undefined') {
+					break;
+				}
+
+				parentThemeDisplay = parentWindow.themeDisplay;
+			}
+			catch (error) {
+				break;
+			}
+
+			if (
+				!parentThemeDisplay ||
+				window.name === SIMULATION_DEVICE_IFRAME
+			) {
+				break;
+			}
+			else if (
+				!parentThemeDisplay.isStatePopUp() ||
+				parentWindow === parentWindow.parent
+			) {
+				topWindow = parentWindow;
+
+				break;
+			}
+
+			parentWindow = parentWindow.parent;
+		}
+
+		if (!topWindow) {
+			topWindow = window;
+		}
+
+		_topWindow = topWindow;
+	}
+
+	return topWindow;
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_top.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_top.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getTop from '../../../src/main/resources/META-INF/resources/liferay/util/get_top';
+
+describe('Liferay.Util.getTop', () => {
+	it('returns the window object if there is no parent window', () => {
+		Object.defineProperty(window, 'parent', {value: null, writable: true});
+
+		global.name = 'foo';
+
+		const topWindow = getTop();
+
+		expect(topWindow.parent).toBe(null);
+		expect(topWindow.name).toEqual('foo');
+	});
+
+	it('returns the window object if the parent window has no location.href', () => {
+		const parent = {
+			name: 'bar',
+			themeDisplay: {
+				isStatePopUp: jest.fn(() => false),
+			},
+		};
+
+		Object.defineProperty(window, 'parent', {
+			value: parent,
+			writable: true,
+		});
+
+		global.name = 'foo';
+
+		const topWindow = getTop();
+
+		expect(topWindow.name).toEqual('foo');
+	});
+
+	it("returns the window object if the parent window has no themeDisplay or its name is 'simulationDeviceIframe'", () => {
+		const parent = {
+			location: {
+				href: 'bar',
+			},
+			name: 'simulationDeviceIframe',
+			themeDisplay: {
+				isStatePopUp: jest.fn(() => false),
+			},
+		};
+
+		Object.defineProperty(window, 'parent', {
+			value: parent,
+			writable: true,
+		});
+
+		global.name = 'foo';
+
+		const topWindow = getTop();
+
+		expect(topWindow.name).toEqual('foo');
+	});
+});


### PR DESCRIPTION
LPS in question: https://issues.liferay.com/browse/LPS-113532

This one was a bit of a hassle due to testing woes around the Window object. The implementation itself is kinda whatever, nothing fancy. 

This util usually gets invoked in modals/popups to retrieve the proper Window object needed for further work in the app.