### PR TITLE
LPS-147853 Add ResponsiveModeFilterAndOrderAsIconButtons

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/ManagementBar.path
@@ -102,6 +102,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>FILTER_OR_ORDER_MOBILE</td>
+	<td>//nav[contains(@class,'management-bar')]//*[contains(@title,'${key_title}')]//*[name()='svg'][contains(@class,'icon-${key_icon}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>ICON_AND_TEXT_ACTION_BUTTON</td>
 	<td>//nav[contains(@class,'management-bar')]//*[*[name()='svg'][contains(@class,'icon-${key_icon}')]]//following-sibling::span[text()='${key_action}']</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -319,6 +319,46 @@ definition {
 		}
 	}
 
+	@description = "LPS-147853. Assert tooltip messages will be displayed when hovered over the filter and order buttons in responsive mode"
+	@priority = "4"
+	test ResponsiveModeFilterAndOrderAsIconButtons {
+		task ("Given a window size set to phone size") {
+			SetWindowSize(value1 = "360,720");
+		}
+
+		task ("Then the 'filter' and 'order' buttons will be displayed as icon buttons") {
+			AssertElementPresent(
+				key_icon = "filter",
+				key_title = "Show Filter Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER_MOBILE");
+
+			AssertElementPresent(
+				key_icon = "order-list-down",
+				key_title = "Show Order Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER_MOBILE");
+		}
+
+		task ("And a tooltip message will be displayed") {
+			MouseOver(
+				key_icon = "filter",
+				key_title = "Show Filter Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER_MOBILE");
+
+			AssertTextEquals(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Show Filter Options");
+
+			MouseOver(
+				key_icon = "order-list-down",
+				key_title = "Show Order Options",
+				locator1 = "ManagementBar#FILTER_OR_ORDER_MOBILE");
+
+			AssertTextEquals(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Show Order Options");
+		}
+	}
+
 	@description = "LPS-147865. Assert the new button is displayed as an icon button in responsive mode"
 	@priority = "5"
 	test ResponsiveModeNewButtonAsIconButton {


### PR DESCRIPTION
**Background**
Create automated tests for Management Toolbar.

**Test Plan**
Given a user of the portal on responsive mode
When the user opens any section with the management toolbar
Then the 'filter' and 'order' buttons will be displayed as icon buttons
And a tooltip message will be displayed

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147853