### PR TITLE
LPS-152837 Enable a generic mechanism to pass options to a FDS view

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/FDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/FDSView.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.data.set.view;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Marco Leo
@@ -37,6 +38,10 @@ public interface FDSView {
 	public String getLabel();
 
 	public String getName();
+
+	public default Map<String, Object> getOptions() {
+		return null;
+	}
 
 	public String getThumbnail();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/cards/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/cards/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/list/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/list/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/selectable/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/selectable/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/timeline/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/timeline/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
@@ -58,9 +58,9 @@ public class FDSViewSerializerImpl implements FDSViewSerializer {
 						"content.Language", locale, getClass()),
 					fdsView.getLabel())
 			).put(
-				"options", fdsView.getOptions()
-			).put(
 				"name", fdsView.getName()
+			).put(
+				"options", fdsView.getOptions()
 			).put(
 				"thumbnail", fdsView.getThumbnail()
 			);

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
@@ -58,6 +58,8 @@ public class FDSViewSerializerImpl implements FDSViewSerializer {
 						"content.Language", locale, getClass()),
 					fdsView.getLabel())
 			).put(
+				"options", fdsView.getOptions()
+			).put(
 				"name", fdsView.getName()
 			).put(
 				"thumbnail", fdsView.getThumbnail()

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -20,8 +20,10 @@ import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -60,6 +62,12 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 			"creator.name", "author",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
 				"sampleCustomDataRenderer")
+		).build();
+	}
+
+	public Map<String, Object> getOptions() {
+		return HashMapBuilder.<String, Object>put(
+			"quickActionsEnabled", true
 		).build();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
@@ -85,7 +85,15 @@ function Table({dataLoading, items, itemsActions, schema, style}) {
 		sorting,
 		updateSorting,
 	} = useContext(DataSetContext);
-	const [{visibleFieldNames}] = useContext(ViewsContext);
+
+	const [
+		{
+			activeView: {options},
+			visibleFieldNames,
+		},
+	] = useContext(ViewsContext);
+
+	const {quickActionsEnabled} = options || {};
 
 	const visibleFields = getVisibleFields(schema.fields, visibleFieldNames);
 
@@ -113,7 +121,9 @@ function Table({dataLoading, items, itemsActions, schema, style}) {
 					(!inlineAddingSettings && !!items.length)) && (
 					<DndTable.Table
 						borderless
-						className={`table-style-${style}`}
+						className={classNames(`table-style-${style}`, {
+							'show-quick-actions-on-hover': quickActionsEnabled,
+						})}
 						hover={false}
 						responsive
 						striped


### PR DESCRIPTION
[Jira task](https://issues.liferay.com/browse/LPS-152837)

### Motivation

Properties belonging just to a FDS view (like enable the table quick actions on hover) should have a place to get configured.
This pr tries to address that issue enabling an `options` configuration object for each view.

### How to

In the desired view, ie. CustomizedTableFDSView.java, configure a getOptions method:

```
       @Override
	public Map<String, Object> getOptions() {
		return HashMapBuilder.<String, Object>put(
			"quickActionsEnabled", true
		).build();
	}
```

This options should be available in FE under `views > options`

