### PR TITLE
LPS-152847  Add horizontal scroll when the table is fixed and has many columns

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
@@ -140,6 +140,7 @@
 
 	&.fixed {
 		display: block;
+		overflow: auto;
 	}
 
 	&.is-dragging {


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-152847

### Motivation

Hey! When we create a Custom View on Objects, if we put many fields to display, the frontend-data-set table has a limit to show these fields, to solve this I think the best solution is to put a horizontal scroll, allowing users to see all the fields he chose. What do you think?

### Currently

![Screenshot from 2022-05-04 17-44-34](https://user-images.githubusercontent.com/46692326/166823121-7e3615a2-3cc8-4b58-8bba-bb50b912b0a3.png)

### With the solution

![Table Horizontal Scroll](https://user-images.githubusercontent.com/46692326/166821570-8cb8f85d-d84a-43cc-b1d1-0519d2c40763.gif)

