### PR TITLE
LPS-146233 Have remote apps upgrade tests run on other databases

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
@@ -2,8 +2,11 @@
 definition {
 
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
+	property environment.acceptance = "true";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
+	property test.assert.warning.exceptions = "true";
 	property testray.component.names = "Remote Apps";
 	property testray.main.component.name = "Upgrades Remote Apps";
 
@@ -21,7 +24,6 @@ definition {
 	@priority = "4"
 	test CanViewRemoteAppCustomElementPortletAfterUpgrade7413 {
 		property data.archive.type = "data-archive-remote-app";
-		property portal.acceptance = "true";
 		property portal.version = "7.4.13";
 		property test.run.environment = "EE";
 
@@ -54,7 +56,6 @@ definition {
 	@priority = "5"
 	test CanViewRemoteAppFieldsAfterUpgrade73101 {
 		property data.archive.type = "data-archive-remote-app";
-		property portal.acceptance = "true";
 		property portal.version = "7.3.10.1";
 		property test.run.environment = "EE";
 

--- a/test.properties
+++ b/test.properties
@@ -3745,12 +3745,14 @@
     test.batch.names[frontend]=\
         functional-tomcat90-mysql57-jdk8,\
         functional-upgrade-tomcat90-db2111-jdk8,\
+        functional-upgrade-tomcat90-mariadb102-jdk8,\
         functional-upgrade-tomcat90-mariadb104-jdk8,\
         functional-upgrade-tomcat90-mysql57-jdk8,\
         functional-upgrade-tomcat90-oracle193-jdk8,\
         functional-upgrade-tomcat90-postgresql134-jdk8,\
         functional-upgrade-tomcat90-sqlserver2017-jdk8,\
-        functional-upgrade-tomcat90-sybase160-jdk8,\
+        functional-upgrade-tomcat90-sqlserver2019-jdk8,\
+        #functional-upgrade-tomcat90-sybase160-jdk8,\
         js-unit-jdk8,\
         modules-unit-jdk8
 

--- a/test.properties
+++ b/test.properties
@@ -3744,6 +3744,13 @@
 
     test.batch.names[frontend]=\
         functional-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-db2111-jdk8,\
+        functional-upgrade-tomcat90-mariadb104-jdk8,\
+        functional-upgrade-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-oracle193-jdk8,\
+        functional-upgrade-tomcat90-postgresql134-jdk8,\
+        functional-upgrade-tomcat90-sqlserver2017-jdk8,\
+        functional-upgrade-tomcat90-sybase160-jdk8,\
         js-unit-jdk8,\
         modules-unit-jdk8
 
@@ -3762,6 +3769,33 @@
             (testray.main.component.name ~ "Upgrades Remote Apps") OR \
             (testray.main.component.name ~ "User Interface")\
         )
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-db2111-jdk8][frontend]=\
+        (database.types ~ db2) AND \
+        (testray.main.component.name == "Upgrades Remote Apps")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-mariadb104-jdk8][frontend]=\
+        (database.types ~ mariadb) AND \
+        (testray.main.component.name == "Upgrades Remote Apps")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][frontend]=\
+        (testray.main.component.name == "Upgrades Remote Apps")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-oracle193-jdk8][frontend]=\
+        (database.types ~ oracle) AND \
+        (testray.main.component.name == "Upgrades Remote Apps")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-postgresql134-jdk8][frontend]=\
+        (database.types ~ postgresql) AND \
+        (testray.main.component.name == "Upgrades Remote Apps")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-sqlserver2017-jdk8][frontend]=\
+        (database.types ~ sqlserver) AND \
+        (testray.main.component.name == "Upgrades Remote Apps")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-sybase160-jdk8][frontend]=\
+        (database.types ~ sybase) AND \
+        (testray.main.component.name == "Upgrades Remote Apps")
 
     #
     # Gauntlet


### PR DESCRIPTION
**Background**
Add ci properties to the RemoteAppsUpgrade.testcase file to make sure they are included in those test runs to better catch database issues with remote apps earlier. ie: [LPS-146200](https://issues.liferay.com/browse/LPS-146200)

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-146233