### PR TITLE
LPS-152227 deprecate AUI `enableFormButtons`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -304,6 +304,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		enableFormButtons(inputs) {
 			Util._submitLocked = null;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -104,6 +104,12 @@
 				}
 			}
 
+			function enableFormButtons(inputs) {
+				Util._submitLocked = null;
+
+				Util.toggleDisabled(inputs, false);
+			}
+
 			if (!hasErrors) {
 				var action = event.action || form.getAttribute('action');
 
@@ -119,7 +125,7 @@
 					Util._submitLocked = A.later(
 						1000,
 						Util,
-						Util.enableFormButtons,
+						enableFormButtons,
 						[inputs, form]
 					);
 				}


### PR DESCRIPTION
This util is a thin wrapper around `toggleDisabled`, so I've decided to rewrite the usage and deprecate the util.

This change can be tested inside Documents and Media's form, with the `if Util._submitLocked` check removed.