### PR TITLE
LPS-134171 AdvancedObjectAPI#NestedFieldsInOneToManyRelationship

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -1,0 +1,316 @@
+definition {
+
+	macro _assertEmployeeFirstnameCorrect {
+		var actualEmployeeFirstname = ObjectDefinitionAPI._getObjectFirstnameById(
+			objectId = "${objectId}",
+			responseToParse = "${responseToParse}");
+
+		TestUtils.assertEquals(
+			actual = "${actualEmployeeFirstname}",
+			expected = "${expectedEmployeeFirstname}");
+	}
+
+	macro _assertManagerFirstnameCorrect {
+		var actualManagerFirstname = ObjectDefinitionAPI._getNestedObjectFirstnameByObjectId(
+			nestedField = "${nestedField}",
+			objectId = "${objectId}",
+			relationshipName = "${relationshipName}",
+			responseToParse = "${responseToParse}");
+
+		TestUtils.assertEquals(
+			actual = "${actualManagerFirstname}",
+			expected = "${expectedManagerFirstname}");
+	}
+
+	macro _assertManagerIdCorrect {
+		var actualManagerId = ObjectDefinitionAPI._getNestedObjectIdByObjectId(
+			nestedField = "${nestedField}",
+			objectId = "${objectId}",
+			relationshipName = "${relationshipName}",
+			responseToParse = "${responseToParse}");
+
+		TestUtils.assertEquals(
+			actual = "${actualManagerId}",
+			expected = "${expectedManagerId}");
+	}
+
+	macro _createEmployee {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/employees \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+            -d
+					{	                 
+	"firstname": "${firstname}",
+	"r_supervisor_c_managerId": "${managerId}"
+	}
+		''';
+		var employeeId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${employeeId}";
+	}
+
+	macro _createManager {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/managers \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+            -d
+					{	                 
+	"firstname": "${firstname}"
+	}
+		''';
+		var managerId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${managerId}";
+	}
+
+	macro _createObjectDefinition {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+            -d
+					{	                 
+	"active": true,
+	"label": {
+		"en_US": "${en_US_label}"
+	},
+	"name": "${name}",
+	"objectFields": [{
+		"DBType": "String",
+		"businessType": "Text",
+		"indexed": true,
+		"indexedAsKeyword": true,
+		"label": {
+			"en_US": "${requiredStringFieldName}"
+		},
+		"name": "${requiredStringFieldName}",
+		"required": true,
+		"dbtype": "String"
+	}],
+	"pluralLabel": {
+		"en_US": "${en_US_plural_label}"
+	},
+	"portlet": true,
+	"scope": "company"
+					}
+		''';
+		var objectDefinitionId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${objectDefinitionId}";
+	}
+
+	macro _createRelationship {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId1}/object-relationships \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+            -d
+					{	                 
+	"deletionType": "${deletionType}",
+  	"label": {
+    	"en_US": "${en_US_label}"
+    },
+  	"name": "${name}",
+  	"objectDefinitionId2": "${objectDefinitionId2}",
+  	"type": "${type}"
+					}
+		''';
+		var relationshipId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${relationshipId}";
+	}
+
+	macro _getEmployeeFirstnameById {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+        	http://localhost:8080/o/c/employees/${employeeId} \
+			-u test@liferay.com:test
+		''';
+		var employeeFirstname = JSONCurlUtil.get("${curl}", "$.firstname");
+
+		return "${employeeFirstname}";
+	}
+
+	macro _getManagerFirstnameById {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+        	http://localhost:8080/o/c/managers/${managerId} \
+			-u test@liferay.com:test
+		''';
+		var managerFirstname = JSONCurlUtil.get("${curl}", "$.firstname");
+
+		return "${managerFirstname}";
+	}
+
+	macro _getNestedObjectFirstnameByObjectId {
+		var nestedObjectFirstname = JSONUtil.getWithJSONPath("${responseToParse}", "$.items[?(@.id==${objectId})].r_${relationshipName}_c_${nestedField}.firstname");
+
+		return "${nestedObjectFirstname}";
+	}
+
+	macro _getNestedObjectIdByObjectId {
+		var nestedObjectId = JSONUtil.getWithJSONPath("${responseToParse}", "$.items[?(@.id==${objectId})].r_${relationshipName}_c_${nestedField}.id");
+
+		return "${nestedObjectId}";
+	}
+
+	macro _getObjectDefinitionStatusById {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+        	${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId} \
+			-u test@liferay.com:test
+		''';
+		var objectDefinitionStatus = JSONCurlUtil.get("${curl}", "$.active");
+
+		return "${objectDefinitionStatus}";
+	}
+
+	macro _getObjectFirstnameById {
+		var objectFirstname = JSONUtil.getWithJSONPath("${responseToParse}", "$.items[?(@.id==${objectId})].firstname");
+
+		return "${objectFirstname}";
+	}
+
+	macro _getObjectsWithNestedField {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+        	${portalURL}/o/c/${objects}?nestedFields=${nestedField} \
+			-u test@liferay.com:test
+		''';
+		var json = JSONCurlUtil.get("${curl}");
+
+		return "${json}";
+	}
+
+	macro _getRelationshipNameById {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+        	http://localhost:8080/o/object-admin/v1.0/object-relationships/${relationshipId} \
+			-u test@liferay.com:test
+		''';
+		var relationshipName = JSONCurlUtil.get("${curl}", "$.name");
+
+		return "${relationshipName}";
+	}
+
+	macro _publishObjectDefinition {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+        	${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/publish \
+			-u test@liferay.com:test
+		''';
+		var json = JSONCurlUtil.post("${curl}");
+
+		return "${json}";
+	}
+
+	macro assertCorrectManagerInformation {
+		ObjectDefinitionAPI._assertEmployeeFirstnameCorrect(
+			expectedEmployeeFirstname = "${expectedEmployeeFirstname}",
+			objectId = "${objectId}",
+			responseToParse = "${responseToParse}");
+
+		ObjectDefinitionAPI._assertManagerFirstnameCorrect(
+			expectedManagerFirstname = "${expectedManagerFirstname}",
+			nestedField = "${nestedField}",
+			objectId = "${objectId}",
+			relationshipName = "${relationshipName}",
+			responseToParse = "${responseToParse}");
+
+		ObjectDefinitionAPI._assertManagerIdCorrect(
+			expectedManagerFirstname = "${expectedManagerFirstname}",
+			expectedManagerId = "${expectedManagerId}",
+			nestedField = "${nestedField}",
+			objectId = "${objectId}",
+			relationshipName = "${relationshipName}",
+			responseToParse = "${responseToParse}");
+	}
+
+	macro createAndPublishObjectDefinition {
+		var objectDefinitionId = ObjectDefinitionAPI._createObjectDefinition(
+			en_US_label = "${en_US_label}",
+			en_US_plural_label = "${en_US_plural_label}",
+			name = "${name}",
+			requiredStringFieldName = "${requiredStringFieldName}");
+
+		ObjectDefinitionAPI._publishObjectDefinition(objectDefinitionId = "${objectDefinitionId}");
+
+		var objectDefinitionStatus = ObjectDefinitionAPI._getObjectDefinitionStatusById(objectDefinitionId = "${objectDefinitionId}");
+
+		TestUtils.assertEquals(
+			actual = "${objectDefinitionStatus}",
+			expected = "true");
+
+		return "${objectDefinitionId}";
+	}
+
+	macro createEmployee {
+		var employeeId = ObjectDefinitionAPI._createEmployee(
+			firstname = "${employeeFirstname}",
+			managerId = "${managerId}");
+
+		var firstname = ObjectDefinitionAPI._getEmployeeFirstnameById(employeeId = "${employeeId}");
+
+		TestUtils.assertEquals(
+			actual = "${firstname}",
+			expected = "${employeeFirstname}");
+
+		return "${employeeId}";
+	}
+
+	macro createManager {
+		var managerId = ObjectDefinitionAPI._createManager(firstname = "${managerFirstname}");
+
+		var firstname = ObjectDefinitionAPI._getManagerFirstnameById(managerId = "${managerId}");
+
+		TestUtils.assertEquals(
+			actual = "${firstname}",
+			expected = "${managerFirstname}");
+
+		return "${managerId}";
+	}
+
+	macro createRelationship {
+		var relationshipId = ObjectDefinitionAPI._createRelationship(
+			deletionType = "${deletionType}",
+			en_US_label = "${en_US_label}",
+			name = "${name}",
+			objectDefinitionId1 = "${objectDefinitionId1}",
+			objectDefinitionId2 = "${objectDefinitionId2}",
+			type = "${type}");
+
+		var relationshipName = ObjectDefinitionAPI._getRelationshipNameById(relationshipId = "${relationshipId}");
+
+		TestUtils.assertEquals(
+			actual = "${relationshipName}",
+			expected = "${name}");
+
+		return "${relationshipName}";
+	}
+
+	macro getObjectsWithNestedField {
+		var getObjectsWithNestedFieldJSON = ObjectDefinitionAPI._getObjectsWithNestedField(
+			nestedField = "${nestedObject}",
+			objectId = "${objectId}",
+			objects = "${objects}");
+
+		return "${getObjectsWithNestedFieldJSON}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -70,6 +70,8 @@ definition {
 	}
 
 	macro _createObjectDefinition {
+		Variables.assertDefined(parameterList = "${en_US_label},${name},${requiredStringFieldName},${en_US_plural_label}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -108,6 +110,8 @@ definition {
 	}
 
 	macro _createRelationship {
+		Variables.assertDefined(parameterList = "${deletionType},${en_US_label},${name},${objectDefinitionId1},${objectDefinitionId2},${type}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -131,6 +135,8 @@ definition {
 	}
 
 	macro _getEmployeeFirstnameById {
+		Variables.assertDefined(parameterList = "${employeeId}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -143,6 +149,8 @@ definition {
 	}
 
 	macro _getManagerFirstnameById {
+		Variables.assertDefined(parameterList = "${managerId}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -167,6 +175,8 @@ definition {
 	}
 
 	macro _getObjectDefinitionStatusById {
+		Variables.assertDefined(parameterList = "${objectDefinitionId}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -185,6 +195,8 @@ definition {
 	}
 
 	macro _getObjectsWithNestedField {
+		Variables.assertDefined(parameterList = "${nestedField}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -197,6 +209,8 @@ definition {
 	}
 
 	macro _getRelationshipNameById {
+		Variables.assertDefined(parameterList = "${relationshipId}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -209,6 +223,8 @@ definition {
 	}
 
 	macro _publishObjectDefinition {
+		Variables.assertDefined(parameterList = "${objectDefinitionId}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -220,7 +236,7 @@ definition {
 		return "${json}";
 	}
 
-	macro assertCorrectManagerInformation {
+	macro assertEmployeeHasNestedFieldManager {
 		ObjectDefinitionAPI._assertEmployeeFirstnameCorrect(
 			expectedEmployeeFirstname = "${expectedEmployeeFirstname}",
 			objectId = "${objectId}",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -1,0 +1,71 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+	}
+
+	tearDown {
+		PortalInstances.tearDownCP();
+	}
+
+	@description = "Nested fields in oneToMany relationship"
+	@priority = "5"
+	test NestedFieldsInOneToManyRelationship {
+		task ("Given active object definitions created") {
+			var objectDefinitionId1 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Manager",
+				en_US_plural_label = "Managers",
+				name = "Manager",
+				requiredStringFieldName = "firstname");
+
+			var objectDefinitionId2 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "Employee",
+				en_US_plural_label = "Employees",
+				name = "Employee",
+				requiredStringFieldName = "firstname");
+		}
+
+		task ("Given a relationship between two object definitions created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "Supervisor",
+				name = "supervisor",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "oneToMany");
+		}
+
+		task ("Given manager accounts created") {
+			var managerId = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
+		}
+
+		task ("Given employee accounts created") {
+			var employeeId = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Bruce",
+				managerId = "${managerId}");
+		}
+
+		task ("When calling for 'employees' with a 'manager' as nestedFields parameter") {
+			var getEmployeesWithManager = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedObject = "manager",
+				objects = "employees");
+		}
+
+		task ("Then 'employee' information should be provided with 'manager' information nested as an object") {
+			ObjectDefinitionAPI.assertCorrectManagerInformation(
+				expectedEmployeeFirstname = "Bruce",
+				expectedManagerFirstname = "Courtney",
+				expectedManagerId = "${managerId}",
+				nestedField = "manager",
+				objectId = "${employeeId}",
+				relationshipName = "supervisor",
+				responseToParse = "${getEmployeesWithManager}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -40,6 +40,8 @@ definition {
 	@description = "Nested fields in oneToMany relationship"
 	@priority = "5"
 	test NestedFieldsDetailsReturnedCorrectlyInOneToManyRelationship {
+		property portal.acceptance = "true";
+
 		task ("Given manager accounts created") {
 			var managerId = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -40,7 +40,6 @@ definition {
 	@description = "Nested fields in oneToMany relationship"
 	@priority = "5"
 	test NestedFieldsInOneToManyRelationship {
-
 		task ("Given manager accounts created") {
 			var managerId = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.main.component.name = "Headless";
+	property testray.main.component.name = "Headless FI";
 
 	setUp {
 		TestCase.setUpPortalInstance();
@@ -39,7 +39,7 @@ definition {
 
 	@description = "Nested fields in oneToMany relationship"
 	@priority = "5"
-	test NestedFieldsInOneToManyRelationship {
+	test NestedFieldsDetailsReturnedCorrectlyInOneToManyRelationship {
 		task ("Given manager accounts created") {
 			var managerId = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
 		}
@@ -57,7 +57,7 @@ definition {
 		}
 
 		task ("Then 'employee' information should be provided with 'manager' information nested as an object") {
-			ObjectDefinitionAPI.assertCorrectManagerInformation(
+			ObjectDefinitionAPI.assertEmployeeHasNestedFieldManager(
 				expectedEmployeeFirstname = "Bruce",
 				expectedManagerFirstname = "Courtney",
 				expectedManagerId = "${managerId}",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -7,15 +7,7 @@ definition {
 
 	setUp {
 		TestCase.setUpPortalInstance();
-	}
 
-	tearDown {
-		PortalInstances.tearDownCP();
-	}
-
-	@description = "Nested fields in oneToMany relationship"
-	@priority = "5"
-	test NestedFieldsInOneToManyRelationship {
 		task ("Given active object definitions created") {
 			var objectDefinitionId1 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
 				en_US_label = "Manager",
@@ -39,6 +31,15 @@ definition {
 				objectDefinitionId2 = "${objectDefinitionId2}",
 				type = "oneToMany");
 		}
+	}
+
+	tearDown {
+		PortalInstances.tearDownCP();
+	}
+
+	@description = "Nested fields in oneToMany relationship"
+	@priority = "5"
+	test NestedFieldsInOneToManyRelationship {
 
 		task ("Given manager accounts created") {
 			var managerId = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -39,7 +39,7 @@ definition {
 
 	@description = "Nested fields in oneToMany relationship"
 	@priority = "5"
-	test NestedFieldsDetailsReturnedCorrectlyInOneToManyRelationship {
+	test CanReturnNestedFieldsDetailsInOneToManyRelationship {
 		property portal.acceptance = "true";
 
 		task ("Given manager accounts created") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-headless"
+@component-name = "portal-headless-fi"
 definition {
 
 	property portal.release = "true";

--- a/test.properties
+++ b/test.properties
@@ -218,6 +218,7 @@
         portal-friendly-url,\
         portal-frontend-infrastructure,\
         portal-gogo-shell,\
+        portal-headless-fi,\
         portal-infrastructure,\
         portal-integrations,\
         portal-ip-address,\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-134171

Given active object definitions created
And Given a relationship between two object definitions created
And Given manager accounts created
And Given employee accounts created
When calling for employees with "manager" as nestedFields parameter
Then "employee" information should be provided with "manager" information nested as an object