### PR TITLE
LPS-113534 Deprecate `getWindow`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -39,9 +39,6 @@
 
 	var STR_RIGHT_SQUARE_BRACKET = ']';
 
-	/**
-	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
-	 */
 	var Window = {
 		_map: {},
 
@@ -430,7 +427,7 @@
 		},
 
 		/**
-		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `openModal`
 		 */
 		getWindow(id) {
 			if (!id) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -39,6 +39,9 @@
 
 	var STR_RIGHT_SQUARE_BRACKET = ']';
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
 	var Window = {
 		_map: {},
 
@@ -426,6 +429,9 @@
 			return columnId;
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		getWindow(id) {
 			if (!id) {
 				id = Util.getWindowName();


### PR DESCRIPTION
This is a weird one. It returns the default `window` or `undefined`, not a specific window that it should. 

If you take a look at the implementations of both `getWindow` and `getById` you can see how it returns `undefined` if an `id` is provided, because the `_map` object is empty, and is not getting populated.

The `_map` object was being populated in the past by the `_register` method, removed some time ago, you can find its existence in this [commit](https://github.com/liferay/liferay-portal/commit/de3bbce36ecfbdcbbca2ab7ec1080384d9f4a92c).

I assume that deprecating the local variable `Window` is wrong but this is an exploration and a suggestion, so tell me if it's wrong.

The other road we can take is to fix this utility, making a modern variant of the `_register` method, etc. but I believe that's not what we want, as we have modernized modals and the whole system works much differently now. But we might want to push for teams to look into their usages of `getWindow` and double-check if it even does anything for them.