### PR TITLE
LPS-143148 Send external model instead of internal model when sending webhooks notifications

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
@@ -31,6 +31,7 @@ import com.liferay.headless.admin.user.internal.dto.v1_0.util.PhoneUtil;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.PostalAddressUtil;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.ServiceBuilderListTypeUtil;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.WebUrlUtil;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Group;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ContactLocalService;
 import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -50,6 +52,9 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
+
+import java.util.Collections;
+import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -90,7 +95,8 @@ public class UserAccountResourceDTOConverter
 			return null;
 		}
 
-		Contact contact = user.getContact();
+		Contact contact = _contactLocalService.fetchContact(
+			user.getContactId());
 		User contextUser = dtoConverterContext.getUser();
 
 		return new UserAccount() {
@@ -98,7 +104,6 @@ public class UserAccountResourceDTOConverter
 				actions = dtoConverterContext.getActions();
 				additionalName = user.getMiddleName();
 				alternateName = user.getScreenName();
-				birthDate = user.getBirthday();
 				customFields = CustomFieldsUtil.toCustomFields(
 					dtoConverterContext.isAcceptAllLanguages(),
 					User.class.getName(), user.getUserId(), user.getCompanyId(),
@@ -109,12 +114,6 @@ public class UserAccountResourceDTOConverter
 				externalReferenceCode = user.getExternalReferenceCode();
 				familyName = user.getLastName();
 				givenName = user.getFirstName();
-				honorificPrefix =
-					ServiceBuilderListTypeUtil.getServiceBuilderListTypeMessage(
-						contact.getPrefixId(), dtoConverterContext.getLocale());
-				honorificSuffix =
-					ServiceBuilderListTypeUtil.getServiceBuilderListTypeMessage(
-						contact.getSuffixId(), dtoConverterContext.getLocale());
 				id = user.getUserId();
 				jobTitle = user.getJobTitle();
 				keywords = ListUtil.toArray(
@@ -127,10 +126,6 @@ public class UserAccountResourceDTOConverter
 					user.getOrganizations(),
 					organization -> _toOrganizationBrief(organization),
 					OrganizationBrief.class);
-				roleBriefs = TransformUtil.transformToArray(
-					_roleService.getUserRoles(user.getUserId()),
-					role -> _toRoleBrief(dtoConverterContext, role),
-					RoleBrief.class);
 				siteBriefs = TransformUtil.transformToArray(
 					_groupService.getGroups(
 						contextUser.getCompanyId(),
@@ -144,8 +139,6 @@ public class UserAccountResourceDTOConverter
 								user.getEmailAddresses(),
 								EmailAddressUtil::toEmailAddress,
 								EmailAddress.class);
-							facebook = contact.getFacebookSn();
-							jabber = contact.getJabberSn();
 							postalAddresses = TransformUtil.transformToArray(
 								user.getAddresses(),
 								address -> PostalAddressUtil.toPostalAddress(
@@ -153,18 +146,39 @@ public class UserAccountResourceDTOConverter
 									address, user.getCompanyId(),
 									dtoConverterContext.getLocale()),
 								PostalAddress.class);
-							skype = contact.getSkypeSn();
-							sms = contact.getSmsSn();
 							telephones = TransformUtil.transformToArray(
 								user.getPhones(), PhoneUtil::toPhone,
 								Phone.class);
-							twitter = contact.getTwitterSn();
 							webUrls = TransformUtil.transformToArray(
 								user.getWebsites(), WebUrlUtil::toWebUrl,
 								WebUrl.class);
+							setFacebook(
+								_getContactField(
+									contact, Contact::getFacebookSn));
+							setJabber(
+								_getContactField(
+									contact, Contact::getJabberSn));
+							setSkype(
+								_getContactField(contact, Contact::getSkypeSn));
+							setSms(
+								_getContactField(contact, Contact::getSmsSn));
+							setTwitter(
+								_getContactField(
+									contact, Contact::getTwitterSn));
 						}
 					};
+				setRoleBriefs(
+					() -> {
+						List<Role> userRoles = (contact != null) ?
+							_roleService.getUserRoles(user.getUserId()) :
+								Collections.emptyList();
 
+						return TransformUtil.transformToArray(
+							userRoles,
+							role -> _toRoleBrief(dtoConverterContext, role),
+							RoleBrief.class);
+					});
+				setBirthDate(_getContactField(contact, Contact::getBirthday));
 				setDashboardURL(
 					() -> {
 						Group group = user.getGroup();
@@ -176,6 +190,22 @@ public class UserAccountResourceDTOConverter
 						return group.getDisplayURL(
 							_getThemeDisplay(group), true);
 					});
+				setHonorificPrefix(
+					() -> _getContactField(
+						contact,
+						c ->
+							ServiceBuilderListTypeUtil.
+								getServiceBuilderListTypeMessage(
+									c.getPrefixId(),
+									dtoConverterContext.getLocale())));
+				setHonorificSuffix(
+					() -> _getContactField(
+						contact,
+						c ->
+							ServiceBuilderListTypeUtil.
+								getServiceBuilderListTypeMessage(
+									c.getSuffixId(),
+									dtoConverterContext.getLocale())));
 				setImage(
 					() -> {
 						if (user.getPortraitId() == 0) {
@@ -202,6 +232,17 @@ public class UserAccountResourceDTOConverter
 					});
 			}
 		};
