### PR TITLE
LPS-148659 Migrate use cases of alert to use `Liferay.Util.openAlertModal` on JSP files

### DIFF
--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
@@ -131,7 +131,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "merge-tags"));
 			);
 
 			if (mergeTagNames.length < 2) {
-				if (Liferay.__FF__.enableCustomDialogs) {
+				if (Liferay.__FF__.customDialogsEnabled) {
 					Liferay.Util.openAlertModal({
 						message:
 							'<liferay-ui:message arguments="2" key="please-choose-at-least-x-tags" />',

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/merge_tag.jsp
@@ -131,9 +131,17 @@ renderResponse.setTitle(LanguageUtil.get(request, "merge-tags"));
 			);
 
 			if (mergeTagNames.length < 2) {
-				alert(
-					'<liferay-ui:message arguments="2" key="please-choose-at-least-x-tags" />'
-				);
+				if (Liferay.__FF__.enableCustomDialogs) {
+					Liferay.Util.openAlertModal({
+						message:
+							'<liferay-ui:message arguments="2" key="please-choose-at-least-x-tags" />',
+					});
+				}
+				else {
+					alert(
+						'<liferay-ui:message arguments="2" key="please-choose-at-least-x-tags" />'
+					);
+				}
 
 				return;
 			}

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_discounts/rule/edit_commerce_discount_rule.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_discounts/rule/edit_commerce_discount_rule.jsp
@@ -124,7 +124,7 @@ String type = BeanParamUtil.getString(commerceDiscountRule, request, "type");
 					return;
 				})
 				.catch(() => {
-					if (Liferay.__FF__.enableCustomDialogs) {
+					if (Liferay.__FF__.customDialogsEnabled) {
 						Liferay.Util.openAlertModal({
 							message:
 								'<liferay-ui:message key="your-request-failed-to-complete" />',

--- a/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_discounts/rule/edit_commerce_discount_rule.jsp
+++ b/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_discounts/rule/edit_commerce_discount_rule.jsp
@@ -124,9 +124,17 @@ String type = BeanParamUtil.getString(commerceDiscountRule, request, "type");
 					return;
 				})
 				.catch(() => {
-					alert(
-						'<liferay-ui:message key="your-request-failed-to-complete" />'
-					);
+					if (Liferay.__FF__.enableCustomDialogs) {
+						Liferay.Util.openAlertModal({
+							message:
+								'<liferay-ui:message key="your-request-failed-to-complete" />',
+						});
+					}
+					else {
+						alert(
+							'<liferay-ui:message key="your-request-failed-to-complete" />'
+						);
+					}
 
 					return;
 				});

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_rel.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_rel.jsp
@@ -199,7 +199,7 @@ String defaultLanguageId = cpDefinitionOptionRelDisplayContext.getCatalogDefault
 					formFieldTypeSelect.value != '' &&
 					!endsWith(formFieldTypeSelect.value, array)
 				) {
-					if (Liferay.__FF__.enableCustomDialogs) {
+					if (Liferay.__FF__.customDialogsEnabled) {
 						Liferay.Util.openAlertModal({
 							message:
 								'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />',
@@ -247,7 +247,7 @@ String defaultLanguageId = cpDefinitionOptionRelDisplayContext.getCatalogDefault
 						disable(priceTypeSelect);
 					}
 					else {
-						if (Liferay.__FF__.enableCustomDialogs) {
+						if (Liferay.__FF__.customDialogsEnabled) {
 							Liferay.Util.openAlertModal(
 								'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
 							);
@@ -275,7 +275,7 @@ String defaultLanguageId = cpDefinitionOptionRelDisplayContext.getCatalogDefault
 						disable(skuContributorInput);
 					}
 					else {
-						if (Liferay.__FF__.enableCustomDialogs) {
+						if (Liferay.__FF__.customDialogsEnabled) {
 							Liferay.Util.openAlertModal({
 								message:
 									'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />',

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_rel.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_rel.jsp
@@ -199,9 +199,17 @@ String defaultLanguageId = cpDefinitionOptionRelDisplayContext.getCatalogDefault
 					formFieldTypeSelect.value != '' &&
 					!endsWith(formFieldTypeSelect.value, array)
 				) {
-					alert(
-						'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
-					);
+					if (Liferay.__FF__.enableCustomDialogs) {
+						Liferay.Util.openAlertModal({
+							message:
+								'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />',
+						});
+					}
+					else {
+						alert(
+							'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
+						);
+					}
 
 					return;
 				}
@@ -239,9 +247,16 @@ String defaultLanguageId = cpDefinitionOptionRelDisplayContext.getCatalogDefault
 						disable(priceTypeSelect);
 					}
 					else {
-						alert(
-							'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
-						);
+						if (Liferay.__FF__.enableCustomDialogs) {
+							Liferay.Util.openAlertModal(
+								'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
+							);
+						}
+						else {
+							alert(
+								'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
+							);
+						}
 
 						return;
 					}
@@ -260,9 +275,17 @@ String defaultLanguageId = cpDefinitionOptionRelDisplayContext.getCatalogDefault
 						disable(skuContributorInput);
 					}
 					else {
-						alert(
-							'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
-						);
+						if (Liferay.__FF__.enableCustomDialogs) {
+							Liferay.Util.openAlertModal({
+								message:
+									'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />',
+							});
+						}
+						else {
+							alert(
+								'<liferay-ui:message key="selected-field-type-price-type-and-sku-contributor-combination-is-not-allowed" />'
+							);
+						}
 
 						return;
 					}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/FrontendComponentsTopHeadDynamicInclude.java
@@ -63,9 +63,9 @@ public class FrontendComponentsTopHeadDynamicInclude
 				_ffFrontendJSComponentsConfiguration.enableClayTreeView()));
 		sb.append(
 			_buildFeatureFlagJSGlobalVariable(
-				"enableCustomDialogs",
+				"customDialogsEnabled",
 				GetterUtil.getBoolean(
-					PropsUtil.get("feature.flag.enableCustomDialogs"))));
+					PropsUtil.get("feature.flag.customDialogsEnabled"))));
 		sb.append("</script>");
 
 		printWriter.println(sb);

--- a/portal-web/docroot/html/portal/license.jsp
+++ b/portal-web/docroot/html/portal/license.jsp
@@ -610,7 +610,11 @@ dateFormatDateTime.setTimeZone(timeZone);
 							var checkboxes = A.one(document.license_fm).all('input[type=checkbox]:checked');
 
 							if (!checkboxes || (checkboxes.size() <= 0)) {
-								alert('<liferay-ui:message key="there-are-no-selected-servers-to-register" />');
+								if (Liferay.__FF__.enableCustomDialogs) {
+									Liferay.Util.openAlertModal({message: '<liferay-ui:message key="there-are-no-selected-servers-to-register" />'});
+								} else {
+									alert('<liferay-ui:message key="there-are-no-selected-servers-to-register" />');
+								}
 
 								return false;
 							}

--- a/portal-web/docroot/html/portal/license.jsp
+++ b/portal-web/docroot/html/portal/license.jsp
@@ -610,7 +610,7 @@ dateFormatDateTime.setTimeZone(timeZone);
 							var checkboxes = A.one(document.license_fm).all('input[type=checkbox]:checked');
 
 							if (!checkboxes || (checkboxes.size() <= 0)) {
-								if (Liferay.__FF__.enableCustomDialogs) {
+								if (Liferay.__FF__.customDialogsEnabled) {
 									Liferay.Util.openAlertModal({message: '<liferay-ui:message key="there-are-no-selected-servers-to-register" />'});
 								} else {
 									alert('<liferay-ui:message key="there-are-no-selected-servers-to-register" />');

--- a/portal-web/docroot/html/portal/terms_of_use.jsp
+++ b/portal-web/docroot/html/portal/terms_of_use.jsp
@@ -69,7 +69,9 @@ TermsOfUseContentProvider termsOfUseContentProvider = TermsOfUseContentProviderU
 					<aui:button type="submit" value="i-agree" />
 
 					<%
-					String taglibOnClick = "alert('" + UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue") + "');";
+					String disagreeMessage = '" + UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue") + "';
+
+					String taglibOnClick = "Liferay.__FF__.enableCustomDialogs ? Liferay.Util.openAlertModal({message: '" + disagreeMessage + "'}) : alert('" + disagreeMessage + "');";
 					%>
 
 					<aui:button onClick="<%= taglibOnClick %>" type="cancel" value="i-disagree" />

--- a/portal-web/docroot/html/portal/terms_of_use.jsp
+++ b/portal-web/docroot/html/portal/terms_of_use.jsp
@@ -71,7 +71,7 @@ TermsOfUseContentProvider termsOfUseContentProvider = TermsOfUseContentProviderU
 					<%
 					String disagreeMessage = '" + UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue") + "';
 
-					String taglibOnClick = "Liferay.__FF__.enableCustomDialogs ? Liferay.Util.openAlertModal({message: '" + disagreeMessage + "'}) : alert('" + disagreeMessage + "');";
+					String taglibOnClick = "Liferay.__FF__.customDialogsEnabled ? Liferay.Util.openAlertModal({message: '" + disagreeMessage + "'}) : alert('" + disagreeMessage + "');";
 					%>
 
 					<aui:button onClick="<%= taglibOnClick %>" type="cancel" value="i-disagree" />

--- a/portal-web/docroot/html/portal/terms_of_use.jsp
+++ b/portal-web/docroot/html/portal/terms_of_use.jsp
@@ -69,9 +69,9 @@ TermsOfUseContentProvider termsOfUseContentProvider = TermsOfUseContentProviderU
 					<aui:button type="submit" value="i-agree" />
 
 					<%
-					String disagreeMessage = '" + UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue") + "';
+					String disagreeMessage = UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue");
 
-					String taglibOnClick = "Liferay.__FF__.customDialogsEnabled ? Liferay.Util.openAlertModal({message: '" + disagreeMessage + "'}) : alert('" + disagreeMessage + "');";
+					String taglibOnClick = String.format("Liferay.__FF__.customDialogsEnabled ? Liferay.Util.openAlertModal({message: '%s'}) : alert('%s');", disagreeMessage, disagreeMessage);
 					%>
 
 					<aui:button onClick="<%= taglibOnClick %>" type="cancel" value="i-disagree" />


### PR DESCRIPTION
Requires https://github.com/liferay-frontend/liferay-portal/pull/2010 (The FF was renamed)

## How to test it

0. `terms.of.use.required=true` and `feature.flag. customDialogsEnabled=true` on portal-ext.properties
1. Start a clear DXP bundle(make sure you removed osgi/state and data/ folders and set )
2. Open Terms of Use page by advancing the steps

See it working:


https://user-images.githubusercontent.com/7663513/163872484-6b41e39a-babf-4505-a9c1-891bc3cdb129.mp4

## Important things to share

I used `String.format` to properly match quotes and interpolate easily with JS strings. When not using it, complexity blew up and I wasn't able to compile properly those strings (missing template literals of JS 😢 ) 
