### PR TITLE
LPS-152909 Deprecate the AUI `reorder` utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -554,6 +554,9 @@
 			return Math.ceil(Math.random() * new Date().getTime());
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		reorder(box, down) {
 			box = Util.getElement(box);
 


### PR DESCRIPTION
This util is only used once, inside the `frontend-js-aui-web` module so we decided to just deprecate it.