### PR TITLE
LRQA-65496: Autom. tests for nested indeterminate checkbox

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,6 +17,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
@@ -38,7 +38,7 @@ export default function ClaySampleTreeViewWithCheckbox() {
 								{id: 11, name: 'Bookmarks'},
 							],
 							id: 7,
-							name: 'Content e Data',
+							name: 'Content & Data',
 						},
 						{
 							children: [],

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {TreeView} from '@clayui/core';
+import {ClayCheckbox as Checkbox} from '@clayui/form';
+import React from 'react';
+
+export default function ClaySampleTreeViewWithCheckbox() {
+	return (
+		<TreeView
+			defaultItems={[
+				{
+					children: [
+						{
+							children: [
+								{id: 5, name: 'Blogs'},
+								{id: 6, name: 'Documents and Media'},
+							],
+							id: 4,
+							name: 'Repositories',
+						},
+						{
+							children: [
+								{id: 8, name: 'PDF'},
+								{id: 9, name: 'Word'},
+								{id: 10, name: 'Google Drive'},
+								{id: 11, name: 'Figma'},
+							],
+							id: 7,
+							name: 'Documents and Media',
+						},
+						{
+							children: [],
+							id: 12,
+							name: 'Empty directory',
+						},
+					],
+					id: 1,
+					name: 'Liferay Drive',
+				},
+			]}
+			defaultSelectedKeys={new Set([5, 6, 8])}
+			selectionMode="multiple-recursive"
+			showExpanderOnHover={false}
+		>
+			{(item) => (
+				<TreeView.Item key={item.name}>
+					<TreeView.ItemStack>
+						<Checkbox />
+
+						{item.name}
+					</TreeView.ItemStack>
+
+					<TreeView.Group items={item.children}>
+						{(item) => (
+							<TreeView.Item>
+								<Checkbox />
+
+								{item.name}
+							</TreeView.Item>
+						)}
+					</TreeView.Group>
+				</TreeView.Item>
+			)}
+		</TreeView>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleTreeViewWithCheckbox.js
@@ -24,33 +24,33 @@ export default function ClaySampleTreeViewWithCheckbox() {
 					children: [
 						{
 							children: [
-								{id: 5, name: 'Blogs'},
-								{id: 6, name: 'Documents and Media'},
+								{id: 5, name: 'Style Books'},
+								{id: 6, name: 'Fragments'},
 							],
 							id: 4,
-							name: 'Repositories',
+							name: 'Design',
 						},
 						{
 							children: [
-								{id: 8, name: 'PDF'},
-								{id: 9, name: 'Word'},
-								{id: 10, name: 'Google Drive'},
-								{id: 11, name: 'Figma'},
+								{id: 8, name: 'Kaleo Forms Admin'},
+								{id: 9, name: 'Web Contend'},
+								{id: 10, name: 'Blogs'},
+								{id: 11, name: 'Bookmarks'},
 							],
 							id: 7,
-							name: 'Documents and Media',
+							name: 'Content e Data',
 						},
 						{
 							children: [],
 							id: 12,
-							name: 'Empty directory',
+							name: 'Categorization',
 						},
 					],
 					id: 1,
-					name: 'Liferay Drive',
+					name: 'Liferay DXP',
 				},
 			]}
-			defaultSelectedKeys={new Set([5, 6, 8])}
+			defaultSelectedKeys={new Set([4, 5, 6, 8])}
 			selectionMode="multiple-recursive"
 			showExpanderOnHover={false}
 		>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/form_elements.jsp
@@ -62,6 +62,16 @@
 	</tbody>
 </table>
 
+<blockquote>
+	<p>Demonstration of the checkbox with the state of indeterminate in the TreeView component.</p>
+</blockquote>
+
+<div>
+	<react:component
+		module="js/ClaySampleTreeViewWithCheckbox"
+	/>
+</div>
+
 <h3>RADIO</h3>
 
 <blockquote>

--- a/portal-web/test/functional/com/liferay/portalweb/functions/AssertAttributeValue.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/AssertAttributeValue.function
@@ -13,4 +13,16 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function assertAttributeValueAtNotVisible {
+		WaitForSPARefresh();
+
+		selenium.waitForElementPresent();
+
+		selenium.assertAttributeValue("${attribute1}", "${locator1}", "${value1}");
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/functions/DoubleClick.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/DoubleClick.function
@@ -29,6 +29,20 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function doubleClickNotVisible {
+		WaitForSPARefresh();
+
+		selenium.waitForElementPresent();
+
+		selenium.mouseOver();
+
+		selenium.doubleClick();
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 	function javaScriptDoubleClick {
 		WaitForSPARefresh();
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
@@ -42,6 +42,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CHECKBOX_NESTED</td>
+	<td>//div[contains(@class,'autofit-row')]//div[contains(text(),'${key_label}')]//..//..//input</td>
+	<td></td>
+</tr>
+<tr>
 	<td>CARD_ACTIVE</td>
 	<td>//h4[contains(text(), '${key_header}')]//following::div[contains(@class,'active file-card')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -83,7 +83,7 @@ definition {
 			locator1 = "ClaySamplePortlet#CHECKBOX");
 	}
 
-	@description = "LRQA-65496: Verify status checked in clay checkbox indeterminate"
+	@description = "LRQA-65496: Validate that a parent checkbox is a checked state when all nested checkboxes are checked."
 	@priority = "3"
 	test ParentMustBeCheckedIfAllChildrenAreChecked {
 		task ("Given treeview with indeterminate state checkboxes") {
@@ -98,7 +98,7 @@ definition {
 				value1 = "true");
 		}
 
-		task ("When all children checkboxes states become checked") {
+		task ("When all children checkboxes states are checked") {
 			Click.clickAtNotVisible(
 				key_label = "Content & Data",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
@@ -108,21 +108,33 @@ definition {
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}
 
-		task ("Then the top most treeview checkbox state is checked") {
+		task ("Then the parent checkbox is checked state") {
 			AssertChecked.assertCheckedNotVisible(
 				key_label = "Liferay DXP",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}
 	}
 
-	@description = "LRQA-65496: Verify status indeterminate in clay checkbox indeterminate"
+	@description = "LRQA-65496: Validate that a parent checkbox is an indeterminate state when some nested checkboxes are checked."
 	@priority = "3"
-	test ParentMustBeIndeterminateIfNotAllChildrenCheckedOrUnChecked {
+	test ParentMustBeIndeterminateIfSomeChildrenChecked {
 		task ("Given treeview with indeterminate state checkboxes") {
 			Navigator.gotoNavTab(navTab = "Form Elements");
 		}
 
-		task ("Then the state of indeterminate checkbox is indeterminate") {
+		task ("When treeview has atleast 1 child checkbox state is checked") {
+			AssertChecked.assertCheckedNotVisible(
+				key_label = "Content & Data",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+		}
+
+		task ("And when treeview has atleast 1 child checkbox state is unchecked") {
+			IsNotChecked.isNotCheckedNotVisible(
+				key_label = "Categorization",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+		}
+
+		task ("Then parent checkbox is indeterminate state") {
 			AssertAttributeValue(
 				attribute1 = "indeterminate",
 				key_label = "Liferay DXP",
@@ -131,14 +143,14 @@ definition {
 		}
 	}
 
-	@description = "LRQA-65496: Verify status unchecked in clay checkbox indeterminate"
+	@description = "LRQA-65496: Validate that a parent checkbox is an unchecked state when all nested checkboxes are unchecked."
 	@priority = "3"
-	test ParentMustBeUncheckedIfAllChildrenUnchecked {
+	test ParentMustBeUncheckedIfNoChildrenChecked {
 		task ("Given treeview with indeterminate state checkboxes") {
 			Navigator.gotoNavTab(navTab = "Form Elements");
 		}
 
-		task ("When children checkboxes are unchecked") {
+		task ("When all children checkboxes states are unchecked") {
 			Click.clickAtNotVisible(
 				key_label = "Design",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
@@ -148,7 +160,7 @@ definition {
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}
 
-		task ("Then parent checkbox is unchecked") {
+		task ("Then parent checkbox is unchecked state") {
 			Uncheck.uncheckNotVisible(
 				key_label = "Liferay DXP",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -83,6 +83,72 @@ definition {
 			locator1 = "ClaySamplePortlet#CHECKBOX");
 	}
 
+	@description = "LRQA-65496: Verify status checked in clay checkbox indeterminate"
+	@priority = "3"
+	test CheckboxIndeterminateStatusChecked {
+		task ("Go to Form Elements tab") {
+			Navigator.gotoNavTab(navTab = "Form Elements");
+		}
+
+		task ("Click at Design and Categorization checkboxes") {
+			Click.clickAtNotVisible(
+				key_label = "Content e Data",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+
+			Click.clickAtNotVisible(
+				key_label = "Categorization",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+		}
+
+		task ("Assert the status of undetermined checkbox is checked") {
+			AssertChecked.assertCheckedNotVisible(
+				key_label = "Liferay DXP",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+		}
+	}
+
+	@description = "LRQA-65496: Verify status indeterminate in clay checkbox indeterminate"
+	@priority = "3"
+	test CheckboxIndeterminateStatusDefaut {
+		task ("Go to Form Elements tab") {
+			Navigator.gotoNavTab(navTab = "Form Elements");
+		}
+
+		task ("Assert the status in checkbox is indeterminate") {
+			AssertAttributeValue(
+				attribute1 = "indeterminate",
+				key_label = "Liferay DXP",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED",
+				value1 = "true");
+		}
+	}
+
+	@description = "LRQA-65496: Verify status unchecked in clay checkbox indeterminate"
+	@priority = "3"
+	test CheckboxIndeterminateStatusUnchecked {
+		task ("Go to Form Elements tab") {
+			Navigator.gotoNavTab(navTab = "Form Elements");
+		}
+
+		task ("Click at Design and Categorization checkboxes") {
+			Click.clickAtNotVisible(
+				key_label = "Design",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+
+			for (var click : list "1,2") {
+				Click.clickAtNotVisible(
+					key_label = "Content e Data",
+					locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+			}
+		}
+
+		task ("Assert the status of undetermined checkbox is uncheck") {
+			Uncheck.uncheckNotVisible(
+				key_label = "Liferay DXP",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+		}
+	}
+
 	@description = "Verify clay checkbox UI looks ok"
 	@priority = "5"
 	@refactordone

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -123,15 +123,19 @@ definition {
 		}
 
 		task ("When treeview has atleast 1 child checkbox state is checked") {
-			AssertChecked.assertCheckedNotVisible(
-				key_label = "Content & Data",
-				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+			if (IsNotChecked.isNotCheckedNotVisible(key_label = "Design", locator1 = "ClaySamplePortlet#CHECKBOX_NESTED")) {
+				Click(
+					key_label = "Fragments",
+					locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+			}
 		}
 
 		task ("And when treeview has atleast 1 child checkbox state is unchecked") {
-			IsNotChecked.isNotCheckedNotVisible(
-				key_label = "Categorization",
-				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+			if (IsChecked(key_label = "Categorization", locator1 = "ClaySamplePortlet#CHECKBOX_NESTED")) {
+				Click(
+					key_label = "Categorization",
+					locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
+			}
 		}
 
 		task ("Then parent checkbox is indeterminate state") {
@@ -155,13 +159,13 @@ definition {
 				key_label = "Design",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 
-			DoubleClick(
+			DoubleClick.doubleClickNotVisible(
 				key_label = "Content & Data",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}
 
 		task ("Then parent checkbox is unchecked state") {
-			Uncheck.uncheckNotVisible(
+			IsNotChecked.isNotCheckedNotVisible(
 				key_label = "Liferay DXP",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -85,14 +85,22 @@ definition {
 
 	@description = "LRQA-65496: Verify status checked in clay checkbox indeterminate"
 	@priority = "3"
-	test CheckboxIndeterminateStatusChecked {
-		task ("Go to Form Elements tab") {
+	test ParentMustBeCheckedIfAllChildrenAreChecked {
+		task ("Given treeview with indeterminate state checkboxes") {
 			Navigator.gotoNavTab(navTab = "Form Elements");
 		}
 
-		task ("Click at Design and Categorization checkboxes") {
+		task ("And Given top most treeview checkbox state is indeterminate") {
+			AssertAttributeValue(
+				attribute1 = "indeterminate",
+				key_label = "Liferay DXP",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED",
+				value1 = "true");
+		}
+
+		task ("When all children checkboxes states become checked") {
 			Click.clickAtNotVisible(
-				key_label = "Content e Data",
+				key_label = "Content & Data",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 
 			Click.clickAtNotVisible(
@@ -100,7 +108,7 @@ definition {
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}
 
-		task ("Assert the status of undetermined checkbox is checked") {
+		task ("Then the top most treeview checkbox state is checked") {
 			AssertChecked.assertCheckedNotVisible(
 				key_label = "Liferay DXP",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
@@ -109,12 +117,12 @@ definition {
 
 	@description = "LRQA-65496: Verify status indeterminate in clay checkbox indeterminate"
 	@priority = "3"
-	test CheckboxIndeterminateStatusDefaut {
-		task ("Go to Form Elements tab") {
+	test ParentMustBeIndeterminateIfNotAllChildrenCheckedOrUnChecked {
+		task ("Given treeview with indeterminate state checkboxes") {
 			Navigator.gotoNavTab(navTab = "Form Elements");
 		}
 
-		task ("Assert the status in checkbox is indeterminate") {
+		task ("Then the state of indeterminate checkbox is indeterminate") {
 			AssertAttributeValue(
 				attribute1 = "indeterminate",
 				key_label = "Liferay DXP",
@@ -125,24 +133,22 @@ definition {
 
 	@description = "LRQA-65496: Verify status unchecked in clay checkbox indeterminate"
 	@priority = "3"
-	test CheckboxIndeterminateStatusUnchecked {
-		task ("Go to Form Elements tab") {
+	test ParentMustBeUncheckedIfAllChildrenUnchecked {
+		task ("Given treeview with indeterminate state checkboxes") {
 			Navigator.gotoNavTab(navTab = "Form Elements");
 		}
 
-		task ("Click at Design and Categorization checkboxes") {
+		task ("When children checkboxes are unchecked") {
 			Click.clickAtNotVisible(
 				key_label = "Design",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 
-			for (var click : list "1,2") {
-				Click.clickAtNotVisible(
-					key_label = "Content e Data",
-					locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
-			}
+			DoubleClick(
+				key_label = "Content & Data",
+				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 		}
 
-		task ("Assert the status of undetermined checkbox is uncheck") {
+		task ("Then parent checkbox is unchecked") {
 			Uncheck.uncheckNotVisible(
 				key_label = "Liferay DXP",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");


### PR DESCRIPTION
**Background**
Create automated tests for nested indeterminate checkbox

**Test Plan**
Given Test Page with Clay Sample Portlet added
When view Form Elements
And When viewing default state (indeterminate) of checkbox indeterminate
Then it should be indeterminate state

Given Test Page with Clay Sample Portlet added
When view Form Elements
And When check the nested children
Then it should check the checkbox
And Then it should be checked state

Given Test Page with Clay Sample Portlet added
When view Form Elements
And When uncheck the nested children
Then it should uncheck the checkbox
And Then it should be unchecked state

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-65496