+	}
+
+	private <T, E extends Exception> T _getContactField(
+			Contact contact, UnsafeFunction<Contact, T, E> fieldFunction)
+		throws E {
+
+		if (contact != null) {
+			return fieldFunction.apply(contact);
+		}
+
+		return null;
 	}
 
 	private ThemeDisplay _getThemeDisplay(Group group) {
@@ -255,6 +296,9 @@ public class UserAccountResourceDTOConverter
 
 	@Reference
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private ContactLocalService _contactLocalService;
 
 	@Reference
 	private GroupService _groupService;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
@@ -167,17 +167,6 @@ public class UserAccountResourceDTOConverter
 									contact, Contact::getTwitterSn));
 						}
 					};
-				setRoleBriefs(
-					() -> {
-						List<Role> userRoles = (contact != null) ?
-							_roleService.getUserRoles(user.getUserId()) :
-								Collections.emptyList();
-
-						return TransformUtil.transformToArray(
-							userRoles,
-							role -> _toRoleBrief(dtoConverterContext, role),
-							RoleBrief.class);
-					});
 				setBirthDate(_getContactField(contact, Contact::getBirthday));
 				setDashboardURL(
 					() -> {
@@ -229,6 +218,17 @@ public class UserAccountResourceDTOConverter
 						}
 
 						return group.getDisplayURL(_getThemeDisplay(group));
+					});
+				setRoleBriefs(
+					() -> {
+						List<Role> userRoles = (contact != null) ?
+							_roleService.getUserRoles(user.getUserId()) :
+								Collections.emptyList();
+
+						return TransformUtil.transformToArray(
+							userRoles,
+							role -> _toRoleBrief(dtoConverterContext, role),
+							RoleBrief.class);
 					});
 			}
 		};

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
@@ -177,21 +177,27 @@ public class UserAccountResourceDTOConverter
 							_getThemeDisplay(group), true);
 					});
 				setHonorificPrefix(
-					() -> _getContactField(
-						contact,
-						c ->
-							ServiceBuilderListTypeUtil.
-								getServiceBuilderListTypeMessage(
-									c.getPrefixId(),
-									dtoConverterContext.getLocale())));
+					() -> {
+						if (contact == null) {
+							return null;
+						}
+
+						return ServiceBuilderListTypeUtil.
+							getServiceBuilderListTypeMessage(
+								contact.getPrefixId(),
+								dtoConverterContext.getLocale());
+					});
 				setHonorificSuffix(
-					() -> _getContactField(
-						contact,
-						c ->
-							ServiceBuilderListTypeUtil.
-								getServiceBuilderListTypeMessage(
-									c.getSuffixId(),
-									dtoConverterContext.getLocale())));
+					() -> {
+						if (contact == null) {
+							return null;
+						}
+
+						return ServiceBuilderListTypeUtil.
+							getServiceBuilderListTypeMessage(
+								contact.getSuffixId(),
+								dtoConverterContext.getLocale());
+					});
 				setImage(
 					() -> {
 						if (user.getPortraitId() == 0) {
@@ -231,9 +237,10 @@ public class UserAccountResourceDTOConverter
 		};
 	}
 
-	private <T, E extends Exception> T _getContactField(
-			Contact contact, UnsafeFunction<Contact, T, E> fieldFunction)
-		throws E {
+	private <T> T _getContactField(
+			Contact contact,
+			UnsafeFunction<Contact, T, Exception> fieldFunction)
+		throws Exception {
 
 		if (contact != null) {
 			return fieldFunction.apply(contact);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/UserAccountResourceDTOConverter.java
@@ -53,9 +53,6 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -221,12 +218,12 @@ public class UserAccountResourceDTOConverter
 					});
 				setRoleBriefs(
 					() -> {
-						List<Role> userRoles = (contact != null) ?
-							_roleService.getUserRoles(user.getUserId()) :
-								Collections.emptyList();
+						if (contact == null) {
+							return new RoleBrief[0];
+						}
 
 						return TransformUtil.transformToArray(
-							userRoles,
+							_roleService.getUserRoles(user.getUserId()),
 							role -> _toRoleBrief(dtoConverterContext, role),
 							RoleBrief.class);
 					});

--- a/modules/apps/object/object-api/bnd.bnd
+++ b/modules/apps/object/object-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object API
 Bundle-SymbolicName: com.liferay.object.api
-Bundle-Version: 16.1.1
+Bundle-Version: 17.0.0
 Export-Package:\
 	com.liferay.object.action.engine,\
 	com.liferay.object.action.executor,\

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/system/BaseSystemObjectDefinitionMetadata.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/system/BaseSystemObjectDefinitionMetadata.java
@@ -14,27 +14,15 @@
 
 package com.liferay.object.system;
 
-import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.model.ObjectField;
-import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
-import com.liferay.object.system.model.listener.SystemObjectDefinitionMetadataModelListener;
 import com.liferay.object.util.LocalizedMapUtil;
 import com.liferay.object.util.ObjectFieldUtil;
 import com.liferay.petra.sql.dsl.Table;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.util.LocaleUtil;
 
 import java.util.Locale;
 import java.util.Map;
-
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Marco Leo
@@ -63,16 +51,6 @@ public abstract class BaseSystemObjectDefinitionMetadata
 		return tableName;
 	}
 
-	@Activate
-	protected void activate(BundleContext bundleContext) throws Exception {
-		_serviceRegistration = bundleContext.registerService(
-			ModelListener.class.getName(),
-			new SystemObjectDefinitionMetadataModelListener(
-				jsonFactory, getModelClass(), objectActionEngine,
-				objectDefinitionLocalService, objectEntryLocalService),
-			null);
-	}
-
 	protected Map<Locale, String> createLabelMap(String labelKey) {
 		return LocalizedMapUtil.getLocalizedMap(_translate(labelKey));
 	}
@@ -94,27 +72,8 @@ public abstract class BaseSystemObjectDefinitionMetadata
 			_translate(labelKey), name, required);
 	}
 
