### PR TITLE
LPS-152031 FDS instances in different modules cannot have the same ID

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/constants/FDSSampleFDSNames.java
@@ -20,9 +20,9 @@ package com.liferay.frontend.data.set.sample.web.internal.constants;
 public class FDSSampleFDSNames {
 
 	public static final String CUSTOMIZED =
-		FDSSamplePortletKeys.FDS_SAMPLE + "#customized";
+		FDSSamplePortletKeys.FDS_SAMPLE + "-customized";
 
 	public static final String MINIMUM =
-		FDSSamplePortletKeys.FDS_SAMPLE + "#minimum";
+		FDSSamplePortletKeys.FDS_SAMPLE + "-minimum";
 
 }


### PR DESCRIPTION
### References

- [LPS-152031 FDS instances in different modules cannot have the same ID](https://issues.liferay.com/browse/LPS-152031)
- [COMMERCE-8596 Migrate FDS displays in the remaining commerce modules - Regression Testing](https://issues.liferay.com/browse/COMMERCE-8596)
- this is a followup on #2140
- this is a followup on #2149

### What is the goal of this PR?

In this PR, we are changing separator between FDS name and namespace, from  `#` to `-`. 

We cannot use `#` as a delimiter. While it works fine with headless `apiURL` in headless-display tag, it breaks `dataProviderKey` API in the `classic-display` tag. The problem is that ID [ends up as part of the appURL](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java#L79-L81). `#` has a special meaning in a URL, and it gets cut down the line, [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js#L235).

As a solution, we are using the `-` character, that has no special meaning in URLs.

Following up on this PR, the plan it to apply this convention to all FDS instances in DXP.