### PR TITLE
LRQA-74339 Add refresh to load in portlet

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -2,9 +2,9 @@
 definition {
 
 	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "false";
-	property portal.release = "false";
-	property portal.upstream = "quarantine";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
 	property testray.component.names = "Frontend Dataset";
 	property testray.main.component.name = "User Interface";
 
@@ -28,6 +28,8 @@ definition {
 			widgetName = "Frontend Data Set Sample");
 
 		Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+
+		Refresh();
 	}
 
 	tearDown {


### PR DESCRIPTION
**Background**
Test is flaky because the FDS sample portlet wouldn't load on ci. Adding a Refresh() helps it load in.

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-74339