-	@Deactivate
-	protected void deactivate() throws Exception {
-		_serviceRegistration.unregister();
-	}
-
-	@Reference
-	protected JSONFactory jsonFactory;
-
-	@Reference
-	protected ObjectActionEngine objectActionEngine;
-
-	@Reference
-	protected ObjectDefinitionLocalService objectDefinitionLocalService;
-
-	@Reference
-	protected ObjectEntryLocalService objectEntryLocalService;
-
 	private String _translate(String labelKey) {
 		return LanguageUtil.get(LocaleUtil.getDefault(), labelKey);
 	}
-
-	private ServiceRegistration<?> _serviceRegistration;
 
 }

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/system/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/system/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/object/object-service/build.gradle
+++ b/modules/apps/object/object-service/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/object/object-service/build.gradle
+++ b/modules/apps/object/object-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "commons-io", name: "commons-io", version: "2.8.0"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
+	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
@@ -27,6 +28,7 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -153,7 +153,7 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 			return _jsonFactory.looseSerializeDeep(externalModel);
 		}
 		catch (Exception exception) {
-			_log.error(exception, exception);
+			_log.error(exception);
 		}
 
 		return objectEntry.toString();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/ObjectEntryModelListener.java
@@ -16,7 +16,9 @@ package com.liferay.object.internal.model.listener;
 
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
+import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectValidationRuleLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -30,11 +32,16 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
 import java.util.Collections;
+import java.util.Locale;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -128,26 +135,31 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		}
 	}
 
-	private String _getExternalModel(ObjectEntry objectEntry, long userId)
+	private String _getExternalModel(ObjectEntry objectEntry, User user)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(userId);
+		DTOConverter<ObjectEntry, ?> objectEntryDTOConverter =
+			(DTOConverter<ObjectEntry, ?>)_dtoConverterRegistry.getDTOConverter(
+				ObjectEntry.class.getName());
+
+		String objectDefinitionLabel = _getObjectDefinitionLabel(
+			objectEntry.getObjectDefinitionId(), user.getLocale());
+
+		if (objectEntryDTOConverter == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("No DTOConverter found for " + objectDefinitionLabel);
+			}
+
+			return objectEntry.toString();
+		}
 
 		DefaultDTOConverterContext defaultDTOConverterContext =
 			new DefaultDTOConverterContext(
 				false, Collections.emptyMap(), _dtoConverterRegistry, null,
 				user.getLocale(), null, user);
 
