### PR TITLE
LPS-151474 ActiveViewSettings are not being applied

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -29,18 +29,34 @@ const FrontendDataSet = ({
 	views,
 	...props
 }) => {
-	const activeViewName = activeViewSettings?.name;
+	const getInitialViewsState = () => {
+		let initialActiveView = views[0];
+		let initialVisibleFieldNames = {};
 
-	const activeView = activeViewName
-		? views.find(({name}) => name === activeViewName)
-		: views[0];
-	const [state, dispatch] = useThunk(
-		useReducer(viewsReducer, {
-			activeView,
+		if (activeViewSettings) {
+			const {name, visibleFieldNames} = JSON.parse(activeViewSettings);
+
+			if (name) {
+				initialActiveView = views.find(
+					({viewName}) => viewName === name
+				);
+			}
+
+			if (visibleFieldNames) {
+				initialVisibleFieldNames = visibleFieldNames;
+			}
+		}
+
+		return {
+			activeView: initialActiveView,
 			customViewsEnabled,
 			views,
-			visibleFieldNames: activeViewSettings?.visibleFieldNames || {},
-		})
+			visibleFieldNames: initialVisibleFieldNames,
+		};
+	};
+
+	const [state, dispatch] = useThunk(
+		useReducer(viewsReducer, getInitialViewsState())
 	);
 
 	return (


### PR DESCRIPTION
### References

- [LPS-151474 ActiveViewSettings are not being applied](https://issues.liferay.com/browse/LPS-151474)

### What is the goal of this PR?

We are fixing handling of view persistence, more specifically selection of visible columns. The root cause of the issue is that the `activeViewSettings` attribute of the tag is a JSON string, not an object. We need to parse this string first.

### What does it look like?

#### After PR

![after](https://user-images.githubusercontent.com/5435511/163402178-4be84d76-5efd-4087-b7ac-a8b2cef03561.gif)

### Steps to reproduce

See steps to reproduce in [LPS-151474 ActiveViewSettings are not being applied](https://issues.liferay.com/browse/LPS-151474)