### PR TITLE
LPS-152229 Replace and deprecate `listSelect` with new `getSelectedOptionValues` utility

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements/configuration.jsp
@@ -371,7 +371,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			if (currentScopeGroupIds && selectedScopeGroupIds) {
 				selectedScopeGroupIds.setAttribute(
 					'value',
-					Liferay.Util.listSelect(currentScopeGroupIds)
+					Liferay.Util.getSelectedOptionValues(currentScopeGroupIds)
 				);
 			}
 
@@ -385,7 +385,9 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			if (currentScopeOrganizationIds && selectedScopeOrganizationIds) {
 				selectedScopeOrganizationIds.setAttribute(
 					'value',
-					Liferay.Util.listSelect(currentScopeOrganizationIds)
+					Liferay.Util.getSelectedOptionValues(
+						currentScopeOrganizationIds
+					)
 				);
 			}
 
@@ -399,7 +401,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			if (currentScopeRoleIds && selectedScopeRoleIds) {
 				selectedScopeRoleIds.setAttribute(
 					'value',
-					Liferay.Util.listSelect(currentScopeRoleIds)
+					Liferay.Util.getSelectedOptionValues(currentScopeRoleIds)
 				);
 			}
 
@@ -413,7 +415,7 @@ announcementsPortletInstanceConfiguration = ParameterMapUtil.setParameterMap(Ann
 			if (currentScopeUserGroupIds && selectedScopeUserGroupIds) {
 				selectedScopeUserGroupIds.setAttribute(
 					'value',
-					Liferay.Util.listSelect(currentScopeUserGroupIds)
+					Liferay.Util.getSelectedOptionValues(currentScopeUserGroupIds)
 				);
 			}
 

--- a/modules/apps/asset/asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-categories-navigation-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -77,7 +77,7 @@
 
 		Liferay.Util.postForm(form, {
 			data: {
-				assetVocabularyIds: Liferay.Util.listSelect(
+				assetVocabularyIds: Liferay.Util.getSelectedOptionValues(
 					Liferay.Util.getFormElement(form, 'currentAssetVocabularyIds')
 				),
 			},

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -111,7 +111,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 		%>
 
 			Liferay.Util.setFormValues(form, {
-				classTypeIds<%= className %>: Liferay.Util.listSelect(
+				classTypeIds<%= className %>: Liferay.Util.getSelectedOptionValues(
 					Liferay.Util.getFormElement(
 						form,
 						'<%= className %>currentClassTypeIds'
@@ -131,7 +131,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 		if (currentClassNameIdsSelect) {
 			Liferay.Util.postForm(form, {
 				data: {
-					classNameIds: Liferay.Util.listSelect(
+					classNameIds: Liferay.Util.getSelectedOptionValues(
 						currentClassNameIdsSelect
 					),
 				},

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -74,7 +74,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		%>
 
 			Liferay.Util.setFormValues(form, {
-				classTypeIds<%= className %>: Liferay.Util.listSelect(
+				classTypeIds<%= className %>: Liferay.Util.getSelectedOptionValues(
 					Liferay.Util.getFormElement(
 						form,
 						'<%= className %>currentClassTypeIds'
@@ -98,10 +98,10 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		if (currentClassNameIdsSelect && currentMetadataFieldsInput) {
 			Liferay.Util.postForm(form, {
 				data: {
-					classNameIds: Liferay.Util.listSelect(
+					classNameIds: Liferay.Util.getSelectedOptionValues(
 						currentClassNameIdsSelect
 					),
-					metadataFields: Liferay.Util.listSelect(
+					metadataFields: Liferay.Util.getSelectedOptionValues(
 						currentMetadataFieldsInput
 					),
 				},
@@ -110,7 +110,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 		else if (currentMetadataFieldsInput) {
 			Liferay.Util.postForm(form, {
 				data: {
-					metadataFields: Liferay.Util.listSelect(
+					metadataFields: Liferay.Util.getSelectedOptionValues(
 						currentMetadataFieldsInput
 					),
 				},

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration.jsp
@@ -276,7 +276,9 @@ catch (NoSuchFolderException nsfe) {
 			);
 
 			if (currentFolderColumns && folderColumns) {
-				folderColumns.value = Util.listSelect(currentFolderColumns);
+				folderColumns.value = Util.getSelectedOptionValues(
+					currentFolderColumns
+				);
 			}
 
 			var currentEntryColumns = form.querySelector(
@@ -287,7 +289,9 @@ catch (NoSuchFolderException nsfe) {
 			);
 
 			if (currentEntryColumns && entryColumns) {
-				entryColumns.value = Util.listSelect(currentEntryColumns);
+				entryColumns.value = Util.getSelectedOptionValues(
+					currentEntryColumns
+				);
 			}
 
 			submitForm(form);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/edit_content_dashboard_configuration.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/edit_content_dashboard_configuration.jsp
@@ -90,7 +90,7 @@ ContentDashboardAdminConfigurationDisplayContext contentDashboardAdminConfigurat
 		var form = document.<portlet:namespace />fm;
 		Liferay.Util.postForm(form, {
 			data: {
-				assetVocabularyIds: Liferay.Util.listSelect(
+				assetVocabularyIds: Liferay.Util.getSelectedOptionValues(
 					Liferay.Util.getFormElement(form, 'currentAssetVocabularyIds')
 				),
 			},

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -246,10 +246,10 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 
 		Util.postForm(form, {
 			data: {
-				displayViews: Util.listSelect(
+				displayViews: Util.getSelectedOptionValues(
 					Util.getFormElement(form, 'currentDisplayViews')
 				),
-				entryColumns: Util.listSelect(
+				entryColumns: Util.getSelectedOptionValues(
 					Util.getFormElement(form, 'currentEntryColumns')
 				),
 			},

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -164,7 +164,7 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 
 		Liferay.Util.postForm(form, {
 			data: {
-				mimeTypes: Liferay.Util.listSelect(
+				mimeTypes: Liferay.Util.getSelectedOptionValues(
 					Liferay.Util.getFormElement(form, 'currentMimeTypes')
 				),
 			},

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -489,6 +489,9 @@
 			return Util.listCheckboxesExcept(form, except, name, true);
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `import {getSelectedOptionValues} from 'frontend-js-web';`
+		 */
 		listSelect(select, delimeter) {
 			select = Util.getElement(select);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -105,6 +105,7 @@ export {default as inBrowserView} from './liferay/util/in_browser_view';
 export {default as isObject} from './liferay/util/is_object';
 export {default as isPhone} from './liferay/util/is_phone';
 export {default as isTablet} from './liferay/util/is_tablet';
+export {default as getSelectedOptionValues} from './liferay/util/get_selected_option_values';
 export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
 export {default as removeEntitySelection} from './liferay/util/remove_entity_selection';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -61,6 +61,7 @@ import getLexiconIconTpl from './util/get_lexicon_icon_template';
 import getOpener from './util/get_opener';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
+import getSelectedOptionValues from './util/get_selected_option_values';
 import getTop from './util/get_top';
 import getURLWithSessionId from './util/get_url_with_session_id';
 import getWindow from './util/get_window';
@@ -250,6 +251,8 @@ Liferay.Util.isPhone = isPhone;
  * @deprecated As of Athanasius (7.3.x), replaced by `import {isTablet} from 'frontend-js-web'`
  */
 Liferay.Util.isTablet = isTablet;
+
+Liferay.Util.getSelectedOptionValues = getSelectedOptionValues;
 
 Liferay.Util.navigate = navigate;
 Liferay.Util.ns = ns;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -349,6 +349,11 @@ declare module Liferay {
 
 		export function getWindow(windowId?: string): Window;
 
+		export function getSelectedOptionValues(
+			select: HTMLSelectElement,
+			delimiter?: string
+		): string;
+
 		/**
 		 * Performs navigation to the given url. If SPA is enabled, it will route the
 		 * request through the SPA engine. If not, it will simple change the document

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_selected_option_values.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_selected_option_values.js
@@ -15,10 +15,6 @@
 export default function getSelectedOptionValues(select, delimiter = ',') {
 	const optionsArray = Array.from(select.getElementsByTagName('option'));
 
-	if (!optionsArray.length) {
-		return;
-	}
-
 	return optionsArray
 		.reduce((previous, item) => {
 			const {value} = item;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_selected_option_values.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_selected_option_values.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function getSelectedOptionValues(select, delimiter = ',') {
+	const optionsArray = Array.from(select.getElementsByTagName('option'));
+
+	if (!optionsArray.length) {
+		return;
+	}
+
+	return optionsArray
+		.reduce((previous, item) => {
+			const {value} = item;
+
+			if (value) {
+				previous.push(value);
+			}
+
+			return previous;
+		}, [])
+		.join(delimiter);
+}

--- a/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/portal-rules-engine/portal-rules-engine-sample-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -97,7 +97,7 @@ long[] classNameIdValues = StringUtil.split(ParamUtil.getString(request, "classN
 			if (classNameIds && currentClassNameIds) {
 				classNameIds.setAttribute(
 					'value',
-					Liferay.Util.listSelect(currentClassNameIds)
+					Liferay.Util.getSelectedOptionValues(currentClassNameIds)
 				);
 			}
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/configuration/asset_entries.jsp
@@ -76,7 +76,7 @@ for (AssetRendererFactory<?> assetRendererFactory : assetEntriesSearchFacet.getA
 
 			data[
 				'<%= assetEntriesSearchFacet.getClassName() + "assetTypes" %>'
-			] = Liferay.Util.listSelect(currentAssetTypes);
+			] = Liferay.Util.getSelectedOptionValues(currentAssetTypes);
 
 			Liferay.Util.postForm(form, {data: data});
 		});

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
@@ -124,7 +124,7 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 
 			data[
 				'<%= PortletPreferencesJspUtil.getInputName(TypeFacetPortletPreferences.PREFERENCE_KEY_ASSET_TYPES) %>'
-			] = Liferay.Util.listSelect(currentAssetTypes);
+			] = Liferay.Util.getSelectedOptionValues(currentAssetTypes);
 
 			Liferay.Util.postForm(form, {data: data});
 		});

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
@@ -137,7 +137,7 @@
 
 		if (currentLanguageIdsElement) {
 			Liferay.Util.setFormValues(form, {
-				<%= PropsKeys.LOCALES %>: Liferay.Util.listSelect(
+				<%= PropsKeys.LOCALES %>: Liferay.Util.getSelectedOptionValues(
 					currentLanguageIdsElement
 				),
 			});

--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -87,7 +87,9 @@
 		if (currentLanguageIdsInput) {
 			Liferay.Util.postForm(form, {
 				data: {
-					languageIds: Liferay.Util.listSelect(currentLanguageIdsInput),
+					languageIds: Liferay.Util.getSelectedOptionValues(
+						currentLanguageIdsInput
+					),
 				},
 			});
 		}

--- a/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
+++ b/modules/apps/social/social-bookmarks-taglib/src/main/resources/META-INF/resources/bookmarks_settings/page.jsp
@@ -97,11 +97,11 @@ rightList = ListUtil.sort(rightList, new KeyValuePairComparator(false, true));
 		);
 
 		Liferay.after('inputmoveboxes:moveItem', (event) => {
-			socialBookmarksTypes.value = Util.listSelect(currentTypes);
+			socialBookmarksTypes.value = Util.getSelectedOptionValues(currentTypes);
 		});
 
 		Liferay.after('inputmoveboxes:orderItem', (event) => {
-			socialBookmarksTypes.value = Util.listSelect(currentTypes);
+			socialBookmarksTypes.value = Util.getSelectedOptionValues(currentTypes);
 		});
 	})();
 </script>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration.jsp
@@ -141,8 +141,12 @@
 		if (availableVisibleNodes && currentVisibleNodes) {
 			Liferay.Util.postForm(form, {
 				data: {
-					hiddenNodes: Liferay.Util.listSelect(availableVisibleNodes),
-					visibleNodes: Liferay.Util.listSelect(currentVisibleNodes),
+					hiddenNodes: Liferay.Util.getSelectedOptionValues(
+						availableVisibleNodes
+					),
+					visibleNodes: Liferay.Util.getSelectedOptionValues(
+						currentVisibleNodes
+					),
 				},
 			});
 		}


### PR DESCRIPTION
## Overview

`listSelect` is a utility that accepts a `<select>` element, and an optional `delimiter` argument. It returns a CSV string consisting of values of `<option>` elements that are children of the `<select>` element.

I've decided to rename this utility as it doesn't do what the name `listSelect` suggests but instead it gets the selected options inside the provided select element. 

🧪 This util can be tested by dragging the `Documents & Media` portlet onto the landing page and going to its Configuration. Once there, click Save and the util will be invoked.