### PR TITLE
[TECHNICAL SUPPORT] LPS-152166 UserPortraitTag does not setAttributes for jsp override

### DIFF
--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 9.1.2
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
@@ -18,16 +18,20 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.IncludeTag;
+import com.liferay.taglib.util.TagResourceBundleUtil;
 
+import java.util.ResourceBundle;
 import java.util.function.Supplier;
 
 import javax.servlet.http.HttpServletRequest;
@@ -210,6 +214,32 @@ public class UserPortraitTag extends IncludeTag {
 		return _getPortraitURL(user, themeDisplay);
 	}
 
+	protected String getUserInitials(User user) {
+		if (user != null) {
+			return user.getInitials();
+		}
+
+		ResourceBundle resourceBundle = TagResourceBundleUtil.getResourceBundle(
+			pageContext);
+
+		String userName = LanguageUtil.get(resourceBundle, "user");
+
+		String[] userNames = StringUtil.split(userName, CharPool.SPACE);
+
+		StringBuilder sb = new StringBuilder(2);
+
+		for (int i = 0; (i < userNames.length) && (i < 2); i++) {
+			if (!userNames[i].isEmpty()) {
+				int codePoint = Character.toUpperCase(
+					userNames[i].codePointAt(0));
+
+				sb.append(Character.toChars(codePoint));
+			}
+		}
+
+		return sb.toString();
+	}
+
 	@Override
 	protected boolean isCleanUpSetAttributes() {
 		return true;
@@ -220,20 +250,23 @@ public class UserPortraitTag extends IncludeTag {
 		User user = getUser();
 
 		if ((user != null) && (user.getPortraitId() > 0)) {
-			ThemeDisplay themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
 
 			try {
 				httpServletRequest.setAttribute(
 					"liferay-ui:user-portrait:portraitURL",
 					user.getPortraitURL(themeDisplay));
 			}
-			catch (PortalException pe) {
-				_log.error(pe);
+			catch (PortalException portalException) {
+				_log.error(portalException);
 			}
 		}
 
 		httpServletRequest.setAttribute("liferay-ui:user-portrait:user", user);
+		httpServletRequest.setAttribute(
+			"liferay-ui:user-portrait:userInitials", getUserInitials(user));
 	}
 
 	private static String _getPortraitURL(

--- a/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
@@ -212,11 +212,28 @@ public class UserPortraitTag extends IncludeTag {
 
 	@Override
 	protected boolean isCleanUpSetAttributes() {
-		return false;
+		return true;
 	}
 
 	@Override
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		User user = getUser();
+
+		if ((user != null) && (user.getPortraitId() > 0)) {
+			ThemeDisplay themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+			try {
+				httpServletRequest.setAttribute(
+					"liferay-ui:user-portrait:portraitURL",
+					user.getPortraitURL(themeDisplay));
+			}
+			catch (PortalException pe) {
+				_log.error(pe);
+			}
+		}
+
+		httpServletRequest.setAttribute("liferay-ui:user-portrait:user", user);
 	}
 
 	private static String _getPortraitURL(

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 12.4.0
+version 12.5.0


### PR DESCRIPTION
Hey,
[LPS-152166](https://issues.liferay.com/browse/LPS-152166)

The customer wanted to use the old feature of displaying user initials in our userPortrait taglib. However they failed to create the customisation due to the missing attributes we removed in https://github.com/liferay/liferay-portal/commit/c8aa67e0f80bfe920a2e106d14c641911c9bc3ef#diff-2dea5f2dacc39552fed8fd8f87c40ed8bb7e961aac3debc76c6060c07cdf7337

I added the attributes and also recreated the userInitials feature and shared it as an attribute in the request.

Please review my changes