### PR TITLE
LPS-153119 Deprecate `Liferay.provide('_openWindowProvider')`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -532,11 +532,11 @@
 		openWindow(config, callback) {
 			config.openingWindow = window;
 
-			var top = Util.getTop();
+			var dialog = Window.getWindow(config);
 
-			var topUtil = top.Liferay.Util;
-
-			topUtil._openWindowProvider(config, callback);
+			if (typeof callback === 'function') {
+				callback(dialog);
+			}
 		},
 
 		/**
@@ -1390,6 +1390,9 @@
 		['aui-base', 'liferay-util-window']
 	);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+	 */
 	Liferay.provide(
 		Util,
 		'_openWindowProvider',


### PR DESCRIPTION
I've moved the implementation of `_openWindowProvider` into `openWindow` because that is the only place where it is used. Because of this, it is possible to deprecate the `_openWindowProvider` 👍 

It's debatable if we can just straight up delete `_openWindowProvider` because it is a "private" method and it shouldn't be used by anyone by us, right?

Can be tested by dragging a Calendar portlet to the landing page and creating a new event.