### PR TITLE
LPS-152222 - Deprecate AUI `addInputCancel` utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -121,6 +121,9 @@
 			return editable;
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		addInputCancel() {
 			A.use('aui-button-search-cancel', (A) => {
 				new A.ButtonSearchCancel({

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -94,12 +94,6 @@
 	);
 </aui:script>
 
-<aui:script use="aui-base">
-	if (A.UA.mobile) {
-		Liferay.Util.addInputCancel();
-	}
-</aui:script>
-
 <%
 Group group = null;
 


### PR DESCRIPTION
This utility used to add a cancel or clear button to the target inputs (passwords, search...), but it doesn't anymore. It also seems that we've moved away from having inputs with those attributes (`'input[type=password], input[type=search], input.clearable, input.search-query'`). Not all, but certainly the classes aren't really used.

Even if this util was used, I am ashamed of the ancient design of it - putting it inside the `bottom_js.jspf` and just having it traverse the dom constantly.

# 🧪 Testing

I've tested this by going to the sign-in popup on the device toolbar. The `A.UA.mobile` returns the brand of the mobile device, but the util just does nothing.

<img width="525" alt="image" src="https://user-images.githubusercontent.com/24564752/165903486-3af81bd8-e088-45db-93b2-572bee32b69d.png">