### PR TITLE
LPS-113541 Deprecate `setSelectionRange` and `setCursorPosition`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -655,6 +655,9 @@
 			});
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		setCursorPosition(element, position) {
 			var instance = this;
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -661,6 +661,9 @@
 			instance.setSelectionRange(element, position, position);
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		setSelectionRange(element, selectionStart, selectionEnd) {
 			element = Util.getDOM(element);
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -656,7 +656,7 @@
 		},
 
 		/**
-		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange}
 		 */
 		setCursorPosition(element, position) {
 			var instance = this;
@@ -665,7 +665,7 @@
 		},
 
 		/**
-		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange}
 		 */
 		setSelectionRange(element, selectionStart, selectionEnd) {
 			element = Util.getDOM(element);

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
@@ -59,9 +59,11 @@
 
 			customCSSTextarea.focus();
 
+			var newCursorPosition = customCSSTextarea.value.length - 3;
+
 			customCSSTextarea.setSelectionRange(
-				customCSSTextarea.value.length - 3,
-				customCSSTextarea.value.length - 3
+				newCursorPosition,
+				newCursorPosition
 			);
 		}
 	}

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/advanced_styling.jsp
@@ -42,20 +42,27 @@
 
 <aui:script>
 	function <portlet:namespace />insertCustomCSSValue(value) {
-		var customCSS = document.getElementById('<portlet:namespace />customCSS');
+		var customCSSTextarea = document.getElementById(
+			'<portlet:namespace />customCSS'
+		);
 
-		if (customCSS) {
-			var customCSSVal = customCSS.value.trim();
+		if (customCSSTextarea) {
+			var customCSSTextareaValue = customCSSTextarea.value.trim();
 
-			if (customCSSVal.length) {
-				customCSSVal += '\n\n';
+			if (customCSSTextareaValue.length) {
+				customCSSTextareaValue += '\n\n';
 			}
 
-			var newVal = customCSSVal + value + ' {\n\t\n}\n';
+			var newValue = customCSSTextareaValue + value + ' {\n\t\n}\n';
 
-			customCSS.value = newVal;
+			customCSSTextarea.value = newValue;
 
-			Liferay.Util.setCursorPosition(customCSS, newVal.length - 3);
+			customCSSTextarea.focus();
+
+			customCSSTextarea.setSelectionRange(
+				customCSSTextarea.value.length - 3,
+				customCSSTextarea.value.length - 3
+			);
 		}
 	}
 


### PR DESCRIPTION
Here we deprecate both of these utils because the latter is a thin wrapper around the former.

There are no usages of `setSelectionRange` and only one usage of `setCursorPosition`, which I have modernized in this PR.

The modernization can be tested by going to any `Look & Feel Configuration > Advanced Styling > "Add Custom CSS" button`.