### PR TITLE
LPS-151331 Quarantine test OpenGraphPreview#CanPreviewWithLongInputs

### DIFF
--- a/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/OpenGraphPreview.testcase
+++ b/modules/apps/layout/layout-seo-web-test/src/testFunctional/tests/OpenGraphPreview.testcase
@@ -189,7 +189,7 @@ definition {
 	@priority = "5"
 	@refactordone
 	test CanPreviewWithLongInputs {
-		property portal.acceptance = "true";
+		property portal.acceptance = "quarantine";
 
 		var portalURL = PropsUtil.get("portal.url");
 


### PR DESCRIPTION
The test `OpenGraphPreview#CanPreviewWithLongInputs` has been set in quarantine in order not to interfere while the issue discovered probably related to Sikuli is being solved  in [LPS-151331](https://issues.liferay.com/browse/LPS-151331)