### PR TITLE
LPS-152038 Improve first-render time of the FDS sample portlet

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FDSSamplePortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FDSSamplePortlet.java
@@ -43,6 +43,7 @@ import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -77,19 +78,22 @@ public class FDSSamplePortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		try {
-			_generate(_portal.getCompanyId(renderRequest));
-		}
-		catch (Exception exception) {
-			_log.error(exception);
-		}
-
 		renderRequest.setAttribute(
 			FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT,
 			new FDSSampleDisplayContext(
 				_portal.getHttpServletRequest(renderRequest)));
 
 		super.doDispatch(renderRequest, renderResponse);
+	}
+
+	@Activate
+	protected void activate() {
+		try {
+			_generate(_portal.getDefaultCompanyId());
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
 	}
 
 	private synchronized void _generate(long companyId) throws Exception {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -2,9 +2,9 @@
 definition {
 
 	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "false";
-	property portal.release = "false";
-	property portal.upstream = "quarantine";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
 	property testray.component.names = "Frontend Dataset";
 	property testray.main.component.name = "User Interface";
 
@@ -28,8 +28,6 @@ definition {
 			widgetName = "Frontend Data Set Sample");
 
 		Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
-
-		Refresh();
 	}
 
 	tearDown {


### PR DESCRIPTION
## Motivation

E2E tests fail due to timeout. 

## Proposed Solution

Moving the sample data generation to `activate` method seems to improve performance and allow e2e tests to run without the need of using the `Refresh` method

## Steps to Verify:

- use a clean portal installation
- deploy fds sample module `liferay-portal/modules/apps/frontend-data-set/frontend-data-set-sample-web`
- remove `Refresh()` execution from `portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase`
- run the test `ant -f build-test.xml run-selenium-test -Dtest.class=FrontendDataSet#ActionsCanBeCustomized`

**Expected**
- Poshi successful message
- FDS Sample module sample data generated correctly

<img width="1573" alt="image" src="https://user-images.githubusercontent.com/19485114/166008408-b8e56669-e5db-4629-9686-4fb34aeca044.png">


