### PR TITLE
LPS-152444 Remote Apps rename remoteAppsEntryId is now clientAppsEntryId

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -3,10 +3,10 @@ definition {
 	macro _deleteRemoteAppAPI {
 		var currentURL = Navigator.getCurrentURL();
 
-		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "remoteAppEntryId=");
-		var remoteAppEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
+		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "clientExtensionEntryId=");
+		var clientExtensionEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
 
-		JSONRemoteApp.deleteIFrameRemoteAppEntry(remoteAppEntryId = "${remoteAppEntryIdValue}");
+		JSONRemoteApp.deleteIFrameRemoteAppEntry(clientExtensionEntryId = "${clientExtensionEntryIdValue}");
 	}
 
 	macro addApp {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
@@ -25,9 +25,9 @@ definition {
 	}
 
 	macro deleteIFrameRemoteAppEntry {
-		Variables.assertDefined(parameterList = "${remoteAppEntryId}");
+		Variables.assertDefined(parameterList = "${clientExtensionEntryId}");
 
-		JSONRemoteAppAPI._deleteIFrameRemoteAppEntry(remoteAppEntryId = "${remoteAppEntryId}");
+		JSONRemoteAppAPI._deleteIFrameRemoteAppEntry(clientExtensionEntryId = "${clientExtensionEntryId}");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
@@ -31,7 +31,7 @@ definition {
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
-			${portalURL}/api/jsonws/remoteapp.remoteappentry/add-custom-element-remote-app-entry \
+			${portalURL}/api/jsonws/remoteapp.clientextensionentry/add-custom-element-client-extension-entry \
 				  -u test@liferay.com:test \
 				  -d customElementCSSURLs=${customElementCssurlModified} \
 				  -d customElementHTMLElementName=${htmlNameModified} \
@@ -46,9 +46,9 @@ definition {
 				  -d properties=${customElementPropertiesModified} \
 				  -d sourceCodeURL=
 		''';
-		var remoteAppEntryId = JSONCurlUtil.post("${curl}", "$.['remoteAppEntryId']");
+		var clientExtensionEntryId = JSONCurlUtil.post("${curl}", "$.['clientExtensionEntryId']");
 
-		return "${remoteAppEntryId}";
+		return "${clientExtensionEntryId}";
 	}
 
 	macro _addIFrameRemoteAppEntry {
@@ -60,7 +60,7 @@ definition {
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
-			${portalURL}/api/jsonws/remoteapp.remoteappentry/add-i-frame-remote-app-entry \
+			${portalURL}/api/jsonws/remoteapp.clientextensionentry/add-i-frame-client-extension-entry \
 				  -u test@liferay.com:test \
 				  -d description= \
 				  -d friendlyURLMapping= \
@@ -71,20 +71,20 @@ definition {
 				  -d properties= \
 				  -d sourceCodeURL=
 		''';
-		var remoteAppEntryId = JSONCurlUtil.post("${curl}", "$.['remoteAppEntryId']");
+		var clientExtensionEntryId = JSONCurlUtil.post("${curl}", "$.['clientExtensionEntryId']");
 
-		return "${remoteAppEntryId}";
+		return "${clientExtensionEntryId}";
 	}
 
 	macro _deleteIFrameRemoteAppEntry {
-		Variables.assertDefined(parameterList = "${remoteAppEntryId}");
+		Variables.assertDefined(parameterList = "${clientExtensionEntryId}");
 
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
-			${portalURL}/api/jsonws/remoteapp.remoteappentry/delete-remote-app-entry \
+			${portalURL}/api/jsonws/remoteapp.clientextensionentry/delete-client-extension-entry \
 				  -u test@liferay.com:test \
-				  -d remoteAppEntryId=${remoteAppEntryId}
+				  -d clientExtensionEntryId=${clientExtensionEntryId}
 		''';
 
 		com.liferay.poshi.runner.util.JSONCurlUtil.post("${curl}");


### PR DESCRIPTION
Although UI for Remote Apps has not changed, there has been a change in the code where `remoteAppsEntryId` is now  `clientAppsEntryId`

The goal of this PR is fix it also in the Poshi tests, where the JSON calls are perform to create the Remote Apps, as well as change in it the endpoints, which has change as well, for instance from `/api/jsonws/remoteapp.remoteappentry/delete-remote-app-entry`  to`/api/jsonws/remoteapp.clientextensionentry/delete-client-extension-entry`


Jira issue [LPS-152444](https://issues.liferay.com/browse/LPS-152444)
