### PR TITLE
LPS-152608 Include pathContext when doing requests using fetch

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
@@ -22,14 +22,17 @@
  */
 
 export default function defaultFetch(resource, init = {}) {
+	const pathContext = themeDisplay.getPathContext();
+
 	if (!resource) {
-		resource = '/o/';
+		resource = `${pathContext}/o/`;
 	}
 
 	let resourceLocation = resource.url ? resource.url : resource.toString();
 
 	if (resourceLocation.startsWith('/')) {
-		resourceLocation = window.location.origin + resourceLocation;
+		resourceLocation =
+			window.location.origin + pathContext + resourceLocation;
 	}
 
 	const resourceURL = new URL(resourceLocation);
@@ -37,7 +40,10 @@ export default function defaultFetch(resource, init = {}) {
 	const headers = new Headers({});
 	const config = {};
 
-	if (resourceURL.origin === window.location.origin) {
+	if (
+		resourceURL.origin + pathContext ===
+		window.location.origin + pathContext
+	) {
 		headers.set('x-csrf-token', Liferay.authToken);
 		config.credentials = 'include';
 	}
@@ -47,5 +53,5 @@ export default function defaultFetch(resource, init = {}) {
 	});
 
 	// eslint-disable-next-line @liferay/portal/no-global-fetch
-	return fetch(resource, {...config, ...init, headers});
+	return fetch(resourceURL.toString(), {...config, ...init, headers});
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
@@ -40,10 +40,7 @@ export default function defaultFetch(resource, init = {}) {
 	const headers = new Headers({});
 	const config = {};
 
-	if (
-		resourceURL.origin + pathContext ===
-		window.location.origin + pathContext
-	) {
+	if (resourceURL.origin === window.location.origin) {
 		headers.set('x-csrf-token', Liferay.authToken);
 		config.credentials = 'include';
 	}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
@@ -15,7 +15,7 @@
 import fetchWrapper from '../../../src/main/resources/META-INF/resources/liferay/util/fetch.es';
 
 describe('Liferay.Util.fetch', () => {
-	const externalOriginUrl = 'http://externalOriginUrl.com';
+	const externalOriginUrl = 'http://externaloriginurl.com/';
 	const sameOriginUrl = window.location.origin + '/o/test';
 
 	beforeEach(() => {
@@ -204,8 +204,6 @@ describe('Liferay.Util.fetch', () => {
 	});
 
 	it('includes path context when it is defined on themeDisplay.getPathContext()', () => {
-		const sameOriginUrl = '/o/api/something';
-
 		const init = {
 			credentials: 'include',
 			headers: new Headers({
@@ -214,15 +212,12 @@ describe('Liferay.Util.fetch', () => {
 			}),
 		};
 
-		globalThis.themeDisplay = {
+		window.themeDisplay = {
 			getPathContext: () => '/myportal',
 		};
 
 		fetchWrapper(sameOriginUrl, init);
 
-		expect(fetch).toHaveBeenCalledWith(
-			`http://localhost/myportal${sameOriginUrl}`,
-			init
-		);
+		expect(fetch).toHaveBeenCalledWith(sameOriginUrl, init);
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/fetch.es.js
@@ -202,4 +202,27 @@ describe('Liferay.Util.fetch', () => {
 
 		expect(fetch).toHaveBeenCalledWith(externalOriginUrl, mergedInit);
 	});
+
+	it('includes path context when it is defined on themeDisplay.getPathContext()', () => {
+		const sameOriginUrl = '/o/api/something';
+
+		const init = {
+			credentials: 'include',
+			headers: new Headers({
+				'content-type': 'application/json',
+				'x-csrf-token': 'efgh',
+			}),
+		};
+
+		globalThis.themeDisplay = {
+			getPathContext: () => '/myportal',
+		};
+
+		fetchWrapper(sameOriginUrl, init);
+
+		expect(fetch).toHaveBeenCalledWith(
+			`http://localhost/myportal${sameOriginUrl}`,
+			init
+		);
+	});
 });


### PR DESCRIPTION
## How to reproduce:
From: https://issues.liferay.com/browse/LPS-152608

1. Change the ROOT folder name (under {LIFERAY_HOME}/tomcat-9.0.17/webapps/ROOT) to 'myportal'.
2. Change the ROOT.xml file name (under {LIFERAY_HOME}
/tomcat-9.0.17/conf/Catalina/localhost/) to 'myportal.xml'.
3. Change the ROOT to 'myportal' in the tomcat-9.0.53\conf\catalina.properties file
4. Clear temp and work directories under TOMCAT_HOME.
5. Start the server and log in as admin
6. Navigate to http://localhost:8080/myportal/
7. Go to Open Menu -> Workflow -> Process Builder -> Single Approver

See many errors thrown by `fetch` on console

## WHY are these changes introduced?

We can follow two possible alternatives:

1) Force people who uses fetch to include pathContext to their URLs
2) Add pathContext to our custom fetch implementation 

I decided go with 2) for fixing the issue inside a centralized method and it will fix this behaviour DXP-wide.

When a pathContext is not defined, it will return `''`, so, it's fine to concat with strings without any change :)