### PR TITLE
LRQA-74362 Stabilize ResponsiveModeFilterAndOrderButtonsShouldDisplayAsIcons

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -339,7 +339,7 @@ definition {
 		}
 
 		task ("And a tooltip message will be displayed") {
-			MouseOver(
+			MouseOver.javaScriptMouseOver(
 				key_icon = "filter",
 				key_title = "Show Filter Options",
 				locator1 = "ManagementBar#FILTER_OR_ORDER_MOBILE");
@@ -348,7 +348,7 @@ definition {
 				locator1 = "Message#TOOLTIP",
 				value1 = "Show Filter Options");
 
-			MouseOver(
+			MouseOver.javaScriptMouseOver(
 				key_icon = "order-list-down",
 				key_title = "Show Order Options",
 				locator1 = "ManagementBar#FILTER_OR_ORDER_MOBILE");


### PR DESCRIPTION
**Background**
ManagementToolbar#ResponsiveModeFilterAndOrderButtonsShouldDisplayAsIcons is failing on `//div[contains(@class,'tooltip') and contains(@class,'show')]`. 
Due to `stale element reference: element is not attached to the page document`.

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-74362