### PR TITLE
LPS-113539 Modernize the `selectFolder` utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -655,32 +655,6 @@
 			});
 		},
 
-		selectFolder(folderData, namespace) {
-			const folderDataElement = document.getElementById(
-				namespace + folderData.idString
-			);
-
-			if (folderDataElement) {
-				folderDataElement.value = folderData.idValue;
-			}
-
-			const folderNameElement = document.getElementById(
-				namespace + folderData.nameString
-			);
-
-			if (folderNameElement) {
-				folderNameElement.value = this.unescape(folderData.nameValue);
-			}
-
-			const removeFolderButton = document.getElementById(
-				`${namespace}removeFolderButton`
-			);
-
-			if (removeFolderButton) {
-				this.toggleDisabled(removeFolderButton, false);
-			}
-		},
-
 		setCursorPosition(element, position) {
 			var instance = this;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -106,4 +106,5 @@ export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
 export {default as removeEntitySelection} from './liferay/util/remove_entity_selection';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
+export {default as selectFolder} from './liferay/util/select_folder';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -79,6 +79,7 @@ import createPortletURL from './util/portlet_url/create_portlet_url.es';
 import createRenderURL from './util/portlet_url/create_render_url.es';
 import createResourceURL from './util/portlet_url/create_resource_url.es';
 import removeEntitySelection from './util/remove_entity_selection';
+import selectFolder from './util/select_folder';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
@@ -300,6 +301,7 @@ Liferay.Util.openToast = (...args) => {
 };
 
 Liferay.Util.removeEntitySelection = removeEntitySelection;
+Liferay.Util.selectFolder = selectFolder;
 Liferay.Util.sub = sub;
 
 Liferay.Util.Session = {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -178,6 +178,16 @@ declare module Liferay {
 			namespace: string
 		): void;
 
+		export function selectFolder(
+			folderData: {
+				idString: string;
+				idValue: string;
+				nameString: string;
+				nameValue: string;
+			},
+			namespace: string
+		): void;
+
 		/**
 		 * Sets the form elements to given values.
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/select_folder.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/select_folder.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import toggleDisabled from './toggle_disabled';
+
+export default function selectFolder(folderData, namespace) {
+	const folderDataElement = document.getElementById(
+		`${namespace}${folderData.idString}`
+	);
+
+	if (folderDataElement) {
+		folderDataElement.value = folderData.idValue;
+	}
+
+	const folderNameElement = document.getElementById(
+		`${namespace}${folderData.nameString}`
+	);
+
+	if (folderNameElement) {
+		folderNameElement.value = Liferay.Util.unescape(folderData.nameValue);
+	}
+
+	const removeFolderButton = document.getElementById(
+		`${namespace}removeFolderButton`
+	);
+
+	if (removeFolderButton) {
+		toggleDisabled(removeFolderButton, false);
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/select_folder.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/select_folder.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import selectFolder from '../../../src/main/resources/META-INF/resources/liferay/util/select_folder';
+
+describe('Liferay.Util.selectFolder', () => {
+	const folderData = {
+		idString: 'fooId',
+		idValue: '1',
+		nameString: 'fooName',
+		nameValue: 'fooNameValue',
+	};
+	const namespace = 'foo';
+
+	Liferay = {
+		Util: {
+			unescape: jest.fn(() => folderData.nameValue),
+		},
+	};
+
+	it('sets the value of the folderNameElement to match the name of the selected folder', () => {
+		const folderNameElement = document.createElement('input');
+
+		folderNameElement.id = `${namespace}${folderData.nameString}`;
+
+		document.body.appendChild(folderNameElement);
+
+		selectFolder(folderData, namespace);
+
+		expect(folderNameElement.value).toBe(folderData.nameValue);
+	});
+
+	it('sets the value of the folderDataElement to match the id of the selected folder', () => {
+		const folderDataElement = document.createElement('input');
+
+		folderDataElement.id = `${namespace}${folderData.idString}`;
+
+		document.body.appendChild(folderDataElement);
+
+		selectFolder(folderData, namespace);
+
+		expect(folderDataElement.value).toBe(folderData.idValue);
+	});
+
+	it('enables the removeFolderButton', () => {
+		const mockButton = document.createElement('button');
+
+		mockButton.id = `${namespace}removeFolderButton`;
+
+		selectFolder(folderData, namespace);
+
+		expect(mockButton.disabled).toBe(false);
+	});
+});


### PR DESCRIPTION
This one can be tested by following these steps:
1. go to web content 
2. edit a folder 
3. under the parent folder tab click on the “select” button
4. click on any folder in the list
5. save changes
6. the “remove” button should be enabled