### PR TITLE
LPS-148708 Create `enableCustomDialogs` feature flag

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
@@ -16,9 +16,12 @@ package com.liferay.frontend.js.components.web.internal.servlet.taglib;
 
 import com.liferay.frontend.js.components.web.internal.configuration.FFFrontendJSComponentsConfiguration;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -53,10 +56,17 @@ public class FrontendComponentsTopHeadDynamicInclude
 		StringBundler sb = new StringBundler(5);
 
 		sb.append("<script>var Liferay = window.Liferay || {};");
+
 		sb.append("Liferay.__FF__ = Liferay.__FF__ || {};");
-		sb.append("Liferay.__FF__.enableClayTreeView = ");
-		sb.append(_ffFrontendJSComponentsConfiguration.enableClayTreeView());
-		sb.append(";</script>");
+
+		_createRuntimeFeatureFlag(
+			sb, "enableClayTreeView",
+			_ffFrontendJSComponentsConfiguration.enableClayTreeView());
+
+		_createRuntimeFeatureFlag(
+			sb, "enableCustomDialogs", _shouldEnableCustomDialogs());
+
+		sb.append("</script>");
 
 		printWriter.println(sb);
 	}
@@ -72,6 +82,26 @@ public class FrontendComponentsTopHeadDynamicInclude
 		_ffFrontendJSComponentsConfiguration =
 			ConfigurableUtil.createConfigurable(
 				FFFrontendJSComponentsConfiguration.class, properties);
+	}
+
+	private void _createRuntimeFeatureFlag(
+		StringBundler sb, String featureFlagName, boolean validator) {
+
+		sb.append("Liferay.__FF__.");
+		sb.append(featureFlagName);
+		sb.append(" = ");
+		sb.append(validator);
+		sb.append(StringPool.SEMICOLON);
+	}
+
+	private boolean _shouldEnableCustomDialogs() {
+		if (GetterUtil.getBoolean(
+				PropsUtil.get("feature.flag.enableCustomDialogs"))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private volatile FFFrontendJSComponentsConfiguration

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
@@ -59,12 +59,16 @@ public class FrontendComponentsTopHeadDynamicInclude
 
 		sb.append("Liferay.__FF__ = Liferay.__FF__ || {};");
 
-		_createRuntimeFeatureFlag(
-			sb, "enableClayTreeView",
-			_ffFrontendJSComponentsConfiguration.enableClayTreeView());
+		sb.append(
+			_buildFeatureFlagJSGlobalVariable(
+				"enableClayTreeView",
+				_ffFrontendJSComponentsConfiguration.enableClayTreeView()));
 
-		_createRuntimeFeatureFlag(
-			sb, "enableCustomDialogs", _shouldEnableCustomDialogs());
+		sb.append(
+			_buildFeatureFlagJSGlobalVariable(
+				"enableCustomDialogs",
+				GetterUtil.getBoolean(
+					PropsUtil.get("feature.flag.enableCustomDialogs"))));
 
 		sb.append("</script>");
 
@@ -84,24 +88,18 @@ public class FrontendComponentsTopHeadDynamicInclude
 				FFFrontendJSComponentsConfiguration.class, properties);
 	}
 
-	private void _createRuntimeFeatureFlag(
-		StringBundler sb, String featureFlagName, boolean validator) {
+	private String _buildFeatureFlagJSGlobalVariable(
+		String featureFlagName, boolean validator) {
+
+		StringBundler sb = new StringBundler(5);
 
 		sb.append("Liferay.__FF__.");
 		sb.append(featureFlagName);
 		sb.append(" = ");
 		sb.append(validator);
 		sb.append(StringPool.SEMICOLON);
-	}
 
-	private boolean _shouldEnableCustomDialogs() {
-		if (GetterUtil.getBoolean(
-				PropsUtil.get("feature.flag.enableCustomDialogs"))) {
-
-			return true;
-		}
-
-		return false;
+		return sb.toString();
 	}
 
 	private volatile FFFrontendJSComponentsConfiguration


### PR DESCRIPTION
## Purpose

This feature flag is intended to be used for testing new dialogs from https://issues.liferay.com/browse/LPS-147548.

Are you expecting more context? Here is the context: https://liferay.atlassian.net/wiki/spaces/~73202423/pages/2004943076/Dialogs+migration+FF+or+not

Also, if you want more, go to: https://liferay.slack.com/archives/C035D3FKHPG/p1648152035966609

## How to test

How to activate?

0. Stop catalina
1. Open `portal-ext.properties`
2. Add a new entry there:

```
feature.flag.enableCustomDialogs=true
```
3. Start catalina again and when running the global JS call as:

```
Liferay.__FF__.enableCustomDialogs
> true
```

It will return true :)

