### PR TITLE
LPS-152816 | Nested fields in oneToMany Updated relationship

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -236,6 +236,25 @@ definition {
 		return "${json}";
 	}
 
+	macro _updateEmployee {
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/employees/${employeeId} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+
+			-d
+					{	                 
+	"firstname": "${firstname}",
+	"r_supervisor_c_managerId": "${newManagerId}"
+					}
+	''';
+		var response = JSONCurlUtil.put("${curl}");
+
+		return "${response}";
+	}
+
 	macro assertEmployeeHasNestedFieldManager {
 		ObjectDefinitionAPI._assertEmployeeFirstnameCorrect(
 			expectedEmployeeFirstname = "${expectedEmployeeFirstname}",
@@ -327,6 +346,21 @@ definition {
 			objects = "${objects}");
 
 		return "${getObjectsWithNestedFieldJSON}";
+	}
+
+	macro updateEmployee {
+		ObjectDefinitionAPI._updateEmployee(
+			employeeId = "${employeeId}",
+			firstname = "${employeeFirstname}",
+			newManagerId = "${newManagerId}");
+
+		var firstname = ObjectDefinitionAPI._getEmployeeFirstnameById(employeeId = "${employeeId}");
+
+		TestUtils.assertEquals(
+			actual = "${firstname}",
+			expected = "${employeeFirstname}");
+
+		return "${employeeId}";
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -237,6 +237,8 @@ definition {
 	}
 
 	macro _updateEmployee {
+		Variables.assertDefined(parameterList = "${employeeId},${firstname},${managerId}");
+
 		var portalURL = JSONCompany.getDefaultPortalURL();
 
 		var curl = '''
@@ -247,7 +249,7 @@ definition {
 			-d
 					{	                 
 	"firstname": "${firstname}",
-	"r_supervisor_c_managerId": "${newManagerId}"
+	"r_supervisor_c_managerId": "${managerId}"
 					}
 	''';
 		var response = JSONCurlUtil.put("${curl}");
@@ -352,7 +354,7 @@ definition {
 		ObjectDefinitionAPI._updateEmployee(
 			employeeId = "${employeeId}",
 			firstname = "${employeeFirstname}",
-			newManagerId = "${newManagerId}");
+			managerId = "${managerId}");
 
 		var firstname = ObjectDefinitionAPI._getEmployeeFirstnameById(employeeId = "${employeeId}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -70,4 +70,50 @@ definition {
 		}
 	}
 
+	@description = "Nested fields in oneToMany Updated relationship"
+	@priority = "5"
+	test CanReturnNestedFieldsDetailsInOneToManyUpdatedRelationship {
+		property portal.acceptance = "true";
+
+		task ("Given two manager accounts created") {
+			var managerId1 = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
+
+			var managerId2 = ObjectDefinitionAPI.createManager(managerFirstname = "Aaron");
+		}
+
+		task ("Given two employee accounts created") {
+			var employeeId1 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Bruce",
+				managerId = "${managerId1}");
+
+			var employeeId2 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Riley",
+				managerId = "${managerId2}");
+		}
+
+		task ("Given the employee account updated by changing manager") {
+			ObjectDefinitionAPI.updateEmployee(
+				employeeFirstname = "Bruce",
+				employeeId = "${employeeId1}",
+				newManagerId = "${managerId2}");
+		}
+
+		task ("When calling for 'employees' with a 'manager' as nestedFields parameter") {
+			var getEmployeesWithManager = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedObject = "manager",
+				objects = "employees");
+		}
+
+		task ("Then 'employee' information should be provided with 'manager' information nested as an object") {
+			ObjectDefinitionAPI.assertEmployeeHasNestedFieldManager(
+				expectedEmployeeFirstname = "Bruce",
+				expectedManagerFirstname = "Aaron",
+				expectedManagerId = "${managerId2}",
+				nestedField = "manager",
+				objectId = "${employeeId1}",
+				relationshipName = "supervisor",
+				responseToParse = "${getEmployeesWithManager}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -95,7 +95,7 @@ definition {
 			ObjectDefinitionAPI.updateEmployee(
 				employeeFirstname = "Bruce",
 				employeeId = "${employeeId1}",
-				newManagerId = "${managerId2}");
+				managerId = "${managerId2}");
 		}
 
 		task ("When calling for 'employees' with a 'manager' as nestedFields parameter") {


### PR DESCRIPTION
**Background**
AdvancedObjectAPI#CanReturnNestedFieldsDetailsInOneToManyUpdatedRelationship

**Test Plan**
Given active object definitions created
And Given a relationship between two object definitions created
And Given two manager accounts created
And Given two employee accounts created
And Given the employee account updated by changing manager
When calling for employees with "manager" as nested Fields parameter
Then "employee" information should be provided with updated "manager" information

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-152816