### PR TITLE
LPS-113534 Modernize getWindow util

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -414,17 +414,6 @@
 		},
 
 		/**
-		 * @deprecated As of Cavanaugh (7.4.x), replaced by `openModal`
-		 */
-		getWindow(id) {
-			if (!id) {
-				id = Util.getWindowName();
-			}
-
-			return Util.getTop().Liferay.Util.Window.getById(id);
-		},
-
-		/**
 		 * @deprecated As of Cavanaugh (7.4.x), replaced by `window.name`
 		 */
 		getWindowName() {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -100,6 +100,7 @@ export {default as buildFragment} from './liferay/util/build_fragment';
 export {default as fetch} from './liferay/util/fetch.es';
 export {default as focusFormField} from './liferay/util/focus_form_field';
 export {default as getPortletId} from './liferay/util/get_portlet_id';
+export {default as getWindow} from './liferay/util/get_window';
 export {default as inBrowserView} from './liferay/util/in_browser_view';
 export {default as isObject} from './liferay/util/is_object';
 export {default as isPhone} from './liferay/util/is_phone';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -63,6 +63,7 @@ import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
 import getTop from './util/get_top';
 import getURLWithSessionId from './util/get_url_with_session_id';
+import getWindow from './util/get_window';
 import {
 	MAP_HTML_CHARS_ESCAPED,
 	escapeHTML,
@@ -230,6 +231,7 @@ Liferay.Util.getPortletId = getPortletId;
 Liferay.Util.getPortletNamespace = getPortletNamespace;
 Liferay.Util.getTop = getTop;
 Liferay.Util.getURLWithSessionId = getURLWithSessionId;
+Liferay.Util.getWindow = getWindow;
 Liferay.Util.groupBy = groupBy;
 
 /**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -347,6 +347,8 @@ declare module Liferay {
 
 		export function getURLWithSessionId(url: string): string;
 
+		export function getWindow(windowId?: string): Window;
+
 		/**
 		 * Performs navigation to the given url. If SPA is enabled, it will route the
 		 * request through the SPA engine. If not, it will simple change the document

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_window.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_window.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getTop from './get_top';
+
+export default function getWindow(windowId = window.name) {
+	const topWindow = getTop();
+
+	return topWindow.Liferay.Util.Window.getById(windowId);
+}


### PR DESCRIPTION
After @magjed4289 noticed a discrepancy with the [previously deprecated getWindow util](https://github.com/liferay-frontend/liferay-portal/pull/2096) I decided to investigate which lead me to the [conclusion](https://github.com/liferay-frontend/liferay-portal/pull/2096#discussion_r856174767) that we need to modernize it instead.

A potentially controversial change is adding the default argument value `windowId = window.name`, which I did to avoid assigning it inside the function like the old implementation did.

# 🧪  Testing

This util can be tested by going to the Device Simulation page:
![image](https://user-images.githubusercontent.com/24564752/165056668-6557c492-48f3-4d67-8731-9a9bfcb2a040.png)
