### PR TITLE
LPS-147852 Add test OrderButtonAsAToggleCanDisplayTooltip

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -107,6 +107,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ORDER_TOGGLE_BUTTON</td>
+	<td>//nav[contains(@class,'management-bar')]//*[*[name()='svg'][contains(@class,'icon-${key_icon}')] and contains(@title,'Reverse Order Direction')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>MORE_ACTIONS_ELLIPSIS</td>
 	<td>//nav[contains(@class,'management-bar')]//button[contains(@class, 'dropdown-toggle')][*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -149,7 +149,7 @@ definition {
 			MessageboardsCategory.addCP(categoryName = "Test Category");
 		}
 
-		task ("And clicks on the order button") {			
+		task ("And clicks on the order button") {
 			Click(
 				key_text = "order-list-up",
 				locator1 = "ManagementBar#ANY_ICON");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -137,6 +137,47 @@ definition {
 		}
 	}
 
+	@description = "LPS-147852. Assert a tooltip message will be displayed when hovered over the order toggle button"
+	@priority = "3"
+	test OrderButtonAsAToggleCanDisplayTooltip {
+		task ("When the user opens any section with the management toolbar") {
+
+			// Using message boards as workaround until LPS-150056
+
+			MessageBoardsAdmin.openMessageBoardsAdmin(siteURLKey = "guest");
+
+			MessageboardsCategory.addCP(categoryName = "Test Category");
+		}
+
+		task ("And clicks on the order button") {			
+			Click(
+				key_text = "order-list-up",
+				locator1 = "ManagementBar#ANY_ICON");
+		}
+
+		task ("Then there is no dropdown menu") {
+			AssertElementNotPresent(
+				key_item = "",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+		}
+
+		task ("And the button is changed to the other order direction") {
+			AssertElementPresent(locator1 = "xpath=(//nav[contains(@class,'management-bar')]//*[*[name()='svg'][contains(@class,'icon-order-list-down')] and contains(@title,'Reverse Order Direction')])");
+		}
+
+		task ("And a tooltip message will be displayed") {
+			WaitForPageLoad();
+
+			MouseOver(
+				key_text = "order-list-down",
+				locator1 = "ManagementBar#ANY_ICON");
+
+			AssertTextEquals(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Reverse Order Direction");
+		}
+	}
+
 	@description = "LPS-147850. Assert the order button can sort results by descending order"
 	@priority = "5"
 	test OrderButtonCanSortOptionsByDescending {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -162,7 +162,9 @@ definition {
 		}
 
 		task ("And the button is changed to the other order direction") {
-			AssertElementPresent(locator1 = "xpath=(//nav[contains(@class,'management-bar')]//*[*[name()='svg'][contains(@class,'icon-order-list-down')] and contains(@title,'Reverse Order Direction')])");
+			AssertElementPresent(
+				key_icon = "order-list-down",
+				locator1 = "ManagementBar#ORDER_TOGGLE_BUTTON");
 		}
 
 		task ("And a tooltip message will be displayed") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -166,7 +166,7 @@ definition {
 		}
 
 		task ("And a tooltip message will be displayed") {
-			WaitForPageLoad();
+			Refresh();
 
 			MouseOver(
 				key_text = "order-list-down",


### PR DESCRIPTION
**Background**
Create automated tests for Management Toolbar.

**Test Plan**
Given a user of the portal
When the user opens any section with the management toolbar
And clicks on the order button
Then there is no dropdown menu
And the button is changed to the other order direction
And a tooltip message will be displayed

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147852