### PR TITLE
[TECHNICAL SUPPORT] LPS-150923 Liferay.Service invokes Error Callback in case of empty response object

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.js
@@ -123,7 +123,6 @@ Liferay = window.Liferay || {};
 
 			ioConfig.complete = function (response) {
 				if (
-					Object.keys(response).length > 0 &&
 					!Object.prototype.hasOwnProperty.call(response, 'exception')
 				) {
 					if (callbackSuccess) {


### PR DESCRIPTION
Hey,
[LPS-150923](https://issues.liferay.com/browse/LPS-150923),

This issue is a regression of [LPS-142748](https://issues.liferay.com/browse/LPS-142748)
I removed the check for the length of the response object, as it does not tell us anything about wether its a good response or not, and we are already checking response.ok at line 202

Please review my changes,
Thanks