### PR TITLE
LPS-151371 Review mandatory fields for FDS taglibs

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
@@ -118,6 +118,8 @@ public class BaseDisplayTag extends AttributesTagSupport {
 			props.put("additionalProps", _additionalProps);
 		}
 
+		props.put("namespace", _randomNamespace);
+
 		return props;
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -79,7 +79,7 @@
 		</attribute>
 		<attribute>
 			<name>namespace</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
@@ -217,7 +217,7 @@
 		</attribute>
 		<attribute>
 			<name>namespace</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -94,7 +94,7 @@
 		</attribute>
 		<attribute>
 			<name>pageNumber</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>int</type>
 		</attribute>
@@ -232,7 +232,7 @@
 		</attribute>
 		<attribute>
 			<name>pageNumber</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>int</type>
 		</attribute>

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -211,7 +211,7 @@
 		</attribute>
 		<attribute>
 			<name>itemsPerPage</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>int</type>
 		</attribute>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
@@ -58,6 +58,8 @@ import getJsModule from './utils/modules';
 import ViewsContext from './views/ViewsContext';
 import {getViewContentRenderer} from './views/index';
 
+const PAGINATION_DEFAULT_DELTA = 20;
+
 const DataSet = ({
 	actionParameterName,
 	bulkActions,
@@ -98,8 +100,7 @@ const DataSet = ({
 		sidePanelId || `support-side-panel-${getRandomId()}`
 	);
 	const [delta, setDelta] = useState(
-		showPagination &&
-			(pagination.initialDelta || pagination.deltas[0].label)
+		showPagination && (pagination.initialDelta || PAGINATION_DEFAULT_DELTA)
 	);
 
 	const [filters, setFilters] = useState(() => {
@@ -744,7 +745,7 @@ DataSet.propTypes = {
 				label: PropTypes.number.isRequired,
 			}).isRequired
 		),
-		initialDelta: PropTypes.number.isRequired,
+		initialDelta: PropTypes.number,
 	}),
 	selectedItems: PropTypes.array,
 	selectedItemsKey: PropTypes.string,
@@ -768,9 +769,6 @@ DataSet.defaultProps = {
 	inlineEditingSettings: null,
 	items: null,
 	itemsActions: null,
-	pagination: {
-		initialDelta: 10,
-	},
 	selectedItemsKey: 'id',
 	selectionType: 'multiple',
 	showManagementBar: true,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
@@ -122,7 +122,9 @@ const DataSet = ({
 	const [highlightedItemsValue, setHighlightedItemsValue] = useState([]);
 	const [items, setItems] = useState(itemsProp);
 	const [itemsChanges, setItemsChanges] = useState({});
-	const [pageNumber, setPageNumber] = useState(1);
+	const [pageNumber, setPageNumber] = useState(
+		pagination.initialPageNumber || 1
+	);
 	const [searchParam, setSearchParam] = useState('');
 	const [selectedItemsValue, setSelectedItemsValue] = useState(
 		selectedItems || []
@@ -746,6 +748,7 @@ DataSet.propTypes = {
 			}).isRequired
 		),
 		initialDelta: PropTypes.number,
+		initialPageNumber: PropTypes.number,
 	}),
 	selectedItems: PropTypes.array,
 	selectedItemsKey: PropTypes.string,


### PR DESCRIPTION
## Changes

- LPS-151149 namespace attribute marked as not required
- LPS-151149 itemsPerPage attribute marked as not required
- LPS-151149 initialPageNumber attribute marked as not required

[Jira issue](https://issues.liferay.com/browse/LPS-151371)

## How to

- Deploy and use in a page the FDS Sample module
- Remove the mentioned attributes
  - The `namespace` should be rendered in FE props. This value is set in backend.
  - The `itemsPerPage` should be 20 and the taglib should respond OK if you set another value, ie. 75. This value is set in FE.
  - The `initialPageNumber` should be 1 and the taglib should respond OK if you set another value, ie. 4. This value is set in FE.
