### PR TITLE
LPS-152049 frontend-js-components-web: Address warning for prop type specification in ManagementToolbar components

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ItemList.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ItemList.js
@@ -13,6 +13,7 @@
  */
 
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const ItemList = ({children, expand}) => (
@@ -26,7 +27,7 @@ const ItemList = ({children, expand}) => (
 );
 
 ItemList.propTypes = {
-	expand: Boolean,
+	expand: PropTypes.bool,
 };
 
 export default ItemList;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBarItem.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/ResultsBarItem.js
@@ -13,6 +13,7 @@
  */
 
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const ResultsBarItem = ({
@@ -32,7 +33,7 @@ const ResultsBarItem = ({
 );
 
 ResultsBarItem.propTypes = {
-	expand: Boolean,
+	expand: PropTypes.bool,
 };
 
 export default ResultsBarItem;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Search.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Search.js
@@ -14,6 +14,7 @@
 
 import ClayLayout from '@clayui/layout';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const Search = ({children, onlySearch, showMobile, ...otherProps}) => {
@@ -40,8 +41,8 @@ const Search = ({children, onlySearch, showMobile, ...otherProps}) => {
 };
 
 Search.propTypes = {
-	onlySearch: Boolean,
-	showMobile: Boolean,
+	onlySearch: PropTypes.bool,
+	showMobile: PropTypes.bool,
 };
 
 export default Search;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152049 - Warning on ManagementToolbar components for certain propTypes

There was a warning on some search-experiences frontend tests, hopefully this small change helps:

`Warning: ItemList: type specification of prop expand is invalid; the type checker function must return null or an Error but returned a boolean. You may have forgotten to pass an argument to the type checker creator (arrayOf, instanceOf, objectOf, oneOf, oneOfType, and shape all require an argument).`