### PR TITLE
LPS-113538 Deprecate AUI `savePortletTitle` utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -618,6 +618,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		savePortletTitle(params) {
 			params = {
 				doAsUserId: 0,


### PR DESCRIPTION
Used only in the `frontend-js-aui-web` module by another utility that will get modernized/deprecated in the future.