### PR TITLE
LPS-152751 Update tests from RemoteAppsWorkflow file.

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsWorkflow.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteAppsWorkflow.macro
@@ -25,7 +25,7 @@ definition {
 
 		Permissions.definePermissionViaJSONAPI(
 			resourceAction = "ADD_ENTRY",
-			resourceName = "com.liferay.remote.app",
+			resourceName = "com.liferay.client.extension",
 			roleTitle = "New Regular Role");
 	}
 
@@ -39,7 +39,7 @@ definition {
 
 		Workflow.configureWorkflow(
 			workflowDefinition = "Single Approver",
-			workflowResourceValue = "Remote App Entry");
+			workflowResourceValue = "Client Extension Entry");
 	}
 
 	macro assertTableStatus {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsWorkflow.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsWorkflow.testcase
@@ -60,7 +60,7 @@ definition {
 
 			AssertClick(
 				locator1 = "Notifications#NOTIFICATIONS_WORKFLOW_TITLE",
-				value1 = "userfn userln sent you a Remote App Entry for review in the workflow.");
+				value1 = "userfn userln sent you a Client Extension Entry for review in the workflow.");
 
 			LexiconEntry.gotoEllipsisMenuItem(menuItem = "Assign to Me");
 
@@ -111,12 +111,12 @@ definition {
 		}
 
 		task ("Search for Remote App Entry") {
-			Search.searchCP(searchTerm = "Remote App Entry");
+			Search.searchCP(searchTerm = "Client Extension Entry");
 		}
 
 		task ("Assert Remote App Entry is listed") {
 			AssertElementPresent(
-				key_fieldName = "Remote App Entry",
+				key_fieldName = "Client Extension Entry",
 				key_order = "1",
 				locator1 = "WorkflowConfiguration#PROCESS_BUILDER_TABLE_FIELD_NAME");
 


### PR DESCRIPTION
Background:
Follow up on [LPS-152607](https://issues.liferay.com/browse/LPS-152607). The Workflow System Settings is planned to change to Client Extension Entry. Please update the poshi tests to match this with the fix.

Affected Cases:
[LocalFile.RemoteAppsWorkflow#AdminCanApproveRemotePortlet](https://testray.liferay.com/home/-/testray/case_results/1713924092)
[LocalFile.RemoteAppsWorkflow#CanSendWorkflowNotification](https://testray.liferay.com/home/-/testray/case_results/1713924325)
[LocalFile.RemoteAppsWorkflow#PendingRemoteAppCannotBeAddedToPage](https://testray.liferay.com/home/-/testray/case_results/1713924327)
[LocalFile.RemoteAppsWorkflow#CanConfigureWorkflowInstanceLevel](https://testray.liferay.com/home/-/testray/case_results/1713924324)

JIRA Ticket:
https://issues.liferay.com/browse/LPS-152751