### PR TITLE
LPS-150490 Fix NullPointerException when calling batch mutations from GraphQL

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Admin Account API
 Bundle-SymbolicName: com.liferay.headless.commerce.admin.account.api
-Bundle-Version: 11.4.2
+Bundle-Version: 11.5.0
 Export-Package:\
 	com.liferay.headless.commerce.admin.account.dto.v1_0,\
 	com.liferay.headless.commerce.admin.account.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountAddressResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -147,6 +148,10 @@ public interface AccountAddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountGroupResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -137,6 +138,10 @@ public interface AccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountMemberResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountMemberResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -138,6 +139,10 @@ public interface AccountMemberResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountOrganizationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountOrganizationResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -134,6 +135,10 @@ public interface AccountOrganizationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/AccountResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -142,6 +143,10 @@ public interface AccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/UserResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/resource/v1_0/UserResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,6 +95,10 @@ public interface UserResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/resources/com/liferay/headless/commerce/admin/account/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/resources/com/liferay/headless/commerce/admin/account/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 5.4.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/graphql/mutation/v1_0/Mutation.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -722,6 +723,8 @@ public class Mutation {
 		accountResource.setContextUser(_user);
 		accountResource.setGroupLocalService(_groupLocalService);
 		accountResource.setRoleLocalService(_roleLocalService);
+		accountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -738,6 +741,8 @@ public class Mutation {
 		accountAddressResource.setContextUser(_user);
 		accountAddressResource.setGroupLocalService(_groupLocalService);
 		accountAddressResource.setRoleLocalService(_roleLocalService);
+		accountAddressResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -753,6 +758,8 @@ public class Mutation {
 		accountGroupResource.setContextUser(_user);
 		accountGroupResource.setGroupLocalService(_groupLocalService);
 		accountGroupResource.setRoleLocalService(_roleLocalService);
+		accountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -768,6 +775,8 @@ public class Mutation {
 		accountMemberResource.setContextUser(_user);
 		accountMemberResource.setGroupLocalService(_groupLocalService);
 		accountMemberResource.setRoleLocalService(_roleLocalService);
+		accountMemberResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -784,6 +793,8 @@ public class Mutation {
 		accountOrganizationResource.setContextUser(_user);
 		accountOrganizationResource.setGroupLocalService(_groupLocalService);
 		accountOrganizationResource.setRoleLocalService(_roleLocalService);
+		accountOrganizationResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(UserResource userResource)
@@ -797,6 +808,8 @@ public class Mutation {
 		userResource.setContextUser(_user);
 		userResource.setGroupLocalService(_groupLocalService);
 		userResource.setRoleLocalService(_roleLocalService);
+		userResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<AccountResource>
@@ -821,5 +834,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountAddressResourceImpl.java
@@ -847,6 +847,14 @@ public abstract class BaseAccountAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -658,6 +658,14 @@ public abstract class BaseAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountMemberResourceImpl.java
@@ -672,6 +672,14 @@ public abstract class BaseAccountMemberResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountOrganizationResourceImpl.java
@@ -603,6 +603,14 @@ public abstract class BaseAccountOrganizationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -729,6 +729,14 @@ public abstract class BaseAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -241,6 +241,14 @@ public abstract class BaseUserResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/AttachmentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/AttachmentResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -161,6 +162,10 @@ public interface AttachmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/CatalogResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/CatalogResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -132,6 +133,10 @@ public interface CatalogResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/CategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/CategoryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -108,6 +109,10 @@ public interface CategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/DiagramResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/DiagramResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -106,6 +107,10 @@ public interface DiagramResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/MappedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/MappedProductResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -130,6 +131,10 @@ public interface MappedProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/OptionCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/OptionCategoryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -115,6 +116,10 @@ public interface OptionCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/OptionResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/OptionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface OptionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/OptionValueResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/OptionValueResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -137,6 +138,10 @@ public interface OptionValueResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/PinResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/PinResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -116,6 +117,10 @@ public interface PinResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductAccountGroupResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -110,6 +111,10 @@ public interface ProductAccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductChannelResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -110,6 +111,10 @@ public interface ProductChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductConfigurationResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -107,6 +108,10 @@ public interface ProductConfigurationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductGroupProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductGroupProductResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface ProductGroupProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -127,6 +128,10 @@ public interface ProductGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductOptionResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductOptionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface ProductOptionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductOptionValueResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductOptionValueResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -106,6 +107,10 @@ public interface ProductOptionValueResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -131,6 +132,10 @@ public interface ProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductShippingConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductShippingConfigurationResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -109,6 +110,10 @@ public interface ProductShippingConfigurationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductSpecificationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductSpecificationResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -105,6 +106,10 @@ public interface ProductSpecificationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductSubscriptionConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductSubscriptionConfigurationResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -112,6 +113,10 @@ public interface ProductSubscriptionConfigurationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductTaxConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/ProductTaxConfigurationResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -108,6 +109,10 @@ public interface ProductTaxConfigurationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/RelatedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/RelatedProductResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface RelatedProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/SkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/SkuResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -135,6 +136,10 @@ public interface SkuResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/SpecificationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/resource/v1_0/SpecificationResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -115,6 +116,10 @@ public interface SpecificationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/resources/com/liferay/headless/commerce/admin/catalog/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/resources/com/liferay/headless/commerce/admin/catalog/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/graphql/mutation/v1_0/Mutation.java
@@ -68,6 +68,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -1880,6 +1881,8 @@ public class Mutation {
 		attachmentResource.setContextUser(_user);
 		attachmentResource.setGroupLocalService(_groupLocalService);
 		attachmentResource.setRoleLocalService(_roleLocalService);
+		attachmentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(CatalogResource catalogResource)
@@ -1893,6 +1896,8 @@ public class Mutation {
 		catalogResource.setContextUser(_user);
 		catalogResource.setGroupLocalService(_groupLocalService);
 		catalogResource.setRoleLocalService(_roleLocalService);
+		catalogResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(CategoryResource categoryResource)
@@ -1906,6 +1911,8 @@ public class Mutation {
 		categoryResource.setContextUser(_user);
 		categoryResource.setGroupLocalService(_groupLocalService);
 		categoryResource.setRoleLocalService(_roleLocalService);
+		categoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(DiagramResource diagramResource)
@@ -1919,6 +1926,8 @@ public class Mutation {
 		diagramResource.setContextUser(_user);
 		diagramResource.setGroupLocalService(_groupLocalService);
 		diagramResource.setRoleLocalService(_roleLocalService);
+		diagramResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1934,6 +1943,8 @@ public class Mutation {
 		mappedProductResource.setContextUser(_user);
 		mappedProductResource.setGroupLocalService(_groupLocalService);
 		mappedProductResource.setRoleLocalService(_roleLocalService);
+		mappedProductResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(OptionResource optionResource)
@@ -1947,6 +1958,8 @@ public class Mutation {
 		optionResource.setContextUser(_user);
 		optionResource.setGroupLocalService(_groupLocalService);
 		optionResource.setRoleLocalService(_roleLocalService);
+		optionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1963,6 +1976,8 @@ public class Mutation {
 		optionCategoryResource.setContextUser(_user);
 		optionCategoryResource.setGroupLocalService(_groupLocalService);
 		optionCategoryResource.setRoleLocalService(_roleLocalService);
+		optionCategoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1977,6 +1992,8 @@ public class Mutation {
 		optionValueResource.setContextUser(_user);
 		optionValueResource.setGroupLocalService(_groupLocalService);
 		optionValueResource.setRoleLocalService(_roleLocalService);
+		optionValueResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(PinResource pinResource)
@@ -1990,6 +2007,8 @@ public class Mutation {
 		pinResource.setContextUser(_user);
 		pinResource.setGroupLocalService(_groupLocalService);
 		pinResource.setRoleLocalService(_roleLocalService);
+		pinResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(ProductResource productResource)
@@ -2003,6 +2022,8 @@ public class Mutation {
 		productResource.setContextUser(_user);
 		productResource.setGroupLocalService(_groupLocalService);
 		productResource.setRoleLocalService(_roleLocalService);
+		productResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2019,6 +2040,8 @@ public class Mutation {
 		productAccountGroupResource.setContextUser(_user);
 		productAccountGroupResource.setGroupLocalService(_groupLocalService);
 		productAccountGroupResource.setRoleLocalService(_roleLocalService);
+		productAccountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2035,6 +2058,8 @@ public class Mutation {
 		productChannelResource.setContextUser(_user);
 		productChannelResource.setGroupLocalService(_groupLocalService);
 		productChannelResource.setRoleLocalService(_roleLocalService);
+		productChannelResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2051,6 +2076,8 @@ public class Mutation {
 		productConfigurationResource.setContextUser(_user);
 		productConfigurationResource.setGroupLocalService(_groupLocalService);
 		productConfigurationResource.setRoleLocalService(_roleLocalService);
+		productConfigurationResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2066,6 +2093,8 @@ public class Mutation {
 		productGroupResource.setContextUser(_user);
 		productGroupResource.setGroupLocalService(_groupLocalService);
 		productGroupResource.setRoleLocalService(_roleLocalService);
+		productGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2082,6 +2111,8 @@ public class Mutation {
 		productGroupProductResource.setContextUser(_user);
 		productGroupProductResource.setGroupLocalService(_groupLocalService);
 		productGroupProductResource.setRoleLocalService(_roleLocalService);
+		productGroupProductResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2097,6 +2128,8 @@ public class Mutation {
 		productOptionResource.setContextUser(_user);
 		productOptionResource.setGroupLocalService(_groupLocalService);
 		productOptionResource.setRoleLocalService(_roleLocalService);
+		productOptionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2113,6 +2146,8 @@ public class Mutation {
 		productOptionValueResource.setContextUser(_user);
 		productOptionValueResource.setGroupLocalService(_groupLocalService);
 		productOptionValueResource.setRoleLocalService(_roleLocalService);
+		productOptionValueResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2133,6 +2168,9 @@ public class Mutation {
 			_groupLocalService);
 		productShippingConfigurationResource.setRoleLocalService(
 			_roleLocalService);
+		productShippingConfigurationResource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2149,6 +2187,8 @@ public class Mutation {
 		productSpecificationResource.setContextUser(_user);
 		productSpecificationResource.setGroupLocalService(_groupLocalService);
 		productSpecificationResource.setRoleLocalService(_roleLocalService);
+		productSpecificationResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2169,6 +2209,9 @@ public class Mutation {
 			_groupLocalService);
 		productSubscriptionConfigurationResource.setRoleLocalService(
 			_roleLocalService);
+		productSubscriptionConfigurationResource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2187,6 +2230,8 @@ public class Mutation {
 		productTaxConfigurationResource.setGroupLocalService(
 			_groupLocalService);
 		productTaxConfigurationResource.setRoleLocalService(_roleLocalService);
+		productTaxConfigurationResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2203,6 +2248,8 @@ public class Mutation {
 		relatedProductResource.setContextUser(_user);
 		relatedProductResource.setGroupLocalService(_groupLocalService);
 		relatedProductResource.setRoleLocalService(_roleLocalService);
+		relatedProductResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(SkuResource skuResource)
@@ -2216,6 +2263,8 @@ public class Mutation {
 		skuResource.setContextUser(_user);
 		skuResource.setGroupLocalService(_groupLocalService);
 		skuResource.setRoleLocalService(_roleLocalService);
+		skuResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2231,6 +2280,8 @@ public class Mutation {
 		specificationResource.setContextUser(_user);
 		specificationResource.setGroupLocalService(_groupLocalService);
 		specificationResource.setRoleLocalService(_roleLocalService);
+		specificationResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<AttachmentResource>
@@ -2292,5 +2343,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -811,6 +811,14 @@ public abstract class BaseAttachmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCatalogResourceImpl.java
@@ -659,6 +659,14 @@ public abstract class BaseCatalogResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -358,6 +358,14 @@ public abstract class BaseCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseDiagramResourceImpl.java
@@ -367,6 +367,14 @@ public abstract class BaseDiagramResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -588,6 +588,14 @@ public abstract class BaseMappedProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionCategoryResourceImpl.java
@@ -489,6 +489,14 @@ public abstract class BaseOptionCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionResourceImpl.java
@@ -580,6 +580,14 @@ public abstract class BaseOptionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseOptionValueResourceImpl.java
@@ -679,6 +679,14 @@ public abstract class BaseOptionValueResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -487,6 +487,14 @@ public abstract class BasePinResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductAccountGroupResourceImpl.java
@@ -421,6 +421,14 @@ public abstract class BaseProductAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductChannelResourceImpl.java
@@ -411,6 +411,14 @@ public abstract class BaseProductChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductConfigurationResourceImpl.java
@@ -355,6 +355,14 @@ public abstract class BaseProductConfigurationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupProductResourceImpl.java
@@ -517,6 +517,14 @@ public abstract class BaseProductGroupProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductGroupResourceImpl.java
@@ -576,6 +576,14 @@ public abstract class BaseProductGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -544,6 +544,14 @@ public abstract class BaseProductOptionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductOptionValueResourceImpl.java
@@ -348,6 +348,14 @@ public abstract class BaseProductOptionValueResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -656,6 +656,14 @@ public abstract class BaseProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductShippingConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductShippingConfigurationResourceImpl.java
@@ -359,6 +359,14 @@ public abstract class BaseProductShippingConfigurationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -342,6 +342,14 @@ public abstract class BaseProductSpecificationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSubscriptionConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductSubscriptionConfigurationResourceImpl.java
@@ -364,6 +364,14 @@ public abstract class BaseProductSubscriptionConfigurationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductTaxConfigurationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseProductTaxConfigurationResourceImpl.java
@@ -359,6 +359,14 @@ public abstract class BaseProductTaxConfigurationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -551,6 +551,14 @@ public abstract class BaseRelatedProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -696,6 +696,14 @@ public abstract class BaseSkuResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/BaseSpecificationResourceImpl.java
@@ -496,6 +496,14 @@ public abstract class BaseSpecificationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Admin Channel API
 Bundle-SymbolicName: com.liferay.headless.commerce.admin.channel.api
-Bundle-Version: 6.6.2
+Bundle-Version: 6.7.0
 Export-Package:\
 	com.liferay.headless.commerce.admin.channel.dto.v1_0,\
 	com.liferay.headless.commerce.admin.channel.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ChannelResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -134,6 +135,10 @@ public interface ChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/OrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/OrderTypeResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,6 +99,10 @@ public interface OrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/PaymentMethodGroupRelOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/PaymentMethodGroupRelOrderTypeResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -114,6 +115,10 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/PaymentMethodGroupRelTermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/PaymentMethodGroupRelTermResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -113,6 +114,10 @@ public interface PaymentMethodGroupRelTermResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ShippingFixedOptionOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ShippingFixedOptionOrderTypeResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -114,6 +115,10 @@ public interface ShippingFixedOptionOrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ShippingFixedOptionTermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ShippingFixedOptionTermResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -112,6 +113,10 @@ public interface ShippingFixedOptionTermResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ShippingMethodResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/ShippingMethodResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -96,6 +97,10 @@ public interface ShippingMethodResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/TaxCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/TaxCategoryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -98,6 +99,10 @@ public interface TaxCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/TermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/resource/v1_0/TermResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -97,6 +98,10 @@ public interface TermResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/resources/com/liferay/headless/commerce/admin/channel/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/resources/com/liferay/headless/commerce/admin/channel/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.6.0
+version 2.7.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/graphql/mutation/v1_0/Mutation.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -468,6 +469,8 @@ public class Mutation {
 		channelResource.setContextUser(_user);
 		channelResource.setGroupLocalService(_groupLocalService);
 		channelResource.setRoleLocalService(_roleLocalService);
+		channelResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -488,6 +491,9 @@ public class Mutation {
 			_groupLocalService);
 		paymentMethodGroupRelOrderTypeResource.setRoleLocalService(
 			_roleLocalService);
+		paymentMethodGroupRelOrderTypeResource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -507,6 +513,9 @@ public class Mutation {
 			_groupLocalService);
 		paymentMethodGroupRelTermResource.setRoleLocalService(
 			_roleLocalService);
+		paymentMethodGroupRelTermResource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -527,6 +536,9 @@ public class Mutation {
 			_groupLocalService);
 		shippingFixedOptionOrderTypeResource.setRoleLocalService(
 			_roleLocalService);
+		shippingFixedOptionOrderTypeResource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -545,6 +557,8 @@ public class Mutation {
 		shippingFixedOptionTermResource.setGroupLocalService(
 			_groupLocalService);
 		shippingFixedOptionTermResource.setRoleLocalService(_roleLocalService);
+		shippingFixedOptionTermResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<ChannelResource>
@@ -568,5 +582,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -742,6 +742,14 @@ public abstract class BaseChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -272,6 +272,14 @@ public abstract class BaseOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelOrderTypeResourceImpl.java
@@ -407,6 +407,14 @@ public abstract class BasePaymentMethodGroupRelOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BasePaymentMethodGroupRelTermResourceImpl.java
@@ -404,6 +404,14 @@ public abstract class BasePaymentMethodGroupRelTermResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionOrderTypeResourceImpl.java
@@ -406,6 +406,14 @@ public abstract class BaseShippingFixedOptionOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingFixedOptionTermResourceImpl.java
@@ -404,6 +404,14 @@ public abstract class BaseShippingFixedOptionTermResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -254,6 +254,14 @@ public abstract class BaseShippingMethodResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -276,6 +276,14 @@ public abstract class BaseTaxCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -271,6 +271,14 @@ public abstract class BaseTermResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Admin Inventory API
 Bundle-SymbolicName: com.liferay.headless.commerce.admin.inventory.api
-Bundle-Version: 7.2.5
+Bundle-Version: 7.3.0
 Export-Package:\
 	com.liferay.headless.commerce.admin.inventory.dto.v1_0,\
 	com.liferay.headless.commerce.admin.inventory.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/WarehouseItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/WarehouseItemResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -142,6 +143,10 @@ public interface WarehouseItemResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/WarehouseResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/resource/v1_0/WarehouseResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -119,6 +120,10 @@ public interface WarehouseResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/resources/com/liferay/headless/commerce/admin/inventory/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/resources/com/liferay/headless/commerce/admin/inventory/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/graphql/mutation/v1_0/Mutation.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -282,6 +283,8 @@ public class Mutation {
 		warehouseResource.setContextUser(_user);
 		warehouseResource.setGroupLocalService(_groupLocalService);
 		warehouseResource.setRoleLocalService(_roleLocalService);
+		warehouseResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -297,6 +300,8 @@ public class Mutation {
 		warehouseItemResource.setContextUser(_user);
 		warehouseItemResource.setGroupLocalService(_groupLocalService);
 		warehouseItemResource.setRoleLocalService(_roleLocalService);
+		warehouseItemResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<WarehouseResource>
@@ -313,5 +318,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseItemResourceImpl.java
@@ -711,6 +711,14 @@ public abstract class BaseWarehouseItemResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -463,6 +463,14 @@ public abstract class BaseWarehouseResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/AccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/AccountGroupResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,6 +95,10 @@ public interface AccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/AccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/AccountResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -99,6 +100,10 @@ public interface AccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/BillingAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/BillingAddressResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -105,6 +106,10 @@ public interface BillingAddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/ChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/ChannelResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -102,6 +103,10 @@ public interface ChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderItemResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -135,6 +136,10 @@ public interface OrderItemResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderNoteResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderNoteResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -135,6 +136,10 @@ public interface OrderNoteResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface OrderResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleAccountGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface OrderRuleAccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleAccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleAccountResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface OrderRuleAccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleChannelResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface OrderRuleChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleOrderTypeResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface OrderRuleOrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderRuleResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -126,6 +127,10 @@ public interface OrderRuleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderTypeChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderTypeChannelResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface OrderTypeChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/OrderTypeResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -132,6 +133,10 @@ public interface OrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/ShippingAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/ShippingAddressResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -108,6 +109,10 @@ public interface ShippingAddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/TermOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/TermOrderTypeResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -118,6 +119,10 @@ public interface TermOrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/TermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/resource/v1_0/TermResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface TermResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/resources/com/liferay/headless/commerce/admin/order/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/resources/com/liferay/headless/commerce/admin/order/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.6.0
+version 3.7.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/graphql/mutation/v1_0/Mutation.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -1306,6 +1307,8 @@ public class Mutation {
 		billingAddressResource.setContextUser(_user);
 		billingAddressResource.setGroupLocalService(_groupLocalService);
 		billingAddressResource.setRoleLocalService(_roleLocalService);
+		billingAddressResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(OrderResource orderResource)
@@ -1319,6 +1322,8 @@ public class Mutation {
 		orderResource.setContextUser(_user);
 		orderResource.setGroupLocalService(_groupLocalService);
 		orderResource.setRoleLocalService(_roleLocalService);
+		orderResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(OrderItemResource orderItemResource)
@@ -1332,6 +1337,8 @@ public class Mutation {
 		orderItemResource.setContextUser(_user);
 		orderItemResource.setGroupLocalService(_groupLocalService);
 		orderItemResource.setRoleLocalService(_roleLocalService);
+		orderItemResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(OrderNoteResource orderNoteResource)
@@ -1345,6 +1352,8 @@ public class Mutation {
 		orderNoteResource.setContextUser(_user);
 		orderNoteResource.setGroupLocalService(_groupLocalService);
 		orderNoteResource.setRoleLocalService(_roleLocalService);
+		orderNoteResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(OrderRuleResource orderRuleResource)
@@ -1358,6 +1367,8 @@ public class Mutation {
 		orderRuleResource.setContextUser(_user);
 		orderRuleResource.setGroupLocalService(_groupLocalService);
 		orderRuleResource.setRoleLocalService(_roleLocalService);
+		orderRuleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1374,6 +1385,8 @@ public class Mutation {
 		orderRuleAccountResource.setContextUser(_user);
 		orderRuleAccountResource.setGroupLocalService(_groupLocalService);
 		orderRuleAccountResource.setRoleLocalService(_roleLocalService);
+		orderRuleAccountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1390,6 +1403,8 @@ public class Mutation {
 		orderRuleAccountGroupResource.setContextUser(_user);
 		orderRuleAccountGroupResource.setGroupLocalService(_groupLocalService);
 		orderRuleAccountGroupResource.setRoleLocalService(_roleLocalService);
+		orderRuleAccountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1406,6 +1421,8 @@ public class Mutation {
 		orderRuleChannelResource.setContextUser(_user);
 		orderRuleChannelResource.setGroupLocalService(_groupLocalService);
 		orderRuleChannelResource.setRoleLocalService(_roleLocalService);
+		orderRuleChannelResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1422,6 +1439,8 @@ public class Mutation {
 		orderRuleOrderTypeResource.setContextUser(_user);
 		orderRuleOrderTypeResource.setGroupLocalService(_groupLocalService);
 		orderRuleOrderTypeResource.setRoleLocalService(_roleLocalService);
+		orderRuleOrderTypeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(OrderTypeResource orderTypeResource)
@@ -1435,6 +1454,8 @@ public class Mutation {
 		orderTypeResource.setContextUser(_user);
 		orderTypeResource.setGroupLocalService(_groupLocalService);
 		orderTypeResource.setRoleLocalService(_roleLocalService);
+		orderTypeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1451,6 +1472,8 @@ public class Mutation {
 		orderTypeChannelResource.setContextUser(_user);
 		orderTypeChannelResource.setGroupLocalService(_groupLocalService);
 		orderTypeChannelResource.setRoleLocalService(_roleLocalService);
+		orderTypeChannelResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1467,6 +1490,8 @@ public class Mutation {
 		shippingAddressResource.setContextUser(_user);
 		shippingAddressResource.setGroupLocalService(_groupLocalService);
 		shippingAddressResource.setRoleLocalService(_roleLocalService);
+		shippingAddressResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(TermResource termResource)
@@ -1480,6 +1505,8 @@ public class Mutation {
 		termResource.setContextUser(_user);
 		termResource.setGroupLocalService(_groupLocalService);
 		termResource.setRoleLocalService(_roleLocalService);
+		termResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1495,6 +1522,8 @@ public class Mutation {
 		termOrderTypeResource.setContextUser(_user);
 		termOrderTypeResource.setGroupLocalService(_groupLocalService);
 		termOrderTypeResource.setRoleLocalService(_roleLocalService);
+		termOrderTypeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<BillingAddressResource>
@@ -1535,5 +1564,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountGroupResourceImpl.java
@@ -240,6 +240,14 @@ public abstract class BaseAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -298,6 +298,14 @@ public abstract class BaseAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseBillingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseBillingAddressResourceImpl.java
@@ -347,6 +347,14 @@ public abstract class BaseBillingAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseChannelResourceImpl.java
@@ -328,6 +328,14 @@ public abstract class BaseChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderItemResourceImpl.java
@@ -655,6 +655,14 @@ public abstract class BaseOrderItemResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderNoteResourceImpl.java
@@ -655,6 +655,14 @@ public abstract class BaseOrderNoteResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderResourceImpl.java
@@ -580,6 +580,14 @@ public abstract class BaseOrderResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountGroupResourceImpl.java
@@ -520,6 +520,14 @@ public abstract class BaseOrderRuleAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleAccountResourceImpl.java
@@ -506,6 +506,14 @@ public abstract class BaseOrderRuleAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleChannelResourceImpl.java
@@ -514,6 +514,14 @@ public abstract class BaseOrderRuleChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleOrderTypeResourceImpl.java
@@ -505,6 +505,14 @@ public abstract class BaseOrderRuleOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderRuleResourceImpl.java
@@ -570,6 +570,14 @@ public abstract class BaseOrderRuleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeChannelResourceImpl.java
@@ -509,6 +509,14 @@ public abstract class BaseOrderTypeChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseOrderTypeResourceImpl.java
@@ -632,6 +632,14 @@ public abstract class BaseOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
@@ -378,6 +378,14 @@ public abstract class BaseShippingAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermOrderTypeResourceImpl.java
@@ -502,6 +502,14 @@ public abstract class BaseTermOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/BaseTermResourceImpl.java
@@ -562,6 +562,14 @@ public abstract class BaseTermResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Admin Pricing API
 Bundle-SymbolicName: com.liferay.headless.commerce.admin.pricing.api
-Bundle-Version: 15.2.5
+Bundle-Version: 15.3.0
 Export-Package:\
 	com.liferay.headless.commerce.admin.pricing.dto.v1_0,\
 	com.liferay.headless.commerce.admin.pricing.dto.v2_0,\

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountAccountGroupResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface DiscountAccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountCategoryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -120,6 +121,10 @@ public interface DiscountCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountProductResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -120,6 +121,10 @@ public interface DiscountProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface DiscountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountRuleResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/DiscountRuleResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface DiscountRuleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/PriceEntryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/PriceEntryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -135,6 +136,10 @@ public interface PriceEntryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/PriceListAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/PriceListAccountGroupResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface PriceListAccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/PriceListResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/PriceListResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -126,6 +127,10 @@ public interface PriceListResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/TierPriceResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v1_0/TierPriceResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -135,6 +136,10 @@ public interface TierPriceResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/AccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/AccountGroupResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,6 +99,10 @@ public interface AccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/AccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/AccountResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -96,6 +97,10 @@ public interface AccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/CategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/CategoryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -97,6 +98,10 @@ public interface CategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/ChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/ChannelResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -96,6 +97,10 @@ public interface ChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountAccountGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface DiscountAccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountAccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountAccountResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface DiscountAccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountCategoryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface DiscountCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountChannelResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface DiscountChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountOrderTypeResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface DiscountOrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountProductGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface DiscountProductGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountProductResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface DiscountProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface DiscountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountRuleResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountRuleResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -127,6 +128,10 @@ public interface DiscountRuleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountSkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/DiscountSkuResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -120,6 +121,10 @@ public interface DiscountSkuResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/OrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/OrderTypeResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -96,6 +97,10 @@ public interface OrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceEntryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceEntryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -136,6 +137,10 @@ public interface PriceEntryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListAccountGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -125,6 +126,10 @@ public interface PriceListAccountGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListAccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListAccountResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface PriceListAccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListChannelResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface PriceListChannelResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListDiscountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListDiscountResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface PriceListDiscountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListOrderTypeResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface PriceListOrderTypeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceListResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -126,6 +127,10 @@ public interface PriceListResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierCategoryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -126,6 +127,10 @@ public interface PriceModifierCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierProductGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -128,6 +129,10 @@ public interface PriceModifierProductGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierProductResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -126,6 +127,10 @@ public interface PriceModifierProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/PriceModifierResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -139,6 +140,10 @@ public interface PriceModifierResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/ProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/ProductGroupResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,6 +99,10 @@ public interface ProductGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/ProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/ProductResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,6 +99,10 @@ public interface ProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/SkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/SkuResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,6 +95,10 @@ public interface SkuResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/TierPriceResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/resource/v2_0/TierPriceResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -136,6 +137,10 @@ public interface TierPriceResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/resource/v2_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/resource/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/mutation/v1_0/Mutation.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -946,6 +947,8 @@ public class Mutation {
 		discountResource.setContextUser(_user);
 		discountResource.setGroupLocalService(_groupLocalService);
 		discountResource.setRoleLocalService(_roleLocalService);
+		discountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -962,6 +965,8 @@ public class Mutation {
 		discountAccountGroupResource.setContextUser(_user);
 		discountAccountGroupResource.setGroupLocalService(_groupLocalService);
 		discountAccountGroupResource.setRoleLocalService(_roleLocalService);
+		discountAccountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -978,6 +983,8 @@ public class Mutation {
 		discountCategoryResource.setContextUser(_user);
 		discountCategoryResource.setGroupLocalService(_groupLocalService);
 		discountCategoryResource.setRoleLocalService(_roleLocalService);
+		discountCategoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -994,6 +1001,8 @@ public class Mutation {
 		discountProductResource.setContextUser(_user);
 		discountProductResource.setGroupLocalService(_groupLocalService);
 		discountProductResource.setRoleLocalService(_roleLocalService);
+		discountProductResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1009,6 +1018,8 @@ public class Mutation {
 		discountRuleResource.setContextUser(_user);
 		discountRuleResource.setGroupLocalService(_groupLocalService);
 		discountRuleResource.setRoleLocalService(_roleLocalService);
+		discountRuleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(PriceEntryResource priceEntryResource)
@@ -1022,6 +1033,8 @@ public class Mutation {
 		priceEntryResource.setContextUser(_user);
 		priceEntryResource.setGroupLocalService(_groupLocalService);
 		priceEntryResource.setRoleLocalService(_roleLocalService);
+		priceEntryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(PriceListResource priceListResource)
@@ -1035,6 +1048,8 @@ public class Mutation {
 		priceListResource.setContextUser(_user);
 		priceListResource.setGroupLocalService(_groupLocalService);
 		priceListResource.setRoleLocalService(_roleLocalService);
+		priceListResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1051,6 +1066,8 @@ public class Mutation {
 		priceListAccountGroupResource.setContextUser(_user);
 		priceListAccountGroupResource.setGroupLocalService(_groupLocalService);
 		priceListAccountGroupResource.setRoleLocalService(_roleLocalService);
+		priceListAccountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(TierPriceResource tierPriceResource)
@@ -1064,6 +1081,8 @@ public class Mutation {
 		tierPriceResource.setContextUser(_user);
 		tierPriceResource.setGroupLocalService(_groupLocalService);
 		tierPriceResource.setRoleLocalService(_roleLocalService);
+		tierPriceResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<DiscountResource>
@@ -1094,5 +1113,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/mutation/v2_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/graphql/mutation/v2_0/Mutation.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -2141,6 +2142,8 @@ public class Mutation {
 		discountResource.setContextUser(_user);
 		discountResource.setGroupLocalService(_groupLocalService);
 		discountResource.setRoleLocalService(_roleLocalService);
+		discountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2157,6 +2160,8 @@ public class Mutation {
 		discountAccountResource.setContextUser(_user);
 		discountAccountResource.setGroupLocalService(_groupLocalService);
 		discountAccountResource.setRoleLocalService(_roleLocalService);
+		discountAccountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2173,6 +2178,8 @@ public class Mutation {
 		discountAccountGroupResource.setContextUser(_user);
 		discountAccountGroupResource.setGroupLocalService(_groupLocalService);
 		discountAccountGroupResource.setRoleLocalService(_roleLocalService);
+		discountAccountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2189,6 +2196,8 @@ public class Mutation {
 		discountCategoryResource.setContextUser(_user);
 		discountCategoryResource.setGroupLocalService(_groupLocalService);
 		discountCategoryResource.setRoleLocalService(_roleLocalService);
+		discountCategoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2205,6 +2214,8 @@ public class Mutation {
 		discountChannelResource.setContextUser(_user);
 		discountChannelResource.setGroupLocalService(_groupLocalService);
 		discountChannelResource.setRoleLocalService(_roleLocalService);
+		discountChannelResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2221,6 +2232,8 @@ public class Mutation {
 		discountOrderTypeResource.setContextUser(_user);
 		discountOrderTypeResource.setGroupLocalService(_groupLocalService);
 		discountOrderTypeResource.setRoleLocalService(_roleLocalService);
+		discountOrderTypeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2237,6 +2250,8 @@ public class Mutation {
 		discountProductResource.setContextUser(_user);
 		discountProductResource.setGroupLocalService(_groupLocalService);
 		discountProductResource.setRoleLocalService(_roleLocalService);
+		discountProductResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2253,6 +2268,8 @@ public class Mutation {
 		discountProductGroupResource.setContextUser(_user);
 		discountProductGroupResource.setGroupLocalService(_groupLocalService);
 		discountProductGroupResource.setRoleLocalService(_roleLocalService);
+		discountProductGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2268,6 +2285,8 @@ public class Mutation {
 		discountRuleResource.setContextUser(_user);
 		discountRuleResource.setGroupLocalService(_groupLocalService);
 		discountRuleResource.setRoleLocalService(_roleLocalService);
+		discountRuleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2282,6 +2301,8 @@ public class Mutation {
 		discountSkuResource.setContextUser(_user);
 		discountSkuResource.setGroupLocalService(_groupLocalService);
 		discountSkuResource.setRoleLocalService(_roleLocalService);
+		discountSkuResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(PriceEntryResource priceEntryResource)
@@ -2295,6 +2316,8 @@ public class Mutation {
 		priceEntryResource.setContextUser(_user);
 		priceEntryResource.setGroupLocalService(_groupLocalService);
 		priceEntryResource.setRoleLocalService(_roleLocalService);
+		priceEntryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(PriceListResource priceListResource)
@@ -2308,6 +2331,8 @@ public class Mutation {
 		priceListResource.setContextUser(_user);
 		priceListResource.setGroupLocalService(_groupLocalService);
 		priceListResource.setRoleLocalService(_roleLocalService);
+		priceListResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2324,6 +2349,8 @@ public class Mutation {
 		priceListAccountResource.setContextUser(_user);
 		priceListAccountResource.setGroupLocalService(_groupLocalService);
 		priceListAccountResource.setRoleLocalService(_roleLocalService);
+		priceListAccountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2340,6 +2367,8 @@ public class Mutation {
 		priceListAccountGroupResource.setContextUser(_user);
 		priceListAccountGroupResource.setGroupLocalService(_groupLocalService);
 		priceListAccountGroupResource.setRoleLocalService(_roleLocalService);
+		priceListAccountGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2356,6 +2385,8 @@ public class Mutation {
 		priceListChannelResource.setContextUser(_user);
 		priceListChannelResource.setGroupLocalService(_groupLocalService);
 		priceListChannelResource.setRoleLocalService(_roleLocalService);
+		priceListChannelResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2372,6 +2403,8 @@ public class Mutation {
 		priceListDiscountResource.setContextUser(_user);
 		priceListDiscountResource.setGroupLocalService(_groupLocalService);
 		priceListDiscountResource.setRoleLocalService(_roleLocalService);
+		priceListDiscountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2388,6 +2421,8 @@ public class Mutation {
 		priceListOrderTypeResource.setContextUser(_user);
 		priceListOrderTypeResource.setGroupLocalService(_groupLocalService);
 		priceListOrderTypeResource.setRoleLocalService(_roleLocalService);
+		priceListOrderTypeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2403,6 +2438,8 @@ public class Mutation {
 		priceModifierResource.setContextUser(_user);
 		priceModifierResource.setGroupLocalService(_groupLocalService);
 		priceModifierResource.setRoleLocalService(_roleLocalService);
+		priceModifierResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2419,6 +2456,8 @@ public class Mutation {
 		priceModifierCategoryResource.setContextUser(_user);
 		priceModifierCategoryResource.setGroupLocalService(_groupLocalService);
 		priceModifierCategoryResource.setRoleLocalService(_roleLocalService);
+		priceModifierCategoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2435,6 +2474,8 @@ public class Mutation {
 		priceModifierProductResource.setContextUser(_user);
 		priceModifierProductResource.setGroupLocalService(_groupLocalService);
 		priceModifierProductResource.setRoleLocalService(_roleLocalService);
+		priceModifierProductResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -2454,6 +2495,9 @@ public class Mutation {
 			_groupLocalService);
 		priceModifierProductGroupResource.setRoleLocalService(
 			_roleLocalService);
+		priceModifierProductGroupResource.
+			setVulcanBatchEngineImportTaskResource(
+				_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(TierPriceResource tierPriceResource)
@@ -2467,6 +2511,8 @@ public class Mutation {
 		tierPriceResource.setContextUser(_user);
 		tierPriceResource.setGroupLocalService(_groupLocalService);
 		tierPriceResource.setRoleLocalService(_roleLocalService);
+		tierPriceResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<DiscountResource>
@@ -2523,5 +2569,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountAccountGroupResourceImpl.java
@@ -523,6 +523,14 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountCategoryResourceImpl.java
@@ -506,6 +506,14 @@ public abstract class BaseDiscountCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountProductResourceImpl.java
@@ -506,6 +506,14 @@ public abstract class BaseDiscountProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountResourceImpl.java
@@ -565,6 +565,14 @@ public abstract class BaseDiscountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseDiscountRuleResourceImpl.java
@@ -554,6 +554,14 @@ public abstract class BaseDiscountRuleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceEntryResourceImpl.java
@@ -655,6 +655,14 @@ public abstract class BasePriceEntryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListAccountGroupResourceImpl.java
@@ -524,6 +524,14 @@ public abstract class BasePriceListAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BasePriceListResourceImpl.java
@@ -575,6 +575,14 @@ public abstract class BasePriceListResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/BaseTierPriceResourceImpl.java
@@ -655,6 +655,14 @@ public abstract class BaseTierPriceResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountGroupResourceImpl.java
@@ -272,6 +272,14 @@ public abstract class BaseAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseAccountResourceImpl.java
@@ -267,6 +267,14 @@ public abstract class BaseAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseCategoryResourceImpl.java
@@ -270,6 +270,14 @@ public abstract class BaseCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseChannelResourceImpl.java
@@ -267,6 +267,14 @@ public abstract class BaseChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountGroupResourceImpl.java
@@ -531,6 +531,14 @@ public abstract class BaseDiscountAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountAccountResourceImpl.java
@@ -513,6 +513,14 @@ public abstract class BaseDiscountAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountCategoryResourceImpl.java
@@ -513,6 +513,14 @@ public abstract class BaseDiscountCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountChannelResourceImpl.java
@@ -513,6 +513,14 @@ public abstract class BaseDiscountChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountOrderTypeResourceImpl.java
@@ -514,6 +514,14 @@ public abstract class BaseDiscountOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductGroupResourceImpl.java
@@ -531,6 +531,14 @@ public abstract class BaseDiscountProductGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountProductResourceImpl.java
@@ -513,6 +513,14 @@ public abstract class BaseDiscountProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountResourceImpl.java
@@ -570,6 +570,14 @@ public abstract class BaseDiscountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountRuleResourceImpl.java
@@ -565,6 +565,14 @@ public abstract class BaseDiscountRuleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseDiscountSkuResourceImpl.java
@@ -498,6 +498,14 @@ public abstract class BaseDiscountSkuResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseOrderTypeResourceImpl.java
@@ -270,6 +270,14 @@ public abstract class BaseOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceEntryResourceImpl.java
@@ -656,6 +656,14 @@ public abstract class BasePriceEntryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountGroupResourceImpl.java
@@ -520,6 +520,14 @@ public abstract class BasePriceListAccountGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListAccountResourceImpl.java
@@ -506,6 +506,14 @@ public abstract class BasePriceListAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListChannelResourceImpl.java
@@ -514,6 +514,14 @@ public abstract class BasePriceListChannelResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListDiscountResourceImpl.java
@@ -497,6 +497,14 @@ public abstract class BasePriceListDiscountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListOrderTypeResourceImpl.java
@@ -497,6 +497,14 @@ public abstract class BasePriceListOrderTypeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceListResourceImpl.java
@@ -570,6 +570,14 @@ public abstract class BasePriceListResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierCategoryResourceImpl.java
@@ -534,6 +534,14 @@ public abstract class BasePriceModifierCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductGroupResourceImpl.java
@@ -541,6 +541,14 @@ public abstract class BasePriceModifierProductGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierProductResourceImpl.java
@@ -533,6 +533,14 @@ public abstract class BasePriceModifierProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BasePriceModifierResourceImpl.java
@@ -689,6 +689,14 @@ public abstract class BasePriceModifierResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductGroupResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductGroupResourceImpl.java
@@ -272,6 +272,14 @@ public abstract class BaseProductGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseProductResourceImpl.java
@@ -299,6 +299,14 @@ public abstract class BaseProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseSkuResourceImpl.java
@@ -267,6 +267,14 @@ public abstract class BaseSkuResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/BaseTierPriceResourceImpl.java
@@ -650,6 +650,14 @@ public abstract class BaseTierPriceResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Admin Shipment API
 Bundle-SymbolicName: com.liferay.headless.commerce.admin.shipment.api
-Bundle-Version: 1.4.3
+Bundle-Version: 1.5.0
 Export-Package:\
 	com.liferay.headless.commerce.admin.shipment.dto.v1_0,\
 	com.liferay.headless.commerce.admin.shipment.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/ShipmentItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/ShipmentItemResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -132,6 +133,10 @@ public interface ShipmentItemResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/ShipmentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/ShipmentResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -149,6 +150,10 @@ public interface ShipmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/ShippingAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/resource/v1_0/ShippingAddressResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -105,6 +106,10 @@ public interface ShippingAddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/resources/com/liferay/headless/commerce/admin/shipment/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/resources/com/liferay/headless/commerce/admin/shipment/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/graphql/mutation/v1_0/Mutation.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -430,6 +431,8 @@ public class Mutation {
 		shipmentResource.setContextUser(_user);
 		shipmentResource.setGroupLocalService(_groupLocalService);
 		shipmentResource.setRoleLocalService(_roleLocalService);
+		shipmentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -445,6 +448,8 @@ public class Mutation {
 		shipmentItemResource.setContextUser(_user);
 		shipmentItemResource.setGroupLocalService(_groupLocalService);
 		shipmentItemResource.setRoleLocalService(_roleLocalService);
+		shipmentItemResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -461,6 +466,8 @@ public class Mutation {
 		shippingAddressResource.setContextUser(_user);
 		shippingAddressResource.setGroupLocalService(_groupLocalService);
 		shippingAddressResource.setRoleLocalService(_roleLocalService);
+		shippingAddressResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<ShipmentResource>
@@ -479,5 +486,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentItemResourceImpl.java
@@ -590,6 +590,14 @@ public abstract class BaseShipmentItemResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShipmentResourceImpl.java
@@ -855,6 +855,14 @@ public abstract class BaseShipmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/BaseShippingAddressResourceImpl.java
@@ -344,6 +344,14 @@ public abstract class BaseShippingAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Admin Site Setting API
 Bundle-SymbolicName: com.liferay.headless.commerce.admin.site.setting.api
-Bundle-Version: 6.2.5
+Bundle-Version: 6.3.0
 Export-Package:\
 	com.liferay.headless.commerce.admin.site.setting.dto.v1_0,\
 	com.liferay.headless.commerce.admin.site.setting.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/AvailabilityEstimateResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/AvailabilityEstimateResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -120,6 +121,10 @@ public interface AvailabilityEstimateResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/MeasurementUnitResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/MeasurementUnitResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -117,6 +118,10 @@ public interface MeasurementUnitResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/TaxCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/TaxCategoryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -116,6 +117,10 @@ public interface TaxCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/WarehouseResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/WarehouseResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -115,6 +116,10 @@ public interface WarehouseResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/resources/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/resources/com/liferay/headless/commerce/admin/site/setting/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/graphql/mutation/v1_0/Mutation.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -407,6 +408,8 @@ public class Mutation {
 		availabilityEstimateResource.setContextUser(_user);
 		availabilityEstimateResource.setGroupLocalService(_groupLocalService);
 		availabilityEstimateResource.setRoleLocalService(_roleLocalService);
+		availabilityEstimateResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -423,6 +426,8 @@ public class Mutation {
 		measurementUnitResource.setContextUser(_user);
 		measurementUnitResource.setGroupLocalService(_groupLocalService);
 		measurementUnitResource.setRoleLocalService(_roleLocalService);
+		measurementUnitResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -437,6 +442,8 @@ public class Mutation {
 		taxCategoryResource.setContextUser(_user);
 		taxCategoryResource.setGroupLocalService(_groupLocalService);
 		taxCategoryResource.setRoleLocalService(_roleLocalService);
+		taxCategoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(WarehouseResource warehouseResource)
@@ -450,6 +457,8 @@ public class Mutation {
 		warehouseResource.setContextUser(_user);
 		warehouseResource.setGroupLocalService(_groupLocalService);
 		warehouseResource.setRoleLocalService(_roleLocalService);
+		warehouseResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<AvailabilityEstimateResource>
@@ -470,5 +479,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseAvailabilityEstimateResourceImpl.java
@@ -527,6 +527,14 @@ public abstract class BaseAvailabilityEstimateResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseMeasurementUnitResourceImpl.java
@@ -509,6 +509,14 @@ public abstract class BaseMeasurementUnitResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseTaxCategoryResourceImpl.java
@@ -487,6 +487,14 @@ public abstract class BaseTaxCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/BaseWarehouseResourceImpl.java
@@ -494,6 +494,14 @@ public abstract class BaseWarehouseResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/bnd.bnd
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Delivery Cart API
 Bundle-SymbolicName: com.liferay.headless.commerce.delivery.cart.api
-Bundle-Version: 9.0.2
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.headless.commerce.delivery.cart.dto.v1_0,\
 	com.liferay.headless.commerce.delivery.cart.resource.v1_0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/AddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/AddressResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -94,6 +95,10 @@ public interface AddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/CartCommentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/CartCommentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -118,6 +119,10 @@ public interface CartCommentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/CartItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/CartItemResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -116,6 +117,10 @@ public interface CartItemResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/CartResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/CartResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -122,6 +123,10 @@ public interface CartResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/PaymentMethodResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/PaymentMethodResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -94,6 +95,10 @@ public interface PaymentMethodResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/ShippingMethodResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/resource/v1_0/ShippingMethodResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -94,6 +95,10 @@ public interface ShippingMethodResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/resources/com/liferay/headless/commerce/delivery/cart/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/resources/com/liferay/headless/commerce/delivery/cart/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/graphql/mutation/v1_0/Mutation.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -369,6 +370,8 @@ public class Mutation {
 		cartResource.setContextUser(_user);
 		cartResource.setGroupLocalService(_groupLocalService);
 		cartResource.setRoleLocalService(_roleLocalService);
+		cartResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -383,6 +386,8 @@ public class Mutation {
 		cartCommentResource.setContextUser(_user);
 		cartCommentResource.setGroupLocalService(_groupLocalService);
 		cartCommentResource.setRoleLocalService(_roleLocalService);
+		cartCommentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(CartItemResource cartItemResource)
@@ -396,6 +401,8 @@ public class Mutation {
 		cartItemResource.setContextUser(_user);
 		cartItemResource.setGroupLocalService(_groupLocalService);
 		cartItemResource.setRoleLocalService(_roleLocalService);
+		cartItemResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<CartResource>
@@ -414,5 +421,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseAddressResourceImpl.java
@@ -273,6 +273,14 @@ public abstract class BaseAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartCommentResourceImpl.java
@@ -526,6 +526,14 @@ public abstract class BaseCartCommentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartItemResourceImpl.java
@@ -593,6 +593,14 @@ public abstract class BaseCartItemResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseCartResourceImpl.java
@@ -736,6 +736,14 @@ public abstract class BaseCartResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BasePaymentMethodResourceImpl.java
@@ -245,6 +245,14 @@ public abstract class BasePaymentMethodResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/BaseShippingMethodResourceImpl.java
@@ -245,6 +245,14 @@ public abstract class BaseShippingMethodResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/AttachmentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/AttachmentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -102,6 +103,10 @@ public interface AttachmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/CategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/CategoryResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -96,6 +97,10 @@ public interface CategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/MappedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/MappedProductResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -98,6 +99,10 @@ public interface MappedProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/PinResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/PinResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -98,6 +99,10 @@ public interface PinResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/ProductOptionResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/ProductOptionResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -96,6 +97,10 @@ public interface ProductOptionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/ProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/ProductResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -102,6 +103,10 @@ public interface ProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/ProductSpecificationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/ProductSpecificationResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -97,6 +98,10 @@ public interface ProductSpecificationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/RelatedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/RelatedProductResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -96,6 +97,10 @@ public interface RelatedProductResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/SkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/SkuResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -97,6 +98,10 @@ public interface SkuResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/resources/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/resources/com/liferay/headless/commerce/delivery/catalog/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/graphql/mutation/v1_0/Mutation.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.function.BiFunction;
 
@@ -86,5 +87,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseAttachmentResourceImpl.java
@@ -317,6 +317,14 @@ public abstract class BaseAttachmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseCategoryResourceImpl.java
@@ -259,6 +259,14 @@ public abstract class BaseCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseMappedProductResourceImpl.java
@@ -279,6 +279,14 @@ public abstract class BaseMappedProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BasePinResourceImpl.java
@@ -274,6 +274,14 @@ public abstract class BasePinResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductOptionResourceImpl.java
@@ -260,6 +260,14 @@ public abstract class BaseProductOptionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductResourceImpl.java
@@ -315,6 +315,14 @@ public abstract class BaseProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseProductSpecificationResourceImpl.java
@@ -263,6 +263,14 @@ public abstract class BaseProductSpecificationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseRelatedProductResourceImpl.java
@@ -270,6 +270,14 @@ public abstract class BaseRelatedProductResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/BaseSkuResourceImpl.java
@@ -265,6 +265,14 @@ public abstract class BaseSkuResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
+++ b/modules/apps/data-engine/data-engine-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Data Engine REST API
 Bundle-SymbolicName: com.liferay.data.engine.rest.api
-Bundle-Version: 26.0.4
+Bundle-Version: 26.1.0
 Export-Package:\
 	com.liferay.data.engine.rest.dto.v2_0,\
 	com.liferay.data.engine.rest.dto.v2_0.util,\

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionFieldLinkResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionFieldLinkResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -96,6 +97,10 @@ public interface DataDefinitionFieldLinkResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataDefinitionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -150,6 +151,10 @@ public interface DataDefinitionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataLayoutResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -133,6 +134,10 @@ public interface DataLayoutResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataListViewResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataListViewResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface DataListViewResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordCollectionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordCollectionResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -150,6 +151,10 @@ public interface DataRecordCollectionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordResource.java
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/java/com/liferay/data/engine/rest/resource/v2_0/DataRecordResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -140,6 +141,10 @@ public interface DataRecordResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
+++ b/modules/apps/data-engine/data-engine-rest-api/src/main/resources/com/liferay/data/engine/rest/resource/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/graphql/mutation/v2_0/Mutation.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -713,6 +714,8 @@ public class Mutation {
 		dataDefinitionResource.setContextUser(_user);
 		dataDefinitionResource.setGroupLocalService(_groupLocalService);
 		dataDefinitionResource.setRoleLocalService(_roleLocalService);
+		dataDefinitionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(DataLayoutResource dataLayoutResource)
@@ -726,6 +729,8 @@ public class Mutation {
 		dataLayoutResource.setContextUser(_user);
 		dataLayoutResource.setGroupLocalService(_groupLocalService);
 		dataLayoutResource.setRoleLocalService(_roleLocalService);
+		dataLayoutResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -741,6 +746,8 @@ public class Mutation {
 		dataListViewResource.setContextUser(_user);
 		dataListViewResource.setGroupLocalService(_groupLocalService);
 		dataListViewResource.setRoleLocalService(_roleLocalService);
+		dataListViewResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(DataRecordResource dataRecordResource)
@@ -754,6 +761,8 @@ public class Mutation {
 		dataRecordResource.setContextUser(_user);
 		dataRecordResource.setGroupLocalService(_groupLocalService);
 		dataRecordResource.setRoleLocalService(_roleLocalService);
+		dataRecordResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -770,6 +779,8 @@ public class Mutation {
 		dataRecordCollectionResource.setContextUser(_user);
 		dataRecordCollectionResource.setGroupLocalService(_groupLocalService);
 		dataRecordCollectionResource.setRoleLocalService(_roleLocalService);
+		dataRecordCollectionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<DataDefinitionResource>
@@ -792,5 +803,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionFieldLinkResourceImpl.java
@@ -258,6 +258,14 @@ public abstract class BaseDataDefinitionFieldLinkResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataDefinitionResourceImpl.java
@@ -958,6 +958,14 @@ public abstract class BaseDataDefinitionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataLayoutResourceImpl.java
@@ -662,6 +662,14 @@ public abstract class BaseDataLayoutResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataListViewResourceImpl.java
@@ -581,6 +581,14 @@ public abstract class BaseDataListViewResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordCollectionResourceImpl.java
@@ -918,6 +918,14 @@ public abstract class BaseDataRecordCollectionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/BaseDataRecordResourceImpl.java
@@ -799,6 +799,14 @@ public abstract class BaseDataRecordResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/digital-signature/digital-signature-rest-api/bnd.bnd
+++ b/modules/apps/digital-signature/digital-signature-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Digital Signature REST API
 Bundle-SymbolicName: com.liferay.digital.signature.rest.api
-Bundle-Version: 1.1.4
+Bundle-Version: 1.2.0
 Export-Package:\
 	com.liferay.digital.signature.rest.dto.v1_0,\
 	com.liferay.digital.signature.rest.resource.v1_0

--- a/modules/apps/digital-signature/digital-signature-rest-api/src/main/java/com/liferay/digital/signature/rest/resource/v1_0/DSEnvelopeResource.java
+++ b/modules/apps/digital-signature/digital-signature-rest-api/src/main/java/com/liferay/digital/signature/rest/resource/v1_0/DSEnvelopeResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -108,6 +109,10 @@ public interface DSEnvelopeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/digital-signature/digital-signature-rest-api/src/main/resources/com/liferay/digital/signature/rest/resource/v1_0/packageinfo
+++ b/modules/apps/digital-signature/digital-signature-rest-api/src/main/resources/com/liferay/digital/signature/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -131,6 +132,8 @@ public class Mutation {
 		dsEnvelopeResource.setContextUser(_user);
 		dsEnvelopeResource.setGroupLocalService(_groupLocalService);
 		dsEnvelopeResource.setRoleLocalService(_roleLocalService);
+		dsEnvelopeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<DSEnvelopeResource>
@@ -145,5 +148,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/BaseDSEnvelopeResourceImpl.java
@@ -397,6 +397,14 @@ public abstract class BaseDSEnvelopeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin List Type API
 Bundle-SymbolicName: com.liferay.headless.admin.list.type.api
-Bundle-Version: 3.1.2
+Bundle-Version: 3.2.0
 Export-Package:\
 	com.liferay.headless.admin.list.type.dto.v1_0,\
 	com.liferay.headless.admin.list.type.resource.v1_0

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/resource/v1_0/ListTypeDefinitionResource.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/resource/v1_0/ListTypeDefinitionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -130,6 +131,10 @@ public interface ListTypeDefinitionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/resource/v1_0/ListTypeEntryResource.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/java/com/liferay/headless/admin/list/type/resource/v1_0/ListTypeEntryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface ListTypeEntryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/resources/com/liferay/headless/admin/list/type/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-api/src/main/resources/com/liferay/headless/admin/list/type/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/graphql/mutation/v1_0/Mutation.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -299,6 +300,8 @@ public class Mutation {
 		listTypeDefinitionResource.setContextUser(_user);
 		listTypeDefinitionResource.setGroupLocalService(_groupLocalService);
 		listTypeDefinitionResource.setRoleLocalService(_roleLocalService);
+		listTypeDefinitionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -314,6 +317,8 @@ public class Mutation {
 		listTypeEntryResource.setContextUser(_user);
 		listTypeEntryResource.setGroupLocalService(_groupLocalService);
 		listTypeEntryResource.setRoleLocalService(_roleLocalService);
+		listTypeEntryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<ListTypeDefinitionResource>
@@ -330,5 +335,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeDefinitionResourceImpl.java
@@ -611,6 +611,14 @@ public abstract class BaseListTypeDefinitionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/BaseListTypeEntryResourceImpl.java
@@ -578,6 +578,14 @@ public abstract class BaseListTypeEntryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Taxonomy API
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.api
-Bundle-Version: 8.0.3
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.headless.admin.taxonomy.dto.v1_0,\
 	com.liferay.headless.admin.taxonomy.resource.v1_0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/KeywordResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -159,6 +160,10 @@ public interface KeywordResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyCategoryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -167,6 +168,10 @@ public interface TaxonomyCategoryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/resource/v1_0/TaxonomyVocabularyResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -188,6 +189,10 @@ public interface TaxonomyVocabularyResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/mutation/v1_0/Mutation.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -736,6 +737,8 @@ public class Mutation {
 		keywordResource.setContextUser(_user);
 		keywordResource.setGroupLocalService(_groupLocalService);
 		keywordResource.setRoleLocalService(_roleLocalService);
+		keywordResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -752,6 +755,8 @@ public class Mutation {
 		taxonomyCategoryResource.setContextUser(_user);
 		taxonomyCategoryResource.setGroupLocalService(_groupLocalService);
 		taxonomyCategoryResource.setRoleLocalService(_roleLocalService);
+		taxonomyCategoryResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -768,6 +773,8 @@ public class Mutation {
 		taxonomyVocabularyResource.setContextUser(_user);
 		taxonomyVocabularyResource.setGroupLocalService(_groupLocalService);
 		taxonomyVocabularyResource.setRoleLocalService(_roleLocalService);
+		taxonomyVocabularyResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<KeywordResource>
@@ -786,5 +793,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseKeywordResourceImpl.java
@@ -1128,6 +1128,14 @@ public abstract class BaseKeywordResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -1178,6 +1178,14 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -1435,6 +1435,14 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin User API
 Bundle-SymbolicName: com.liferay.headless.admin.user.api
-Bundle-Version: 16.0.2
+Bundle-Version: 16.1.0
 Export-Package:\
 	com.liferay.headless.admin.user.dto.v1_0,\
 	com.liferay.headless.admin.user.resource.v1_0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -162,6 +163,10 @@ public interface AccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/AccountRoleResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -159,6 +160,10 @@ public interface AccountRoleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/EmailAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/EmailAddressResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -101,6 +102,10 @@ public interface EmailAddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/OrganizationResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/OrganizationResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -191,6 +192,10 @@ public interface OrganizationResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PhoneResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PhoneResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -99,6 +100,10 @@ public interface PhoneResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PostalAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/PostalAddressResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -102,6 +103,10 @@ public interface PostalAddressResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/RoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/RoleResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -120,6 +121,10 @@ public interface RoleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -99,6 +100,10 @@ public interface SegmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentUserResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SegmentUserResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -96,6 +97,10 @@ public interface SegmentUserResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SiteResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -100,6 +101,10 @@ public interface SiteResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SubscriptionResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/SubscriptionResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -102,6 +103,10 @@ public interface SubscriptionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -212,6 +213,10 @@ public interface UserAccountResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserGroupResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserGroupResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -141,6 +142,10 @@ public interface UserGroupResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/WebUrlResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/WebUrlResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -99,6 +100,10 @@ public interface WebUrlResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -1501,6 +1502,8 @@ public class Mutation {
 		accountResource.setContextUser(_user);
 		accountResource.setGroupLocalService(_groupLocalService);
 		accountResource.setRoleLocalService(_roleLocalService);
+		accountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1515,6 +1518,8 @@ public class Mutation {
 		accountRoleResource.setContextUser(_user);
 		accountRoleResource.setGroupLocalService(_groupLocalService);
 		accountRoleResource.setRoleLocalService(_roleLocalService);
+		accountRoleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1530,6 +1535,8 @@ public class Mutation {
 		organizationResource.setContextUser(_user);
 		organizationResource.setGroupLocalService(_groupLocalService);
 		organizationResource.setRoleLocalService(_roleLocalService);
+		organizationResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(RoleResource roleResource)
@@ -1543,6 +1550,8 @@ public class Mutation {
 		roleResource.setContextUser(_user);
 		roleResource.setGroupLocalService(_groupLocalService);
 		roleResource.setRoleLocalService(_roleLocalService);
+		roleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1558,6 +1567,8 @@ public class Mutation {
 		subscriptionResource.setContextUser(_user);
 		subscriptionResource.setGroupLocalService(_groupLocalService);
 		subscriptionResource.setRoleLocalService(_roleLocalService);
+		subscriptionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -1572,6 +1583,8 @@ public class Mutation {
 		userAccountResource.setContextUser(_user);
 		userAccountResource.setGroupLocalService(_groupLocalService);
 		userAccountResource.setRoleLocalService(_roleLocalService);
+		userAccountResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(UserGroupResource userGroupResource)
@@ -1585,6 +1598,8 @@ public class Mutation {
 		userGroupResource.setContextUser(_user);
 		userGroupResource.setGroupLocalService(_groupLocalService);
 		userGroupResource.setRoleLocalService(_roleLocalService);
+		userGroupResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<AccountResource>
@@ -1611,5 +1626,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountResourceImpl.java
@@ -1060,6 +1060,14 @@ public abstract class BaseAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseAccountRoleResourceImpl.java
@@ -857,6 +857,14 @@ public abstract class BaseAccountRoleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseEmailAddressResourceImpl.java
@@ -308,6 +308,14 @@ public abstract class BaseEmailAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -1394,6 +1394,14 @@ public abstract class BaseOrganizationResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePhoneResourceImpl.java
@@ -308,6 +308,14 @@ public abstract class BasePhoneResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BasePostalAddressResourceImpl.java
@@ -314,6 +314,14 @@ public abstract class BasePostalAddressResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -560,6 +560,14 @@ public abstract class BaseRoleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentResourceImpl.java
@@ -297,6 +297,14 @@ public abstract class BaseSegmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSegmentUserResourceImpl.java
@@ -251,6 +251,14 @@ public abstract class BaseSegmentUserResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -293,6 +293,14 @@ public abstract class BaseSiteResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseSubscriptionResourceImpl.java
@@ -305,6 +305,14 @@ public abstract class BaseSubscriptionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -1546,6 +1546,14 @@ public abstract class BaseUserAccountResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserGroupResourceImpl.java
@@ -795,6 +795,14 @@ public abstract class BaseUserGroupResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseWebUrlResourceImpl.java
@@ -308,6 +308,14 @@ public abstract class BaseWebUrlResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 38.0.2
+Bundle-Version: 38.1.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingImageResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -120,6 +121,10 @@ public interface BlogPostingImageResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/BlogPostingResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -176,6 +177,10 @@ public interface BlogPostingResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/CommentResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -155,6 +156,10 @@ public interface CommentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentElementResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentElementResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -105,6 +106,10 @@ public interface ContentElementResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentSetElementResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentSetElementResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -115,6 +116,10 @@ public interface ContentSetElementResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentStructureResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -141,6 +142,10 @@ public interface ContentStructureResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentTemplateResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/ContentTemplateResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -109,6 +110,10 @@ public interface ContentTemplateResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentFolderResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -189,6 +190,10 @@ public interface DocumentFolderResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/DocumentResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -215,6 +216,10 @@ public interface DocumentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -226,6 +227,10 @@ public interface KnowledgeBaseArticleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseAttachmentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -119,6 +120,10 @@ public interface KnowledgeBaseAttachmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -175,6 +176,10 @@ public interface KnowledgeBaseFolderResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/LanguageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/LanguageResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.Collections;
@@ -96,6 +97,10 @@ public interface LanguageResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardAttachmentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -132,6 +133,10 @@ public interface MessageBoardAttachmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardMessageResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -213,6 +214,10 @@ public interface MessageBoardMessageResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardSectionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -171,6 +172,10 @@ public interface MessageBoardSectionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/MessageBoardThreadResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -198,6 +199,10 @@ public interface MessageBoardThreadResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/NavigationMenuResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -141,6 +142,10 @@ public interface NavigationMenuResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/SitePageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/SitePageResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -118,6 +119,10 @@ public interface SitePageResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentFolderResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -203,6 +204,10 @@ public interface StructuredContentFolderResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/StructuredContentResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -248,6 +249,10 @@ public interface StructuredContentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiNodeResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -156,6 +157,10 @@ public interface WikiNodeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageAttachmentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 
@@ -116,6 +117,10 @@ public interface WikiPageAttachmentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/resource/v1_0/WikiPageResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -153,6 +154,10 @@ public interface WikiPageResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 15.1.0
+version 15.2.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4903,7 +4903,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.24'."
+        'com.liferay.headless.delivery.client', and version '4.0.25'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/mutation/v1_0/Mutation.java
@@ -58,6 +58,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -4110,6 +4111,8 @@ public class Mutation {
 		blogPostingResource.setContextUser(_user);
 		blogPostingResource.setGroupLocalService(_groupLocalService);
 		blogPostingResource.setRoleLocalService(_roleLocalService);
+		blogPostingResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4126,6 +4129,8 @@ public class Mutation {
 		blogPostingImageResource.setContextUser(_user);
 		blogPostingImageResource.setGroupLocalService(_groupLocalService);
 		blogPostingImageResource.setRoleLocalService(_roleLocalService);
+		blogPostingImageResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(CommentResource commentResource)
@@ -4139,6 +4144,8 @@ public class Mutation {
 		commentResource.setContextUser(_user);
 		commentResource.setGroupLocalService(_groupLocalService);
 		commentResource.setRoleLocalService(_roleLocalService);
+		commentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4155,6 +4162,8 @@ public class Mutation {
 		contentStructureResource.setContextUser(_user);
 		contentStructureResource.setGroupLocalService(_groupLocalService);
 		contentStructureResource.setRoleLocalService(_roleLocalService);
+		contentStructureResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(DocumentResource documentResource)
@@ -4168,6 +4177,8 @@ public class Mutation {
 		documentResource.setContextUser(_user);
 		documentResource.setGroupLocalService(_groupLocalService);
 		documentResource.setRoleLocalService(_roleLocalService);
+		documentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4184,6 +4195,8 @@ public class Mutation {
 		documentFolderResource.setContextUser(_user);
 		documentFolderResource.setGroupLocalService(_groupLocalService);
 		documentFolderResource.setRoleLocalService(_roleLocalService);
+		documentFolderResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4200,6 +4213,8 @@ public class Mutation {
 		knowledgeBaseArticleResource.setContextUser(_user);
 		knowledgeBaseArticleResource.setGroupLocalService(_groupLocalService);
 		knowledgeBaseArticleResource.setRoleLocalService(_roleLocalService);
+		knowledgeBaseArticleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4218,6 +4233,8 @@ public class Mutation {
 		knowledgeBaseAttachmentResource.setGroupLocalService(
 			_groupLocalService);
 		knowledgeBaseAttachmentResource.setRoleLocalService(_roleLocalService);
+		knowledgeBaseAttachmentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4234,6 +4251,8 @@ public class Mutation {
 		knowledgeBaseFolderResource.setContextUser(_user);
 		knowledgeBaseFolderResource.setGroupLocalService(_groupLocalService);
 		knowledgeBaseFolderResource.setRoleLocalService(_roleLocalService);
+		knowledgeBaseFolderResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4251,6 +4270,8 @@ public class Mutation {
 		messageBoardAttachmentResource.setContextUser(_user);
 		messageBoardAttachmentResource.setGroupLocalService(_groupLocalService);
 		messageBoardAttachmentResource.setRoleLocalService(_roleLocalService);
+		messageBoardAttachmentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4267,6 +4288,8 @@ public class Mutation {
 		messageBoardMessageResource.setContextUser(_user);
 		messageBoardMessageResource.setGroupLocalService(_groupLocalService);
 		messageBoardMessageResource.setRoleLocalService(_roleLocalService);
+		messageBoardMessageResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4283,6 +4306,8 @@ public class Mutation {
 		messageBoardSectionResource.setContextUser(_user);
 		messageBoardSectionResource.setGroupLocalService(_groupLocalService);
 		messageBoardSectionResource.setRoleLocalService(_roleLocalService);
+		messageBoardSectionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4299,6 +4324,8 @@ public class Mutation {
 		messageBoardThreadResource.setContextUser(_user);
 		messageBoardThreadResource.setGroupLocalService(_groupLocalService);
 		messageBoardThreadResource.setRoleLocalService(_roleLocalService);
+		messageBoardThreadResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4315,6 +4342,8 @@ public class Mutation {
 		navigationMenuResource.setContextUser(_user);
 		navigationMenuResource.setGroupLocalService(_groupLocalService);
 		navigationMenuResource.setRoleLocalService(_roleLocalService);
+		navigationMenuResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4331,6 +4360,8 @@ public class Mutation {
 		structuredContentResource.setContextUser(_user);
 		structuredContentResource.setGroupLocalService(_groupLocalService);
 		structuredContentResource.setRoleLocalService(_roleLocalService);
+		structuredContentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4349,6 +4380,8 @@ public class Mutation {
 		structuredContentFolderResource.setGroupLocalService(
 			_groupLocalService);
 		structuredContentFolderResource.setRoleLocalService(_roleLocalService);
+		structuredContentFolderResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(WikiNodeResource wikiNodeResource)
@@ -4362,6 +4395,8 @@ public class Mutation {
 		wikiNodeResource.setContextUser(_user);
 		wikiNodeResource.setGroupLocalService(_groupLocalService);
 		wikiNodeResource.setRoleLocalService(_roleLocalService);
+		wikiNodeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(WikiPageResource wikiPageResource)
@@ -4375,6 +4410,8 @@ public class Mutation {
 		wikiPageResource.setContextUser(_user);
 		wikiPageResource.setGroupLocalService(_groupLocalService);
 		wikiPageResource.setRoleLocalService(_roleLocalService);
+		wikiPageResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -4391,6 +4428,8 @@ public class Mutation {
 		wikiPageAttachmentResource.setContextUser(_user);
 		wikiPageAttachmentResource.setGroupLocalService(_groupLocalService);
 		wikiPageAttachmentResource.setRoleLocalService(_roleLocalService);
+		wikiPageAttachmentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<BlogPostingResource>
@@ -4441,5 +4480,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -512,6 +512,14 @@ public abstract class BaseBlogPostingImageResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -1356,6 +1356,14 @@ public abstract class BaseBlogPostingResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -965,6 +965,14 @@ public abstract class BaseCommentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -341,6 +341,14 @@ public abstract class BaseContentElementResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -465,6 +465,14 @@ public abstract class BaseContentSetElementResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -823,6 +823,14 @@ public abstract class BaseContentStructureResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -381,6 +381,14 @@ public abstract class BaseContentTemplateResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -1481,6 +1481,14 @@ public abstract class BaseDocumentFolderResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -1676,6 +1676,14 @@ public abstract class BaseDocumentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -1831,6 +1831,14 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -504,6 +504,14 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -1261,6 +1261,14 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -284,6 +284,14 @@ public abstract class BaseLanguageResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -643,6 +643,14 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -1706,6 +1706,14 @@ public abstract class BaseMessageBoardMessageResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -1235,6 +1235,14 @@ public abstract class BaseMessageBoardSectionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -1556,6 +1556,14 @@ public abstract class BaseMessageBoardThreadResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -883,6 +883,14 @@ public abstract class BaseNavigationMenuResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -507,6 +507,14 @@ public abstract class BaseSitePageResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -1571,6 +1571,14 @@ public abstract class BaseStructuredContentFolderResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -2129,6 +2129,14 @@ public abstract class BaseStructuredContentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -1067,6 +1067,14 @@ public abstract class BaseWikiNodeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -474,6 +474,14 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -1011,6 +1011,14 @@ public abstract class BaseWikiPageResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-form/headless-form-api/bnd.bnd
+++ b/modules/apps/headless/headless-form/headless-form-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Form API
 Bundle-SymbolicName: com.liferay.headless.form.api
-Bundle-Version: 11.3.6
+Bundle-Version: 11.4.0
 Export-Package:\
 	com.liferay.headless.form.dto.v1_0,\
 	com.liferay.headless.form.dto.v1_0.util,\

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormDocumentResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -98,6 +99,10 @@ public interface FormDocumentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormRecordResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -115,6 +116,10 @@ public interface FormRecordResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormResource.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -108,6 +109,10 @@ public interface FormResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/java/com/liferay/headless/form/resource/v1_0/FormStructureResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -99,6 +100,10 @@ public interface FormStructureResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/headless/headless-form/headless-form-api/src/main/resources/com/liferay/headless/form/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-form/headless-form-api/src/main/resources/com/liferay/headless/form/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.9.0
+version 3.10.0

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/graphql/mutation/v1_0/Mutation.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -232,6 +233,8 @@ public class Mutation {
 		formResource.setContextUser(_user);
 		formResource.setGroupLocalService(_groupLocalService);
 		formResource.setRoleLocalService(_roleLocalService);
+		formResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -247,6 +250,8 @@ public class Mutation {
 		formDocumentResource.setContextUser(_user);
 		formDocumentResource.setGroupLocalService(_groupLocalService);
 		formDocumentResource.setRoleLocalService(_roleLocalService);
+		formDocumentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(FormRecordResource formRecordResource)
@@ -260,6 +265,8 @@ public class Mutation {
 		formRecordResource.setContextUser(_user);
 		formRecordResource.setGroupLocalService(_groupLocalService);
 		formRecordResource.setRoleLocalService(_roleLocalService);
+		formRecordResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<FormResource>
@@ -278,5 +285,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormDocumentResourceImpl.java
@@ -319,6 +319,14 @@ public abstract class BaseFormDocumentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormRecordResourceImpl.java
@@ -501,6 +501,14 @@ public abstract class BaseFormRecordResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormResourceImpl.java
@@ -357,6 +357,14 @@ public abstract class BaseFormResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/BaseFormStructureResourceImpl.java
@@ -292,6 +292,14 @@ public abstract class BaseFormStructureResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectActionResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectActionResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface ObjectActionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectDefinitionResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectDefinitionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -131,6 +132,10 @@ public interface ObjectDefinitionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectFieldResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectFieldResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -123,6 +124,10 @@ public interface ObjectFieldResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectLayoutResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectLayoutResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -119,6 +120,10 @@ public interface ObjectLayoutResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectRelationshipResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectRelationshipResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -124,6 +125,10 @@ public interface ObjectRelationshipResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectValidationRuleResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectValidationRuleResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -131,6 +132,10 @@ public interface ObjectValidationRuleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectViewResource.java
+++ b/modules/apps/object/object-admin-rest-api/src/main/java/com/liferay/object/admin/rest/resource/v1_0/ObjectViewResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -120,6 +121,10 @@ public interface ObjectViewResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -839,6 +840,8 @@ public class Mutation {
 		objectActionResource.setContextUser(_user);
 		objectActionResource.setGroupLocalService(_groupLocalService);
 		objectActionResource.setRoleLocalService(_roleLocalService);
+		objectActionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -855,6 +858,8 @@ public class Mutation {
 		objectDefinitionResource.setContextUser(_user);
 		objectDefinitionResource.setGroupLocalService(_groupLocalService);
 		objectDefinitionResource.setRoleLocalService(_roleLocalService);
+		objectDefinitionResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -869,6 +874,8 @@ public class Mutation {
 		objectFieldResource.setContextUser(_user);
 		objectFieldResource.setGroupLocalService(_groupLocalService);
 		objectFieldResource.setRoleLocalService(_roleLocalService);
+		objectFieldResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -884,6 +891,8 @@ public class Mutation {
 		objectLayoutResource.setContextUser(_user);
 		objectLayoutResource.setGroupLocalService(_groupLocalService);
 		objectLayoutResource.setRoleLocalService(_roleLocalService);
+		objectLayoutResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -900,6 +909,8 @@ public class Mutation {
 		objectRelationshipResource.setContextUser(_user);
 		objectRelationshipResource.setGroupLocalService(_groupLocalService);
 		objectRelationshipResource.setRoleLocalService(_roleLocalService);
+		objectRelationshipResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -916,6 +927,8 @@ public class Mutation {
 		objectValidationRuleResource.setContextUser(_user);
 		objectValidationRuleResource.setGroupLocalService(_groupLocalService);
 		objectValidationRuleResource.setRoleLocalService(_roleLocalService);
+		objectValidationRuleResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(ObjectViewResource objectViewResource)
@@ -929,6 +942,8 @@ public class Mutation {
 		objectViewResource.setContextUser(_user);
 		objectViewResource.setGroupLocalService(_groupLocalService);
 		objectViewResource.setRoleLocalService(_roleLocalService);
+		objectViewResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<ObjectActionResource>
@@ -955,5 +970,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectActionResourceImpl.java
@@ -619,6 +619,14 @@ public abstract class BaseObjectActionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectDefinitionResourceImpl.java
@@ -673,6 +673,14 @@ public abstract class BaseObjectDefinitionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectFieldResourceImpl.java
@@ -636,6 +636,14 @@ public abstract class BaseObjectFieldResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectLayoutResourceImpl.java
@@ -548,6 +548,14 @@ public abstract class BaseObjectLayoutResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectRelationshipResourceImpl.java
@@ -577,6 +577,14 @@ public abstract class BaseObjectRelationshipResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectValidationRuleResourceImpl.java
@@ -683,6 +683,14 @@ public abstract class BaseObjectValidationRuleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/BaseObjectViewResourceImpl.java
@@ -578,6 +578,14 @@ public abstract class BaseObjectViewResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 3.0.2
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.manager.v1_0,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -153,6 +154,10 @@ public interface ObjectEntryResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -812,6 +812,14 @@ public abstract class BaseObjectEntryResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -53,6 +53,7 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.aggregation.Aggregation;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -1324,6 +1325,11 @@ public class GraphQLServletExtender {
 				field.set(
 					instance,
 					_portal.getUser(httpServletRequestOptional.orElse(null)));
+			}
+			else if (fieldClass.isAssignableFrom(VulcanBatchEngineImportTaskResource.class)) {
+				field.setAccessible(true);
+
+				field.set(instance, _vulcanBatchEngineImportTaskResource);
 			}
 			else {
 				Map<String, String[]> parameterMap = new HashMap<>(
@@ -2608,6 +2614,9 @@ public class GraphQLServletExtender {
 
 	@Reference
 	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private VulcanBatchEngineImportTaskResource _vulcanBatchEngineImportTaskResource;
 
 	private static class DateTypeFunction implements TypeFunction {
 

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/bnd.bnd
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Commerce Punch Out API
 Bundle-SymbolicName: com.liferay.headless.commerce.punchout.api
-Bundle-Version: 5.2.5
+Bundle-Version: 5.3.0
 Export-Package:\
 	com.liferay.headless.commerce.punchout.dto.v1_0,\
 	com.liferay.headless.commerce.punchout.helper,\

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/resource/v1_0/PunchOutSessionResource.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/resource/v1_0/PunchOutSessionResource.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.Collections;
 import java.util.List;
@@ -95,6 +96,10 @@ public interface PunchOutSessionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/resources/com/liferay/headless/commerce/punchout/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/resources/com/liferay/headless/commerce/punchout/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/BasePunchOutSessionResourceImpl.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/BasePunchOutSessionResourceImpl.java
@@ -234,6 +234,14 @@ public abstract class BasePunchOutSessionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/AccountCategoryForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/AccountCategoryForecastResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -100,6 +101,10 @@ public interface AccountCategoryForecastResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/AccountForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/AccountForecastResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -98,6 +99,10 @@ public interface AccountForecastResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/SkuForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/resource/v1_0/SkuForecastResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
@@ -98,6 +99,10 @@ public interface SkuForecastResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/resources/com/liferay/headless/commerce/machine/learning/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/resources/com/liferay/headless/commerce/machine/learning/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
@@ -720,7 +720,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.5'."
+        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.6'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/graphql/mutation/v1_0/Mutation.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import java.util.function.BiFunction;
 
@@ -86,5 +87,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountCategoryForecastResourceImpl.java
@@ -286,6 +286,14 @@ public abstract class BaseAccountCategoryForecastResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseAccountForecastResourceImpl.java
@@ -273,6 +273,14 @@ public abstract class BaseAccountForecastResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/BaseSkuForecastResourceImpl.java
@@ -271,6 +271,14 @@ public abstract class BaseSkuForecastResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.5'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/bnd.bnd
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Workflow Metrics REST API
 Bundle-SymbolicName: com.liferay.portal.workflow.metrics.rest.api
-Bundle-Version: 11.2.5
+Bundle-Version: 11.3.0
 Export-Package:\
 	com.liferay.portal.workflow.metrics.rest.dto.v1_0,\
 	com.liferay.portal.workflow.metrics.rest.dto.v1_0.util,\

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/AssigneeMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/AssigneeMetricResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeMetric;
@@ -99,6 +100,10 @@ public interface AssigneeMetricResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/AssigneeResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/AssigneeResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Assignee;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeBulkSelection;
@@ -96,6 +97,10 @@ public interface AssigneeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/CalendarResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/CalendarResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Calendar;
 
@@ -93,6 +94,10 @@ public interface CalendarResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/HistogramMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/HistogramMetricResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.HistogramMetric;
 
 import java.util.Collections;
@@ -95,6 +96,10 @@ public interface HistogramMetricResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/IndexResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/IndexResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Index;
 
@@ -97,6 +98,10 @@ public interface IndexResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/InstanceResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/InstanceResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Instance;
@@ -122,6 +123,10 @@ public interface InstanceResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/NodeMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/NodeMetricResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.NodeMetric;
@@ -100,6 +101,10 @@ public interface NodeMetricResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/NodeResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/NodeResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Node;
 
@@ -102,6 +103,10 @@ public interface NodeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ProcessMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ProcessMetricResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessMetric;
@@ -102,6 +103,10 @@ public interface ProcessMetricResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ProcessResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ProcessResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Process;
 
 import java.util.Collections;
@@ -110,6 +111,10 @@ public interface ProcessResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ProcessVersionResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ProcessVersionResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessVersion;
 
@@ -94,6 +95,10 @@ public interface ProcessVersionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ReindexStatusResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/ReindexStatusResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ReindexStatus;
 
@@ -93,6 +94,10 @@ public interface ReindexStatusResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/RoleResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/RoleResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
 
@@ -94,6 +95,10 @@ public interface RoleResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/SLAResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/SLAResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLA;
@@ -117,6 +118,10 @@ public interface SLAResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/SLAResultResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/SLAResultResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLAResult;
 
 import java.util.Collections;
@@ -92,6 +93,10 @@ public interface SLAResultResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/TaskResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/TaskResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Task;
@@ -116,6 +117,10 @@ public interface TaskResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/TimeRangeResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/java/com/liferay/portal/workflow/metrics/rest/resource/v1_0/TimeRangeResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.workflow.metrics.rest.dto.v1_0.TimeRange;
 
@@ -93,6 +94,10 @@ public interface TimeRangeResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/resources/com/liferay/portal/workflow/metrics/rest/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-api/src/main/resources/com/liferay/portal/workflow/metrics/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -594,6 +595,8 @@ public class Mutation {
 		assigneeResource.setContextUser(_user);
 		assigneeResource.setGroupLocalService(_groupLocalService);
 		assigneeResource.setRoleLocalService(_roleLocalService);
+		assigneeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -610,6 +613,8 @@ public class Mutation {
 		assigneeMetricResource.setContextUser(_user);
 		assigneeMetricResource.setGroupLocalService(_groupLocalService);
 		assigneeMetricResource.setRoleLocalService(_roleLocalService);
+		assigneeMetricResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(IndexResource indexResource)
@@ -623,6 +628,8 @@ public class Mutation {
 		indexResource.setContextUser(_user);
 		indexResource.setGroupLocalService(_groupLocalService);
 		indexResource.setRoleLocalService(_roleLocalService);
+		indexResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(InstanceResource instanceResource)
@@ -636,6 +643,8 @@ public class Mutation {
 		instanceResource.setContextUser(_user);
 		instanceResource.setGroupLocalService(_groupLocalService);
 		instanceResource.setRoleLocalService(_roleLocalService);
+		instanceResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(NodeResource nodeResource)
@@ -649,6 +658,8 @@ public class Mutation {
 		nodeResource.setContextUser(_user);
 		nodeResource.setGroupLocalService(_groupLocalService);
 		nodeResource.setRoleLocalService(_roleLocalService);
+		nodeResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(ProcessResource processResource)
@@ -662,6 +673,8 @@ public class Mutation {
 		processResource.setContextUser(_user);
 		processResource.setGroupLocalService(_groupLocalService);
 		processResource.setRoleLocalService(_roleLocalService);
+		processResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(SLAResource slaResource)
@@ -675,6 +688,8 @@ public class Mutation {
 		slaResource.setContextUser(_user);
 		slaResource.setGroupLocalService(_groupLocalService);
 		slaResource.setRoleLocalService(_roleLocalService);
+		slaResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(TaskResource taskResource)
@@ -688,6 +703,8 @@ public class Mutation {
 		taskResource.setContextUser(_user);
 		taskResource.setGroupLocalService(_groupLocalService);
 		taskResource.setRoleLocalService(_roleLocalService);
+		taskResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<AssigneeResource>
@@ -716,5 +733,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeMetricResourceImpl.java
@@ -258,6 +258,14 @@ public abstract class BaseAssigneeMetricResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseAssigneeResourceImpl.java
@@ -242,6 +242,14 @@ public abstract class BaseAssigneeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseCalendarResourceImpl.java
@@ -225,6 +225,14 @@ public abstract class BaseCalendarResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseHistogramMetricResourceImpl.java
@@ -262,6 +262,14 @@ public abstract class BaseHistogramMetricResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseIndexResourceImpl.java
@@ -256,6 +256,14 @@ public abstract class BaseIndexResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseInstanceResourceImpl.java
@@ -559,6 +559,14 @@ public abstract class BaseInstanceResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeMetricResourceImpl.java
@@ -288,6 +288,14 @@ public abstract class BaseNodeMetricResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseNodeResourceImpl.java
@@ -373,6 +373,14 @@ public abstract class BaseNodeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessMetricResourceImpl.java
@@ -308,6 +308,14 @@ public abstract class BaseProcessMetricResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessResourceImpl.java
@@ -499,6 +499,14 @@ public abstract class BaseProcessResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseProcessVersionResourceImpl.java
@@ -242,6 +242,14 @@ public abstract class BaseProcessVersionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseReindexStatusResourceImpl.java
@@ -227,6 +227,14 @@ public abstract class BaseReindexStatusResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseRoleResourceImpl.java
@@ -247,6 +247,14 @@ public abstract class BaseRoleResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResourceImpl.java
@@ -561,6 +561,14 @@ public abstract class BaseSLAResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResultResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseSLAResultResourceImpl.java
@@ -238,6 +238,14 @@ public abstract class BaseSLAResultResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTaskResourceImpl.java
@@ -521,6 +521,14 @@ public abstract class BaseTaskResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/BaseTimeRangeResourceImpl.java
@@ -225,6 +225,14 @@ public abstract class BaseTimeRangeResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/bnd.bnd
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Search Experiences REST API
 Bundle-SymbolicName: com.liferay.search.experiences.rest.api
-Bundle-Version: 1.0.5
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.search.experiences.rest.dto.v1_0,\
 	com.liferay.search.experiences.rest.dto.v1_0.util,\

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/FieldMappingInfoResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/FieldMappingInfoResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.FieldMappingInfo;
 
@@ -94,6 +95,10 @@ public interface FieldMappingInfoResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/KeywordQueryContributorResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/KeywordQueryContributorResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.KeywordQueryContributor;
 
@@ -94,6 +95,10 @@ public interface KeywordQueryContributorResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/ModelPrefilterContributorResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/ModelPrefilterContributorResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.ModelPrefilterContributor;
 
@@ -94,6 +95,10 @@ public interface ModelPrefilterContributorResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/QueryPrefilterContributorResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/QueryPrefilterContributorResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.QueryPrefilterContributor;
 
@@ -94,6 +95,10 @@ public interface QueryPrefilterContributorResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPBlueprintResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPBlueprintResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
@@ -125,6 +126,10 @@ public interface SXPBlueprintResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPElementResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPElementResource.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPElement;
@@ -121,6 +122,10 @@ public interface SXPElementResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPParameterContributorDefinitionResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SXPParameterContributorDefinitionResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPParameterContributorDefinition;
 
@@ -95,6 +96,10 @@ public interface SXPParameterContributorDefinitionResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SearchResponseResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SearchResponseResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
 import com.liferay.search.experiences.rest.dto.v1_0.SearchResponse;
@@ -96,6 +97,10 @@ public interface SearchResponseResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SearchableAssetNameDisplayResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SearchableAssetNameDisplayResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetNameDisplay;
 
@@ -95,6 +96,10 @@ public interface SearchableAssetNameDisplayResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SearchableAssetNameResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/java/com/liferay/search/experiences/rest/resource/v1_0/SearchableAssetNameResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetName;
 
@@ -94,6 +95,10 @@ public interface SearchableAssetNameResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/resources/com/liferay/search/experiences/rest/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-api/src/main/resources/com/liferay/search/experiences/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -322,6 +323,8 @@ public class Mutation {
 		sxpBlueprintResource.setContextUser(_user);
 		sxpBlueprintResource.setGroupLocalService(_groupLocalService);
 		sxpBlueprintResource.setRoleLocalService(_roleLocalService);
+		sxpBlueprintResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(SXPElementResource sxpElementResource)
@@ -335,6 +338,8 @@ public class Mutation {
 		sxpElementResource.setContextUser(_user);
 		sxpElementResource.setGroupLocalService(_groupLocalService);
 		sxpElementResource.setRoleLocalService(_roleLocalService);
+		sxpElementResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -351,6 +356,8 @@ public class Mutation {
 		searchResponseResource.setContextUser(_user);
 		searchResponseResource.setGroupLocalService(_groupLocalService);
 		searchResponseResource.setRoleLocalService(_roleLocalService);
+		searchResponseResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<SXPBlueprintResource>
@@ -369,5 +376,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseFieldMappingInfoResourceImpl.java
@@ -241,6 +241,14 @@ public abstract class BaseFieldMappingInfoResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseKeywordQueryContributorResourceImpl.java
@@ -234,6 +234,14 @@ public abstract class BaseKeywordQueryContributorResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseModelPrefilterContributorResourceImpl.java
@@ -234,6 +234,14 @@ public abstract class BaseModelPrefilterContributorResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseQueryPrefilterContributorResourceImpl.java
@@ -234,6 +234,14 @@ public abstract class BaseQueryPrefilterContributorResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPBlueprintResourceImpl.java
@@ -563,6 +563,14 @@ public abstract class BaseSXPBlueprintResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPElementResourceImpl.java
@@ -559,6 +559,14 @@ public abstract class BaseSXPElementResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSXPParameterContributorDefinitionResourceImpl.java
@@ -236,6 +236,14 @@ public abstract class BaseSXPParameterContributorDefinitionResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchResponseResourceImpl.java
@@ -252,6 +252,14 @@ public abstract class BaseSearchResponseResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameDisplayResourceImpl.java
@@ -247,6 +247,14 @@ public abstract class BaseSearchableAssetNameDisplayResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/BaseSearchableAssetNameResourceImpl.java
@@ -231,6 +231,14 @@ public abstract class BaseSearchableAssetNameResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/segments/segments-asah-rest-api/bnd.bnd
+++ b/modules/dxp/apps/segments/segments-asah-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments Asah REST API
 Bundle-SymbolicName: com.liferay.segments.asah.rest.api
-Bundle-Version: 4.2.5
+Bundle-Version: 4.3.0
 Export-Package:\
 	com.liferay.segments.asah.rest.dto.v1_0,\
 	com.liferay.segments.asah.rest.resource.v1_0

--- a/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentResource.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
 
 import java.util.Collections;
@@ -98,6 +99,10 @@ public interface ExperimentResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentRunResource.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/ExperimentRunResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.segments.asah.rest.dto.v1_0.ExperimentRun;
 
 import java.util.Collections;
@@ -94,6 +95,10 @@ public interface ExperimentRunResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/StatusResource.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-api/src/main/java/com/liferay/segments/asah/rest/resource/v1_0/StatusResource.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
 import com.liferay.segments.asah.rest.dto.v1_0.Status;
 
@@ -99,6 +100,10 @@ public interface StatusResource {
 		ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(

--- a/modules/dxp/apps/segments/segments-asah-rest-api/src/main/resources/com/liferay/segments/asah/rest/resource/v1_0/packageinfo
+++ b/modules/dxp/apps/segments/segments-asah-rest-api/src/main/resources/com/liferay/segments/asah/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
@@ -188,6 +189,8 @@ public class Mutation {
 		experimentResource.setContextUser(_user);
 		experimentResource.setGroupLocalService(_groupLocalService);
 		experimentResource.setRoleLocalService(_roleLocalService);
+		experimentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(
@@ -203,6 +206,8 @@ public class Mutation {
 		experimentRunResource.setContextUser(_user);
 		experimentRunResource.setGroupLocalService(_groupLocalService);
 		experimentRunResource.setRoleLocalService(_roleLocalService);
+		experimentRunResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private void _populateResourceContext(StatusResource statusResource)
@@ -216,6 +221,8 @@ public class Mutation {
 		statusResource.setContextUser(_user);
 		statusResource.setGroupLocalService(_groupLocalService);
 		statusResource.setRoleLocalService(_roleLocalService);
+		statusResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<ExperimentResource>
@@ -234,5 +241,7 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
 
 }

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentResourceImpl.java
@@ -315,6 +315,14 @@ public abstract class BaseExperimentResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentRunResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseExperimentRunResourceImpl.java
@@ -242,6 +242,14 @@ public abstract class BaseExperimentRunResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/BaseStatusResourceImpl.java
@@ -306,6 +306,14 @@ public abstract class BaseStatusResourceImpl
 		this.roleLocalService = roleLocalService;
 	}
 
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
 	@Override
 	public Filter toFilter(
 		String filterString, Map<String, List<String>> multivaluedMap) {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -606,6 +606,10 @@ public abstract class Base${schemaName}ResourceImpl
 	}
 
 	<#if generateBatch>
+		public void setVulcanBatchEngineImportTaskResource(VulcanBatchEngineImportTaskResource vulcanBatchEngineImportTaskResource) {
+			this.vulcanBatchEngineImportTaskResource = vulcanBatchEngineImportTaskResource;
+		}
+
 		@Override
 		public Filter toFilter(String filterString, Map<String, List<String>> multivaluedMap) {
 			try {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
@@ -48,6 +49,8 @@ public class Mutation {
 		javaMethodSignatures = freeMarkerTool.getGraphQLJavaMethodSignatures(configYAML, "mutation", openAPIYAML)
 
 		schemaNames = freeMarkerTool.getGraphQLSchemaNames(javaMethodSignatures)
+
+		generateBatch = configYAML.generateBatch
 	/>
 
 	<#list schemaNames as schemaName>
@@ -124,6 +127,9 @@ public class Mutation {
 			${freeMarkerTool.getSchemaVarName(schemaName)}Resource.setContextUser(_user);
 			${freeMarkerTool.getSchemaVarName(schemaName)}Resource.setGroupLocalService(_groupLocalService);
 			${freeMarkerTool.getSchemaVarName(schemaName)}Resource.setRoleLocalService(_roleLocalService);
+			<#if generateBatch>
+				${freeMarkerTool.getSchemaVarName(schemaName)}Resource.setVulcanBatchEngineImportTaskResource(_vulcanBatchEngineImportTaskResource);
+			</#if>
 		}
 	</#list>
 
@@ -140,5 +146,9 @@ public class Mutation {
 	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
+
+	<#if generateBatch>
+		private VulcanBatchEngineImportTaskResource _vulcanBatchEngineImportTaskResource;
+	</#if>
 
 }

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
@@ -88,6 +89,10 @@ public interface ${schemaName}Resource {
 	public void setResourcePermissionLocalService(ResourcePermissionLocalService resourcePermissionLocalService);
 
 	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	<#if configYAML.generateBatch>
+		public void setVulcanBatchEngineImportTaskResource(VulcanBatchEngineImportTaskResource vulcanBatchEngineImportTaskResource);
+	</#if>
 
 	public default Filter toFilter(String filterString) {
 		return toFilter(filterString, Collections.<String, List<String>>emptyMap());


### PR DESCRIPTION
Related ticket: [LPS-150490](https://issues.liferay.com/browse/LPS-150490)

This PR contains the fix to the bug with GraphQL and batch mutations.

To reproduce it, it is just necessary to invoke the GraphQL endpoint with the following mutation (given a siteKey/siteId and a contentStructuredId):

```
mutation {
    createSiteStructuredContentBatch(
        siteKey: "20123"
        object: [
        {
            contentStructureId: 42505
            title: "My content from graphQL batch 1"
        },
        {
            contentStructureId: 42505
            title: "My content from graphQL batch 2"
        }
        ]
    )
}
```
Two Structured Contents must be created.

_NOTE_: Do not forget to include the headers: "accept: application/json" and "Content-Type: application/json".


Before the PR:

![image](https://user-images.githubusercontent.com/32699538/162183687-60bf8aa1-40b1-485e-831e-598605032745.png)


Once fixed the NullPointerException, it has been necessary to include the parameters such as siteId or assetLibraryId in the UriInfoImpl to make it accesible in the Batch Engine as they are not included in the URI directly.



After the PR:

![image](https://user-images.githubusercontent.com/32699538/162180620-f308ca96-0dc3-49e8-805f-06720f2b0894.png)


![image](https://user-images.githubusercontent.com/32699538/162181849-7ad60af9-f45b-4c9a-8c72-c441ecaea14b.png)