-		DTOConverter<ObjectEntry, ?> dtoConverter =
-			(DTOConverter<ObjectEntry, ?>)_dtoConverterRegistry.getDTOConverter(
-				ObjectEntry.class.getName());
-
-		if (dtoConverter == null) {
-			return objectEntry.toString();
-		}
-
 		try {
-			Object externalModel = dtoConverter.toDTO(
+			Object externalModel = objectEntryDTOConverter.toDTO(
 				defaultDTOConverterContext, objectEntry);
 
 			return _jsonFactory.looseSerializeDeep(externalModel);
@@ -159,23 +171,67 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 		return objectEntry.toString();
 	}
 
+	private String _getObjectDefinitionLabel(
+			long objectDefinitionId, Locale locale)
+		throws PortalException {
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectDefinitionId);
+
+		return objectDefinition.getLabel(locale);
+	}
+
 	private JSONObject _getPayloadJSONObject(
 			String objectActionTriggerKey, ObjectEntry originalObjectEntry,
 			ObjectEntry objectEntry, long userId)
 		throws PortalException {
 
+		boolean sendInternalModel = GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.WEBHOOK_EXPOSE_INTERNAL_MODEL));
+
+		User user = _userLocalService.getUser(userId);
+
+		String objectDefinitionLabel = _getObjectDefinitionLabel(
+			objectEntry.getObjectDefinitionId(), user.getLocale());
+
 		return JSONUtil.put(
+			StringUtil.lowerCaseFirstLetter(objectDefinitionLabel),
+			_jsonFactory.createJSONObject(_getExternalModel(objectEntry, user))
+		).put(
 			"objectActionTriggerKey", objectActionTriggerKey
 		).put(
 			"objectEntry",
-			_jsonFactory.createJSONObject(
-				_getExternalModel(objectEntry, userId))
+			() -> {
+				if (sendInternalModel) {
+					return _jsonFactory.createJSONObject(
+						objectEntry.toString()
+					).put(
+						"values", objectEntry.getValues()
+					);
+				}
+
+				return null;
+			}
 		).put(
 			"originalObjectEntry",
 			() -> {
+				if (sendInternalModel && (originalObjectEntry != null)) {
+					return _jsonFactory.createJSONObject(
+						originalObjectEntry.toString()
+					).put(
+						"values", originalObjectEntry.getValues()
+					);
+				}
+
+				return null;
+			}
+		).put(
+			"previous" + objectDefinitionLabel,
+			() -> {
 				if (originalObjectEntry != null) {
 					return _jsonFactory.createJSONObject(
-						_getExternalModel(originalObjectEntry, userId));
+						_getExternalModel(originalObjectEntry, user));
 				}
 
 				return null;
@@ -194,6 +250,9 @@ public class ObjectEntryModelListener extends BaseModelListener<ObjectEntry> {
 
 	@Reference
 	private ObjectActionEngine _objectActionEngine;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
 	private ObjectValidationRuleLocalService _objectValidationRuleLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.object.system.model.listener;
+package com.liferay.object.internal.model.listener;
 
 import com.liferay.object.action.engine.ObjectActionEngine;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
@@ -21,35 +21,46 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.vulcan.dto.converter.DTOConverter;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
 /**
  * @author Brian Wing Shun Chan
  */
-public class SystemObjectDefinitionMetadataModelListener
-	extends BaseModelListener {
+public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
+	extends BaseModelListener<T> {
 
 	public SystemObjectDefinitionMetadataModelListener(
 		JSONFactory jsonFactory, Class<?> modelClass,
 		ObjectActionEngine objectActionEngine,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
-		ObjectEntryLocalService objectEntryLocalService) {
+		ObjectEntryLocalService objectEntryLocalService,
+		UserLocalService userLocalService,
+		DTOConverterRegistry dtoConverterRegistry) {
 
 		_jsonFactory = jsonFactory;
 		_modelClass = modelClass;
 		_objectActionEngine = objectActionEngine;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
+		_userLocalService = userLocalService;
+		_dtoConverterRegistry = dtoConverterRegistry;
 	}
 
 	@Override
@@ -58,35 +69,29 @@ public class SystemObjectDefinitionMetadataModelListener
 	}
 
 	@Override
-	public void onAfterCreate(BaseModel baseModel)
-		throws ModelListenerException {
-
+	public void onAfterCreate(T baseModel) throws ModelListenerException {
 		_executeObjectActions(
 			ObjectActionTriggerConstants.KEY_ON_AFTER_ADD, null,
-			(BaseModel)baseModel.clone());
+			(T)baseModel.clone());
 	}
 
 	@Override
-	public void onAfterRemove(BaseModel baseModel)
-		throws ModelListenerException {
-
+	public void onAfterRemove(T baseModel) throws ModelListenerException {
 		_executeObjectActions(
 			ObjectActionTriggerConstants.KEY_ON_AFTER_DELETE, null, baseModel);
 	}
 
 	@Override
-	public void onAfterUpdate(BaseModel originalBaseModel, BaseModel baseModel)
+	public void onAfterUpdate(T originalBaseModel, T baseModel)
 		throws ModelListenerException {
 
 		_executeObjectActions(
 			ObjectActionTriggerConstants.KEY_ON_AFTER_UPDATE, originalBaseModel,
-			(BaseModel)baseModel.clone());
+			(T)baseModel.clone());
 	}
 
 	@Override
-	public void onBeforeRemove(BaseModel baseModel)
-		throws ModelListenerException {
-
+	public void onBeforeRemove(T baseModel) throws ModelListenerException {
 		try {
 			ObjectDefinition objectDefinition =
 				_objectDefinitionLocalService.fetchObjectDefinitionByClassName(
@@ -106,8 +111,7 @@ public class SystemObjectDefinitionMetadataModelListener
 	}
 
 	private void _executeObjectActions(
-			String objectActionTriggerKey, BaseModel originalBaseModel,
-			BaseModel baseModel)
+			String objectActionTriggerKey, T originalBaseModel, T baseModel)
 		throws ModelListenerException {
 
 		try {
@@ -121,7 +125,8 @@ public class SystemObjectDefinitionMetadataModelListener
 				_modelClass.getName(), _getCompanyId(baseModel),
 				objectActionTriggerKey,
 				_getPayloadJSONObject(
-					objectActionTriggerKey, originalBaseModel, baseModel),
+					objectActionTriggerKey, originalBaseModel, baseModel,
+					userId),
 				userId);
 		}
 		catch (PortalException portalException) {
@@ -129,7 +134,7 @@ public class SystemObjectDefinitionMetadataModelListener
 		}
 	}
 
-	private long _getCompanyId(BaseModel<?> baseModel) {
+	private long _getCompanyId(T baseModel) {
 		Map<String, Function<Object, Object>> functions =
 			(Map<String, Function<Object, Object>>)
 				(Map<String, ?>)baseModel.getAttributeGetterFunctions();
@@ -144,22 +149,53 @@ public class SystemObjectDefinitionMetadataModelListener
 		return (Long)function.apply(baseModel);
 	}
 
+	private String _getExternalModel(T baseModel, long userId)
+		throws PortalException {
+
+		User user = _userLocalService.getUser(userId);
+
+		DefaultDTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				false, Collections.emptyMap(), _dtoConverterRegistry, null,
+				user.getLocale(), null, user);
+
+		DTOConverter<T, ?> dtoConverter =
+			(DTOConverter<T, ?>)_dtoConverterRegistry.getDTOConverter(
+				baseModel.getModelClassName());
+
+		if (dtoConverter == null) {
+			return baseModel.toString();
+		}
+
+		try {
+			Object externalModel = dtoConverter.toDTO(
+				defaultDTOConverterContext, baseModel);
+
+			return _jsonFactory.looseSerializeDeep(externalModel);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+		}
+
+		return baseModel.toString();
+	}
+
 	private JSONObject _getPayloadJSONObject(
-			String objectActionTriggerKey, BaseModel originalBaseModel,
-			BaseModel baseModel)
-		throws JSONException {
+			String objectActionTriggerKey, T originalBaseModel, T baseModel,
+			long userId)
+		throws PortalException {
 
 		return JSONUtil.put(
 			"objectActionTriggerKey", objectActionTriggerKey
 		).put(
 			"model" + _modelClass.getSimpleName(),
-			_jsonFactory.createJSONObject(_jsonFactory.serialize(baseModel))
+			_jsonFactory.createJSONObject(_getExternalModel(baseModel, userId))
 		).put(
 			"original" + _modelClass.getSimpleName(),
 			() -> {
 				if (originalBaseModel != null) {
 					return _jsonFactory.createJSONObject(
-						_jsonFactory.serialize(originalBaseModel));
+						_getExternalModel(originalBaseModel, userId));
 				}
 
 				return null;
@@ -167,7 +203,7 @@ public class SystemObjectDefinitionMetadataModelListener
 		);
 	}
 
-	private long _getUserId(BaseModel<?> baseModel) {
+	private long _getUserId(T baseModel) {
 		Map<String, Function<Object, Object>> functions =
 			(Map<String, Function<Object, Object>>)
 				(Map<String, ?>)baseModel.getAttributeGetterFunctions();
@@ -182,10 +218,15 @@ public class SystemObjectDefinitionMetadataModelListener
 		return (Long)function.apply(baseModel);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		SystemObjectDefinitionMetadataModelListener.class);
+
+	private final DTOConverterRegistry _dtoConverterRegistry;
 	private final JSONFactory _jsonFactory;
 	private final Class<?> _modelClass;
 	private final ObjectActionEngine _objectActionEngine;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;
+	private final UserLocalService _userLocalService;
 
 }

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
@@ -183,7 +183,7 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
+				_log.debug(exception);
 			}
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
@@ -149,10 +149,12 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 		return (Long)function.apply(baseModel);
 	}
 
-	private String _getExternalModel(T baseModel, long userId)
-		throws PortalException {
+	private String _getExternalModel(T baseModel, long userId) {
+		User user = _userLocalService.fetchUser(userId);
 
-		User user = _userLocalService.getUser(userId);
+		if (user == null) {
+			return baseModel.toString();
+		}
 
 		DefaultDTOConverterContext defaultDTOConverterContext =
 			new DefaultDTOConverterContext(
@@ -164,6 +166,12 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 				baseModel.getModelClassName());
 
 		if (dtoConverter == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"No DTOConverter found for " +
+						baseModel.getModelClassName());
+			}
+
 			return baseModel.toString();
 		}
 
@@ -174,7 +182,9 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 			return _jsonFactory.looseSerializeDeep(externalModel);
 		}
 		catch (Exception exception) {
-			_log.error(exception, exception);
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
 		}
 
 		return baseModel.toString();

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/model/listener/SystemObjectDefinitionMetadataModelListener.java
@@ -32,12 +32,16 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 /**
@@ -149,6 +153,12 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 		return (Long)function.apply(baseModel);
 	}
 
+	private Optional<DTOConverter<T, ?>> _getDTOConverter(T baseModel) {
+		return Optional.ofNullable(
+			(DTOConverter<T, ?>)_dtoConverterRegistry.getDTOConverter(
+				baseModel.getModelClassName()));
+	}
+
 	private String _getExternalModel(T baseModel, long userId) {
 		User user = _userLocalService.fetchUser(userId);
 
@@ -156,16 +166,10 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 			return baseModel.toString();
 		}
 
-		DefaultDTOConverterContext defaultDTOConverterContext =
-			new DefaultDTOConverterContext(
-				false, Collections.emptyMap(), _dtoConverterRegistry, null,
-				user.getLocale(), null, user);
+		Optional<DTOConverter<T, ?>> dtoConverterOptional = _getDTOConverter(
+			baseModel);
 
-		DTOConverter<T, ?> dtoConverter =
-			(DTOConverter<T, ?>)_dtoConverterRegistry.getDTOConverter(
-				baseModel.getModelClassName());
-
-		if (dtoConverter == null) {
+		if (!dtoConverterOptional.isPresent()) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"No DTOConverter found for " +
@@ -174,6 +178,13 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 
 			return baseModel.toString();
 		}
+
+		DefaultDTOConverterContext defaultDTOConverterContext =
+			new DefaultDTOConverterContext(
+				false, Collections.emptyMap(), _dtoConverterRegistry, null,
+				user.getLocale(), null, user);
+
+		DTOConverter<T, ?> dtoConverter = dtoConverterOptional.get();
 
 		try {
 			Object externalModel = dtoConverter.toDTO(
@@ -195,17 +206,49 @@ public class SystemObjectDefinitionMetadataModelListener<T extends BaseModel<T>>
 			long userId)
 		throws PortalException {
 
+		boolean sendInternalModel = GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.WEBHOOK_EXPOSE_INTERNAL_MODEL));
+
+		String dtoConverterType = _getDTOConverter(
+			baseModel
+		).map(
+			DTOConverter::getContentType
+		).orElse(
+			_modelClass.getSimpleName()
+		);
+
 		return JSONUtil.put(
+			StringUtil.lowerCaseFirstLetter(dtoConverterType),
+			_jsonFactory.createJSONObject(
+				_jsonFactory.serialize(_getExternalModel(baseModel, userId)))
+		).put(
 			"objectActionTriggerKey", objectActionTriggerKey
 		).put(
-			"model" + _modelClass.getSimpleName(),
-			_jsonFactory.createJSONObject(_getExternalModel(baseModel, userId))
-		).put(
-			"original" + _modelClass.getSimpleName(),
+			"previous" + dtoConverterType,
 			() -> {
 				if (originalBaseModel != null) {
 					return _jsonFactory.createJSONObject(
-						_getExternalModel(originalBaseModel, userId));
+						_jsonFactory.serialize(
+							_getExternalModel(originalBaseModel, userId)));
+				}
+
+				return null;
+			}
+		).put(
+			"model" + _modelClass.getSimpleName(),
+			() -> {
+				if (sendInternalModel) {
+					return _jsonFactory.createJSONObject(baseModel.toString());
+				}
+
+				return null;
+			}
+		).put(
+			"original" + _modelClass.getSimpleName(),
+			() -> {
+				if (sendInternalModel && (originalBaseModel != null)) {
+					return _jsonFactory.createJSONObject(
+						originalBaseModel.toString());
 				}
 
 				return null;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/SystemObjectDefinitionMetadataRegistry.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/SystemObjectDefinitionMetadataRegistry.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.internal.system;
+
+import com.liferay.object.action.engine.ObjectActionEngine;
+import com.liferay.object.internal.model.listener.SystemObjectDefinitionMetadataModelListener;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.system.SystemObjectDefinitionMetadata;
+import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.messaging.DestinationNames;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.HashMapDictionary;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.util.tracker.ServiceTracker;
+import org.osgi.util.tracker.ServiceTrackerCustomizer;
+
+/**
+ * @author Luis Miguel Barcos
+ */
+@Component(immediate = true, service = {})
+public class SystemObjectDefinitionMetadataRegistry<T extends BaseModel<T>> {
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
+		_serviceTracker = ServiceTrackerFactory.create(
+			bundleContext, SystemObjectDefinitionMetadata.class,
+			new SystemObjectDefinitionMetadataServiceTrackerCustomizer());
+
+		_serviceTracker.open();
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		for (ServiceRegistration<?> serviceRegistration :
+				_systemObjectDefinitionMetadataServiceRegistrations.values()) {
+
+			serviceRegistration.unregister();
+		}
+
+		_systemObjectDefinitionMetadataServiceRegistrations.clear();
+
+		_serviceTracker.close();
+
+		_serviceTracker = null;
+
+		_bundleContext = null;
+	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private MessageBus _messageBus;
+
+	@Reference
+	private ObjectActionEngine _objectActionEngine;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ServiceTracker
+		<SystemObjectDefinitionMetadata, SystemObjectDefinitionMetadata>
+			_serviceTracker;
+	private final Map<String, ServiceRegistration<?>>
+		_systemObjectDefinitionMetadataServiceRegistrations =
+			new ConcurrentHashMap<>();
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private class SystemObjectDefinitionMetadataServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<SystemObjectDefinitionMetadata, SystemObjectDefinitionMetadata> {
+
+		@Override
+		public SystemObjectDefinitionMetadata addingService(
+			ServiceReference<SystemObjectDefinitionMetadata> serviceReference) {
+
+			Bundle bundle = serviceReference.getBundle();
+
+			String bundleSymbolicName = bundle.getSymbolicName();
+
+			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata =
+				_bundleContext.getService(serviceReference);
+
+			SystemObjectDefinitionMetadataModelListener<T>
+				systemObjectDefinitionMetadataModelListener =
+					new SystemObjectDefinitionMetadataModelListener<>(
+						_jsonFactory,
+						systemObjectDefinitionMetadata.getModelClass(),
+						_objectActionEngine, _objectDefinitionLocalService,
+						_objectEntryLocalService, _userLocalService,
+						_dtoConverterRegistry);
+
+			ServiceRegistration<?> serviceRegistration =
+				_bundleContext.registerService(
+					ModelListener.class.getName(),
+					systemObjectDefinitionMetadataModelListener,
+					new HashMapDictionary<String, Object>());
+
+			_systemObjectDefinitionMetadataServiceRegistrations.put(
+				bundleSymbolicName, serviceRegistration);
+
+			Message message = new Message();
+
+			message.put("command", "deploy");
+			message.put("servletContextName", bundleSymbolicName);
+
+			_messageBus.sendMessage(DestinationNames.HOT_DEPLOY, message);
+
+			return systemObjectDefinitionMetadata;
+		}
+
+		@Override
+		public void modifiedService(
+			ServiceReference<SystemObjectDefinitionMetadata> serviceReference,
+			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata) {
+		}
+
+		@Override
+		public void removedService(
+			ServiceReference<SystemObjectDefinitionMetadata> serviceReference,
+			SystemObjectDefinitionMetadata systemObjectDefinitionMetadata) {
+
+			Bundle bundle = serviceReference.getBundle();
+
+			String bundleSymbolicName = bundle.getSymbolicName();
+
+			ServiceRegistration<?> serviceRegistration =
+				_systemObjectDefinitionMetadataServiceRegistrations.remove(
+					bundleSymbolicName);
+
+			if (serviceRegistration != null) {
+				serviceRegistration.unregister();
+			}
+		}
+
+	}
+
+}

