### PR TITLE
LPS-146064 Process external schema references if paths are not defined

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -1548,7 +1548,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.17'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.18'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.17'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-openapi.yaml
@@ -621,7 +621,7 @@ components:
 info:
     description:
         "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.18'."
+        artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.19'."
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0.html

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.18'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
+	info = @Info(description = "Headless Commerce Delivery Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.delivery.catalog.client', and version '4.0.19'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Commerce Delivery Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4908,7 +4908,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.25'."
+        'com.liferay.headless.delivery.client', and version '4.0.26'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.25'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.26'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -422,7 +422,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.20'."
+        'com.liferay.object.admin.rest.client', and version '1.0.22'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.20'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.22'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-openapi.yaml
@@ -720,7 +720,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.6'."
+        'com.liferay.headless.commerce.machine.learning.client', and version '1.0.7'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -48,7 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce ML API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.machine.learning.client', and version '1.0.7'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce ML API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/util/OpenAPIParserUtil.java
@@ -153,13 +153,10 @@ public class OpenAPIParserUtil {
 	}
 
 	public static List<String> getExternalReferences(OpenAPIYAML openAPIYAML) {
+		Set<String> externalReferences = new HashSet<>();
+
 		Map<String, PathItem> pathItems = openAPIYAML.getPathItems();
 
-		if (pathItems == null) {
-			return Collections.emptyList();
-		}
-
-		Set<String> externalReferences = new HashSet<>();
 		Map<String, Schema> schemas = Optional.ofNullable(
 			openAPIYAML.getComponents()
 		).map(
@@ -168,28 +165,44 @@ public class OpenAPIParserUtil {
 			new HashMap<>()
 		);
 
-		for (Map.Entry<String, PathItem> entry1 : pathItems.entrySet()) {
-			List<Operation> operations = getOperations(entry1.getValue());
+		if (pathItems != null) {
+			for (PathItem pathItem : pathItems.values()) {
+				List<Operation> operations = getOperations(pathItem);
 
-			for (Operation operation : operations) {
-				RequestBody requestBody = operation.getRequestBody();
+				for (Operation operation : operations) {
+					RequestBody requestBody = operation.getRequestBody();
 
-				if (requestBody != null) {
-					_getExternalReferences(
-						requestBody.getContent(), externalReferences, schemas);
-				}
-
-				Map<ResponseCode, Response> responses =
-					operation.getResponses();
-
-				for (Response response : responses.values()) {
-					if (response == null) {
-						continue;
+					if (requestBody != null) {
+						_addExternalReferences(
+							requestBody.getContent(), externalReferences,
+							schemas);
 					}
 
-					_getExternalReferences(
-						response.getContent(), externalReferences, schemas);
+					Map<ResponseCode, Response> responses =
+						operation.getResponses();
+
+					for (Response response : responses.values()) {
+						if (response == null) {
+							continue;
+						}
+
+						_addExternalReferences(
+							response.getContent(), externalReferences, schemas);
+					}
 				}
+			}
+		}
+
+		for (Schema schema : schemas.values()) {
+			Map<String, Schema> propertySchemas = schema.getPropertySchemas();
+
+			if (propertySchemas == null) {
+				continue;
+			}
+
+			for (Schema propertySchema : propertySchemas.values()) {
+				_addExternalReferences(
+					externalReferences, propertySchema, schemas);
 			}
 		}
 
@@ -509,7 +522,7 @@ public class OpenAPIParserUtil {
 		return false;
 	}
 
-	private static void _getExternalReferences(
+	private static void _addExternalReferences(
 		Map<String, Content> contents, Set<String> externalReferences,
 		Map<String, Schema> schemas) {
 
@@ -518,59 +531,65 @@ public class OpenAPIParserUtil {
 		}
 
 		for (Content content : contents.values()) {
-			Schema contentSchema = content.getSchema();
+			_addExternalReferences(
+				externalReferences, content.getSchema(), schemas);
+		}
+	}
 
-			if (contentSchema == null) {
-				continue;
-			}
+	private static void _addExternalReferences(
+		Set<String> externalReferences, Schema schema,
+		Map<String, Schema> schemas) {
 
-			Queue<Map<String, Schema>> queue = new LinkedList<>();
+		if (schema == null) {
+			return;
+		}
 
-			queue.add(Collections.singletonMap("content", contentSchema));
+		Queue<Map<String, Schema>> queue = new LinkedList<>();
 
-			Map<String, Schema> map = null;
-			Set<String> visited = new HashSet<>();
+		queue.add(Collections.singletonMap("content", schema));
 
-			while ((map = queue.poll()) != null) {
-				for (Map.Entry<String, Schema> entry : map.entrySet()) {
-					if (visited.contains(entry.getKey())) {
-						continue;
-					}
+		Map<String, Schema> map = null;
+		Set<String> visited = new HashSet<>();
 
-					Schema schema = entry.getValue();
+		while ((map = queue.poll()) != null) {
+			for (Map.Entry<String, Schema> entry : map.entrySet()) {
+				if (visited.contains(entry.getKey())) {
+					continue;
+				}
 
-					String reference = _getReference(schema);
+				Schema currentSchema = entry.getValue();
 
-					if (reference != null) {
-						if (reference.contains("#/components/schemas/")) {
-							String referenceName = getReferenceName(reference);
+				String reference = _getReference(currentSchema);
 
-							Schema referenceSchema = schemas.get(referenceName);
+				if (reference != null) {
+					if (reference.contains("#/components/schemas/")) {
+						String referenceName = getReferenceName(reference);
 
-							if (referenceSchema != null) {
-								queue.add(
-									Collections.singletonMap(
-										referenceName, referenceSchema));
-								visited.add(entry.getKey());
-							}
+						Schema referenceSchema = schemas.get(referenceName);
+
+						if (referenceSchema != null) {
+							queue.add(
+								Collections.singletonMap(
+									referenceName, referenceSchema));
+							visited.add(entry.getKey());
 						}
-						else {
-							externalReferences.add(reference);
-						}
 					}
-					else if (schema.getAllOfSchemas() != null) {
-						List<Schema> allOfSchemas = schema.getAllOfSchemas();
+					else {
+						externalReferences.add(reference);
+					}
+				}
+				else if (currentSchema.getAllOfSchemas() != null) {
+					List<Schema> allOfSchemas = currentSchema.getAllOfSchemas();
 
-						queue.add(
-							Collections.singletonMap(
-								"allOf" + entry.getKey(), allOfSchemas.get(0)));
+					queue.add(
+						Collections.singletonMap(
+							"allOf" + entry.getKey(), allOfSchemas.get(0)));
 
-						visited.add(entry.getKey());
-					}
-					else if (schema.getPropertySchemas() != null) {
-						queue.add(schema.getPropertySchemas());
-						visited.add(entry.getKey());
-					}
+					visited.add(entry.getKey());
+				}
+				else if (currentSchema.getPropertySchemas() != null) {
+					queue.add(currentSchema.getPropertySchemas());
+					visited.add(entry.getKey());
 				}
 			}
 		}

--- a/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
+++ b/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
@@ -61,6 +61,8 @@ public class RESTBuilderTest {
 		_assertResourceFilesExist(filesPath, "Folder");
 		_assertResourceFilesExist(filesPath, "Test");
 
+		_assertDtoFileExist(filesPath, "UnreferencedSchemaComponent");
+
 		_assertPropertiesWithHyphens(
 			filesPath, "Test", "property-with-hyphens");
 		_assertPropertiesWithXML(filesPath, "Test", "xmlProperty");
@@ -78,6 +80,16 @@ public class RESTBuilderTest {
 		FileUtils.deleteDirectory(sampleImplDir);
 
 		Assert.assertFalse(sampleImplDir.exists());
+	}
+
+	private void _assertDtoFileExist(String filesPath, String resourceName) {
+		File dtoFolderFile = new File(
+			_getResourcePath(
+				filesPath,
+				"/sample-api/src/main/java/com/example/sample/dto/v1_0_0/",
+				resourceName, ".java"));
+
+		Assert.assertTrue(dtoFolderFile.exists());
 	}
 
 	private void _assertForcePredictableOperationId(String filesPath)
@@ -171,14 +183,6 @@ public class RESTBuilderTest {
 
 		Assert.assertTrue(propertiesFile.exists());
 
-		File dtoFolderFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-api/src/main/java/com/example/sample/dto/v1_0_0/",
-				resourceName, ".java"));
-
-		Assert.assertTrue(dtoFolderFile.exists());
-
 		File resourceFolderFile = new File(
 			_getResourcePath(
 				filesPath,
@@ -186,6 +190,8 @@ public class RESTBuilderTest {
 				resourceName, "Resource.java"));
 
 		Assert.assertTrue(resourceFolderFile.exists());
+
+		_assertDtoFileExist(filesPath, resourceName);
 	}
 
 	private String _getDependenciesPath() {

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
@@ -35,6 +35,12 @@ components:
                     type: string
                 documentsRepository:
                     $ref: "#/components/schemas/Folder"
+                externalField:
+                    description:
+                        A external field whose schema is defined in other rest-openapi.yaml file.
+                    items:
+                        $ref: "src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/rest-openapi.yaml#ExternalReferenceElement1"
+                    type: array
                 id:
                     format: int64
                     type: integer
@@ -58,6 +64,20 @@ components:
                         name: xmlProperty
                 property-with-hyphens:
                     type: string
+        UnreferencedSchemaComponent:
+            description:
+                Test Schema Component to test the creation of schemas with elements from a external reference without
+                being referenced in any endpoint
+            properties:
+                description:
+                    type: string
+                external-reference-field:
+                    items:
+                        $ref: "src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/rest-openapi.yaml#ExternalReferenceElement2"
+                    type: array
+                id:
+                    format: int64
+                    type: integer
 info:
     title: ""
     version: "1.0.0"

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/copyright.txt
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/copyright.txt
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/rest-config.yaml
@@ -1,0 +1,10 @@
+apiDir: "../sample-external-api/src/main/java"
+apiName: "sample-external"
+apiPackagePath: "com.example.external.sample"
+application:
+    baseURI: "/sample-external"
+    className: "SampleExternalApplication"
+    name: "sample-external-application"
+author: "Carlos Correa"
+forcePredictableOperationId: true
+implDir: "../sample-external-impl/src/main/java"

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/external-dependencies/rest-openapi.yaml
@@ -1,0 +1,22 @@
+components:
+    schemas:
+        ExternalReferenceElement1:
+            description:
+                Component 1 to test the schema import
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+        ExternalReferenceElement2:
+            description:
+                Component 2 to test the schema import
+            properties:
+                name:
+                    type: string
+                value:
+                    type: string
+info:
+    title: ""
+    version: "1.0.0"
+openapi: "3.0.1"


### PR DESCRIPTION
This PR contains the code to fix the bug that did not allow to autogenerate the code associated to a rest-openapi.yaml file if there is not any path defined.

Given this rest-openapi.yaml file without any path, only schemas defined:

```
info:
  description:
    "Liferay openAPI file example"
  license:
    name: "Apache 2.0"
    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
  title: Liferay Example
  version: v1.0
openapi: 3.0.1
paths:
components:
  schemas:
    Product:
      properties:
        id:
          example: 30130
          format: int64
          minimum: 0
          readOnly: true
          type: integer
        customFields:
          description:
            The custom fields associated to the page that renders the Display Page Template.
          items:
            $ref: "../../headless-delivery/headless-delivery-impl/rest-openapi.yaml#CustomField"
          type: array
      required:
        - id
      type: object
    Category:
      properties:
        externalReferenceCode:
          example: AB-34098-789-N
          type: string
        id:
          example: 30130
          format: int64
          minimum: 0
          type: integer
        name:
          description:
            Category Name
          type: string
        siteId:
          format: int64
          type: integer
        vocabulary:
          example: Default Vocabulary
          readOnly: true
          type: string
      required:
        - id
      type: object
```

**Before the PR:**

The `gw buildREST` command throws an error:

```
SEVERE: Error executing FreeMarker template
FreeMarker template error:
Java method "com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool.getDTOProperties(com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML, com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML, com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema)" threw an exception when invoked on com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool object "com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool@62c5bbdc"; see cause exception in the Java stack trace.


----
FTL stack trace ("~" means nesting-related):
	- Failed at: properties = freeMarkerTool.getDTOPro...  [in template "com/liferay/portal/tools/rest/builder/dependencies/dto.ftl" at line 129, column 17]
----


Java stack trace (for programmers):
----
freemarker.core._TemplateModelException: [... Exception message was already printed; see it above ...]
	at freemarker.ext.beans._MethodUtil.newInvocationTemplateModelException(_MethodUtil.java:289)
	at freemarker.ext.beans._MethodUtil.newInvocationTemplateModelException(_MethodUtil.java:261)
	at freemarker.ext.beans.OverloadedMethodsModel.exec(OverloadedMethodsModel.java:65)
	at freemarker.core.MethodCall._eval(MethodCall.java:65)
	at freemarker.core.Expression.eval(Expression.java:83)
	at freemarker.core.Assignment.accept(Assignment.java:134)
	at freemarker.core.Environment.visit(Environment.java:330)
	at freemarker.core.Environment.visit(Environment.java:336)
	at freemarker.core.Environment.visit(Environment.java:336)
	at freemarker.core.Environment.process(Environment.java:309)
	at freemarker.template.Template.process(Template.java:384)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.FreeMarker.processTemplate(FreeMarker.java:60)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.util.FreeMarkerUtil.processTemplate(FreeMarkerUtil.java:32)
	at com.liferay.portal.tools.rest.builder.RESTBuilder._createDTOFile(RESTBuilder.java:797)
	at com.liferay.portal.tools.rest.builder.RESTBuilder.build(RESTBuilder.java:290)
	at com.liferay.portal.tools.rest.builder.RESTBuilder.main(RESTBuilder.java:116)
Caused by: java.lang.NullPointerException
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil.getArrayClassName(OpenAPIParserUtil.java:111)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil.getJavaDataType(OpenAPIParserUtil.java:278)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.DTOOpenAPIParser._getPropertyType(DTOOpenAPIParser.java:249)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.DTOOpenAPIParser.getProperties(DTOOpenAPIParser.java:81)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool.getDTOProperties(FreeMarkerTool.java:262)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at freemarker.ext.beans.BeansWrapper.invokeMethod(BeansWrapper.java:1505)
	at freemarker.ext.beans.ReflectionCallableMemberDescriptor.invokeMethod(ReflectionCallableMemberDescriptor.java:56)
	at freemarker.ext.beans.MemberAndArguments.invokeMethod(MemberAndArguments.java:51)
	at freemarker.ext.beans.OverloadedMethodsModel.exec(OverloadedMethodsModel.java:61)
	... 13 more


Exception in thread "main" java.lang.RuntimeException: Error generating REST API
Java method "com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool.getDTOProperties(com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML, com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML, com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema)" threw an exception when invoked on com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool object "com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool@62c5bbdc"; see cause exception in the Java stack trace.


----
FTL stack trace ("~" means nesting-related):
	- Failed at: properties = freeMarkerTool.getDTOPro...  [in template "com/liferay/portal/tools/rest/builder/dependencies/dto.ftl" at line 129, column 17]
----
	at com.liferay.portal.tools.rest.builder.RESTBuilder.main(RESTBuilder.java:127)
Caused by: freemarker.core._TemplateModelException: Java method "com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool.getDTOProperties(com.liferay.portal.tools.rest.builder.internal.yaml.config.ConfigYAML, com.liferay.portal.tools.rest.builder.internal.yaml.openapi.OpenAPIYAML, com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema)" threw an exception when invoked on com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool object "com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool@62c5bbdc"; see cause exception in the Java stack trace.


----
FTL stack trace ("~" means nesting-related):
	- Failed at: properties = freeMarkerTool.getDTOPro...  [in template "com/liferay/portal/tools/rest/builder/dependencies/dto.ftl" at line 129, column 17]
----
	at freemarker.ext.beans._MethodUtil.newInvocationTemplateModelException(_MethodUtil.java:289)
	at freemarker.ext.beans._MethodUtil.newInvocationTemplateModelException(_MethodUtil.java:261)
	at freemarker.ext.beans.OverloadedMethodsModel.exec(OverloadedMethodsModel.java:65)
	at freemarker.core.MethodCall._eval(MethodCall.java:65)
	at freemarker.core.Expression.eval(Expression.java:83)
	at freemarker.core.Assignment.accept(Assignment.java:134)
	at freemarker.core.Environment.visit(Environment.java:330)
	at freemarker.core.Environment.visit(Environment.java:336)
	at freemarker.core.Environment.visit(Environment.java:336)
	at freemarker.core.Environment.process(Environment.java:309)
	at freemarker.template.Template.process(Template.java:384)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.FreeMarker.processTemplate(FreeMarker.java:60)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.util.FreeMarkerUtil.processTemplate(FreeMarkerUtil.java:32)
	at com.liferay.portal.tools.rest.builder.RESTBuilder._createDTOFile(RESTBuilder.java:797)
	at com.liferay.portal.tools.rest.builder.RESTBuilder.build(RESTBuilder.java:290)
	at com.liferay.portal.tools.rest.builder.RESTBuilder.main(RESTBuilder.java:116)
Caused by: java.lang.NullPointerException
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil.getArrayClassName(OpenAPIParserUtil.java:111)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil.getJavaDataType(OpenAPIParserUtil.java:278)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.DTOOpenAPIParser._getPropertyType(DTOOpenAPIParser.java:249)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.DTOOpenAPIParser.getProperties(DTOOpenAPIParser.java:81)
	at com.liferay.portal.tools.rest.builder.internal.freemarker.tool.FreeMarkerTool.getDTOProperties(FreeMarkerTool.java:262)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at freemarker.ext.beans.BeansWrapper.invokeMethod(BeansWrapper.java:1505)
	at freemarker.ext.beans.ReflectionCallableMemberDescriptor.invokeMethod(ReflectionCallableMemberDescriptor.java:56)
	at freemarker.ext.beans.MemberAndArguments.invokeMethod(MemberAndArguments.java:51)
	at freemarker.ext.beans.OverloadedMethodsModel.exec(OverloadedMethodsModel.java:61)
	... 13 more



```

**After the PR:**

The `gw buildREST` command finishes successfully and the DTOs are generated


