### PR TITLE
LPS-113542 Modernize the `showCapsLock` util

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -685,29 +685,6 @@
 			}
 		},
 
-		showCapsLock(event, spanId) {
-			const span = document.getElementById(spanId);
-
-			if (span) {
-				var keyCode = event.keyCode ? event.keyCode : event.which;
-
-				var shiftKeyCode = keyCode === 16;
-
-				var shiftKey = event.shiftKey ? event.shiftKey : shiftKeyCode;
-
-				var display = 'none';
-
-				if (
-					(keyCode >= 65 && keyCode <= 90 && !shiftKey) ||
-					(keyCode >= 97 && keyCode <= 122 && shiftKey)
-				) {
-					display = '';
-				}
-
-				span.style.display = display;
-			}
-		},
-
 		/**
 		 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -107,6 +107,7 @@ export {default as isTablet} from './liferay/util/is_tablet';
 export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
 export {default as removeEntitySelection} from './liferay/util/remove_entity_selection';
+export {default as showCapsLock} from './liferay/util/show_caps_lock';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
 export {default as selectFolder} from './liferay/util/select_folder';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -82,6 +82,7 @@ import createResourceURL from './util/portlet_url/create_resource_url.es';
 import removeEntitySelection from './util/remove_entity_selection';
 import selectFolder from './util/select_folder';
 import {getSessionValue, setSessionValue} from './util/session.es';
+import showCapsLock from './util/show_caps_lock';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
 import toggleDisabled from './util/toggle_disabled';
@@ -311,6 +312,7 @@ Liferay.Util.openToast = (...args) => {
 
 Liferay.Util.removeEntitySelection = removeEntitySelection;
 Liferay.Util.selectFolder = selectFolder;
+Liferay.Util.showCapsLock = showCapsLock;
 Liferay.Util.sub = sub;
 
 Liferay.Util.Session = {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -464,6 +464,11 @@ declare module Liferay {
 			data: Object
 		): void;
 
+		export function showCapsLock(
+			event: KeyboardEvent,
+			elementId: string
+		): void;
+
 		export function sub(
 			string: string,
 			data:

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/show_caps_lock.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/show_caps_lock.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function showCapsLock(event, elementId) {
+	const element = document.getElementById(elementId);
+
+	if (element) {
+		element.style.display = 'none';
+
+		if (event.getModifierState('CapsLock')) {
+			element.style.display = '';
+		}
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/show_caps_lock.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/show_caps_lock.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {showCapsLock} from '../../../src/main/resources/META-INF/resources/index.es';
+
+describe('Liferay.Util.showCapsLock', () => {
+	it('finds an element by id and sets the display property to an empty string', () => {
+		const input = document.createElement('input');
+
+		input.id = 'foo';
+
+		document.body.appendChild(input);
+
+		showCapsLock(
+			{
+				getModifierState: () => true,
+			},
+			'foo'
+		);
+
+		expect(input.style.display).toBe('');
+
+		document.body.removeChild(input);
+	});
+
+	it('does not change the display style of the caps lock notice if caps lock is not enabled', () => {
+		const input = document.createElement('input');
+
+		input.id = 'foo';
+
+		document.body.appendChild(input);
+
+		showCapsLock(
+			{
+				getModifierState: () => false,
+			},
+			'foo'
+		);
+
+		expect(input.style.display).toBe('none');
+
+		document.body.removeChild(input);
+	});
+});


### PR DESCRIPTION
This util can be tested by going to the login page when you're logged out, enabling caps lock and typing in the password field.
<img width="667" alt="image" src="https://user-images.githubusercontent.com/24564752/162704485-4cb99271-ab55-4420-b2d6-3316a4ab68cf.png">