--- a/modules/apps/object/source-formatter-suppressions.xml
+++ b/modules/apps/object/source-formatter-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <suppressions>
-	<checkstyle>
-		<suppress checks="GenericTypeCheck" files="object-api/src/main/java/com/liferay/object/system/model/listener/SystemObjectDefinitionMetadataModelListener\.java" />
-	</checkstyle>
+	<source-check>
+		<suppress checks="JavaAPISignatureCheck" files="object-api/src/main/java/com/liferay/object/scope/ObjectScopeProvider\.java" />
+	</source-check>
 </suppressions>

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 32.0.1
+Bundle-Version: 32.1.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2635,6 +2635,10 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.WEBDAV_SERVLET_HTTPS_REQUIRED));
 
+	public static final boolean WEBHOOK_EXPOSE_INTERNAL_MODEL =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.WEBHOOK_EXPOSE_INTERNAL_MODEL));
+
 	public static final String WIDGET_SERVLET_MAPPING = PropsUtil.get(
 		PropsKeys.WIDGET_SERVLET_MAPPING);
 

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 26.0.0
+version 26.1.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -11341,6 +11341,19 @@
     trash.entries.max.age=43200
 
 ##
+## Webhook
+##
+
+    #
+    # Set this to false to not expose Liferay's internal model in a webhook
+    # notification. If set to true, Liferay will send the external (used in the
+    # Headless APIs layer) and internal model.
+    #
+    # Env: LIFERAY_WEBHOOK_PERIOD_EXPOSE_PERIOD_INTERNAL_PERIOD_MODEL
+    #
+    webhook.expose.internal.model=true
+
+##
 ## Workflow
 ##
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 44.0.1
+Bundle-Version: 44.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -3020,6 +3020,9 @@ public interface PropsKeys {
 	public static final String WEBDAV_SERVLET_HTTPS_REQUIRED =
 		"webdav.servlet.https.required";
 
+	public static final String WEBHOOK_EXPOSE_INTERNAL_MODEL =
+		"webhook.expose.internal.model";
+
 	public static final String WEBLOGIC_REQUEST_WRAP_NON_SERIALIZABLE =
 		"weblogic.request.wrap.non.serializable";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 32.0.0
+version 32.1.0


### PR DESCRIPTION
Related ticket -> [LPS-143148](https://issues.liferay.com/browse/LPS-143148)

This PR is a follow-up of [this one](https://github.com/liferay-objects/liferay-portal/pull/434) and [this one](https://github.com/brianchandotcom/liferay-portal/pull/115401#issuecomment-1083035243) but with the changes requested.

## Original description
### Send external model instead of internal model

This PR substitutes the entity model that is sent to the webhook's endpoint. The ideal case is to send the model that is specified in the correspondent OpenAPI and that is sent by the Rest APIs so we are consistent with the information Liferay is sharing with external systems. Also, sharing the internal model is dangerous because it could contain sensitive information.

These are the most important changes:
* Extract logic from the `object-api` module to the `object-service` module. To avoid adding more "ugly" dependencies to the `object-api` module (like a dependency to Vulcan) a service tracker was created to register the necessary model listener. Also, the model listener was moved from the `object-api` to the `object-service` module extracting more logic from the `-api` and adding it to `-service`.
* Send the external model instead of the internal model using the DTO converter of the entity. **There are some cases where the internal model will be sent**:
  * When the DTOConverter for the entity does not exist (There isn't an API with a correspondent external model)
  * When the DTOConverter cannot convert the internal model to the external model for some reason. Normally, will be an error or unsupported case in the DTOConverter that should be fixed, so it is important to log the issue

### How to test this functionality
* Deploy the `object-api`, `object-service` and `headless-admin-user-impl` modules.
* Go to Objects and create webhook actions for an object
* Create/update/delete information of the object selected
* Check the information sent by Liferay to the webhook URL
## Modifications
The main changes realized in this PR are:
* Addition of the property  `webhook.expose.internal.model` to specify if we want to send the internal and the external model. By default is `true`
* Little modification in `SystemObjectDefinitionMetadataRegistry` to make it simple.
* Modify the `UserAccountResourceDTOConverter` to also set `RoleBriefs` checking for nulls and avoid failing tests
* Webhook send internal and external model if the property webhook.expose.internal.model is set to true.
The new properties have the name of the entity in the external model. For example, User is UserAccount. For the object entries, in the external model I've set the label name given in the creation. I maintain the old properties name with the internal model to avoid breaking compatibility.