### PR TITLE
LPS-147860 Add test ResponsiveModeClearButtonShouldDisplayTooltip

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -326,7 +326,7 @@ definition {
 			SetWindowSize(value1 = "360,720");
 		}
 
-		task ("And hovers over the clear button") {
+		task ("When mouse hover over the clear button") {
 			ScrollWebElementIntoView(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
 
 			MouseOver.javaScriptMouseOver(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -359,6 +359,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-147860. Assert tooltip message will be displayed when hovered over the clear button in responsive mode"
+	@priority = "3"
+	test ResponsiveModeClearButtonShouldDisplayTooltip {
+		task ("Given a window size set to phone size") {
+			SetWindowSize(value1 = "360,720");
+		}
+
+		task ("And hovers over the clear button") {
+			ScrollWebElementIntoView(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
+
+			MouseOver.javaScriptMouseOver(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
+		}
+
+		task ("Then a tooltip message will be displayed") {
+			AssertTextEquals(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Clear");
+		}
+	}
+
 	@description = "LPS-147865. Assert the new button is displayed as an icon button in responsive mode"
 	@priority = "5"
 	test ResponsiveModeNewButtonAsIconButton {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -319,6 +319,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-147860. Assert tooltip message will be displayed when hovered over the clear button in responsive mode"
+	@priority = "3"
+	test ResponsiveModeClearButtonShouldDisplayTooltip {
+		task ("Given a window size set to phone size") {
+			SetWindowSize(value1 = "360,720");
+		}
+
+		task ("And hovers over the clear button") {
+			ScrollWebElementIntoView(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
+
+			MouseOver.javaScriptMouseOver(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
+		}
+
+		task ("Then a tooltip message will be displayed") {
+			AssertTextEquals(
+				locator1 = "Message#TOOLTIP",
+				value1 = "Clear");
+		}
+	}
+
 	@description = "LPS-147853. Assert tooltip messages will be displayed when hovered over the filter and order buttons in responsive mode"
 	@priority = "4"
 	test ResponsiveModeFilterAndOrderButtonsShouldDisplayAsIcons {
@@ -356,26 +376,6 @@ definition {
 			AssertTextEquals(
 				locator1 = "Message#TOOLTIP",
 				value1 = "Show Order Options");
-		}
-	}
-
-	@description = "LPS-147860. Assert tooltip message will be displayed when hovered over the clear button in responsive mode"
-	@priority = "3"
-	test ResponsiveModeClearButtonShouldDisplayTooltip {
-		task ("Given a window size set to phone size") {
-			SetWindowSize(value1 = "360,720");
-		}
-
-		task ("And hovers over the clear button") {
-			ScrollWebElementIntoView(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
-
-			MouseOver.javaScriptMouseOver(locator1 = "ManagementBar#CLEAR_BUTTON_MOBILE");
-		}
-
-		task ("Then a tooltip message will be displayed") {
-			AssertTextEquals(
-				locator1 = "Message#TOOLTIP",
-				value1 = "Clear");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automated tests for Management Toolbar.

**Test Plan**
Given a user of the portal on responsive mode
When the user opens any section with the management toolbar
And hovers on the 'clear' button
Then a tooltip message will be displayed

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-147860