### PR TITLE
LPS-150221 Update `@clayui/css` package to v3.54.0

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -9,7 +9,7 @@
 		"@clayui/charts": "3.40.0",
 		"@clayui/color-picker": "3.52.0",
 		"@clayui/core": "3.53.0",
-		"@clayui/css": "3.53.0",
+		"@clayui/css": "3.54.0",
 		"@clayui/data-provider": "3.52.0",
 		"@clayui/date-picker": "3.52.0",
 		"@clayui/drop-down": "3.52.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -969,10 +969,10 @@
     react-dnd-html5-backend "^11.1.1"
     react-transition-group "^4.4.1"
 
-"@clayui/css@3.53.0":
-  version "3.53.0"
-  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.53.0.tgz#d5f6e00de068eeec27aed8876dd8dd601709557b"
-  integrity sha512-8+4+SnRBdBiGKC4wueJh8yMjtAg+RzY6LFQk/FXTrJHRFQMl/YzzfOzXYPWMEfTjgI/ZZtE6VdnVnkUwrd8m3w==
+"@clayui/css@3.54.0":
+  version "3.54.0"
+  resolved "https://registry.yarnpkg.com/@clayui/css/-/css-3.54.0.tgz#087d8f00b10b6af4974fd443f4813ab01466b807"
+  integrity sha512-8mht2zHSpDT5HSxRJmkNhHVqyZWmO+8EcKHcVTpyraPVMI95k/ovzIGwApzyT+8qklzJxMtAZkHwo9tvr/Q8qQ==
 
 "@clayui/data-provider@3.52.0":
   version "3.52.0"


### PR DESCRIPTION
This is a very small release, just updating the `@clayui/css` package which also didn't have big changes just adding a new icon the biggest change was in the update of storybook.clayui.com which we updated to the latest version, more organized and with page load performance improvements with a new experimental storybook feature.

## [3.54.0](https://github.com/liferay/clay/compare/v3.53.0...v3.54.0) (2022-04-25)

### Features

-   **@clayui/css:** Add new `diagonal-line` icon ([50f896f](https://github.com/liferay/clay/commit/50f896f10c05a696b6cf53e083d0b017b29dad68))
-   **@clayui/css:** regen `_lx-icons-generated.scss` file ([4444838](https://github.com/liferay/clay/commit/444483860914d22d03e9c6eb01518f3f409fba7e))
