### PR TITLE
LPS-148144 | Assert language status on modal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/ManageTranslations.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/ManageTranslations.macro
@@ -5,13 +5,17 @@ definition {
 
 		Click(
 			key_locale = "${key_locale}",
-			locator1 = "Translation#DROPDOWN_MENU_ITEM");
+			locator1 = "ManageTranslations#DROPDOWN_MENU_ITEM_LANGUAGE");
+	}
+
+	macro deleteAndSaveLanguage {
+		Click(locator1 = "ManageTranslations#LIST_ITEM_DELETE_LANGUAGE_BUTTON");
+
+		Click(locator1 = "Button#DONE");
 	}
 
 	macro deleteLanguage {
 		Click(locator1 = "ManageTranslations#LIST_ITEM_DELETE_LANGUAGE_BUTTON");
-
-		Click(locator1 = "Button#DONE");
 	}
 
 	macro searchLanguage {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/TranslationManagerPortlet.macro
@@ -7,6 +7,15 @@ definition {
 			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_MENU");
 	}
 
+	macro goToAuiTagManageTranslationsModal {
+		Click.clickNoMouseOver(
+			key_currentLocale = "${key_currentLocale}",
+			key_title = "${key_title}",
+			locator1 = "TranslationManager#SELECT_TRANSLATION_LANGUAGE_AUI_TAG_MENU");
+
+		Click(locator1 = "Translation#TRANSLATION_MANAGE_BUTTON");
+	}
+
 	macro goToManageTranslationsModal {
 		TranslationManagerPortlet.clickSelectTranslation(
 			key_currentLocale = "${key_currentLocale}",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/ManageTranslations.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/ManageTranslations.path
@@ -12,6 +12,11 @@
 <tbody>
 
 <tr>
+	<td>DROPDOWN_MENU_ITEM_LANGUAGE</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//button[contains(.,'${key_locale}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>LIST_ITEM_LANGUAGE</td>
 	<td>//tr//td[contains(text(),'${key_language}')]</td>
 	<td></td>
@@ -19,6 +24,11 @@
 <tr>
 	<td>LIST_ITEM_DELETE_LANGUAGE_BUTTON</td>
 	<td>//tr//td[contains(text(),'${key_language}')]/following-sibling::td//button[@*[contains(.,'Delete')]]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>LANGUAGE_STATUS</td>
+	<td>//tr//td[contains(text(),'${key_language}')]/following-sibling::td//span[text()='${key_status}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -266,9 +266,9 @@ definition {
 		}
 	}
 
-	@description = "LPS-148144. Validates language status is not translated after re-add language on modal."
+	@description = "LPS-148144. Validates language status is not translated after deleting and re-adding language on modal."
 	@priority = "3"
-	test HasNotTranslatedStutasAfterDeletingTranslatedLanguageWithSaving {
+	test DeletedTranslatedLanguageDoesNotHaveTranslatedStatus {
 		task ("When input different language text in aui tag field") {
 			TranslationManagerPortlet.inputTextInAuiTagField(
 				key_currentLocale = "en-us",
@@ -309,9 +309,9 @@ definition {
 		}
 	}
 
-	@description = "LPS-148144. Validates language status is translated after re-add language on modal."
+	@description = "LPS-148144. Validates language status is still translated after not saving deleted translation."
 	@priority = "3"
-	test HasTranslatedStutasAfterDeletingTranslatedLanguageWithoutSaving {
+	test NotSavingDeletedTranslatedLanguageStillHasTranslatedStatus {
 		task ("When input different language text in aui tag field") {
 			TranslationManagerPortlet.inputTextInAuiTagField(
 				key_currentLocale = "en-us",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -190,7 +190,7 @@ definition {
 		}
 
 		task ("When delete Catalan language") {
-			ManageTranslations.deleteLanguage(key_language = "Catalan");
+			ManageTranslations.deleteAndSaveLanguage(key_language = "Catalan");
 		}
 
 		task ("Then assert Catalan language menu item is not present in select translation language dropdown") {
@@ -263,6 +263,86 @@ definition {
 			AssertElementNotPresent(
 				key_index = "2",
 				locator1 = "ManageTranslations#TABLE_BODY_ROW_INDEX");
+		}
+	}
+
+	@description = "LPS-148144. Validates language status is not translated after re-add language on modal."
+	@priority = "3"
+	test HasNotTranslatedStutasAfterDeletingTranslatedLanguageWithSaving {
+		task ("When input different language text in aui tag field") {
+			TranslationManagerPortlet.inputTextInAuiTagField(
+				key_currentLocale = "en-us",
+				key_leftTitle = "Default",
+				key_locale = "fr-FR",
+				key_rightTitle = "Admin",
+				languagefirst = "Welcome to Liferay",
+				languagesecond = "Bienvenue sur Liferay");
+		}
+
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToAuiTagManageTranslationsModal(
+				key_currentLocale = "fr-fr",
+				key_title = "Admin");
+		}
+
+		task ("When click done button after deleting French language on modal") {
+			ManageTranslations.deleteAndSaveLanguage(key_language = "French");
+		}
+
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToAuiTagManageTranslationsModal(
+				key_currentLocale = "en-us",
+				key_title = "Admin");
+		}
+
+		task ("Then re-add the French language on Manage Translations modal") {
+			ManageTranslations.addLanguage(key_locale = "fr-FR");
+		}
+
+		task ("Then assert the French language is changed to Not Translated status") {
+			AssertElementPresent(
+				key_language = "French",
+				key_status = "Not Translated",
+				locator1 = "ManageTranslations#LANGUAGE_STATUS");
+
+			Click(locator1 = "Modal#CLOSE_BUTTON");
+		}
+	}
+
+	@description = "LPS-148144. Validates language status is translated after re-add language on modal."
+	@priority = "3"
+	test HasTranslatedStutasAfterDeletingTranslatedLanguageWithoutSaving {
+		task ("When input different language text in aui tag field") {
+			TranslationManagerPortlet.inputTextInAuiTagField(
+				key_currentLocale = "en-us",
+				key_leftTitle = "Default",
+				key_locale = "fr-FR",
+				key_rightTitle = "Admin",
+				languagefirst = "Welcome to Liferay",
+				languagesecond = "Bienvenue sur Liferay");
+		}
+
+		task ("Given manage translations modal") {
+			TranslationManagerPortlet.goToAuiTagManageTranslationsModal(
+				key_currentLocale = "fr-fr",
+				key_title = "Admin");
+		}
+
+		task ("When delete French language without click done button on modal") {
+			ManageTranslations.deleteLanguage(key_language = "French");
+		}
+
+		task ("Then re-add the French language on Manage Translations modal") {
+			ManageTranslations.addLanguage(key_locale = "fr-FR");
+		}
+
+		task ("Assert the French language is still translated status") {
+			AssertElementPresent(
+				key_language = "French",
+				key_status = "Translated",
+				locator1 = "ManageTranslations#LANGUAGE_STATUS");
+
+			Click(locator1 = "Modal#CLOSE_BUTTON");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automation tests for Manage Translations

**Test Plan**
Given A non-default translation has been added
When Open Manage Translations modal
And When Delete the language from the manage translation list
And When Add the language back from the dropdown list
Then Assert the language is still translated
Given A non-default translation has been added
When Open Manage Translations modal
And When Delete the language from the manage translation list, and click Done
And When Open Manage Translations modal again, add the language back from the dropdown list
Then Assert the language is changed back to Not Translated status

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-148144