### PR TITLE
LPS-113546 Modernize `toggleControls`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -20,19 +20,6 @@
 
 	var EVENT_CLICK = 'click';
 
-	var MAP_TOGGLE_STATE = {
-		false: {
-			cssClass: 'controls-hidden',
-			iconCssClass: 'hidden',
-			state: 'hidden',
-		},
-		true: {
-			cssClass: 'controls-visible',
-			iconCssClass: 'view',
-			state: 'visible',
-		},
-	};
-
 	var SRC_HIDE_LINK = {
 		src: 'hideLink',
 	};
@@ -1401,68 +1388,6 @@
 		},
 		['aui-base', 'liferay-util-window']
 	);
-
-	Liferay.provide(Util, 'toggleControls', (node) => {
-		const docBody = document.body;
-
-		node = node._node || docBody;
-
-		const trigger = node.querySelector('.toggle-controls');
-
-		if (!trigger) {
-			return;
-		}
-
-		let controlsVisible = Liferay._editControlsState === 'visible';
-
-		let currentState = MAP_TOGGLE_STATE[controlsVisible];
-
-		let icon = trigger.querySelector('.lexicon-icon');
-
-		if (icon) {
-			currentState.icon = icon;
-		}
-
-		docBody.classList.add(currentState.cssClass);
-
-		Liferay.fire('toggleControls', {
-			enabled: controlsVisible,
-		});
-
-		trigger.addEventListener('click', () => {
-			controlsVisible = !controlsVisible;
-
-			const previousState = currentState;
-
-			currentState = MAP_TOGGLE_STATE[controlsVisible];
-
-			docBody.classList.toggle(previousState.cssClass);
-			docBody.classList.toggle(currentState.cssClass);
-
-			const editControlsIconClass = currentState.iconCssClass;
-			const editControlsState = currentState.state;
-
-			const newIcon = Util.getLexiconIcon(editControlsIconClass);
-
-			currentState.icon = newIcon;
-
-			icon.replaceWith(newIcon);
-
-			icon = newIcon;
-
-			Liferay._editControlsState = editControlsState;
-
-			Liferay.Util.Session.set(
-				'com.liferay.frontend.js.web_toggleControls',
-				editControlsState
-			);
-
-			Liferay.fire('toggleControls', {
-				enabled: controlsVisible,
-				src: 'ui',
-			});
-		});
-	});
 
 	Liferay.provide(
 		Util,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -110,4 +110,5 @@ export {default as removeEntitySelection} from './liferay/util/remove_entity_sel
 export {default as showCapsLock} from './liferay/util/show_caps_lock';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
 export {default as selectFolder} from './liferay/util/select_folder';
+export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -85,6 +85,7 @@ import {getSessionValue, setSessionValue} from './util/session.es';
 import showCapsLock from './util/show_caps_lock';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
+import toggleControls from './util/toggle_controls';
 import toggleDisabled from './util/toggle_disabled';
 import zIndex from './zIndex';
 
@@ -320,6 +321,7 @@ Liferay.Util.Session = {
 	set: setSessionValue,
 };
 
+Liferay.Util.toggleControls = toggleControls;
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_controls.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_controls.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getLexiconIcon from './get_lexicon_icon';
+import {setSessionValue} from './session.es';
+
+const EDIT_CONTROLS_STATE = Liferay._editControlsState;
+
+const MAP_TOGGLE_STATE = {
+	false: {
+		cssClass: 'controls-hidden',
+		iconCssClass: 'hidden',
+		state: 'hidden',
+	},
+	true: {
+		cssClass: 'controls-visible',
+		iconCssClass: 'view',
+		state: 'visible',
+	},
+};
+
+export default function toggleControls(node) {
+	const body = document.body;
+
+	node = node._node || body;
+
+	const trigger = node.querySelector('.toggle-controls');
+
+	if (!trigger) {
+		return;
+	}
+
+	let controlsVisible = EDIT_CONTROLS_STATE === 'visible';
+
+	let currentState = MAP_TOGGLE_STATE[controlsVisible];
+
+	let icon = trigger.querySelector('.lexicon-icon');
+
+	if (icon) {
+		currentState.icon = icon;
+	}
+
+	body.classList.add(currentState.cssClass);
+
+	Liferay.fire('toggleControls', {
+		enabled: controlsVisible,
+	});
+
+	trigger.addEventListener('click', () => {
+		controlsVisible = !controlsVisible;
+
+		const previousState = currentState;
+
+		currentState = MAP_TOGGLE_STATE[controlsVisible];
+
+		body.classList.toggle(previousState.cssClass);
+		body.classList.toggle(currentState.cssClass);
+
+		const editControlsIconClass = currentState.iconCssClass;
+		const editControlsState = currentState.state;
+
+		const newIcon = getLexiconIcon(editControlsIconClass);
+
+		currentState.icon = newIcon;
+
+		icon.replaceWith(newIcon);
+
+		icon = newIcon;
+
+		Liferay._editControlsState = editControlsState;
+
+		setSessionValue(
+			'com.liferay.frontend.js.web_toggleControls',
+			editControlsState
+		);
+
+		Liferay.fire('toggleControls', {
+			enabled: controlsVisible,
+			src: 'ui',
+		});
+	});
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_controls.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_controls.js
@@ -15,8 +15,6 @@
 import getLexiconIcon from './get_lexicon_icon';
 import {setSessionValue} from './session.es';
 
-const EDIT_CONTROLS_STATE = Liferay._editControlsState;
-
 const MAP_TOGGLE_STATE = {
 	false: {
 		cssClass: 'controls-hidden',
@@ -41,7 +39,7 @@ export default function toggleControls(node) {
 		return;
 	}
 
-	let controlsVisible = EDIT_CONTROLS_STATE === 'visible';
+	let controlsVisible = Liferay._editControlsState === 'visible';
 
 	let currentState = MAP_TOGGLE_STATE[controlsVisible];
 

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_controls.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/toggle_controls.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import toggleControls from '../../../src/main/resources/META-INF/resources/liferay/util/toggle_controls';
+
+describe('Liferay.Util.toggleControls', () => {
+	Liferay = {
+		Util: {
+			getLexiconIcon: jest.fn(() => global),
+			setSessionValue: jest.fn(),
+		},
+		fire: jest.fn(),
+		on: (_eventName, callback) => {
+			callback();
+		},
+	};
+
+	beforeEach(() => {
+		const trigger = document.createElement('button');
+		const icon = document.createElement('span');
+
+		icon.classList.add('lexicon-icon');
+		trigger.classList.add('toggle-controls');
+
+		document.body.appendChild(trigger);
+		document.body.appendChild(icon);
+	});
+
+	it('adds the class to the body corresponding to the current state', () => {
+		toggleControls(document.body);
+
+		expect(document.body.classList.contains('controls-hidden')).toBe(true);
+	});
+
+	it('consumes the toggleControls event', () => {
+		toggleControls(document.body);
+
+		const spy = jest.fn();
+
+		Liferay.on('toggleControls', spy);
+
+		expect(spy).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
This util can be tested by going to a widget page and interacting with the eye icon on the top navigation.

The function looks kinda bad, it feels like adding an event listener inside a function like this is a bad idea, but we can't change the implementation. If we want to, we can update [its only usage](https://github.com/liferay/liferay-portal/blob/master/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/js/product_navigation_control_menu.js#L29) and deprecate the current version.