### PR TITLE
LPS-152145 Add margin between notifications

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/toast/commands/OpenToast.es.js
@@ -14,6 +14,7 @@
 
 import ClayAlert from '@clayui/alert';
 import {render} from '@liferay/frontend-js-react-web';
+import classNames from 'classnames';
 import React from 'react';
 import {unmountComponentAtNode} from 'react-dom';
 
@@ -68,7 +69,6 @@ const getRootElement = ({container, containerId}) => {
 	// Creates a fragment to prevent React from unmounting the alert container
 
 	container = document.createElement('div');
-	container.className = 'mb-3';
 
 	const fragmentContainer = document.querySelector(
 		`.alert-notifications.alert-notifications-fixed`
@@ -146,6 +146,7 @@ function openToast({
 			onClose={onCloseFn}
 			variant={variant}
 			{...toastProps}
+			className={classNames('mb-3', toastProps?.className)}
 		>
 			<div
 				dangerouslySetInnerHTML={{


### PR DESCRIPTION
Issue: https://issues.liferay.com/browse/LPS-152145

The notifications stacked do not have a margin.

**How to reproduce:**
It's difficult to get notifications stacked but we can call some on the console.

```js
[...Array(3)].forEach(() =>
    Liferay.Util.openToast({
        autoClose: false, 
        message: 'Lorem ipsum dolor sit amet'
    })
)
```

Execute the code above in the console.

**Before this PR**
![image](https://user-images.githubusercontent.com/67901/165090329-6f36dab7-6721-4432-823b-a7c2a8a02b7a.png)

**After this PR**
![image](https://user-images.githubusercontent.com/67901/165090661-f79eaf30-7422-4b0b-a0c8-8c10be5ee6b4.png)
