### PR TITLE
LPS-152031 FDS instances in different modules cannot have the same ID

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
@@ -20,9 +20,9 @@ package com.liferay.frontend.data.set.sample.web.internal.constants;
 public class FDSSampleFDSNames {
 
 	public static final String CUSTOMIZED =
-		FDSSamplePortletKeys.FDS_SAMPLE + "_customized";
+		FDSSamplePortletKeys.FDS_SAMPLE + "#customized";
 
 	public static final String MINIMUM =
-		FDSSamplePortletKeys.FDS_SAMPLE + "_minimum";
+		FDSSamplePortletKeys.FDS_SAMPLE + "#minimum";
 
 }


### PR DESCRIPTION
### References

- [LPS-152031 FDS instances in different modules cannot have the same ID](https://issues.liferay.com/browse/LPS-152031)
- [COMMERCE-8596 Migrate FDS displays in the remaining commerce modules - Regression Testing](https://issues.liferay.com/browse/COMMERCE-8596)
- this is a followup on #2140

### What is the goal of this PR?

In this PR, we are changing separator between FDS name and namespace to `#`, based on https://github.com/brianchandotcom/liferay-portal/pull/116464#issuecomment-1106689564. See motivation for overall task, and steps to reproduce, in #2140.

I explored ways to make the namespacing process internal. The idea would be a add a namespace when building registry service map, and prefix getter with the same namespace. This would remove potential for a human error. But, I ran into dead ends:
- I tried namespacing with portlet namespace. Registry implementation in an OSGi mechanism. Service map is built on `activate`. It may be impossible to dynamically get portlet namespace here. We have access to `bundleContext` and potentially `serviceReference`, but, as far as I can see, they don't expose portlet namespace. I'm guessing this is something we would need to wire in. We can manually set a service reference property to namespace value, but that defeats the purpose of what we are trying to do. We would just change one convention with another.
- I tried namespacing with bundle symbolic name. We can easily do this on one side, in registry activation. The problem is, I could not find a good way to set bundle symbolic name in usages. We would want to set it internally in `*Tag` class. Tag class would then relay it to serializer, which relays it to registry. `FrameworkUtil.getBundle(class)` is not useful, it returns taglib module symbolic name. We can set symbolic name manually in each usage module and pass it to the tag, but that defeats the purpose of what we are trying to do.

The only reliable alternative that I can see it to **avoid using registries**. We can keep supporting them, but also add support for directly passing in serialized views and filters through tag attributes. With that approach, FDS name would become irrelevant.

@brianchandotcom @dsanz @javierdearcos @beltranrengifo @matijapetanjek


