### PR TITLE
LPS-153011 Remove unnecessary internal form stub in FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
@@ -440,11 +440,6 @@ const DataSet = ({
 			<span aria-hidden="true" className="loading-animation my-7" />
 		);
 
-	const formRef = useRef(null);
-
-	const wrappedView =
-		formId || formName ? view : <form ref={formRef}>{view}</form>;
-
 	const paginationComponent =
 		showPagination && pagination && items?.length && total ? (
 			<div className="data-set-pagination-wrapper">
@@ -650,7 +645,6 @@ const DataSet = ({
 				filters,
 				formId,
 				formName,
-				formRef,
 				highlightItems,
 				highlightedItemsValue,
 				id,
@@ -699,7 +693,7 @@ const DataSet = ({
 						<div className="data-set data-set-inline">
 							{managementBar}
 
-							{wrappedView}
+							{view}
 
 							{paginationComponent}
 						</div>
@@ -709,7 +703,7 @@ const DataSet = ({
 						<div className="data-set data-set-stacked">
 							{managementBar}
 
-							{wrappedView}
+							{view}
 
 							{paginationComponent}
 						</div>
@@ -720,7 +714,7 @@ const DataSet = ({
 							{managementBar}
 
 							<div className="container-fluid container-xl mt-3">
-								{wrappedView}
+								{view}
 
 								{paginationComponent}
 							</div>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSetContext.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSetContext.js
@@ -18,7 +18,6 @@ const DataSetContext = React.createContext({
 	actionParameterName: null,
 	formId: null,
 	formName: null,
-	formRef: null,
 	id: null,
 	loadData: () => {},
 	modalId: null,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/BulkActions.js
@@ -15,29 +15,13 @@
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
+import {postForm} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useState} from 'react';
 
 import DataSetContext from '../../DataSetContext';
 import {OPEN_SIDE_PANEL} from '../../utils/eventsDefinitions';
-import {logError} from '../../utils/logError';
 import {getOpenedSidePanel} from '../../utils/sidePanels';
-
-function submit({action, data, formId, formName, formRef, namespace}) {
-	let form = formRef.current;
-
-	if (!form && (formId || (formName && namespace))) {
-		const namespacedId = formId || `${namespace}${formName}`;
-		form = document.getElementById(namespacedId);
-	}
-
-	if (form) {
-		Liferay.Util.postForm(form, {data, url: action || form.action});
-	}
-	else {
-		logError(`Form not found.`);
-	}
-}
 
 function getQueryString(key, values = []) {
 	return `?${key}=${values.join(',')}`;
@@ -74,7 +58,6 @@ function BulkActions({
 		actionDefinition,
 		formId,
 		formName,
-		formRef,
 		loadData,
 		namespace,
 		sidePanelId
@@ -109,20 +92,22 @@ function BulkActions({
 				},
 			});
 		}
-		else {
-			submit({
-				action: href,
-				data: {
-					...data,
-					[`${
-						actionParameterName || selectedItemsKey
-					}`]: selectedItemsValue.join(','),
-				},
-				formId,
-				formName,
-				formRef,
-				namespace,
-			});
+		else if (formId || (formName && namespace)) {
+			const namespacedId = formId || `${namespace}${formName}`;
+
+			const form = document.getElementById(namespacedId);
+
+			if (form) {
+				postForm(form, {
+					data: {
+						...data,
+						[`${
+							actionParameterName || selectedItemsKey
+						}`]: selectedItemsValue.join(','),
+					},
+					url: href || form.action,
+				});
+			}
 		}
 	}
 
@@ -156,14 +141,7 @@ function BulkActions({
 
 	return selectedItemsValue.length ? (
 		<DataSetContext.Consumer>
-			{({
-				formId,
-				formName,
-				formRef,
-				loadData,
-				namespace,
-				sidePanelId,
-			}) => (
+			{({formId, formName, loadData, namespace, sidePanelId}) => (
 				<nav className="management-bar management-bar-primary navbar navbar-expand-md pb-2 pt-2 subnav-tbar">
 					<div
 						className={classNames(
@@ -209,7 +187,6 @@ function BulkActions({
 											actionDefinition,
 											formId,
 											formName,
-											formRef,
 											loadData,
 											namespace,
 											sidePanelId


### PR DESCRIPTION
### References

- [LPS-153011 Remove unnecessary internal form stub in FDS](https://issues.liferay.com/browse/LPS-153011)

### What is the goal of this PR?

I initially started working on the task to set default `formName` to `fm`. However, I found that if `formName` or `formId` are set, they reference an **external** form. There is, in my opinion, no point to set the default in that case. The default is not to set the attribute, and not use an external form. The default, that we are promoting with FDS, is to use async resolution of [custom actions](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js#L29-L62).

Now, there is a logic in FDS that sets form wrapper if `formName` or `formId` are not set. In this PR, we are removing this API. Not setting `form*` props [adds a form stub](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js#L446). I'm calling it a stub because is not functional with `postForm`. Form elements need to be defined first, and we don't seem to be doing this anywhere internally in FDS. In external form usage, they are set, [here is an example](https://github.com/liferay/liferay-portal/blob/master/modules/apps/commerce/commerce-pricing-web/src/main/resources/META-INF/resources/commerce_discounts/view.jsp#L27-L29). In theory, somebody could hack this in, at various points in usage workflow, but I don't think that's a solution path we want to support. I could not find any such usage in DXP, but I cannot be 100% sure. I think the risk is small and we can just remove this API.

### What does it look like?

There are no UI changes in this PR.

### Steps to reproduce

All FDS and legacy `<clay:data-set-display>` instances in DXP should continue working normally. This includes all commerce and objects.