### PR TITLE
LPS-113537 Modernize `removeEntitySelection`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -566,33 +566,6 @@
 			return Math.ceil(Math.random() * new Date().getTime());
 		},
 
-		removeEntitySelection(
-			entityIdString,
-			entityNameString,
-			removeEntityButton,
-			namespace
-		) {
-			const elementByEntityId = document.getElementById(
-				`${namespace}${entityIdString}`
-			);
-
-			if (elementByEntityId) {
-				elementByEntityId.value = 0;
-			}
-
-			const elementByEntityName = document.getElementById(
-				`${namespace}${entityNameString}`
-			);
-
-			if (elementByEntityName) {
-				elementByEntityName.value = '';
-			}
-
-			Liferay.Util.toggleDisabled(removeEntityButton, true);
-
-			Liferay.fire('entitySelectionRemoved');
-		},
-
 		reorder(box, down) {
 			box = Util.getElement(box);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -104,5 +104,6 @@ export {default as isPhone} from './liferay/util/is_phone';
 export {default as isTablet} from './liferay/util/is_tablet';
 export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
+export {default as removeEntitySelection} from './liferay/util/remove_entity_selection';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -78,6 +78,7 @@ import createActionURL from './util/portlet_url/create_action_url.es';
 import createPortletURL from './util/portlet_url/create_portlet_url.es';
 import createRenderURL from './util/portlet_url/create_render_url.es';
 import createResourceURL from './util/portlet_url/create_resource_url.es';
+import removeEntitySelection from './util/remove_entity_selection';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
@@ -298,6 +299,7 @@ Liferay.Util.openToast = (...args) => {
 	);
 };
 
+Liferay.Util.removeEntitySelection = removeEntitySelection;
 Liferay.Util.sub = sub;
 
 Liferay.Util.Session = {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -171,6 +171,13 @@ declare module Liferay {
 			options?: {data: Object; url: string}
 		): void;
 
+		export function removeEntitySelection(
+			entityIdString: string,
+			entityNameString: string,
+			removeEntityButton: string | HTMLElement,
+			namespace: string
+		): void;
+
 		/**
 		 * Sets the form elements to given values.
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/remove_entity_selection.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/remove_entity_selection.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import toggleDisabled from './toggle_disabled';
+
+export default function removeEntitySelection(
+	entityIdString,
+	entityNameString,
+	removeEntityButton,
+	namespace
+) {
+	const elementByEntityId = document.getElementById(
+		`${namespace}${entityIdString}`
+	);
+
+	if (elementByEntityId) {
+		elementByEntityId.value = 0;
+	}
+
+	const elementByEntityName = document.getElementById(
+		`${namespace}${entityNameString}`
+	);
+
+	if (elementByEntityName) {
+		elementByEntityName.value = '';
+	}
+
+	toggleDisabled(removeEntityButton, true);
+
+	Liferay.fire('entitySelectionRemoved');
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/remove_entity_selection.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/remove_entity_selection.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import removeEntitySelection from '../../../src/main/resources/META-INF/resources/liferay/util/remove_entity_selection';
+
+describe('Liferay.Util.removeEntitySelection', () => {
+	const namespace = 'fooNamespace';
+	const entityIdString = 'fooId';
+	const entityNameString = 'fooName';
+	const removeEntityButton = document.createElement('button');
+
+	const elementByEntityId = document.createElement('input');
+
+	elementByEntityId.id = `${namespace}${entityIdString}`;
+	elementByEntityId.value = '1';
+
+	document.body.appendChild(elementByEntityId);
+
+	const elementByEntityName = document.createElement('input');
+
+	elementByEntityName.id = `${namespace}${entityNameString}`;
+	elementByEntityName.value = '1';
+
+	document.body.appendChild(elementByEntityName);
+
+	it('sets the value of the elementByEntityId to 0', () => {
+		removeEntitySelection(
+			entityIdString,
+			entityNameString,
+			removeEntityButton,
+			namespace
+		);
+
+		expect(elementByEntityId.value).toBe('0');
+	});
+
+	it('sets the value of the elementByEntityName to an empty string', () => {
+		removeEntitySelection(
+			entityIdString,
+			entityNameString,
+			removeEntityButton,
+			namespace
+		);
+
+		expect(elementByEntityName.value).toBe('');
+	});
+
+	it('disables the provided button', () => {
+		removeEntitySelection(
+			entityIdString,
+			entityNameString,
+			removeEntityButton,
+			namespace
+		);
+
+		expect(removeEntityButton.disabled).toBe(true);
+	});
+});


### PR DESCRIPTION
This one can be tested by going to Web Content, making 2 folders, editing one of them and putting it inside the 2nd folder in this part of the UI
<img width="345" alt="image" src="https://user-images.githubusercontent.com/24564752/161972583-9845bbff-db29-4a77-8bbd-41992e47b36d.png">

At this point there will be a parent and a child folder.

Once again go to edit the child folder, and after that when you click on `Remove` and go back to the list of folders and web contents, you will see that both folders are siblings.