### PR TITLE
LPS-152234 Deprecate `submitForm`

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form/FormView.es.js
@@ -81,7 +81,7 @@ const useFormSubmit = ({apiRef, containerRef}) => {
 							}
 
 							if (submittable) {
-								Liferay.Util.submitForm(event.target);
+								event.target.submit();
 							}
 
 							Liferay.fire('ddmFormValid', {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -699,6 +699,9 @@
 
 		submitCountdown: 0,
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `form.submit()`
+		 */
 		submitForm(form) {
 			form.submit();
 		},

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/events.js
@@ -175,7 +175,7 @@
 
 				form.attr('action', action);
 
-				Util.submitForm(form);
+				form.submit();
 
 				form.attr('target', '');
 


### PR DESCRIPTION
In this PR I'm deprecating the `Liferay.Util.submitForm` utility and replacing its 2 usages with `form.submit()`. It can be tested by creating a new blog article.