### PR TITLE
LPS-152225 Deprecate and rewrite usage of `disableFormButtons` AUI util

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -273,6 +273,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		disableFormButtons(inputs, form) {
 			inputs.attr('disabled', true);
 			inputs.setStyle('opacity', 0.5);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -113,7 +113,14 @@
 					'button[type=submit], input[type=button], input[type=image], input[type=reset], input[type=submit]'
 				);
 
-				Util.disableFormButtons(inputs, form);
+				const inputsArray = Array.from(inputs._nodes);
+
+				if (inputsArray.length) {
+					inputsArray.map((input) => {
+						input.disabled = true;
+						input.style.opacity = 0.5;
+					});
+				}
 
 				if (singleSubmit === false) {
 					Util._submitLocked = A.later(


### PR DESCRIPTION
This util is somewhat useful but is only used in one place, so I decided to rewrite its  usage. It's also very simple, with the only complication coming from the util checking for Firefox and Safari, which we don't need to do anymore AFAIK. 

# 🧪 Testing

This util can be tested in almost any form because it was used inside a `submitForm` method provided by `Liferay.provide`. I have tested it in 2 places - on a web content and document and library. Just go to upload a file for D&L and in that form when you click submit it should be disabled. If you can't see it, try with a bigger file so that it takes a bit to upload.