### PR TITLE
LPS-148143 | Add test to add language with no success message and undo option

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -42,7 +42,7 @@ definition {
 
 	@description = "LPS-148143. Add language with no success message and undo option."
 	@priority = "3"
-	test AddLanguageWithNoSuccessMessageAndUndoOption {
+	test AssertNoSuccessMessageAndUndoOptionAfterAddingLanguage {
 		task ("Given manage translations modal") {
 			TranslationManagerPortlet.goToManageTranslationsModal(
 				key_currentLocale = "en-us",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -40,6 +40,44 @@ definition {
 		}
 	}
 
+	@description = "LPS-148143. Add language with no success message and undo option."
+	@priority = "3"
+	test AddLanguageWithNoSuccessMessageAndUndoOption {
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToManageTranslationsModal(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("When add language in Manage Translations table list") {
+			ManageTranslations.addLanguage(key_locale = "zh-CN");
+		}
+
+		task ("Then assert no success message and undo option") {
+			AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
+
+			AssertElementNotPresent(
+				key_text = "undo",
+				locator1 = "Icon#ANY_DISABLED");
+		}
+
+		task ("Then save add language and assert the modal is closed") {
+			Click(locator1 = "Button#DONE");
+
+			AssertElementNotPresent(locator1 = "Modal#MODAL");
+		}
+
+		task ("Then assert the language is active in language selector") {
+			TranslationManagerPortlet.clickSelectTranslation(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+
+			AssertElementPresent(
+				key_locale = "zh-CN",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
+		}
+	}
+
 	@description = "LPS-147612. Validates translation can be synced in selector and text field."
 	@priority = "3"
 	test CanBeSyncedOnSelectedAndTranslatedLanguages {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -40,9 +40,9 @@ definition {
 		}
 	}
 
-	@description = "LPS-148143. Add language with no success message and undo option."
+	@description = "LPS-148143. Translations manager has no success message and undo option after adding language to translations list."
 	@priority = "3"
-	test AssertNoSuccessMessageAndUndoOptionAfterAddingLanguage {
+	test HasNoSuccessMessageAndUndoOptionAfterAddingLanguage {
 		task ("Given manage translations modal") {
 			TranslationManagerPortlet.goToManageTranslationsModal(
 				key_currentLocale = "en-us",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -40,44 +40,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-148143. Translations manager has no success message and undo option after adding language to translations list."
-	@priority = "3"
-	test HasNoSuccessMessageAndUndoOptionAfterAddingLanguage {
-		task ("Given manage translations modal") {
-			TranslationManagerPortlet.goToManageTranslationsModal(
-				key_currentLocale = "en-us",
-				key_title = "Admin");
-		}
-
-		task ("When add language in Manage Translations table list") {
-			ManageTranslations.addLanguage(key_locale = "zh-CN");
-		}
-
-		task ("Then assert no success message and undo option") {
-			AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
-
-			AssertElementNotPresent(
-				key_text = "undo",
-				locator1 = "Icon#ANY_DISABLED");
-		}
-
-		task ("Then save add language and assert the modal is closed") {
-			Click(locator1 = "Button#DONE");
-
-			AssertElementNotPresent(locator1 = "Modal#MODAL");
-		}
-
-		task ("Then assert the language is active in language selector") {
-			TranslationManagerPortlet.clickSelectTranslation(
-				key_currentLocale = "en-us",
-				key_title = "Admin");
-
-			AssertElementPresent(
-				key_locale = "zh-CN",
-				locator1 = "Translation#DROPDOWN_MENU_ITEM");
-		}
-	}
-
 	@description = "LPS-147612. Validates translation can be synced in selector and text field."
 	@priority = "3"
 	test CanBeSyncedOnSelectedAndTranslatedLanguages {
@@ -271,6 +233,44 @@ definition {
 			AssertElementNotPresent(
 				key_index = "2",
 				locator1 = "ManageTranslations#TABLE_BODY_ROW_INDEX");
+		}
+	}
+
+	@description = "LPS-148143. Translations manager has no success message and undo option after adding language to translations list."
+	@priority = "3"
+	test HasNoSuccessMessageAndUndoOptionAfterAddingLanguage {
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToManageTranslationsModal(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("When add language in Manage Translations table list") {
+			ManageTranslations.addLanguage(key_locale = "zh-CN");
+		}
+
+		task ("Then assert no success message and undo option") {
+			AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
+
+			AssertElementNotPresent(
+				key_text = "undo",
+				locator1 = "Icon#ANY_DISABLED");
+		}
+
+		task ("Then save add language and assert the modal is closed") {
+			Click(locator1 = "Button#DONE");
+
+			AssertElementNotPresent(locator1 = "Modal#MODAL");
+		}
+
+		task ("Then assert the language is active in language selector") {
+			TranslationManagerPortlet.clickSelectTranslation(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+
+			AssertElementPresent(
+				key_locale = "zh-CN",
+				locator1 = "Translation#DROPDOWN_MENU_ITEM");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automation tests for Manage Translations

**Test Plan**
Given Manage Translations modal is open
When add a language from the dropdown list
Then assert no success message and undo option
When click Done button
Then assert Manage Translations modal is closed
Then click the language selector
Then assert the language is active options

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-148143