### PR TITLE
LPS-152400 Don't wrap this in ClayModal.Title

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -210,7 +210,7 @@ const Modal = ({
 								}}
 							></div>
 						) : (
-							<ClayModal.Title>{title}</ClayModal.Title>
+							title
 						)}
 					</ClayModal.Header>
 


### PR DESCRIPTION
Hi team! 
I just found this issue (https://issues.liferay.com/browse/LPS-152400) while working with `openModal` today. When you set a status, the title is visually broken (indicator and text are not aligned) because of having double title markup.
Let me know what you think. Thanks 🥰