### PR TITLE
LPS-151456 Minimize required FDS configuration

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/build.gradle
@@ -8,5 +8,6 @@ dependencies {
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:object:object-api")
+	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedSampleCheckBoxFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedSampleCheckBoxFDSFilter.java
@@ -32,10 +32,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSFilter.class
 )
-public class SampleCheckBoxFDSFilter extends BaseCheckBoxFDSFilter {
+public class CustomizedSampleCheckBoxFDSFilter extends BaseCheckBoxFDSFilter {
 
 	@Override
 	public List<CheckBoxFDSFilterItem> getCheckBoxFDSFilterItems(

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedSampleDateRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedSampleDateRangeFDSFilter.java
@@ -27,10 +27,10 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSFilter.class
 )
-public class SampleDateRangeFDSFilter extends BaseDateRangeFDSFilter {
+public class CustomizedSampleDateRangeFDSFilter extends BaseDateRangeFDSFilter {
 
 	@Override
 	public String getId() {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleCardsFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleCardsFDSView.java
@@ -16,7 +16,7 @@ package com.liferay.frontend.data.set.sample.web.internal.view;
 
 import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
 import com.liferay.frontend.data.set.view.FDSView;
-import com.liferay.frontend.data.set.view.timeline.BaseTimelineFDSView;
+import com.liferay.frontend.data.set.view.cards.BaseCardsFDSView;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -25,15 +25,10 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	enabled = false,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSView.class
 )
-public class SampleTimelineFDSView extends BaseTimelineFDSView {
-
-	@Override
-	public String getDate() {
-		return "date";
-	}
+public class CustomizedSampleCardsFDSView extends BaseCardsFDSView {
 
 	@Override
 	public String getDescription() {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleListFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleListFDSView.java
@@ -16,7 +16,7 @@ package com.liferay.frontend.data.set.sample.web.internal.view;
 
 import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
 import com.liferay.frontend.data.set.view.FDSView;
-import com.liferay.frontend.data.set.view.cards.BaseCardsFDSView;
+import com.liferay.frontend.data.set.view.list.BaseListFDSView;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -25,10 +25,10 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	enabled = false,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSView.class
 )
-public class SampleCardsFDSView extends BaseCardsFDSView {
+public class CustomizedSampleListFDSView extends BaseListFDSView {
 
 	@Override
 	public String getDescription() {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleTableFDSView.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
+import com.liferay.frontend.data.set.view.FDSView;
+import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
+import com.liferay.frontend.data.set.view.table.FDSTableSchema;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaField;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier Gamarra
+ * @author Javier de Arcos
+ */
+@Component(
+	enabled = true,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
+	service = FDSView.class
+)
+public class CustomizedSampleTableFDSView extends BaseTableFDSView {
+
+	@Override
+	public FDSTableSchema getFDSTableSchema(Locale locale) {
+		FDSTableSchemaBuilder fdsTableSchemaBuilder =
+			_fdsTableSchemaBuilderFactory.create();
+
+		fdsTableSchemaBuilder.addFDSTableSchemaField("id", "id");
+		fdsTableSchemaBuilder.addFDSTableSchemaField("title", "title");
+		fdsTableSchemaBuilder.addFDSTableSchemaField(
+			"description", "description");
+		fdsTableSchemaBuilder.addFDSTableSchemaField("date", "date");
+
+		FDSTableSchemaField statusFDSTableSchemaField =
+			fdsTableSchemaBuilder.addFDSTableSchemaField("status", "status");
+
+		statusFDSTableSchemaField.setContentRenderer("status");
+
+		FDSTableSchemaField authorFDSTableSchemaField =
+			fdsTableSchemaBuilder.addFDSTableSchemaField(
+				"creator.name", "author");
+
+		authorFDSTableSchemaField.setContentRenderer(
+			"sampleCustomDataRenderer");
+
+		return fdsTableSchemaBuilder.build();
+	}
+
+	@Reference
+	private FDSTableSchemaBuilderFactory _fdsTableSchemaBuilderFactory;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleTimelineFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedSampleTimelineFDSView.java
@@ -16,7 +16,7 @@ package com.liferay.frontend.data.set.sample.web.internal.view;
 
 import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
 import com.liferay.frontend.data.set.view.FDSView;
-import com.liferay.frontend.data.set.view.list.BaseListFDSView;
+import com.liferay.frontend.data.set.view.timeline.BaseTimelineFDSView;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -25,10 +25,15 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	enabled = false,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSView.class
 )
-public class SampleListFDSView extends BaseListFDSView {
+public class CustomizedSampleTimelineFDSView extends BaseTimelineFDSView {
+
+	@Override
+	public String getDate() {
+		return "date";
+	}
 
 	@Override
 	public String getDescription() {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/MinimumSampleTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/MinimumSampleTableFDSView.java
@@ -28,15 +28,14 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Javier Gamarra
- * @author Javier de Arcos
+ * @author Marko Cikos
  */
 @Component(
 	enabled = true,
-	property = "frontend.data.set.name=" + FDSSampleFDSNames.FDS_SAMPLES,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.MINIMUM,
 	service = FDSView.class
 )
-public class SampleTableFDSView extends BaseTableFDSView {
+public class MinimumSampleTableFDSView extends BaseTableFDSView {
 
 	@Override
 	public FDSTableSchema getFDSTableSchema(Locale locale) {
@@ -44,22 +43,17 @@ public class SampleTableFDSView extends BaseTableFDSView {
 			_fdsTableSchemaBuilderFactory.create();
 
 		fdsTableSchemaBuilder.addFDSTableSchemaField("id", "id");
-		fdsTableSchemaBuilder.addFDSTableSchemaField("title", "Title");
+		fdsTableSchemaBuilder.addFDSTableSchemaField("title", "title");
 		fdsTableSchemaBuilder.addFDSTableSchemaField(
-			"description", "Description");
-		fdsTableSchemaBuilder.addFDSTableSchemaField("date", "Date");
+			"description", "description");
+		fdsTableSchemaBuilder.addFDSTableSchemaField("date", "date");
 
 		FDSTableSchemaField statusFDSTableSchemaField =
 			fdsTableSchemaBuilder.addFDSTableSchemaField("status", "status");
 
 		statusFDSTableSchemaField.setContentRenderer("status");
 
-		FDSTableSchemaField authorFDSTableSchemaField =
-			fdsTableSchemaBuilder.addFDSTableSchemaField(
-				"creator.name", "author");
-
-		authorFDSTableSchemaField.setContentRenderer(
-			"sampleCustomDataRenderer");
+		fdsTableSchemaBuilder.addFDSTableSchemaField("creator.name", "author");
 
 		return fdsTableSchemaBuilder.build();
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,15 +14,24 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend-data-set" prefix="frontend-data-set" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend-data-set" prefix="frontend-data-set" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
+taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames" %><%@
 page import="com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleWebKeys" %><%@
 page import="com.liferay.frontend.data.set.sample.web.internal.display.context.FDSSampleDisplayContext" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
+page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %>
+
+<%@ page import="javax.portlet.PortletURL" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/customized.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/customized.jsp
@@ -1,0 +1,38 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+FDSSampleDisplayContext fdsSampleDisplayContext = (FDSSampleDisplayContext)request.getAttribute(FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT);
+%>
+
+<frontend-data-set:headless-display
+	additionalProps='<%=
+		HashMapBuilder.<String, Object>put(
+			"greeting", "Hello"
+		).build()
+	%>'
+	apiURL="<%= fdsSampleDisplayContext.getAPIURL() %>"
+	customViewsEnabled="<%= true %>"
+	fdsActionDropdownItems="<%= fdsSampleDisplayContext.getFDSActionDropdownItems() %>"
+	formId="fm"
+	id="<%= FDSSampleFDSNames.CUSTOMIZED %>"
+	itemsPerPage="<%= 10 %>"
+	pageNumber="<%= 2 %>"
+	propsTransformer="js/SampleFDSPropsTransformer"
+	style="fluid"
+/>

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/minimum.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/minimum.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -11,16 +12,15 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+--%>
 
-package com.liferay.frontend.data.set.sample.web.internal.constants;
+<%@ include file="/init.jsp" %>
 
-/**
- * @author Marko Cikos
- */
-public class FDSSampleFDSNames {
+<%
+FDSSampleDisplayContext fdsSampleDisplayContext = (FDSSampleDisplayContext)request.getAttribute(FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT);
+%>
 
-	public static final String CUSTOMIZED = "customized";
-
-	public static final String MINIMUM = "minimum";
-
-}
+<frontend-data-set:headless-display
+	apiURL="<%= fdsSampleDisplayContext.getAPIURL() %>"
+	id="<%= FDSSampleFDSNames.MINIMUM %>"
+/>

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,24 +17,30 @@
 <%@ include file="/init.jsp" %>
 
 <%
-FDSSampleDisplayContext fdsSampleDisplayContext = (FDSSampleDisplayContext)request.getAttribute(FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT);
+String tabs1 = ParamUtil.getString(request, "tabs1", "customized");
+
+PortletURL portletURL = PortletURLBuilder.createRenderURL(
+	renderResponse
+).setTabs1(
+	tabs1
+).buildPortletURL();
 %>
 
-<frontend-data-set:headless-display
-	additionalProps='<%=
-		HashMapBuilder.<String, Object>put(
-			"greeting", "Hello"
-		).build()
-	%>'
-	apiURL="<%= fdsSampleDisplayContext.getAPIURL() %>"
-	customViewsEnabled="<%= true %>"
-	fdsActionDropdownItems="<%= fdsSampleDisplayContext.getFDSActionDropdownItems() %>"
-	formId="fm"
-	id="<%= FDSSampleFDSNames.FDS_SAMPLES %>"
-	itemsPerPage="<%= 20 %>"
-	namespace="<%= liferayPortletResponse.getNamespace() %>"
-	pageNumber="<%= 1 %>"
-	portletURL="<%= liferayPortletResponse.createRenderURL() %>"
-	propsTransformer="js/SampleFDSPropsTransformer"
-	style="fluid"
-/>
+<clay:container-fluid>
+	<liferay-ui:tabs
+		names="customized,minimum"
+		url="<%= portletURL.toString() %>"
+	>
+		<liferay-ui:section>
+			<c:if test='<%= tabs1.equals("customized") %>'>
+				<liferay-util:include page="/partials/customized.jsp" servletContext="<%= pageContext.getServletContext() %>" />
+			</c:if>
+		</liferay-ui:section>
+
+		<liferay-ui:section>
+			<c:if test='<%= tabs1.equals("minimum") %>'>
+				<liferay-util:include page="/partials/minimum.jsp" servletContext="<%= pageContext.getServletContext() %>" />
+			</c:if>
+		</liferay-ui:section>
+	</liferay-ui:tabs>
+</clay:container-fluid>

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.data.set.taglib.internal.util.ServicesProvider;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNameUtil;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.frontend.js.module.launcher.JSModuleResolver;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.template.react.renderer.ComponentDescriptor;
 import com.liferay.portal.template.react.renderer.ReactRenderer;
@@ -28,6 +29,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
+import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 
 import javax.servlet.ServletContext;
@@ -61,6 +63,24 @@ public class BaseDisplayTag extends AttributesTagSupport {
 		return _id;
 	}
 
+	public String getNamespace() {
+		if (_namespace != null) {
+			return _namespace;
+		}
+
+		HttpServletRequest httpServletRequest = getRequest();
+
+		PortletResponse portletResponse =
+			(PortletResponse)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+		if (portletResponse != null) {
+			_namespace = portletResponse.getNamespace();
+		}
+
+		return _namespace;
+	}
+
 	public String getPropsTransformer() {
 		return _propsTransformer;
 	}
@@ -75,6 +95,10 @@ public class BaseDisplayTag extends AttributesTagSupport {
 
 	public void setId(String id) {
 		_id = id;
+	}
+
+	public void setNamespace(String namespace) {
+		_namespace = namespace;
 	}
 
 	/**
@@ -102,6 +126,7 @@ public class BaseDisplayTag extends AttributesTagSupport {
 	protected void cleanUp() {
 		_additionalProps = null;
 		_id = null;
+		_namespace = null;
 		_portletURL = null;
 		_propsTransformer = null;
 		_propsTransformerServletContext = null;
@@ -128,6 +153,8 @@ public class BaseDisplayTag extends AttributesTagSupport {
 		if (_additionalProps != null) {
 			props.put("additionalProps", _additionalProps);
 		}
+
+		props.put("namespace", getNamespace());
 
 		return props;
 	}
@@ -187,6 +214,7 @@ public class BaseDisplayTag extends AttributesTagSupport {
 
 	private Map<String, Object> _additionalProps;
 	private String _id;
+	private String _namespace;
 	private PortletURL _portletURL;
 	private String _propsTransformer;
 	private ServletContext _propsTransformerServletContext;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
+import javax.portlet.PortletURL;
+
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -75,6 +77,14 @@ public class BaseDisplayTag extends AttributesTagSupport {
 		_id = id;
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
+	@Deprecated
+	public void setPortletURL(PortletURL portletURL) {
+		_portletURL = portletURL;
+	}
+
 	public void setPropsTransformer(String propsTransformer) {
 		_propsTransformer = propsTransformer;
 	}
@@ -92,6 +102,7 @@ public class BaseDisplayTag extends AttributesTagSupport {
 	protected void cleanUp() {
 		_additionalProps = null;
 		_id = null;
+		_portletURL = null;
 		_propsTransformer = null;
 		_propsTransformerServletContext = null;
 		_randomNamespace = null;
@@ -176,6 +187,7 @@ public class BaseDisplayTag extends AttributesTagSupport {
 
 	private Map<String, Object> _additionalProps;
 	private String _id;
+	private PortletURL _portletURL;
 	private String _propsTransformer;
 	private ServletContext _propsTransformerServletContext;
 	private String _randomNamespace;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -44,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
@@ -173,10 +171,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		return _pageNumber;
 	}
 
-	public PortletURL getPortletURL() {
-		return _portletURL;
-	}
-
 	public List<String> getSelectedItems() {
 		return _selectedItems;
 	}
@@ -272,10 +266,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_pageNumber = pageNumber;
 	}
 
-	public void setPortletURL(PortletURL portletURL) {
-		_portletURL = portletURL;
-	}
-
 	public void setSelectedItems(List<String> selectedItems) {
 		_selectedItems = selectedItems;
 	}
@@ -329,7 +319,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_nestedItemsReferenceKey = null;
 		_pageNumber = 0;
 		_paginationSelectedEntry = 0;
-		_portletURL = null;
 		_selectedItems = null;
 		_selectedItemsKey = null;
 		_selectionType = null;
@@ -385,8 +374,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 				).build()
 			).put(
 				"portletId", PortalUtil.getPortletId(getRequest())
-			).put(
-				"portletURL", _portletURL.toString()
 			).put(
 				"selectedItems", _selectedItems
 			).put(
@@ -488,7 +475,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 	private String _nestedItemsReferenceKey;
 	private int _pageNumber;
 	private int _paginationSelectedEntry;
-	private PortletURL _portletURL;
 	private List<String> _selectedItems;
 	private String _selectedItemsKey;
 	private String _selectionType;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -155,10 +155,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		return _itemsPerPage;
 	}
 
-	public String getNamespace() {
-		return _namespace;
-	}
-
 	public String getNestedItemsKey() {
 		return _nestedItemsKey;
 	}
@@ -241,10 +237,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_itemsPerPage = itemsPerPage;
 	}
 
-	public void setNamespace(String namespace) {
-		_namespace = namespace;
-	}
-
 	public void setNestedItemsKey(String nestedItemsKey) {
 		_nestedItemsKey = nestedItemsKey;
 	}
@@ -314,7 +306,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_formId = null;
 		_formName = null;
 		_itemsPerPage = 0;
-		_namespace = null;
 		_nestedItemsKey = null;
 		_nestedItemsReferenceKey = null;
 		_pageNumber = 0;
@@ -356,8 +347,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 				"formName", _toNullOrObject(_formName)
 			).put(
 				"id", getId()
-			).put(
-				"namespace", _namespace
 			).put(
 				"nestedItemsKey", _toNullOrObject(_nestedItemsKey)
 			).put(
@@ -470,7 +459,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 	private String _formId;
 	private String _formName;
 	private int _itemsPerPage;
-	private String _namespace;
 	private String _nestedItemsKey;
 	private String _nestedItemsReferenceKey;
 	private int _pageNumber;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -114,10 +114,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		return _itemsPerPage;
 	}
 
-	public String getNamespace() {
-		return _namespace;
-	}
-
 	public String getNestedItemsKey() {
 		return _nestedItemsKey;
 	}
@@ -204,10 +200,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_itemsPerPage = itemsPerPage;
 	}
 
-	public void setNamespace(String namespace) {
-		_namespace = namespace;
-	}
-
 	public void setNestedItemsKey(String nestedItemsKey) {
 		_nestedItemsKey = nestedItemsKey;
 	}
@@ -280,7 +272,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_formId = null;
 		_formName = null;
 		_itemsPerPage = 0;
-		_namespace = null;
 		_nestedItemsKey = null;
 		_nestedItemsReferenceKey = null;
 		_pageNumber = 0;
@@ -326,8 +317,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 				"id", getId()
 			).put(
 				"itemsActions", _fdsActionDropdownItems
-			).put(
-				"namespace", _namespace
 			).put(
 				"nestedItemsKey", _validateDataAttribute(_nestedItemsKey)
 			).put(
@@ -447,7 +436,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private String _formId;
 	private String _formName;
 	private int _itemsPerPage;
-	private String _namespace;
 	private String _nestedItemsKey;
 	private String _nestedItemsReferenceKey;
 	private int _pageNumber;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -40,8 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import javax.portlet.PortletURL;
-
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
@@ -130,10 +128,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 
 	public int getPageNumber() {
 		return _pageNumber;
-	}
-
-	public PortletURL getPortletURL() {
-		return _portletURL;
 	}
 
 	public List<String> getSelectedItems() {
@@ -237,10 +231,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_pageNumber = pageNumber;
 	}
 
-	public void setPortletURL(PortletURL portletURL) {
-		_portletURL = portletURL;
-	}
-
 	public void setSelectedItems(List<String> selectedItems) {
 		_selectedItems = selectedItems;
 	}
@@ -295,7 +285,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_nestedItemsReferenceKey = null;
 		_pageNumber = 0;
 		_paginationSelectedEntry = 0;
-		_portletURL = null;
 		_selectedItems = null;
 		_selectedItemsKey = null;
 		_selectionType = null;
@@ -355,8 +344,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 				).build()
 			).put(
 				"portletId", PortalUtil.getPortletId(getRequest())
-			).put(
-				"portletURL", _portletURL.toString()
 			).put(
 				"selectedItems", _selectedItems
 			).put(
@@ -465,7 +452,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private String _nestedItemsReferenceKey;
 	private int _pageNumber;
 	private int _paginationSelectedEntry;
-	private PortletURL _portletURL;
 	private List<String> _selectedItems;
 	private String _selectedItemsKey;
 	private String _selectionType;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -165,7 +165,7 @@
 		</attribute>
 		<attribute>
 			<name>apiURL</name>
-			<required>false</required>
+			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
@@ -199,10 +199,12 @@
 		</attribute>
 		<attribute>
 			<name>formId</name>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<name>formName</name>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
@@ -212,13 +214,13 @@
 		</attribute>
 		<attribute>
 			<name>itemsPerPage</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>int</type>
 		</attribute>
 		<attribute>
 			<name>namespace</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
@@ -233,14 +235,14 @@
 		</attribute>
 		<attribute>
 			<name>pageNumber</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>int</type>
 		</attribute>
 		<attribute>
 			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>portletURL</name>
-			<required>true</required>
+			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>javax.portlet.PortletURL</type>
 		</attribute>

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -99,6 +99,7 @@
 			<type>int</type>
 		</attribute>
 		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>portletURL</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -237,6 +238,7 @@
 			<type>int</type>
 		</attribute>
 		<attribute>
+			<description>Deprecated as of 7.4.0, with no direct replacement.</description>
 			<name>portletURL</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
@@ -58,6 +58,9 @@ import getJsModule from './utils/modules';
 import ViewsContext from './views/ViewsContext';
 import {getViewContentRenderer} from './views/index';
 
+const DEFAULT_PAGINATION_DELTA = 20;
+const DEFAULT_PAGINATION_PAGE_NUMBER = 1;
+
 const DataSet = ({
 	actionParameterName,
 	bulkActions,
@@ -98,8 +101,7 @@ const DataSet = ({
 		sidePanelId || `support-side-panel-${getRandomId()}`
 	);
 	const [delta, setDelta] = useState(
-		showPagination &&
-			(pagination.initialDelta || pagination.deltas[0].label)
+		showPagination && (pagination?.initialDelta || DEFAULT_PAGINATION_DELTA)
 	);
 
 	const [filters, setFilters] = useState(() => {
@@ -121,7 +123,10 @@ const DataSet = ({
 	const [highlightedItemsValue, setHighlightedItemsValue] = useState([]);
 	const [items, setItems] = useState(itemsProp);
 	const [itemsChanges, setItemsChanges] = useState({});
-	const [pageNumber, setPageNumber] = useState(1);
+	const [pageNumber, setPageNumber] = useState(
+		showPagination &&
+			(pagination?.initialPageNumber || DEFAULT_PAGINATION_PAGE_NUMBER)
+	);
 	const [searchParam, setSearchParam] = useState('');
 	const [selectedItemsValue, setSelectedItemsValue] = useState(
 		selectedItems || []
@@ -768,9 +773,6 @@ DataSet.defaultProps = {
 	inlineEditingSettings: null,
 	items: null,
 	itemsActions: null,
-	pagination: {
-		initialDelta: 10,
-	},
 	selectedItemsKey: 'id',
 	selectionType: 'multiple',
 	showManagementBar: true,


### PR DESCRIPTION
### References

- [LPS-151456 Minimize required FDS configuration](https://issues.liferay.com/browse/LPS-151456)
- [FDS technical improvements checklist](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/2002681985/FDS+technical+improvements+checklist)
- This is a followup on #2114
- This is partially a followup on #2103

### What is the goal of this PR?

FDS tags have unnecessarily required attributes, that we'd like to make optional, along with defaults. The only required attributes of `headless-display` tag will now be `apiURL` and `id`. We plan to do the same for the `classic-display`, in a separate task.

In addition, we are:
- adding a tab in the sample module with minimal configuration FDS. Intent here is to add all the small features to `customized` tab. If there will be a need for a showcase of a larger disrupting feature, we can add it in additional tabs. Note that both FDS instances are using the same data.
- deprecating unused `portletURL` attribute.
- seting portlet namespace as default `namespace`. This makes it [consistent with `<clay>` tags](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java#L142-L158).

:warning: I fully expect this PR to break our CI tests on the sample module, as we are changing the markup. @Esther-OC @mateusralv

### What does it look like?

![customized](https://user-images.githubusercontent.com/5435511/163381538-976e834c-9edb-4084-bc37-776884e5d09d.png)

![minimum](https://user-images.githubusercontent.com/5435511/163381516-7b0f40d2-2ab3-46d2-a705-30bcbae3d634.png)

### Steps to reproduce

Place sample FDS module on any page.
