### PR TITLE
LPS-152031 FDS instances in different modules cannot have the same ID

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
@@ -19,8 +19,10 @@ package com.liferay.frontend.data.set.sample.web.internal.constants;
  */
 public class FDSSampleFDSNames {
 
-	public static final String CUSTOMIZED = "customized";
+	public static final String CUSTOMIZED =
+		FDSSamplePortletKeys.FDS_SAMPLE + "_customized";
 
-	public static final String MINIMUM = "minimum";
+	public static final String MINIMUM =
+		FDSSamplePortletKeys.FDS_SAMPLE + "_minimum";
 
 }


### PR DESCRIPTION
### References

- [LPS-152031 FDS instances in different modules cannot have the same ID](https://issues.liferay.com/browse/LPS-152031)
- [COMMERCE-8596 Migrate FDS displays in the remaining commerce modules - Regression Testing](https://issues.liferay.com/browse/COMMERCE-8596)

### What is the goal of this PR?

In this PR, we are setting a new convention for FDS IDs. The goal is to ensure uniqueness in DXP scope.

The uniqueness is required because registries of FDS Views, Filters and Data Sources have global scope. The implementations of registries, for example [in FDSViewRegistryImpl](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewRegistryImpl.java), are simple maps. This means that **two completely unrelated FDS instances, in completely unrelated parts of DXP, can override each other**. If ID is the same, it is random which one will be applied. This is what happened in [commerce migration PR](https://github.com/liferay-commerce/liferay-portal/pull/2265), where we tried to set two FDS with ID `pendingOrder`.

An unchecked global registry may have been fine while FDS was only in commerce, but it is not acceptable for FDS as a general purpose component. For example, if a customer sets FDS ID to be `minimum` in their new module, the result will be a flaky buggy mess.

The suggested convention in this PR is to add portlet key as a prefix to ID. This, along with the fact that we are keeping all module IDs in a module-specific `*FDSNames` file, would ensure uniqueness in DXP scope. This seems to me the fastest and easiest solution, but it may not be ideal. A customer could still be unpleasantly surprised when placing two of their own FDS instances with the same ID.

More reliable alternatives:
1. Have some under-the-hood mechanism to ensure uniqueness. Something like capturing in the `*RegistryImpl`s the module where FDS are defined, and add/remove prefix as an internal mechanism. I don't think this is possible with the current registries implementation, so this approach would probably imply creating a new registry mechanism.
2. Stop using registries, create a simpler API where a List of Views and Filters are passed in through tag attributes.

@brianchandotcom @dsanz @javierdearcos @beltranrengifo 

### Steps to reproduce

To test the fact that we using global scope for view registries:
1. Change `id` of an FDS in a sample module to `discountCategories`.
4. Deploy FDS sample module.

Result:
![image](https://user-images.githubusercontent.com/5435511/164706804-e2ec55dd-f3b2-4cc7-a61d-bbd44b06ce12.png)

