### PR TITLE
LPS-149742 Fix SQL Server exception when getting Message Board Messages

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/MessageBoardMessageResourceTest.java
@@ -16,6 +16,8 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.MessageBoardMessage;
+import com.liferay.headless.delivery.client.pagination.Page;
+import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageLocalServiceUtil;
@@ -28,6 +30,10 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +53,53 @@ public class MessageBoardMessageResourceTest
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setScopeGroupId(testGroup.getGroupId());
+	}
+
+	@Override
+	@Test
+	public void testGetMessageBoardMessageMessageBoardMessagesPage()
+		throws Exception {
+
+		super.testGetMessageBoardMessageMessageBoardMessagesPage();
+
+		// Test of flatten parameter with a tree of MessageBoardMessage
+
+		Long parentMessageBoardMessageId =
+			testGetMessageBoardMessageMessageBoardMessagesPage_getParentMessageBoardMessageId();
+
+		MessageBoardMessage messageBoardMessage1 =
+			testGetMessageBoardMessageMessageBoardMessagesPage_addMessageBoardMessage(
+				parentMessageBoardMessageId, randomMessageBoardMessage());
+
+		MessageBoardMessage messageBoardMessage2 =
+			testGetMessageBoardMessageMessageBoardMessagesPage_addMessageBoardMessage(
+				messageBoardMessage1.getId(), randomMessageBoardMessage());
+
+		Page<MessageBoardMessage> page =
+			messageBoardMessageResource.
+				getMessageBoardMessageMessageBoardMessagesPage(
+					parentMessageBoardMessageId, false, null, null, null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(messageBoardMessage1),
+			(List<MessageBoardMessage>)page.getItems());
+		assertValid(page);
+
+		page =
+			messageBoardMessageResource.
+				getMessageBoardMessageMessageBoardMessagesPage(
+					parentMessageBoardMessageId, true, null, null, null,
+					Pagination.of(1, 10), null);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(messageBoardMessage1, messageBoardMessage2),
+			(List<MessageBoardMessage>)page.getItems());
+		assertValid(page);
 	}
 
 	@Test

--- a/modules/apps/message-boards/message-boards-service/src/main/resources/custom-sql/default.xml
+++ b/modules/apps/message-boards/message-boards-service/src/main/resources/custom-sql/default.xml
@@ -116,11 +116,11 @@
 			WHERE
 				(
 					(
-						(NOT ?) AND
+						([$FALSE$] = ?) AND
 						(MBMessage.parentMessageId = ?)
 					) OR
 					(
-						(?) AND
+						([$TRUE$] = ?) AND
 						(MBMessage.treePath LIKE ?)
 					)
 				) AND
@@ -185,11 +185,11 @@
 			WHERE
 				(
 					(
-						(NOT ?) AND
+						([$FALSE$] = ?) AND
 						(MBMessage.parentMessageId = ?)
 					) OR
 					(
-						(?) AND
+						([$TRUE$] = ?) AND
 						(MBMessage.treePath LIKE ?)
 					)
 				) AND


### PR DESCRIPTION
This PR contains the code to fix the exception thrown by **`SQL Server`** when executing some queries.

The queries that are failing are the following:

- `countByParentMessageId`
- `findByParentMessageId`

Those queries were designed by, based on a boolean parameter, execute the first condition or the second condition inside an OR to return just the parent message or all the messages that are related within an ascendent relationship. The problem is that Microsoft SQL Server does not support boolean data types as they are managed as bit data type.

Then, an expression such as `(NOT ?)` or `(?)` fails replacing the `?` with a proper boolean or bit value.

### **How to test:**

We can test it through the Headless Delivery API. Given a siteId, for example, `20124`, the point is to create some message board messages with parent relationships. In this case:

thread `42756` -- message `42760` -- message `42763` -- message `42766`

_1. Create a message board thread:_
```
curl -X 'POST' \
  'http://localhost:8080/o/headless-delivery/v1.0/sites/20124/message-board-threads' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -H 'x-csrf-token: Iftpjgpx' \
  -d '{
    "articleBody": "This is my thread",
    "friendlyUrlPath": "this-is-my-thread",
    "headline": "This is my thread"
  }'
```
This will return the thread created including its id, in this case 42756

