### PR TITLE
[TS] LPS-148819 When inserting a video into AlloyEditor, a line break will be inserted each time you Save as Draft

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java
@@ -49,7 +49,11 @@ public class AlloyEditorConfigContributor
 			jsonObject, inputEditorTaglibAttributes, themeDisplay,
 			requestBackedPortletURLFactory);
 
-		jsonObject.put("entities", Boolean.FALSE);
+		jsonObject.put(
+			"enterMode", 2
+		).put(
+			"entities", Boolean.FALSE
+		);
 
 		String extraPlugins = jsonObject.getString("extraPlugins");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-148819

### Steps to reproduce

1. Create a blog post
2. In the content section, switch to source view and add the following HTML (which imitates the HTML generated in 7.2.x when Xuggler integration is enabled):
```html
<p>AAAA</p>

<p>
<div class="liferayckevideo video-container" data-document-url="" data-width="400">
<div class="ckvideo-no-id"></div>
<script type="text/javascript">AUI().use("aui-base", "aui-video",function(A) {});</script></div>
</p>

<p>AAAA</p>
```
3. Save as draft
4. Save as draft again

**Actual result**
A line break is inserted each time you click "Save as Draft".

**Expected result**
No line breaks are inserted.