### PR TITLE
LPS-147943

### DIFF
--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/management-toolbar/ManagementToolbarResultsBar.js
@@ -86,7 +86,7 @@ export default function ManagementToolbarResultsBar({
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
 								{Liferay.Util.sub(
-									Liferay.Language.get('x-results-for-x'),
+									(totalCount === 1) ? Liferay.Language.get('x-result-for-x') : Liferay.Language.get('x-results-for-x'),
 									totalCount,
 									keywords
 								)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1239,7 +1239,8 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			jspWriter.write(" class=\"text-truncate\">");
 			jspWriter.write(
 				LanguageUtil.format(
-					resourceBundle, "x-results-for",
+					resourceBundle,
+					(getItemsTotal() == 1) ? "x-result-for" : "x-results-for",
 					new Object[] {getItemsTotal()}));
 
 			if (searchValue != null) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -33,7 +33,7 @@ const ResultsBar = ({
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
 							{Liferay.Util.sub(
-								Liferay.Language.get('x-results-for'),
+								(itemsTotal === 1) ? Liferay.Language.get('x-result-for') : Liferay.Language.get('x-results-for'),
 								itemsTotal
 							)}
 

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ResultsMessage.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/ResultsMessage.es.js
@@ -46,7 +46,7 @@ export default function ResultsMessage({
 						<span
 							dangerouslySetInnerHTML={{
 								__html: lang.sub(
-									Liferay.Language.get('x-results-for-x'),
+									(totalCount === 1) ? Liferay.Language.get('x-result-for-x') : Liferay.Language.get('x-results-for-x'),
 									[
 										totalCount,
 										`<strong>"${slugToText(

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/FilterDisplay.es.js
@@ -33,7 +33,7 @@ class FilterDisplay extends Component {
 				<ManagementToolbar.ResultsBarItem expand>
 					<span className="component-text text-truncate-inline">
 						<span className="text-truncate">
-							{sub(Liferay.Language.get('x-results-for-x'), [
+							{sub((totalResultsCount === 1) ? Liferay.Language.get('x-result-for-x') : Liferay.Language.get('x-results-for-x'), [
 								totalResultsCount,
 								searchBarTerm,
 							])}

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/clause_contributors_sidebar/ManagementToolbar.js
@@ -239,7 +239,7 @@ function ManagementToolbar({
 					<FrontendManagementToolbar.ResultsBarItem>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
-								{sub(Liferay.Language.get('x-results-for-x'), [
+								{sub((allItems.length === 1) ? Liferay.Language.get('x-result-for-x') : Liferay.Language.get('x-results-for-x'), [
 									allItems.length,
 									keyword,
 								])}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147943

/cc @hongvo2308 @sontruongces

### Steps to reproduce

1. Go to Control Panel - Configuration - Language Override
1. Add a new language key
1. Search it or filter by Any Language

![](https://issues.liferay.com/secure/attachment/442534/reproduce-LPS-147943.png)

### Solution overview

Identified uses of "x-results-for" and replaced it, as needed, with a ternary statement that's still compatible with the pattern used by [Language.process](https://github.com/liferay/liferay-portal/blob/7.4.1-ga2/portal-impl/src/com/liferay/portal/language/LanguageImpl.java#L2028-L2031), used by LanguageFilter.
