### PR TITLE
LRQA-74187 Fix path to separate dropdown-menu and show

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -78,7 +78,7 @@
 <!--FEATURE FLAG CONFIGURATIONS-->
 <tr>
 	<td>ACTIVE_DROPDOWN_ITEM</td>
-	<td>//div[contains(@class,'dropdown-menu show')]//li//*[contains(@class,'dropdown-item') and contains(.,'${key_item}')]</td>
+	<td>//div[contains(@class,'dropdown-menu') and contains(@class,'show')]//li//*[contains(@class,'dropdown-item') and contains(.,'${key_item}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Background**
Separate dropdown-menu and show because the path looks like this now:
![image](https://user-images.githubusercontent.com/28836926/161331685-5961d20d-8ed1-4e8e-8190-31b0fb3293f2.png)

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-74187