### PR TITLE
LPS-152628 Deprecate forcePost

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -328,6 +328,9 @@
 			});
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		forcePost(link) {
 			const currentElement = Util.getElement(link);
 


### PR DESCRIPTION
This util is only used in one place that is deprecated -> https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/icon.js#L30