### PR TITLE
LPS-152618 Run upgrade tests on release without hypersonic

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
@@ -1,8 +1,8 @@
 @component-name = "portal-upgrades"
 definition {
 
+	property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
-	property environment.acceptance = "true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";


### PR DESCRIPTION
**Background**
RemoteAppsUpgrade#CanViewRemoteAppFieldsAfterUpgrade73101 and RemoteAppsUpgrade#CanViewRemoteAppCustomElementPortletAfterUpgrade7413 don't have a hypersonic db zip. 

**Test Plan:**
Have these tests running on release without the hypersonic db by setting `app.server.types` and not specifying the hypersonic `database.type`

```
    test.batch.run.property.query[functional-bundle-tomcat-hypersonic20-jdk8][portal-release][dxp]=\
        (\
            (environment.acceptance == true) AND \
            (portal.release == true)\
        ) OR \
        (\
            (app.server.types ~ tomcat) AND \
            (\
                (database.types == null) OR \
                (database.types ~ hypersonic)\
            ) AND \
            (portal.release == true)\
        )
```

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-152618