### PR TITLE
LPS-145457 Include parameter to disable batch endpoints for certain entities

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
@@ -73,6 +74,12 @@ public class ResourceOpenAPIParser {
 		if (pathItems == null) {
 			return Collections.emptyList();
 		}
+
+		List<String> disabledBatchEntities = Optional.ofNullable(
+			configYAML.getDisabledBatchEntities()
+		).orElseGet(
+			ArrayList::new
+		);
 
 		Map<String, String> javaDataTypeMap =
 			OpenAPIParserUtil.getJavaDataTypeMap(configYAML, openAPIYAML);
@@ -117,7 +124,9 @@ public class ResourceOpenAPIParser {
 
 							javaMethodSignatures.add(javaMethodSignature);
 
-							if (configYAML.isGenerateBatch()) {
+							if (configYAML.isGenerateBatch() &&
+								!disabledBatchEntities.contains(schemaName)) {
+
 								_addBatchJavaMethodSignature(
 									javaMethodSignature, javaMethodSignatures);
 							}

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/config/ConfigYAML.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.tools.rest.builder.internal.yaml.config;
 
+import java.util.List;
+
 /**
  * @author Peter Shin
  */
@@ -41,6 +43,10 @@ public class ConfigYAML {
 
 	public String getClientMavenGroupId() {
 		return _clientMavenGroupId;
+	}
+
+	public List<String> getDisabledBatchEntities() {
+		return _disabledBatchEntities;
 	}
 
 	public String getGraphQLNamespace() {
@@ -131,6 +137,10 @@ public class ConfigYAML {
 		_clientMavenGroupId = clientMavenGroupId;
 	}
 
+	public void setDisabledBatchEntities(List<String> disabledBatchEntities) {
+		_disabledBatchEntities = disabledBatchEntities;
+	}
+
 	public void setForceClientVersionDescription(
 		boolean forceClientVersionDescription) {
 
@@ -211,6 +221,7 @@ public class ConfigYAML {
 	private String _author;
 	private String _clientDir;
 	private String _clientMavenGroupId;
+	private List<String> _disabledBatchEntities;
 	private boolean _forceClientVersionDescription = true;
 	private boolean _forcePredictableContentApplicationXML = true;
 	private boolean _forcePredictableOperationId;

--- a/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
+++ b/modules/util/portal-tools-rest-builder/src/test/java/com/liferay/portal/tools/rest/builder/RESTBuilderTest.java
@@ -14,20 +14,15 @@
 
 package com.liferay.portal.tools.rest.builder;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.util.StringUtil;
-
 import java.io.File;
 
 import java.net.URL;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 
@@ -41,7 +36,7 @@ public class RESTBuilderTest {
 
 	@Test
 	public void testCreateRESTBuilder() throws Exception {
-		String dependenciesPath = _getDependenciesPath();
+		String dependenciesPath = _getResourcesPath() + "dependencies/";
 
 		RESTBuilder restBuilder = new RESTBuilder(
 			new File(dependenciesPath, "copyright.txt"),
@@ -51,155 +46,49 @@ public class RESTBuilderTest {
 
 		String filesPath = _getFilesPath();
 
-		File applicationFile = new File(
-			filesPath + "/sample-impl/src/main/java/com/example/sample" +
-				"/internal/jaxrs/application/SampleApplication.java");
+		File outputDirectory = new File(_getResourcesPath() + "output/");
 
-		Assert.assertTrue(applicationFile.exists());
+		for (File outputSubdirectory : outputDirectory.listFiles()) {
+			String actualPath = filesPath + "/" + outputSubdirectory.getName();
 
-		_assertResourceFilesExist(filesPath, "Document");
-		_assertResourceFilesExist(filesPath, "Folder");
-		_assertResourceFilesExist(filesPath, "Test");
+			try {
+				_assertEquals(new File(actualPath), outputSubdirectory);
+			}
+			finally {
+				_cleanUp(actualPath);
+			}
+		}
+	}
 
-		_assertDTOFile(filesPath, "UnreferencedSchemaComponent");
+	private void _assertEquals(File actualDirectory, File expectedDirectory)
+		throws Exception {
 
-		_assertPropertiesWithHyphens(
-			filesPath, "Test", "property-with-hyphens");
-		_assertPropertiesWithXML(filesPath, "Test", "xmlProperty");
+		List<File> actualFiles = new ArrayList<>(
+			FileUtils.listFiles(actualDirectory, null, true));
 
-		_assertForcePredictableOperationId(filesPath);
+		List<File> expectedFiles = new ArrayList<>(
+			FileUtils.listFiles(expectedDirectory, null, true));
 
-		File sampleApiDir = new File(filesPath + "/sample-api");
+		Assert.assertEquals(
+			actualFiles.toString(), expectedFiles.size(), actualFiles.size());
 
-		FileUtils.deleteDirectory(sampleApiDir);
+		for (int i = 0; i < expectedFiles.size(); i++) {
+			File actualFile = actualFiles.get(i);
+			File expectedFile = expectedFiles.get(i);
 
-		Assert.assertFalse(sampleApiDir.exists());
+			Assert.assertTrue(
+				expectedFile.toString() + " is not equal to " +
+					actualFile.toString(),
+				FileUtils.contentEquals(expectedFile, actualFile));
+		}
+	}
 
-		File sampleImplDir = new File(filesPath + "/sample-impl");
+	private void _cleanUp(String path) throws Exception {
+		File sampleImplDir = new File(path);
 
 		FileUtils.deleteDirectory(sampleImplDir);
 
 		Assert.assertFalse(sampleImplDir.exists());
-	}
-
-	private void _assertDTOFile(String filesPath, String resourceName) {
-		File dtoFolderFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-api/src/main/java/com/example/sample/dto/v1_0_0/",
-				resourceName, ".java"));
-
-		Assert.assertTrue(dtoFolderFile.exists());
-	}
-
-	private void _assertForcePredictableOperationId(String filesPath)
-		throws Exception {
-
-		File queryJavaFile = new File(
-			filesPath.concat(
-				"/sample-impl/src/main/java/com/example/sample/internal" +
-					"/graphql/query/v1_0_0/Query.java"));
-
-		String text = new String(
-			Files.readAllBytes(queryJavaFile.toPath()), StandardCharsets.UTF_8);
-
-		Assert.assertFalse(text.contains("ForcePredictableOperationIdTest"));
-	}
-
-	private void _assertPropertiesWithHyphens(
-			String filesPath, String resourceName, String propertyName)
-		throws Exception {
-
-		File dtoResourceFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-api/src/main/java/com/example/sample/dto/v1_0_0/",
-				resourceName, ".java"));
-
-		List<String> lines = Files.readAllLines(dtoResourceFile.toPath());
-
-		Stream<String> stream = lines.stream();
-
-		Assert.assertTrue(
-			stream.anyMatch(
-				line -> line.contains(
-					"access = JsonProperty.Access.READ_WRITE, value = \"" +
-						propertyName + "\"")));
-
-		stream = lines.stream();
-
-		Assert.assertTrue(
-			stream.anyMatch(
-				line -> line.contains(
-					"sb.append(\"\\\"" + propertyName + "\\\": \");")));
-	}
-
-	private void _assertPropertiesWithXML(
-			String filesPath, String resourceName, String xmlPropertyName)
-		throws Exception {
-
-		File dtoResourceFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-api/src/main/java/com/example/sample/dto/v1_0_0/",
-				resourceName, ".java"));
-
-		List<String> lines = Files.readAllLines(dtoResourceFile.toPath());
-
-		Stream<String> stream = lines.stream();
-
-		Assert.assertTrue(
-			stream.anyMatch(
-				line -> line.contains(
-					"@XmlElement(name = \"" + xmlPropertyName + "\")")));
-	}
-
-	private void _assertResourceFilesExist(
-		String filesPath, String resourceName) {
-
-		File baseResourceImplFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-impl/src/main/java/com/example/sample/internal" +
-					"/resource/v1_0_0/Base",
-				resourceName, "ResourceImpl.java"));
-
-		Assert.assertTrue(baseResourceImplFile.exists());
-
-		File folderResourceImplFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-impl/src/main/java/com/example/sample/internal" +
-					"/resource/v1_0_0/",
-				resourceName, "ResourceImpl.java"));
-
-		Assert.assertTrue(folderResourceImplFile.exists());
-
-		File propertiesFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/",
-				StringUtil.toLowerCase(resourceName), ".properties"));
-
-		Assert.assertTrue(propertiesFile.exists());
-
-		File resourceFolderFile = new File(
-			_getResourcePath(
-				filesPath,
-				"/sample-api/src/main/java/com/example/sample/resource/v1_0_0/",
-				resourceName, "Resource.java"));
-
-		Assert.assertTrue(resourceFolderFile.exists());
-
-		_assertDTOFile(filesPath, resourceName);
-	}
-
-	private String _getDependenciesPath() {
-		URL resource = getClass().getResource("");
-
-		String path = resource.getPath();
-
-		return path + "dependencies/";
 	}
 
 	private String _getFilesPath() {
@@ -212,12 +101,10 @@ public class RESTBuilderTest {
 		return parentPath.toString();
 	}
 
-	private String _getResourcePath(
-		String filesPath, String resourcePathPrefix, String resourceName,
-		String resourcePathSuffix) {
+	private String _getResourcesPath() {
+		URL resource = getClass().getResource("");
 
-		return StringBundler.concat(
-			filesPath, resourcePathPrefix, resourceName, resourcePathSuffix);
+		return resource.getPath();
 	}
 
 }

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-config.yaml
@@ -6,5 +6,6 @@ application:
     className: "SampleApplication"
     name: "sample-application"
 author: "John Doe"
+disabledBatchEntities: ["Document"]
 forcePredictableOperationId: true
 implDir: "../sample-impl/src/main/java"

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/dependencies/rest-openapi.yaml
@@ -78,6 +78,26 @@ info:
     version: "1.0.0"
 openapi: "3.0.1"
 paths:
+    /document:
+        post:
+            operationId: postDocument
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Document"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Document"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Document"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Document"
     /document/{documentId}:
         get:
             operationId: getDocumentForcePredictableOperationIdTest
@@ -111,6 +131,25 @@ paths:
                                 type: array
                     description:
                         "OK"
+        post:
+            operationId: postFolder
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Folder"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Folder"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Folder"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Folder"
     /folder/count:
         get:
             description:

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/Document.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/Document.java
@@ -1,0 +1,432 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.dto.v1_0_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "https://www.schema.org/Document", value = "Document"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Document")
+public class Document implements Serializable {
+
+	public static Document toDTO(String json) {
+		return ObjectMapperUtil.readValue(Document.class, json);
+	}
+
+	public static Document unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Document.class, json);
+	}
+
+	@Schema
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateCreated;
+
+	@Schema
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateModified;
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	public Long getDocumentId() {
+		return documentId;
+	}
+
+	public void setDocumentId(Long documentId) {
+		this.documentId = documentId;
+	}
+
+	@JsonIgnore
+	public void setDocumentId(
+		UnsafeSupplier<Long, Exception> documentIdUnsafeSupplier) {
+
+		try {
+			documentId = documentIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long documentId;
+
+	@Schema
+	public Long getFolderId() {
+		return folderId;
+	}
+
+	public void setFolderId(Long folderId) {
+		this.folderId = folderId;
+	}
+
+	@JsonIgnore
+	public void setFolderId(
+		UnsafeSupplier<Long, Exception> folderIdUnsafeSupplier) {
+
+		try {
+			folderId = folderIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long folderId;
+
+	@Schema
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Document)) {
+			return false;
+		}
+
+		Document document = (Document)object;
+
+		return Objects.equals(toString(), document.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (documentId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"documentId\": ");
+
+			sb.append(documentId);
+		}
+
+		if (folderId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"folderId\": ");
+
+			sb.append(folderId);
+		}
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.example.sample.dto.v1_0_0.Document",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/Folder.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/Folder.java
@@ -1,0 +1,565 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.dto.v1_0_0;
+
+import com.example.external.sample.dto.v1_0_0.ExternalReferenceElement1;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@GraphQLName(description = "https://www.schema.org/Folder", value = "Folder")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Folder")
+public class Folder implements Serializable {
+
+	public static Folder toDTO(String json) {
+		return ObjectMapperUtil.readValue(Folder.class, json);
+	}
+
+	public static Folder unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Folder.class, json);
+	}
+
+	@Schema
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateCreated;
+
+	@Schema
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateModified;
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	@Valid
+	public Folder getDocumentsRepository() {
+		return documentsRepository;
+	}
+
+	public void setDocumentsRepository(Folder documentsRepository) {
+		this.documentsRepository = documentsRepository;
+	}
+
+	@JsonIgnore
+	public void setDocumentsRepository(
+		UnsafeSupplier<Folder, Exception> documentsRepositoryUnsafeSupplier) {
+
+		try {
+			documentsRepository = documentsRepositoryUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Folder documentsRepository;
+
+	@Schema
+	@Valid
+	public ExternalReferenceElement1[] getExternalReferenceElement1s() {
+		return externalReferenceElement1s;
+	}
+
+	public void setExternalReferenceElement1s(
+		ExternalReferenceElement1[] externalReferenceElement1s) {
+
+		this.externalReferenceElement1s = externalReferenceElement1s;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceElement1s(
+		UnsafeSupplier<ExternalReferenceElement1[], Exception>
+			externalReferenceElement1sUnsafeSupplier) {
+
+		try {
+			externalReferenceElement1s =
+				externalReferenceElement1sUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected ExternalReferenceElement1[] externalReferenceElement1s;
+
+	@Schema
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
+
+	@Schema
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@Schema
+	public String getSelf() {
+		return self;
+	}
+
+	public void setSelf(String self) {
+		this.self = self;
+	}
+
+	@JsonIgnore
+	public void setSelf(UnsafeSupplier<String, Exception> selfUnsafeSupplier) {
+		try {
+			self = selfUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String self;
+
+	@Schema
+	@Valid
+	public Folder getSubFolders() {
+		return subFolders;
+	}
+
+	public void setSubFolders(Folder subFolders) {
+		this.subFolders = subFolders;
+	}
+
+	@JsonIgnore
+	public void setSubFolders(
+		UnsafeSupplier<Folder, Exception> subFoldersUnsafeSupplier) {
+
+		try {
+			subFolders = subFoldersUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Folder subFolders;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Folder)) {
+			return false;
+		}
+
+		Folder folder = (Folder)object;
+
+		return Objects.equals(toString(), folder.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (documentsRepository != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"documentsRepository\": ");
+
+			sb.append(String.valueOf(documentsRepository));
+		}
+
+		if (externalReferenceElement1s != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceElement1s\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < externalReferenceElement1s.length; i++) {
+				sb.append(externalReferenceElement1s[i]);
+
+				if ((i + 1) < externalReferenceElement1s.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		if (self != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"self\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(self));
+
+			sb.append("\"");
+		}
+
+		if (subFolders != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"subFolders\": ");
+
+			sb.append(String.valueOf(subFolders));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.example.sample.dto.v1_0_0.Folder",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/Test.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/Test.java
@@ -1,0 +1,308 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.dto.v1_0_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Test Component to test the REST Builder support for advanced features",
+	value = "Test"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Test")
+public class Test implements Serializable {
+
+	public static Test toDTO(String json) {
+		return ObjectMapperUtil.readValue(Test.class, json);
+	}
+
+	public static Test unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Test.class, json);
+	}
+
+	@Schema
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
+
+	@Schema
+	public String getJsonProperty() {
+		return jsonProperty;
+	}
+
+	public void setJsonProperty(String jsonProperty) {
+		this.jsonProperty = jsonProperty;
+	}
+
+	@JsonIgnore
+	public void setJsonProperty(
+		UnsafeSupplier<String, Exception> jsonPropertyUnsafeSupplier) {
+
+		try {
+			jsonProperty = jsonPropertyUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	@XmlElement(name = "xmlProperty")
+	protected String jsonProperty;
+
+	@Schema
+	public String getPropertyWithHyphens() {
+		return propertyWithHyphens;
+	}
+
+	public void setPropertyWithHyphens(String propertyWithHyphens) {
+		this.propertyWithHyphens = propertyWithHyphens;
+	}
+
+	@JsonIgnore
+	public void setPropertyWithHyphens(
+		UnsafeSupplier<String, Exception> propertyWithHyphensUnsafeSupplier) {
+
+		try {
+			propertyWithHyphens = propertyWithHyphensUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(
+		access = JsonProperty.Access.READ_WRITE, value = "property-with-hyphens"
+	)
+	protected String propertyWithHyphens;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Test)) {
+			return false;
+		}
+
+		Test test = (Test)object;
+
+		return Objects.equals(toString(), test.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		if (jsonProperty != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"jsonProperty\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(jsonProperty));
+
+			sb.append("\"");
+		}
+
+		if (propertyWithHyphens != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"property-with-hyphens\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(propertyWithHyphens));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.example.sample.dto.v1_0_0.Test",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/UnreferencedSchemaComponent.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/dto/v1_0_0/UnreferencedSchemaComponent.java
@@ -1,0 +1,320 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.dto.v1_0_0;
+
+import com.example.external.sample.dto.v1_0_0.ExternalReferenceElement2;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.validation.Valid;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@GraphQLName("UnreferencedSchemaComponent")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "UnreferencedSchemaComponent")
+public class UnreferencedSchemaComponent implements Serializable {
+
+	public static UnreferencedSchemaComponent toDTO(String json) {
+		return ObjectMapperUtil.readValue(
+			UnreferencedSchemaComponent.class, json);
+	}
+
+	public static UnreferencedSchemaComponent unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			UnreferencedSchemaComponent.class, json);
+	}
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	@Valid
+	public ExternalReferenceElement2[] getExternalReferenceElement2s() {
+		return externalReferenceElement2s;
+	}
+
+	public void setExternalReferenceElement2s(
+		ExternalReferenceElement2[] externalReferenceElement2s) {
+
+		this.externalReferenceElement2s = externalReferenceElement2s;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceElement2s(
+		UnsafeSupplier<ExternalReferenceElement2[], Exception>
+			externalReferenceElement2sUnsafeSupplier) {
+
+		try {
+			externalReferenceElement2s =
+				externalReferenceElement2sUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected ExternalReferenceElement2[] externalReferenceElement2s;
+
+	@Schema
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long id;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof UnreferencedSchemaComponent)) {
+			return false;
+		}
+
+		UnreferencedSchemaComponent unreferencedSchemaComponent =
+			(UnreferencedSchemaComponent)object;
+
+		return Objects.equals(
+			toString(), unreferencedSchemaComponent.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (externalReferenceElement2s != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceElement2s\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < externalReferenceElement2s.length; i++) {
+				sb.append(externalReferenceElement2s[i]);
+
+				if ((i + 1) < externalReferenceElement2s.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.example.sample.dto.v1_0_0.UnreferencedSchemaComponent",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/DocumentResource.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/DocumentResource.java
@@ -36,7 +36,6 @@ import javax.annotation.Generated;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import org.osgi.annotation.versioning.ProviderType;
@@ -58,9 +57,6 @@ public interface DocumentResource {
 	}
 
 	public Document postDocument(Document document) throws Exception;
-
-	public Response postDocumentBatch(String callbackURL, Object object)
-		throws Exception;
 
 	public Document getDocument(Long documentId) throws Exception;
 

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/DocumentResource.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/DocumentResource.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.resource.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Document;
+
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/sample/1.0.0
+ *
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface DocumentResource {
+
+	public static Builder builder() {
+		return FactoryHolder.factory.create();
+	}
+
+	public Document postDocument(Document document) throws Exception;
+
+	public Response postDocumentBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public Document getDocument(Long documentId) throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default Filter toFilter(String filterString) {
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public static class FactoryHolder {
+
+		public static volatile Factory factory;
+
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public DocumentResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/FolderResource.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/FolderResource.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.resource.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Folder;
+
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/sample/1.0.0
+ *
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface FolderResource {
+
+	public static Builder builder() {
+		return FactoryHolder.factory.create();
+	}
+
+	public Page<Folder> getFolderPage() throws Exception;
+
+	public Folder postFolder(Folder folder) throws Exception;
+
+	public Response postFolderBatch(String callbackURL, Object object)
+		throws Exception;
+
+	public Folder getFolder(Long folderId) throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default Filter toFilter(String filterString) {
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public static class FactoryHolder {
+
+		public static volatile Factory factory;
+
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public FolderResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/TestResource.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-api/src/main/java/com/example/sample/resource/v1_0_0/TestResource.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.resource.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Test;
+
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/sample/1.0.0
+ *
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface TestResource {
+
+	public static Builder builder() {
+		return FactoryHolder.factory.create();
+	}
+
+	public Test getTest(Long testId) throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default Filter toFilter(String filterString) {
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public static class FactoryHolder {
+
+		public static volatile Factory factory;
+
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public TestResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/mutation/v1_0_0/Mutation.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/mutation/v1_0_0/Mutation.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.graphql.mutation.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Document;
+import com.example.sample.dto.v1_0_0.Folder;
+import com.example.sample.resource.v1_0_0.DocumentResource;
+import com.example.sample.resource.v1_0_0.FolderResource;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+
+import java.util.function.BiFunction;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+public class Mutation {
+
+	public static void setDocumentResourceComponentServiceObjects(
+		ComponentServiceObjects<DocumentResource>
+			documentResourceComponentServiceObjects) {
+
+		_documentResourceComponentServiceObjects =
+			documentResourceComponentServiceObjects;
+	}
+
+	public static void setFolderResourceComponentServiceObjects(
+		ComponentServiceObjects<FolderResource>
+			folderResourceComponentServiceObjects) {
+
+		_folderResourceComponentServiceObjects =
+			folderResourceComponentServiceObjects;
+	}
+
+	@GraphQLField
+	public Document createDocument(@GraphQLName("document") Document document)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentResource -> documentResource.postDocument(document));
+	}
+
+	@GraphQLField
+	public Response createDocumentBatch(
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentResource -> documentResource.postDocumentBatch(
+				callbackURL, object));
+	}
+
+	@GraphQLField
+	public Folder createFolder(@GraphQLName("folder") Folder folder)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_folderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			folderResource -> folderResource.postFolder(folder));
+	}
+
+	@GraphQLField
+	public Response createFolderBatch(
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_folderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			folderResource -> folderResource.postFolderBatch(
+				callbackURL, object));
+	}
+
+	private <T, R, E1 extends Throwable, E2 extends Throwable> R
+			_applyComponentServiceObjects(
+				ComponentServiceObjects<T> componentServiceObjects,
+				UnsafeConsumer<T, E1> unsafeConsumer,
+				UnsafeFunction<T, R, E2> unsafeFunction)
+		throws E1, E2 {
+
+		T resource = componentServiceObjects.getService();
+
+		try {
+			unsafeConsumer.accept(resource);
+
+			return unsafeFunction.apply(resource);
+		}
+		finally {
+			componentServiceObjects.ungetService(resource);
+		}
+	}
+
+	private <T, E1 extends Throwable, E2 extends Throwable> void
+			_applyVoidComponentServiceObjects(
+				ComponentServiceObjects<T> componentServiceObjects,
+				UnsafeConsumer<T, E1> unsafeConsumer,
+				UnsafeConsumer<T, E2> unsafeFunction)
+		throws E1, E2 {
+
+		T resource = componentServiceObjects.getService();
+
+		try {
+			unsafeConsumer.accept(resource);
+
+			unsafeFunction.accept(resource);
+		}
+		finally {
+			componentServiceObjects.ungetService(resource);
+		}
+	}
+
+	private void _populateResourceContext(DocumentResource documentResource)
+		throws Exception {
+
+		documentResource.setContextAcceptLanguage(_acceptLanguage);
+		documentResource.setContextCompany(_company);
+		documentResource.setContextHttpServletRequest(_httpServletRequest);
+		documentResource.setContextHttpServletResponse(_httpServletResponse);
+		documentResource.setContextUriInfo(_uriInfo);
+		documentResource.setContextUser(_user);
+		documentResource.setGroupLocalService(_groupLocalService);
+		documentResource.setRoleLocalService(_roleLocalService);
+
+		documentResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
+	}
+
+	private void _populateResourceContext(FolderResource folderResource)
+		throws Exception {
+
+		folderResource.setContextAcceptLanguage(_acceptLanguage);
+		folderResource.setContextCompany(_company);
+		folderResource.setContextHttpServletRequest(_httpServletRequest);
+		folderResource.setContextHttpServletResponse(_httpServletResponse);
+		folderResource.setContextUriInfo(_uriInfo);
+		folderResource.setContextUser(_user);
+		folderResource.setGroupLocalService(_groupLocalService);
+		folderResource.setRoleLocalService(_roleLocalService);
+
+		folderResource.setVulcanBatchEngineImportTaskResource(
+			_vulcanBatchEngineImportTaskResource);
+	}
+
+	private static ComponentServiceObjects<DocumentResource>
+		_documentResourceComponentServiceObjects;
+	private static ComponentServiceObjects<FolderResource>
+		_folderResourceComponentServiceObjects;
+
+	private AcceptLanguage _acceptLanguage;
+	private com.liferay.portal.kernel.model.Company _company;
+	private GroupLocalService _groupLocalService;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
+	private RoleLocalService _roleLocalService;
+	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
+	private UriInfo _uriInfo;
+	private com.liferay.portal.kernel.model.User _user;
+	private VulcanBatchEngineImportTaskResource
+		_vulcanBatchEngineImportTaskResource;
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/mutation/v1_0_0/Mutation.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/mutation/v1_0_0/Mutation.java
@@ -75,19 +75,6 @@ public class Mutation {
 	}
 
 	@GraphQLField
-	public Response createDocumentBatch(
-			@GraphQLName("callbackURL") String callbackURL,
-			@GraphQLName("object") Object object)
-		throws Exception {
-
-		return _applyComponentServiceObjects(
-			_documentResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			documentResource -> documentResource.postDocumentBatch(
-				callbackURL, object));
-	}
-
-	@GraphQLField
 	public Folder createFolder(@GraphQLName("folder") Folder folder)
 		throws Exception {
 

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/query/v1_0_0/Query.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/query/v1_0_0/Query.java
@@ -1,0 +1,330 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.graphql.query.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Document;
+import com.example.sample.dto.v1_0_0.Folder;
+import com.example.sample.dto.v1_0_0.Test;
+import com.example.sample.resource.v1_0_0.DocumentResource;
+import com.example.sample.resource.v1_0_0.FolderResource;
+import com.example.sample.resource.v1_0_0.TestResource;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLTypeExtension;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.ComponentServiceObjects;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+public class Query {
+
+	public static void setDocumentResourceComponentServiceObjects(
+		ComponentServiceObjects<DocumentResource>
+			documentResourceComponentServiceObjects) {
+
+		_documentResourceComponentServiceObjects =
+			documentResourceComponentServiceObjects;
+	}
+
+	public static void setFolderResourceComponentServiceObjects(
+		ComponentServiceObjects<FolderResource>
+			folderResourceComponentServiceObjects) {
+
+		_folderResourceComponentServiceObjects =
+			folderResourceComponentServiceObjects;
+	}
+
+	public static void setTestResourceComponentServiceObjects(
+		ComponentServiceObjects<TestResource>
+			testResourceComponentServiceObjects) {
+
+		_testResourceComponentServiceObjects =
+			testResourceComponentServiceObjects;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {document(documentId: ___){dateCreated, dateModified, description, documentId, folderId, name}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public Document document(@GraphQLName("documentId") Long documentId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_documentResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			documentResource -> documentResource.getDocument(documentId));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {folder{items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public FolderPage folder() throws Exception {
+		return _applyComponentServiceObjects(
+			_folderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			folderResource -> new FolderPage(folderResource.getFolderPage()));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {folder(folderId: ___){dateCreated, dateModified, description, documentsRepository, externalReferenceElement1s, id, name, self, subFolders}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public Folder folder(@GraphQLName("folderId") Long folderId)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_folderResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			folderResource -> folderResource.getFolder(folderId));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {test(testId: ___){id, jsonProperty, property-with-hyphens}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField
+	public Test test(@GraphQLName("testId") Long testId) throws Exception {
+		return _applyComponentServiceObjects(
+			_testResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			testResource -> testResource.getTest(testId));
+	}
+
+	@GraphQLTypeExtension(Document.class)
+	public class GetFolderTypeExtension {
+
+		public GetFolderTypeExtension(Document document) {
+			_document = document;
+		}
+
+		@GraphQLField
+		public Folder folder() throws Exception {
+			return _applyComponentServiceObjects(
+				_folderResourceComponentServiceObjects,
+				Query.this::_populateResourceContext,
+				folderResource -> folderResource.getFolder(
+					_document.getFolderId()));
+		}
+
+		private Document _document;
+
+	}
+
+	@GraphQLName("DocumentPage")
+	public class DocumentPage {
+
+		public DocumentPage(Page documentPage) {
+			actions = documentPage.getActions();
+
+			items = documentPage.getItems();
+			lastPage = documentPage.getLastPage();
+			page = documentPage.getPage();
+			pageSize = documentPage.getPageSize();
+			totalCount = documentPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map> actions;
+
+		@GraphQLField
+		protected java.util.Collection<Document> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("FolderPage")
+	public class FolderPage {
+
+		public FolderPage(Page folderPage) {
+			actions = folderPage.getActions();
+
+			items = folderPage.getItems();
+			lastPage = folderPage.getLastPage();
+			page = folderPage.getPage();
+			pageSize = folderPage.getPageSize();
+			totalCount = folderPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map> actions;
+
+		@GraphQLField
+		protected java.util.Collection<Folder> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	@GraphQLName("TestPage")
+	public class TestPage {
+
+		public TestPage(Page testPage) {
+			actions = testPage.getActions();
+
+			items = testPage.getItems();
+			lastPage = testPage.getLastPage();
+			page = testPage.getPage();
+			pageSize = testPage.getPageSize();
+			totalCount = testPage.getTotalCount();
+		}
+
+		@GraphQLField
+		protected Map<String, Map> actions;
+
+		@GraphQLField
+		protected java.util.Collection<Test> items;
+
+		@GraphQLField
+		protected long lastPage;
+
+		@GraphQLField
+		protected long page;
+
+		@GraphQLField
+		protected long pageSize;
+
+		@GraphQLField
+		protected long totalCount;
+
+	}
+
+	private <T, R, E1 extends Throwable, E2 extends Throwable> R
+			_applyComponentServiceObjects(
+				ComponentServiceObjects<T> componentServiceObjects,
+				UnsafeConsumer<T, E1> unsafeConsumer,
+				UnsafeFunction<T, R, E2> unsafeFunction)
+		throws E1, E2 {
+
+		T resource = componentServiceObjects.getService();
+
+		try {
+			unsafeConsumer.accept(resource);
+
+			return unsafeFunction.apply(resource);
+		}
+		finally {
+			componentServiceObjects.ungetService(resource);
+		}
+	}
+
+	private void _populateResourceContext(DocumentResource documentResource)
+		throws Exception {
+
+		documentResource.setContextAcceptLanguage(_acceptLanguage);
+		documentResource.setContextCompany(_company);
+		documentResource.setContextHttpServletRequest(_httpServletRequest);
+		documentResource.setContextHttpServletResponse(_httpServletResponse);
+		documentResource.setContextUriInfo(_uriInfo);
+		documentResource.setContextUser(_user);
+		documentResource.setGroupLocalService(_groupLocalService);
+		documentResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private void _populateResourceContext(FolderResource folderResource)
+		throws Exception {
+
+		folderResource.setContextAcceptLanguage(_acceptLanguage);
+		folderResource.setContextCompany(_company);
+		folderResource.setContextHttpServletRequest(_httpServletRequest);
+		folderResource.setContextHttpServletResponse(_httpServletResponse);
+		folderResource.setContextUriInfo(_uriInfo);
+		folderResource.setContextUser(_user);
+		folderResource.setGroupLocalService(_groupLocalService);
+		folderResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private void _populateResourceContext(TestResource testResource)
+		throws Exception {
+
+		testResource.setContextAcceptLanguage(_acceptLanguage);
+		testResource.setContextCompany(_company);
+		testResource.setContextHttpServletRequest(_httpServletRequest);
+		testResource.setContextHttpServletResponse(_httpServletResponse);
+		testResource.setContextUriInfo(_uriInfo);
+		testResource.setContextUser(_user);
+		testResource.setGroupLocalService(_groupLocalService);
+		testResource.setRoleLocalService(_roleLocalService);
+	}
+
+	private static ComponentServiceObjects<DocumentResource>
+		_documentResourceComponentServiceObjects;
+	private static ComponentServiceObjects<FolderResource>
+		_folderResourceComponentServiceObjects;
+	private static ComponentServiceObjects<TestResource>
+		_testResourceComponentServiceObjects;
+
+	private AcceptLanguage _acceptLanguage;
+	private com.liferay.portal.kernel.model.Company _company;
+	private BiFunction<Object, String, Filter> _filterBiFunction;
+	private GroupLocalService _groupLocalService;
+	private HttpServletRequest _httpServletRequest;
+	private HttpServletResponse _httpServletResponse;
+	private RoleLocalService _roleLocalService;
+	private BiFunction<Object, String, Sort[]> _sortsBiFunction;
+	private UriInfo _uriInfo;
+	private com.liferay.portal.kernel.model.User _user;
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/servlet/v1_0_0/ServletDataImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/graphql/servlet/v1_0_0/ServletDataImpl.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.graphql.servlet.v1_0_0;
+
+import com.example.sample.internal.graphql.mutation.v1_0_0.Mutation;
+import com.example.sample.internal.graphql.query.v1_0_0.Query;
+import com.example.sample.resource.v1_0_0.DocumentResource;
+import com.example.sample.resource.v1_0_0.FolderResource;
+import com.example.sample.resource.v1_0_0.TestResource;
+
+import com.liferay.portal.vulcan.graphql.servlet.ServletData;
+
+import javax.annotation.Generated;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Component(immediate = true, service = ServletData.class)
+@Generated("")
+public class ServletDataImpl implements ServletData {
+
+	@Activate
+	public void activate(BundleContext bundleContext) {
+		Mutation.setDocumentResourceComponentServiceObjects(
+			_documentResourceComponentServiceObjects);
+		Mutation.setFolderResourceComponentServiceObjects(
+			_folderResourceComponentServiceObjects);
+
+		Query.setDocumentResourceComponentServiceObjects(
+			_documentResourceComponentServiceObjects);
+		Query.setFolderResourceComponentServiceObjects(
+			_folderResourceComponentServiceObjects);
+		Query.setTestResourceComponentServiceObjects(
+			_testResourceComponentServiceObjects);
+	}
+
+	@Override
+	public Mutation getMutation() {
+		return new Mutation();
+	}
+
+	@Override
+	public String getPath() {
+		return "/sample-graphql/v1_0_0";
+	}
+
+	@Override
+	public Query getQuery() {
+		return new Query();
+	}
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<DocumentResource>
+		_documentResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<FolderResource>
+		_folderResourceComponentServiceObjects;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<TestResource>
+		_testResourceComponentServiceObjects;
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/jaxrs/application/SampleApplication.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/jaxrs/application/SampleApplication.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.jaxrs.application;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.core.Application;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Component(
+	property = {
+		"liferay.jackson=false", "osgi.jaxrs.application.base=/sample",
+		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
+		"osgi.jaxrs.name=sample-application"
+	},
+	service = Application.class
+)
+@Generated("")
+public class SampleApplication extends Application {
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseDocumentResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseDocumentResourceImpl.java
@@ -56,7 +56,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 /**
@@ -82,48 +81,6 @@ public abstract class BaseDocumentResourceImpl
 	@Override
 	public Document postDocument(Document document) throws Exception {
 		return new Document();
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/sample/1.0.0/document/batch'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "callbackURL"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
-	@javax.ws.rs.Consumes("application/json")
-	@javax.ws.rs.Path("/document/batch")
-	@javax.ws.rs.POST
-	@javax.ws.rs.Produces("application/json")
-	@Override
-	public Response postDocumentBatch(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@javax.ws.rs.QueryParam("callbackURL")
-			String callbackURL,
-			Object object)
-		throws Exception {
-
-		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
-			contextAcceptLanguage);
-		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
-		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
-			contextHttpServletRequest);
-		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
-		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
-
-		Response.ResponseBuilder responseBuilder = Response.accepted();
-
-		return responseBuilder.entity(
-			vulcanBatchEngineImportTaskResource.postImportTask(
-				Document.class.getName(), callbackURL, null, object)
-		).build();
 	}
 
 	/**

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseDocumentResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseDocumentResourceImpl.java
@@ -1,0 +1,432 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Document;
+import com.example.sample.resource.v1_0_0.DocumentResource;
+
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.TransformUtil;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/1.0.0")
+public abstract class BaseDocumentResourceImpl
+	implements DocumentResource, EntityModelResource,
+			   VulcanBatchEngineTaskItemDelegate<Document> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/sample/1.0.0/document' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentId": ___, "folderId": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path("/document")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Document postDocument(Document document) throws Exception {
+		return new Document();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/sample/1.0.0/document/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/document/batch")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postDocumentBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				Document.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/sample/1.0.0/document/{documentId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "documentId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/document/{documentId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Document getDocument(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("documentId")
+			Long documentId)
+		throws Exception {
+
+		return new Document();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			java.util.Collection<Document> documents,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeConsumer<Document, Exception> documentUnsafeConsumer =
+			document -> postDocument(document);
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				documents, documentUnsafeConsumer);
+		}
+		else {
+			for (Document document : documents) {
+				documentUnsafeConsumer.accept(document);
+			}
+		}
+	}
+
+	@Override
+	public void delete(
+			java.util.Collection<Document> documents,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getVersion() {
+		return "1.0.0";
+	}
+
+	@Override
+	public Page<Document> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			java.util.Collection<Document> documents,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<java.util.Collection<Document>,
+			 UnsafeConsumer<Document, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+		}
+
+		return null;
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, GroupedModel groupedModel, String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R> List<R> transform(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R> R[] transform(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction,
+		Class<?> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R> R[] transformToArray(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<java.util.Collection<Document>, UnsafeConsumer<Document, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<Filter> expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseDocumentResourceImpl.class);
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseFolderResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseFolderResourceImpl.java
@@ -1,0 +1,445 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Folder;
+import com.example.sample.resource.v1_0_0.FolderResource;
+
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.TransformUtil;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/1.0.0")
+public abstract class BaseFolderResourceImpl
+	implements EntityModelResource, FolderResource,
+			   VulcanBatchEngineTaskItemDelegate<Folder> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/sample/1.0.0/folder'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/folder")
+	@javax.ws.rs.Produces("*/*")
+	@Override
+	public Page<Folder> getFolderPage() throws Exception {
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/sample/1.0.0/folder' -d $'{"dateCreated": ___, "dateModified": ___, "description": ___, "documentsRepository": ___, "externalReferenceElement1s": ___, "id": ___, "name": ___, "self": ___, "subFolders": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.Consumes({"application/json", "application/xml"})
+	@javax.ws.rs.Path("/folder")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Folder postFolder(Folder folder) throws Exception {
+		return new Folder();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/sample/1.0.0/folder/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.Consumes("application/json")
+	@javax.ws.rs.Path("/folder/batch")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces("application/json")
+	@Override
+	public Response postFolderBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				Folder.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/sample/1.0.0/folder/{folderId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "folderId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/folder/{folderId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Folder getFolder(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("folderId")
+			Long folderId)
+		throws Exception {
+
+		return new Folder();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			java.util.Collection<Folder> folders,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeConsumer<Folder, Exception> folderUnsafeConsumer =
+			folder -> postFolder(folder);
+
+		if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(folders, folderUnsafeConsumer);
+		}
+		else {
+			for (Folder folder : folders) {
+				folderUnsafeConsumer.accept(folder);
+			}
+		}
+	}
+
+	@Override
+	public void delete(
+			java.util.Collection<Folder> folders,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getVersion() {
+		return "1.0.0";
+	}
+
+	@Override
+	public Page<Folder> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			java.util.Collection<Folder> folders,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<java.util.Collection<Folder>, UnsafeConsumer<Folder, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+		}
+
+		return null;
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, GroupedModel groupedModel, String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R> List<R> transform(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R> R[] transform(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction,
+		Class<?> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R> R[] transformToArray(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<java.util.Collection<Folder>, UnsafeConsumer<Folder, Exception>,
+		 Exception> contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<Filter> expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseFolderResourceImpl.class);
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseTestResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/BaseTestResourceImpl.java
@@ -1,0 +1,360 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.example.sample.dto.v1_0_0.Test;
+import com.example.sample.resource.v1_0_0.TestResource;
+
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.TransformUtil;
+
+import java.io.Serializable;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Generated("")
+@javax.ws.rs.Path("/1.0.0")
+public abstract class BaseTestResourceImpl
+	implements EntityModelResource, TestResource,
+			   VulcanBatchEngineTaskItemDelegate<Test> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/sample/1.0.0/tests/{testId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "testId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(value = {})
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/tests/{testId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Test getTest(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("testId")
+			Long testId)
+		throws Exception {
+
+		return new Test();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			java.util.Collection<Test> tests,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	@Override
+	public void delete(
+			java.util.Collection<Test> tests,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public String getVersion() {
+		return "1.0.0";
+	}
+
+	@Override
+	public Page<Test> read(
+			Filter filter, Pagination pagination, Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			java.util.Collection<Test> tests,
+			Map<String, Serializable> parameters)
+		throws Exception {
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<java.util.Collection<Test>, UnsafeConsumer<Test, Exception>,
+			 Exception> contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = contextUriInfo;
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<Filter> expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+		}
+
+		return null;
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, GroupedModel groupedModel, String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R> List<R> transform(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	protected <T, R> R[] transform(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction,
+		Class<?> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R> R[] transformToArray(
+		java.util.Collection<T> collection,
+		UnsafeFunction<T, R, Exception> unsafeFunction, Class<?> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	protected <T, R> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, Exception> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<java.util.Collection<Test>, UnsafeConsumer<Test, Exception>, Exception>
+			contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<Filter> expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseTestResourceImpl.class);
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/DocumentResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/DocumentResourceImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.example.sample.resource.v1_0_0.DocumentResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author John Doe
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0_0/document.properties",
+	scope = ServiceScope.PROTOTYPE, service = DocumentResource.class
+)
+public class DocumentResourceImpl extends BaseDocumentResourceImpl {
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/FolderResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/FolderResourceImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.example.sample.resource.v1_0_0.FolderResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author John Doe
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0_0/folder.properties",
+	scope = ServiceScope.PROTOTYPE, service = FolderResource.class
+)
+public class FolderResourceImpl extends BaseFolderResourceImpl {
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/OpenAPIResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/OpenAPIResourceImpl.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.liferay.portal.vulcan.resource.OpenAPIResource;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0_0/openapi.properties",
+	service = OpenAPIResourceImpl.class
+)
+@Generated("")
+@OpenAPIDefinition(
+	info = @Info(license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "1.0.0")
+)
+@Path("/1.0.0")
+public class OpenAPIResourceImpl {
+
+	@GET
+	@Path("/openapi.{type:json|yaml}")
+	@Produces({MediaType.APPLICATION_JSON, "application/yaml"})
+	public Response getOpenAPI(@PathParam("type") String type)
+		throws Exception {
+
+		try {
+			Class<? extends OpenAPIResource> clazz =
+				_openAPIResource.getClass();
+
+			clazz.getMethod(
+				"getOpenAPI", Set.class, String.class, UriInfo.class);
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+		}
+
+		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+	}
+
+	@Reference
+	private OpenAPIResource _openAPIResource;
+
+	@Context
+	private UriInfo _uriInfo;
+
+	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
+		{
+			add(DocumentResourceImpl.class);
+
+			add(FolderResourceImpl.class);
+
+			add(TestResourceImpl.class);
+
+			add(OpenAPIResourceImpl.class);
+		}
+	};
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/TestResourceImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/TestResourceImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0;
+
+import com.example.sample.resource.v1_0_0.TestResource;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author John Doe
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0_0/test.properties",
+	scope = ServiceScope.PROTOTYPE, service = TestResource.class
+)
+public class TestResourceImpl extends BaseTestResourceImpl {
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/factory/DocumentResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/factory/DocumentResourceFactoryImpl.java
@@ -1,0 +1,323 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0.factory;
+
+import com.example.sample.resource.v1_0_0.DocumentResource;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Component(immediate = true, service = DocumentResource.Factory.class)
+@Generated("")
+public class DocumentResourceFactoryImpl implements DocumentResource.Factory {
+
+	@Override
+	public DocumentResource.Builder create() {
+		return new DocumentResource.Builder() {
+
+			@Override
+			public DocumentResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				return _documentResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _user));
+			}
+
+			@Override
+			public DocumentResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public DocumentResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public DocumentResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public DocumentResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public DocumentResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private User _user;
+
+		};
+	}
+
+	@Activate
+	protected void activate() {
+		DocumentResource.FactoryHolder.factory = this;
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		DocumentResource.FactoryHolder.factory = null;
+	}
+
+	private static Function<InvocationHandler, DocumentResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			DocumentResource.class.getClassLoader(), DocumentResource.class);
+
+		try {
+			Constructor<DocumentResource> constructor =
+				(Constructor<DocumentResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				_liberalPermissionCheckerFactory.create(user));
+		}
+
+		DocumentResource documentResource =
+			_componentServiceObjects.getService();
+
+		documentResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		documentResource.setContextCompany(company);
+
+		documentResource.setContextHttpServletRequest(httpServletRequest);
+		documentResource.setContextHttpServletResponse(httpServletResponse);
+		documentResource.setContextUser(user);
+		documentResource.setExpressionConvert(_expressionConvert);
+		documentResource.setFilterParserProvider(_filterParserProvider);
+		documentResource.setGroupLocalService(_groupLocalService);
+		documentResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		documentResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		documentResource.setRoleLocalService(_roleLocalService);
+
+		try {
+			return method.invoke(documentResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(documentResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	private static final Function<InvocationHandler, DocumentResource>
+		_documentResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<DocumentResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference(target = "(permission.checker.type=liberal)")
+	private PermissionCheckerFactory _liberalPermissionCheckerFactory;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/factory/FolderResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/factory/FolderResourceFactoryImpl.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0.factory;
+
+import com.example.sample.resource.v1_0_0.FolderResource;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Component(immediate = true, service = FolderResource.Factory.class)
+@Generated("")
+public class FolderResourceFactoryImpl implements FolderResource.Factory {
+
+	@Override
+	public FolderResource.Builder create() {
+		return new FolderResource.Builder() {
+
+			@Override
+			public FolderResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				return _folderResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _user));
+			}
+
+			@Override
+			public FolderResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public FolderResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public FolderResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public FolderResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public FolderResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private User _user;
+
+		};
+	}
+
+	@Activate
+	protected void activate() {
+		FolderResource.FactoryHolder.factory = this;
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		FolderResource.FactoryHolder.factory = null;
+	}
+
+	private static Function<InvocationHandler, FolderResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			FolderResource.class.getClassLoader(), FolderResource.class);
+
+		try {
+			Constructor<FolderResource> constructor =
+				(Constructor<FolderResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				_liberalPermissionCheckerFactory.create(user));
+		}
+
+		FolderResource folderResource = _componentServiceObjects.getService();
+
+		folderResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		folderResource.setContextCompany(company);
+
+		folderResource.setContextHttpServletRequest(httpServletRequest);
+		folderResource.setContextHttpServletResponse(httpServletResponse);
+		folderResource.setContextUser(user);
+		folderResource.setExpressionConvert(_expressionConvert);
+		folderResource.setFilterParserProvider(_filterParserProvider);
+		folderResource.setGroupLocalService(_groupLocalService);
+		folderResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		folderResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		folderResource.setRoleLocalService(_roleLocalService);
+
+		try {
+			return method.invoke(folderResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(folderResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	private static final Function<InvocationHandler, FolderResource>
+		_folderResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<FolderResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference(target = "(permission.checker.type=liberal)")
+	private PermissionCheckerFactory _liberalPermissionCheckerFactory;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/factory/TestResourceFactoryImpl.java
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/java/com/example/sample/internal/resource/v1_0_0/factory/TestResourceFactoryImpl.java
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.example.sample.internal.resource.v1_0_0.factory;
+
+import com.example.sample.resource.v1_0_0.TestResource;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import javax.annotation.Generated;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author John Doe
+ * @generated
+ */
+@Component(immediate = true, service = TestResource.Factory.class)
+@Generated("")
+public class TestResourceFactoryImpl implements TestResource.Factory {
+
+	@Override
+	public TestResource.Builder create() {
+		return new TestResource.Builder() {
+
+			@Override
+			public TestResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				return _testResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _user));
+			}
+
+			@Override
+			public TestResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public TestResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public TestResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public TestResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public TestResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private User _user;
+
+		};
+	}
+
+	@Activate
+	protected void activate() {
+		TestResource.FactoryHolder.factory = this;
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		TestResource.FactoryHolder.factory = null;
+	}
+
+	private static Function<InvocationHandler, TestResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			TestResource.class.getClassLoader(), TestResource.class);
+
+		try {
+			Constructor<TestResource> constructor =
+				(Constructor<TestResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				_liberalPermissionCheckerFactory.create(user));
+		}
+
+		TestResource testResource = _componentServiceObjects.getService();
+
+		testResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		testResource.setContextCompany(company);
+
+		testResource.setContextHttpServletRequest(httpServletRequest);
+		testResource.setContextHttpServletResponse(httpServletResponse);
+		testResource.setContextUser(user);
+		testResource.setExpressionConvert(_expressionConvert);
+		testResource.setFilterParserProvider(_filterParserProvider);
+		testResource.setGroupLocalService(_groupLocalService);
+		testResource.setResourceActionLocalService(_resourceActionLocalService);
+		testResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		testResource.setRoleLocalService(_roleLocalService);
+
+		try {
+			return method.invoke(testResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(testResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	private static final Function<InvocationHandler, TestResource>
+		_testResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<TestResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference(target = "(permission.checker.type=liberal)")
+	private PermissionCheckerFactory _liberalPermissionCheckerFactory;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/document.properties
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/document.properties
@@ -1,0 +1,9 @@
+#
+# This is a generated file.
+#
+
+api.version=1.0.0
+batch.engine.entity.class.name=com.example.sample.dto.v1_0_0.Document
+batch.engine.task.item.delegate=true
+osgi.jaxrs.application.select=(osgi.jaxrs.name=sample-application)
+osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/folder.properties
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/folder.properties
@@ -1,0 +1,9 @@
+#
+# This is a generated file.
+#
+
+api.version=1.0.0
+batch.engine.entity.class.name=com.example.sample.dto.v1_0_0.Folder
+batch.engine.task.item.delegate=true
+osgi.jaxrs.application.select=(osgi.jaxrs.name=sample-application)
+osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/openapi.properties
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/openapi.properties
@@ -1,0 +1,7 @@
+#
+# This is a generated file.
+#
+
+api.version=1.0.0
+osgi.jaxrs.application.select=(osgi.jaxrs.name=sample-application)
+osgi.jaxrs.resource=true

--- a/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/test.properties
+++ b/modules/util/portal-tools-rest-builder/src/test/resources/com/liferay/portal/tools/rest/builder/output/sample-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0_0/test.properties
@@ -1,0 +1,9 @@
+#
+# This is a generated file.
+#
+
+api.version=1.0.0
+batch.engine.entity.class.name=com.example.sample.dto.v1_0_0.Test
+batch.engine.task.item.delegate=true
+osgi.jaxrs.application.select=(osgi.jaxrs.name=sample-application)
+osgi.jaxrs.resource=true


### PR DESCRIPTION
This PR contains the code of the REST Builder that allows developers to choose, given the parameter generateBatch set to true (or just missing, by default is set to true) in the rest-config.yaml file, which entities should not autogenerate batch endpoints.

---

### Before the PR:

Given the pair of files that REST Builder needs:

- **rest-config.yaml**: Contains the specific configuration for Rest Builder.
- **rest-openapi.yaml**: Contains the openAPI specification.

If the `rest-config.yaml` file contains the parameter `generateBatch` set to `true` (or the parameter is missing), REST Builder generates batch endpoints for **all the entities** that match certain conditions that make it possible.

See the example for `Folder` and `Document` entities:

**rest-config.yaml**:
```
generateBatch: true
```

**rest-openapi.yaml**:
```
[...]
openapi: "3.0.1"
paths:
[...]
    /structure:
        post:
            operationId: postStructure
            requestBody:
                content:
                    application/json:
                        schema:
                            $ref: "#/components/schemas/Structure"
                    application/xml:
                        schema:
                            $ref: "#/components/schemas/Structure"
            responses:
                200:
                    content:
                        application/json:
                            schema:
                                $ref: "#/components/schemas/Structure"
                        application/xml:
                            schema:
                                $ref: "#/components/schemas/Structure"
[...]
    /folder:
        post:
            operationId: postFolder
            requestBody:
                content:
                    application/json:
                        schema:
                            $ref: "#/components/schemas/Folder"
                    application/xml:
                        schema:
                            $ref: "#/components/schemas/Folder"
            responses:
                200:
                    content:
                        application/json:
                            schema:
                                $ref: "#/components/schemas/Folder"
                        application/xml:
                            schema:
                                $ref: "#/components/schemas/Folder"
[...]
    /document:
        post:
            operationId: postDocument
            requestBody:
                content:
                    application/json:
                        schema:
                            $ref: "#/components/schemas/Document"
                    application/xml:
                        schema:
                            $ref: "#/components/schemas/Document"
            responses:
                200:
                    content:
                        application/json:
                            schema:
                                $ref: "#/components/schemas/Document"
                        application/xml:
                            schema:
                                $ref: "#/components/schemas/Document"
[...]
```
The following endpoints will be autogenated with the POST method:

```
http://localhost:8080/o/sample/1.0.0/structure/batch'
http://localhost:8080/o/sample/1.0.0/folder/batch'
http://localhost:8080/o/sample/1.0.0/document/batch'
```


### After the PR:

There is a new parameter `disabledBatchEntities` in the `rest-config.yaml` file.

The parameter represents a list and it must be filled with the name of the entities that the developer does not want to auto-generate its batch endpoints.

For example:

```
disabledBatchEntities: ["Structure", "Folder"]
```

With the same `rest-openapi.yaml` file, the following endpoint will be the only autogenated with the POST method as the rest have been marked to be disabled/ignored:

```
http://localhost:8080/o/sample/1.0.0/document/batch'
```
