### PR TITLE
LPS-148106 Update `@clayui/css` package to v2.51.0

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -9,7 +9,7 @@
 		"@clayui/charts": "3.40.0",
 		"@clayui/color-picker": "3.50.0",
 		"@clayui/core": "3.50.0",
-		"@clayui/css": "3.50.0",
+		"@clayui/css": "3.51.0",
 		"@clayui/data-provider": "3.49.0",
 		"@clayui/date-picker": "3.49.0",
 		"@clayui/drop-down": "3.49.0",

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_dropdowns.scss
@@ -4,7 +4,3 @@
 		display: block;
 	}
 }
-
-.dropdown-menu .dropdown-item.active {
-	pointer-events: initial;
-}

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/fragments/package.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-customer-portal/src/main/resources/site-initializer/fragments/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/button": "3.40.0",
-		"@clayui/css": "3.50.0",
+		"@clayui/css": "3.51.0",
 		"@clayui/drop-down": "3.49.0",
 		"@clayui/form": "3.49.0",
 		"@clayui/icon": "3.40.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -969,10 +969,10 @@
     react-dnd-html5-backend "^11.1.1"
     react-transition-group "^4.4.1"
 
-"@clayui/css@3.50.0":
-  version "3.50.0"
-  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.50.0.tgz#27535b21f6e158bfe914148481818a4238ffba4d"
-  integrity sha512-FwVtFSjol+y+bfLIw2dXkVPmMFctnPG/MA3Bo6uu6pCGWBogP94x5L/laeiAzrAhkyayCETysR6dPQPoP/M06Q==
+"@clayui/css@3.51.0":
+  version "3.51.0"
+  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.51.0.tgz#58f4175521545fd8ce593418cf95ba8dec82478a"
+  integrity sha512-GxmEO6ZZWsjIaPWmGqQYq8vmimp90atgOJC/8JRyfw1luWMEwAdiOwNCbue3jsyq/3F9CZ/L5nSj36fynkmCqQ==
 
 "@clayui/data-provider@3.49.0":
   version "3.49.0"


### PR DESCRIPTION
## [3.51.0](https://github.com/liferay/clay/compare/v3.50.0...v3.51.0) (2022-03-28)

### Bug Fixes

-   **@clayui/css:** Dropdown removes `pointer-events: none` from `.dropdown-item.active` ([e36ba48](https://github.com/liferay/clay/commit/e36ba4833290fa41affe3091d27766e0250d8b58))
-   **@clayui/css:** Map new `$font-scale`s to `$font-size-*` variables ([41edc3b](https://github.com/liferay/clay/commit/41edc3b7f176650b6f37f397cf1d9eb05c2f0c18))
-   **@clayui/css:** Mixin `clay-navbar-variant` get `focus, color` instead of `focus-color` ([606f8ee](https://github.com/liferay/clay/commit/606f8ee431f06a9df3d554096c0927180c6d7522))
-   **@clayui/css:** Mixin clay-nav-nested use css calc() to calculate left padding ([b1e6d1e](https://github.com/liferay/clay/commit/b1e6d1e554039428436a395f166b338e534ea96b))
-   **@clayui/css:** Removes duplicate mixins \_assert-ascending and \_assert-starts-at-zero ([23c72d6](https://github.com/liferay/clay/commit/23c72d64f0bdf6721611ad37527b3beeca38aeda))
-   **@clayui/css:** SVG Icons update shopping-cart.svg to new design ([8044608](https://github.com/liferay/clay/commit/804460816b4608903c33555057957b978d868342))
-   **@clayui/css:** Table removes `border-width: 0` from `.table-responsive > .table-bordered` ([7ddedba](https://github.com/liferay/clay/commit/7ddedba5da821d4c7e26ee3ec57af6fdff0956e7))
-   **@clayui/css:** Utilities Close use newer keys in Sass map ([9d8c40e](https://github.com/liferay/clay/commit/9d8c40ec949ae3199be62a00663a173b6fd70d50))
-   **@clayui/css:** Utilities update `.text-*` values to be generated by the `$font-scale` map ([938a801](https://github.com/liferay/clay/commit/938a801ce0640ab9c8991f1dce61b3e8d01874d8))

### Features

-   **@clayui/css:** Generate \_lx-icons-generated.scss ([deeccbb](https://github.com/liferay/clay/commit/deeccbbd43a348b49d23cd07ff0a91576e6d3299))
-   **@clayui/css:** Globals adds `$font-scale` map for setting a Design System's progression of font sizes ([7e7107d](https://github.com/liferay/clay/commit/7e7107d628a8311987fe9d664d07826c082f5355))
-   **@clayui/css:** Mixins `clay-navbar-size` should use `calc` instead of Sass arithmetic ([9728edb](https://github.com/liferay/clay/commit/9728edb2bcc0adea58d48ebad1e7cb995ad2a480))
-   **@clayui/css:** SVG Icons adds cookie and Commerce icons ([fb49037](https://github.com/liferay/clay/commit/fb490378d66e4ef2a7d7e27cdcd519d7a28095ba))
-   **@clayui/css:** Use `calc` instead of Sass arithmetic for scaling font sizes ([1e1b734](https://github.com/liferay/clay/commit/1e1b7343dc33a74a8ad35b170adcab93a39d1e83))