### PR TITLE
LPS-113535 deprecate `Liferay.Util.getWindowName`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -464,7 +464,7 @@
 			if (!openingWindow) {
 				var topUtil = Liferay.Util.getTop().Liferay.Util;
 
-				var windowName = Liferay.Util.getWindowName();
+				var windowName = window.name;
 
 				var dialog = topUtil.Window.getById(windowName);
 
@@ -571,8 +571,11 @@
 			return Util.getTop().Liferay.Util.Window.getById(id);
 		},
 
+		/**
+		 * @deprecated As of Athanasius (7.3.x), replaced by `window.innerWidth`
+		 */
 		getWindowName() {
-			return window.name || Window._name || '';
+			return window.name || '';
 		},
 
 		/**

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -572,10 +572,10 @@
 		},
 
 		/**
-		 * @deprecated As of Athanasius (7.3.x), replaced by `window.innerWidth`
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `window.name`
 		 */
 		getWindowName() {
-			return window.name || '';
+			return window.name || Window._name || '';
 		},
 
 		/**

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -37,7 +37,7 @@
 				{
 					doc: document,
 					win: window,
-					windowName: Liferay.Util.getWindowName()
+					windowName: window.name
 				}
 			);
 		</c:when>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113535

This util just returns `window.name` because `Window._name` doesn't exist (and hasn't for like 11 years or something). 

After talking with @bryceosterhaus we decided to deprecate it and update it's few usages, apart from 2 that are inside a deprecated file/method.