### PR TITLE
LPS-149497 Pass externalReferenceCode argument from path

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -460,7 +460,7 @@ public class CommentResourceImpl
 		}
 
 		return _postEntityComment(
-			comment.getExternalReferenceCode(), blogsEntry.getGroupId(),
+			externalReferenceCode, blogsEntry.getGroupId(),
 			BlogsEntry.class.getName(), blogsEntry.getEntryId(),
 			comment.getText());
 	}
@@ -490,7 +490,7 @@ public class CommentResourceImpl
 		}
 
 		return _postParentCommentComment(
-			comment.getExternalReferenceCode(), parentComment.getGroupId(),
+			externalReferenceCode, parentComment.getGroupId(),
 			parentComment.getCommentId(), parentComment.getClassName(),
 			parentComment.getClassPK(), comment.getText());
 	}
@@ -517,7 +517,7 @@ public class CommentResourceImpl
 		}
 
 		return _postEntityComment(
-			comment.getExternalReferenceCode(), dlFileEntry.getGroupId(),
+			externalReferenceCode, dlFileEntry.getGroupId(),
 			DLFileEntry.class.getName(), dlFileEntry.getFileEntryId(),
 			comment.getText());
 	}
@@ -544,7 +544,7 @@ public class CommentResourceImpl
 		}
 
 		return _postEntityComment(
-			comment.getExternalReferenceCode(), journalArticle.getGroupId(),
+			externalReferenceCode, journalArticle.getGroupId(),
 			JournalArticle.class.getName(), journalArticle.getResourcePrimKey(),
 			comment.getText());
 	}
@@ -669,11 +669,11 @@ public class CommentResourceImpl
 			StringBundler sb = new StringBundler(6);
 
 			sb.append("No comment exists with external reference code ");
-			sb.append(comment.getExternalReferenceCode());
+			sb.append(externalReferenceCode);
 			sb.append(", site ID ");
 			sb.append(parentComment.getGroupId());
 			sb.append(", and parent comment with external reference code ");
-			sb.append(parentComment.getExternalReferenceCode());
+			sb.append(parentExternalReferenceCode);
 
 			throw new NotFoundException(sb.toString());
 		}


### PR DESCRIPTION
This PR contains the code to assign the externalReferenceCode parameter from the path instead of from the object in case both are set.

**Before the PR:**
Given a site with siteId 20123 and a blog posting with external reference code my-BLOG-1, when this request is executed:

```
curl -X 'PUT' \
	'http://localhost:8080/o/headless-delivery/v1.0/sites/20123/blog-postings/by-external-reference-code/my-BLOG-1/comments/by-external-reference-code/my-COMMENT-1-YES' \
	-H 'accept: application/json' \
	-H 'Content-Type: application/json' \
	-u 'test@liferay.com:test' \
	-d '{
		"externalReferenceCode": "my-COMMENT-1-NO",
		"text": "now a new comment with ERC"
	}'
```
a Comment is created with an incorrect external reference code (from the blog posting element instead of from the path, that should be higher priority
```
{
  "creator" : {
    "additionalName" : "",
    "contentType" : "UserAccount",
    "familyName" : "Test",
    "givenName" : "Test",
    "id" : 20127,
    "name" : "Test Test"
  },
  "dateCreated" : "2022-05-09T16:15:14Z",
  "dateModified" : "2022-05-09T16:15:14Z",
  "externalReferenceCode" : "my-COMMENT-1-NO",
  "id" : 53524,
  "numberOfComments" : 0,
  "parentCommentId" : 53520,
  "text" : "<p>now a new comment with ERC</p>"
}
```

**After the PR:**

The same invocation generates a Comment with the external reference code from the path:

```
curl -X 'PUT' \
	'http://localhost:8080/o/headless-delivery/v1.0/sites/20123/blog-postings/by-external-reference-code/my-BLOG-1/comments/by-external-reference-code/my-COMMENT-1-YES' \
	-H 'accept: application/json' \
	-H 'Content-Type: application/json' \
	-u 'test@liferay.com:test' \
	-d '{
		"externalReferenceCode": "my-COMMENT-1-NO",
		"text": "now a new comment with ERC"
	}'
```
a Comment is created with an incorrect external reference code (from the blog posting element instead of from the path, that should be higher priority
```
{
  "creator" : {
    "additionalName" : "",
    "contentType" : "UserAccount",
    "familyName" : "Test",
    "givenName" : "Test",
    "id" : 20127,
    "name" : "Test Test"
  },
  "dateCreated" : "2022-05-09T16:18:13Z",
  "dateModified" : "2022-05-09T16:18:13Z",
  "externalReferenceCode" : "my-COMMENT-1-YES",
  "id" : 53527,
  "numberOfComments" : 0,
  "parentCommentId" : 53520,
  "text" : "<p>now a new comment with ERC</p>"
}
```