### PR TITLE
LPS-152233 Deprecate AUI `rowCheckerCheckAllBox` util

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -604,6 +604,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		rowCheckerCheckAllBox(
 			ancestorTable,
 			ancestorRow,


### PR DESCRIPTION
Deprecating it because it is not used anywhere, at all.