### PR TITLE
LPS-150674: Display keyword when is not null

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1251,9 +1251,14 @@ public class ManagementToolbarTag extends BaseContainerTag {
 				LanguageUtil.format(
 					resourceBundle, "x-results-for",
 					new Object[] {getItemsTotal()}));
-			jspWriter.write("<strong> \"");
-			jspWriter.write(searchValue);
-			jspWriter.write("\"</strong></span></span></div></li>");
+
+			if (searchValue != null) {
+				jspWriter.write("<strong> \"");
+				jspWriter.write(searchValue);
+				jspWriter.write("\"</strong>");
+			}
+
+			jspWriter.write("</span></span></div></li>");
 
 			if (filterLabelItems != null) {
 				for (int i = 0; i < filterLabelItems.size(); i++) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -35,7 +35,9 @@ const ResultsBar = ({
 								itemsTotal
 							)}
 
-							<strong>{` "${searchValue}"`}</strong>
+							{searchValue && (
+								<strong>{` "${searchValue}"`}</strong>
+							)}
 						</span>
 					</span>
 				</ClayResultsBar.Item>


### PR DESCRIPTION
**Steps to reproduce**:

1. Go to **Control Pane**l > **Configuration** > **Language Override**
2. Search it filter by **Any Language**

**Expected Result.**
The search result is singular like "0 Results for ".

**Before PR.**

![image](https://user-images.githubusercontent.com/44723449/161034640-19caef57-96fe-45c2-b810-5dd2ba4a5483.png)

**After PR:**

![Screenshot 2022-03-31 at 12 28 05](https://user-images.githubusercontent.com/44723449/161034894-a66acfef-b499-4cb9-bf2c-f52ef6577769.png)

**JIRA Ticket.**
https://issues.liferay.com/browse/LPS-150674

