### PR TITLE
LPS-113531 Move `getOpener` to frontend-js-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -439,26 +439,6 @@
 			return Liferay.Util.sub(TPL_LEXICON_ICON, icon, cssClass || '');
 		},
 
-		getOpener() {
-			var openingWindow = Window._opener;
-
-			if (!openingWindow) {
-				var topUtil = Liferay.Util.getTop().Liferay.Util;
-
-				var windowName = window.name;
-
-				var dialog = topUtil.Window.getById(windowName);
-
-				if (dialog) {
-					openingWindow = dialog._opener;
-
-					Window._opener = openingWindow;
-				}
-			}
-
-			return openingWindow || window.opener || window.parent;
-		},
-
 		getTop() {
 			var topWindow = Util._topWindow;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -56,6 +56,7 @@ import getDOM from './util/get_dom';
 import getElement from './util/get_element';
 import getGeolocation from './util/get_geolocation';
 import getLexiconIcon from './util/get_lexicon_icon';
+import getOpener from './util/get_opener';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
 import getURLWithSessionId from './util/get_url_with_session_id';
@@ -202,6 +203,7 @@ Liferay.Util.getElement = getElement;
 Liferay.Util.getGeolocation = getGeolocation;
 Liferay.Util.getFormElement = getFormElement;
 Liferay.Util.getLexiconIcon = getLexiconIcon;
+Liferay.Util.getOpener = getOpener;
 
 /**
  * @deprecated As of Athanasius (7.3.x), replaced by `import {getPortletId} from 'frontend-js-web'`

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_opener.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_opener.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+let _opener;
+
+export default function getOpener() {
+	let openingWindow = _opener;
+
+	if (!openingWindow) {
+		const topUtil = Liferay.Util.getTop().Liferay.Util;
+		const windowName = Liferay.Util.getWindowName();
+
+		const dialog = topUtil.Window.getById(windowName);
+
+		if (dialog) {
+			openingWindow = dialog._opener;
+
+			_opener = openingWindow;
+		}
+	}
+
+	return openingWindow || window.opener || window.parent;
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_opener.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_opener.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getOpener from '../../../src/main/resources/META-INF/resources/liferay/util/get_opener';
+
+describe('Liferay.Util.getOpener', () => {
+	Liferay = {
+		Util: {
+			Window: {
+				getById: jest.fn(() => global.name),
+			},
+			getTop: jest.fn(() => global),
+			getWindowName: jest.fn(() => global.name),
+		},
+	};
+
+	beforeEach(() => {
+		global.name = 'foo';
+		global.opener = global;
+		global.opener.name = 'bar';
+	});
+
+	it('returns the opener window', () => {
+		const opener = getOpener();
+
+		expect(opener.name).toBe('bar');
+	});
+
+	it('returns the most parent opener window', () => {
+		global.parent.parent.parent.name = 'baz';
+
+		const opener = getOpener();
+
+		expect(opener.name).toBe('baz');
+	});
+});


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113531

This util returns the `window` object of the page that caused a new (browser) window/tab to be opened or a page change.

You can test this by going to Blogs > `+` button, which will trigger the function to get invoked.