### PR TITLE
LPS-113530 Move `getLexiconIconTpl` to frontend-js-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -39,13 +39,6 @@
 
 	var STR_RIGHT_SQUARE_BRACKET = ']';
 
-	var TPL_LEXICON_ICON =
-		'<svg aria-hidden="true" class="lexicon-icon lexicon-icon-{0} {1}" focusable="false" role="presentation">' +
-		'<use href="' +
-		themeDisplay.getPathThemeImages() +
-		'/clay/icons.svg#{0}" />' +
-		'</svg>';
-
 	var Window = {
 		_map: {},
 
@@ -431,10 +424,6 @@
 			var columnId = str.replace(/layout-column_/, '');
 
 			return columnId;
-		},
-
-		getLexiconIconTpl(icon, cssClass) {
-			return Liferay.Util.sub(TPL_LEXICON_ICON, icon, cssClass || '');
 		},
 
 		getWindow(id) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -56,6 +56,7 @@ import getDOM from './util/get_dom';
 import getElement from './util/get_element';
 import getGeolocation from './util/get_geolocation';
 import getLexiconIcon from './util/get_lexicon_icon';
+import getLexiconIconTpl from './util/get_lexicon_icon_template';
 import getOpener from './util/get_opener';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
@@ -205,6 +206,7 @@ Liferay.Util.getElement = getElement;
 Liferay.Util.getGeolocation = getGeolocation;
 Liferay.Util.getFormElement = getFormElement;
 Liferay.Util.getLexiconIcon = getLexiconIcon;
+Liferay.Util.getLexiconIconTpl = getLexiconIconTpl;
 Liferay.Util.getOpener = getOpener;
 
 /**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -122,6 +122,11 @@ declare module Liferay {
 			cssClass?: string
 		): HTMLElement;
 
+		export function getLexiconIconTpl(
+			icon: string,
+			cssClass?: string
+		): string;
+
 		export function getTop(): Window;
 
 		export function getOpener(): any;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template.js
@@ -13,12 +13,9 @@
  */
 
 export default function getLexiconIconTpl(icon, cssClass = '') {
-	return `<svg
-		aria-hidden="true"
-		class="lexicon-icon lexicon-icon-${icon} ${cssClass}"
-		focusable="false"
-		role="presentation"
-	>
-		<use href="${themeDisplay.getPathThemeImages()}/clay/icons.svg#${icon}" />
-	</svg>`;
+	return (
+		`<svg aria-hidden="true" class="lexicon-icon lexicon-icon-${icon} ${cssClass}" focusable="false" role="presentation">` +
+		`<use href="${themeDisplay.getPathThemeImages()}/clay/icons.svg#${icon}" />` +
+		'</svg>'
+	);
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function getLexiconIconTpl(icon, cssClass = '') {
+	return `<svg
+		aria-hidden="true"
+		class="lexicon-icon lexicon-icon-${icon} ${cssClass}"
+		focusable="false"
+		role="presentation"
+	>
+		<use href="${themeDisplay.getPathThemeImages()}/clay/icons.svg#${icon}" />
+	</svg>`;
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_lexicon_icon_template.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_lexicon_icon_template.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getLexiconIconTpl from '../../../src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template';
+
+describe('Liferay.Util.getLexiconIconTpl', () => {
+	it('to return a string representing an svg icon', () => {
+		themeDisplay = {
+			getPathThemeImages: jest.fn(() => 'foo'),
+		};
+
+		const icon = getLexiconIconTpl('close', 'test-class');
+
+		expect(icon).toContain('<svg');
+		expect(icon).toContain(
+			'class="lexicon-icon lexicon-icon-close test-class"'
+		);
+		expect(icon).toContain('<use href="foo/clay/icons.svg#close" />');
+	});
+
+	it('adds an empty string if the second argument is missing', () => {
+		const icon = getLexiconIconTpl('close');
+
+		expect(icon).toContain('class="lexicon-icon lexicon-icon-close "');
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_lexicon_icon_template.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/get_lexicon_icon_template.js
@@ -22,16 +22,16 @@ describe('Liferay.Util.getLexiconIconTpl', () => {
 
 		const icon = getLexiconIconTpl('close', 'test-class');
 
-		expect(icon).toContain('<svg');
-		expect(icon).toContain(
-			'class="lexicon-icon lexicon-icon-close test-class"'
+		expect(icon).toMatchInlineSnapshot(
+			`"<svg aria-hidden=\\"true\\" class=\\"lexicon-icon lexicon-icon-close test-class\\" focusable=\\"false\\" role=\\"presentation\\"><use href=\\"foo/clay/icons.svg#close\\" /></svg>"`
 		);
-		expect(icon).toContain('<use href="foo/clay/icons.svg#close" />');
 	});
 
 	it('adds an empty string if the second argument is missing', () => {
 		const icon = getLexiconIconTpl('close');
 
-		expect(icon).toContain('class="lexicon-icon lexicon-icon-close "');
+		expect(icon).toMatchInlineSnapshot(
+			`"<svg aria-hidden=\\"true\\" class=\\"lexicon-icon lexicon-icon-close \\" focusable=\\"false\\" role=\\"presentation\\"><use href=\\"foo/clay/icons.svg#close\\" /></svg>"`
+		);
 	});
 });


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113530

This one is just a little bit different from the rest. It moves `getLexiconIconTpl` but also I remove the usage of `sub` inside it, because `sub` is essentially a glorified template literal in this case. If you don't think it's a good idea, I'll keep it in.

This can be tested in DXP by just dragging a Calendar module onto your page, there are 3 icons using this utility in that case.