### PR TITLE
LPS-152253 Fix modal title with custom status

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -210,7 +210,7 @@ const Modal = ({
 								}}
 							></div>
 						) : (
-							<ClayModal.Title>{title}</ClayModal.Title>
+							title
 						)}
 					</ClayModal.Header>
 

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.js.snap
@@ -33,12 +33,7 @@ exports[`Modal renders markup based on given configuration 1`] = `
               class="modal-title"
               id="clay-modal-label-1"
             >
-              <div
-                class="modal-title"
-                id="clay-modal-label-1"
-              >
-                My Modal
-              </div>
+              My Modal
             </div>
             <button
               aria-label="close"


### PR DESCRIPTION
### References
- [openModal function doesn't render the modal title correctly when changing the status](https://issues.liferay.com/browse/LPS-123456)

### What is the goal of this PR?
Fixing the title of the modal when using custom status

### What does it look like?
Removing the `<ClayModal.Title>` component since it is not needed. Check this in the clay repo: https://github.com/liferay/clay/blob/fef377e64b473090470a0f2446f184e81a957260/packages/clay-modal/src/Header.tsx#L115-L121

#### Before PR
![Screenshot 2022-04-26 at 16 34 58](https://user-images.githubusercontent.com/11654230/165325787-ff49f726-eeb1-4d19-bdb6-292f8f99aac6.png)

#### After PR
![Screenshot 2022-04-26 at 16 40 14](https://user-images.githubusercontent.com/11654230/165325834-81f650cf-245a-4b1d-99f8-b0ba917074f1.png)

### Steps to reproduce
- Paste the following code into the browser terminal:

```javascript
Liferay.Util.openModal({
			title: 'wrong title',
			status: 'danger',
			bodyHTML: 'body',
        });
```
