### PR TITLE
LPS-150868 Review usages of async wrappers in FDS > Utils

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
@@ -44,7 +44,6 @@ import {
 } from './utils/eventsDefinitions';
 import {
 	delay,
-	executeAsyncAction,
 	formatItemChanges,
 	getCurrentItemUpdates,
 	getRandomId,
@@ -420,8 +419,15 @@ const DataSet = ({
 			</div>
 		) : null;
 
-	function executeAsyncItemAction(url, method) {
-		return executeAsyncAction(url, method)
+	function executeAsyncItemAction(url, method = 'GET') {
+		return fetch(url, {
+			headers: {
+				'Accept': 'application/json',
+				'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+				'Content-Type': 'application/json',
+			},
+			method,
+		})
 			.then((_) => {
 				return delay(500).then(() => {
 					if (isMounted()) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -165,17 +165,6 @@ export function formatItemChanges(itemChanges) {
 	return formattedChanges;
 }
 
-export function executeAsyncAction(url, method = 'GET') {
-	return fetch(url, {
-		headers: {
-			'Accept': 'application/json',
-			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-			'Content-Type': 'application/json',
-		},
-		method,
-	});
-}
-
 export function formatActionURL(url, item) {
 	const replacedURL = url.replace(new RegExp('{(.*?)}', 'mg'), (matched) =>
 		getValueFromItem(
@@ -266,7 +255,14 @@ export async function loadData(
 		);
 	}
 
-	const response = await executeAsyncAction(url, 'GET');
+	const response = await fetch(url, {
+		headers: {
+			'Accept': 'application/json',
+			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+			'Content-Type': 'application/json',
+		},
+		method: 'GET',
+	});
 	const responseJSON = await response.json();
 
 	return {


### PR DESCRIPTION
[Jira issue](https://issues.liferay.com/browse/LPS-150868)

## Motivation
Async wrappers seem to overcomplicate API calls with very low benefit

## Proposal
Remove this wrapper and use FI `fetch` method directly

## How to test this task
- Open any page with a FDS in it
- Open browser dev tools > Sources > Command + p > Search for "utils/index"
- Place a breakpoint in line 279

**Expected:** the `responseJSON` object should be correct and the FDS should render normally.

![image](https://user-images.githubusercontent.com/19485114/161545709-eed6f032-f14a-486a-94c0-2ac7b8a78d69.png)