### PR TITLE
LPS-152861 StructuredContentAssetPriority#StructuredContentDraftContainsPriorityField

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -86,4 +86,57 @@ definition {
 		return "${articleId}";
 	}
 
+	macro _createStructuredContentDraft {
+		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title}");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents/draft \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+            -d
+					{
+    "contentFields": [{
+        "contentFieldValue": {
+            "data": "${data}"
+        },
+        "dataType": "string",
+        "label": "${label}",
+        "name": "${name}",
+        "nestedContentFields": [],
+        "repeatable": false
+    }],
+    "contentStructureId": "${ddmStructureId}",
+    "title": "${title}"
+	}
+		''';
+		var curl = JSONCurlUtil.post("${curl}");
+
+		return "${curl}";
+	}
+
+	macro assertPriorityFieldWithDefaultValue {
+		var actualPriorityDefaultValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.priority");
+
+		TestUtils.assertEquals(
+			actual = "${actualPriorityDefaultValue}",
+			expected = "${expectedPriorityDefaultValue}");
+	}
+
+	macro createStructuredContentDraft {
+		var response = HeadlessWebcontentAPI._createStructuredContentDraft(
+			data = "${data}",
+			ddmStructureId = "${ddmStructureId}",
+			label = "${label}",
+			name = "${name}",
+			title = "${title}");
+
+		return "${response}";
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/template/WebContentStructures.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/template/WebContentStructures.macro
@@ -191,6 +191,18 @@ definition {
 			rowEntry = "${structureName}");
 	}
 
+	macro getDdmStructureId {
+		var key_ddlDataDefinitionName = "${structureName}";
+
+		WaitForSPARefresh();
+
+		var href = selenium.getAttribute("//tr/td/a[contains(text(),'${key_ddlDataDefinitionName}')]@href");
+		var findWhereIdBegins = StringUtil.extractLast("${href}", "ddmStructureId=");
+		var ddmStructureId = StringUtil.extractFirst("${findWhereIdBegins}", "&p_p_auth");
+
+		return "${ddmStructureId}";
+	}
+
 	macro openWebContentStructuresAdmin {
 		Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteURLKey}/~/control_panel/manage?p_p_id=com_liferay_journal_web_portlet_JournalPortlet&_com_liferay_journal_web_portlet_JournalPortlet_mvcPath=%2Fview_ddm_structures.jsp");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -1,0 +1,58 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless FI";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = "5"
+	test StructuredContentDraftContainsPriorityField {
+		property portal.acceptance = "true";
+
+		task ("When in Headless Admin Content I create a structuredContent draft without setting the priority") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "Title");
+		}
+
+		task ("Then the response body includes the default priority field") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithDefaultValue(
+				expectedPriorityDefaultValue = "0.0",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-headless"
+@component-name = "portal-headless-fi"
 definition {
 
 	property portal.release = "true";


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152861

**Given** a content structure created
**When** in Headless Admin Content I create a structuredContent draft without setting the priority
**Then** the response body includes the default priority field