_2. Create a message board message associated to the recently created thread:_
```
curl -X POST \
  'http://localhost:8080/o/headless-delivery/v1.0/message-board-threads/42756/message-board-messages' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test' \
  -d '{
      "articleBody": "This is my message",
      "friendlyUrlPath": "this-is-my-message",
      "headline": "This is my message"
    }'
``` 
This will return the message created including its id, in this case 42760

_3. Create a message board message associated to the recently created message:_
```
    curl -X POST \
    'http://localhost:8080/o/headless-delivery/v1.0/message-board-messages/42760/message-board-messages' \
    -H 'accept: application/json' \
    -H 'Content-Type: application/json' \
    -u 'test@liferay.com:test' \
    -d '{
        "articleBody": "This is my message 2",
        "friendlyUrlPath": "this-is-my-message-2",
        "headline": "This is my message 2"
      }'
```
This will return the message created including its id, in this case 42763.

_4. Create a message board message associated to the recently created message:_
```
   curl -X POST \
    'http://localhost:8080/o/headless-delivery/v1.0/message-board-messages/42763/message-board-messages' \
    -H 'accept: application/json' \
    -H 'Content-Type: application/json' \
    -u 'test@liferay.com:test' \
    -d '{
        "articleBody": "This is my message 3",
        "friendlyUrlPath": "this-is-my-message-3",
        "headline": "This is my message 3"
      }'
```

Then we request the message board messages associated to a message board message 42760:

```
curl -X GET \
  'http://localhost:8080/o/headless-delivery/v1.0/message-board-messages/42760/message-board-messages?flatten=true' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -u 'test@liferay.com:test'
```

**Before the PR:**

The response is a 500 code with the body:

```
{
  "status" : "INTERNAL_SERVER_ERROR",
  "title" : "An expression of non-boolean type specified in a context where a condition is expected, near ')'."
}
```

**After the PR:**

The response is a 200 code with the body:

```
{
  "actions" : {
    [...]
  },
  "facets" : [ ],
  "items" : [ {
    "actions" : {
      [...]
    },
    "anonymous" : false,
    "articleBody" : "This is my message 3",
    "creator" : {
      [...]
    },
    "creatorStatistics" : {
      [...]
    },
    "customFields" : [ ],
    "dateCreated" : "2022-04-18T14:54:12Z",
    "dateModified" : "2022-04-18T14:54:12Z",
    "encodingFormat" : "bbcode",
    "externalReferenceCode" : "42766",
    "friendlyUrlPath" : "this-is-my-message-3",
    "headline" : "This is my message 3",
    "id" : 42766,
    "keywords" : [ ],
    "messageBoardSectionId" : 0,
    "messageBoardThreadId" : 42756,
    "numberOfMessageBoardAttachments" : 0,
    "numberOfMessageBoardMessages" : 0,
    "parentMessageBoardMessageId" : 42763,
    "relatedContents" : [ ],
    "showAsAnswer" : false,
    "siteId" : 20124,
    "status" : "approved",
    "subscribed" : false
  }, {
    "actions" : {
      [...]
    },
    "anonymous" : false,
    "articleBody" : "This is my message 2",
    "creator" : {
      [...]
    },
    "creatorStatistics" : {
      "joinDate" : "2022-04-18T14:41:49Z",
      "postsNumber" : 4,
      "rank" : "Youngling"
    },
    "customFields" : [ ],
    "dateCreated" : "2022-04-18T14:53:15Z",
    "dateModified" : "2022-04-18T14:53:15Z",
    "encodingFormat" : "bbcode",
    "externalReferenceCode" : "42763",
    "friendlyUrlPath" : "this-is-my-message-2",
    "headline" : "This is my message 2",
    "id" : 42763,
    "keywords" : [ ],
    "messageBoardSectionId" : 0,
    "messageBoardThreadId" : 42756,
    "numberOfMessageBoardAttachments" : 0,
    "numberOfMessageBoardMessages" : 1,
    "parentMessageBoardMessageId" : 42760,
    "relatedContents" : [ ],
    "showAsAnswer" : false,
    "siteId" : 20124,
    "status" : "approved",
    "subscribed" : false
  } ],
  "lastPage" : 1,
  "page" : 1,
  "pageSize" : 20,
  "totalCount" : 2
}
```



