### PR TITLE
LPS-152226 Deprecate `disableToggleBoxes` and replace its usages

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -297,6 +297,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `toggleDisabled`
+		 */
 		disableToggleBoxes(checkBoxId, toggleBoxId, checkDisabled) {
 			const checkBox = document.getElementById(checkBoxId);
 			const toggleBox = document.getElementById(toggleBoxId);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -109,7 +109,7 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 			);
 
 			if (autoArticleInput && newArticleInput) {
-				newArticleInput.disabled = true && autoArticleInput.checked;
+				newArticleInput.disabled = autoArticleInput.checked;
 
 				autoArticleInput.addEventListener('click', () => {
 					Liferay.Util.toggleDisabled(newArticleInput, !newArticleInput.disabled);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -101,11 +101,20 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		</div>
 
 		<aui:script>
-			Liferay.Util.disableToggleBoxes(
-				'<portlet:namespace />autoArticleId',
-				'<portlet:namespace />newArticleId',
-				true
+			var autoArticleInput = document.getElementById(
+				'<portlet:namespace />autoArticleId'
 			);
+			var newArticleInput = document.getElementById(
+				'<portlet:namespace />newArticleId'
+			);
+
+			if (autoArticleInput && newArticleInput) {
+				newArticleInput.disabled = true && autoArticleInput.checked;
+
+				autoArticleInput.addEventListener('click', () => {
+					Liferay.Util.toggleDisabled(newArticleInput, !newArticleInput.disabled);
+				});
+			}
 		</aui:script>
 	</c:when>
 	<c:otherwise>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -415,7 +415,7 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 	var newFeedCheckbox = document.getElementById('<portlet:namespace />newFeedId');
 
 	if (autoFeedInput && newFeedCheckbox) {
-		newFeedCheckbox.disabled = true && autoFeedInput.checked;
+		newFeedCheckbox.disabled = autoFeedInput.checked;
 
 		autoFeedInput.addEventListener('click', () => {
 			Liferay.Util.toggleDisabled(newFeedCheckbox, !newFeedCheckbox.disabled);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -411,11 +411,16 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 		submitForm(document.<portlet:namespace />fm);
 	}
 
-	Liferay.Util.disableToggleBoxes(
-		'<portlet:namespace />autoFeedId',
-		'<portlet:namespace />newFeedId',
-		true
-	);
+	var autoFeedInput = document.getElementById('<portlet:namespace />autoFeedId');
+	var newFeedCheckbox = document.getElementById('<portlet:namespace />newFeedId');
+
+	if (autoFeedInput && newFeedCheckbox) {
+		newFeedCheckbox.disabled = true && autoFeedInput.checked;
+
+		autoFeedInput.addEventListener('click', () => {
+			Liferay.Util.toggleDisabled(newFeedCheckbox, !newFeedCheckbox.disabled);
+		});
+	}
 </aui:script>
 
 <aui:script sandbox="<%= true %>">

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_public_render_parameters.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_public_render_parameters.jsp
@@ -23,7 +23,6 @@ List<PublicRenderParameterConfiguration> publicRenderParameterConfigurations = (
 Set<PublicRenderParameter> publicRenderParameters = (Set<PublicRenderParameter>)request.getAttribute(WebKeys.PUBLIC_RENDER_PARAMETERS);
 %>
 
-<h1>edit_public_render_parameters</h1>
 <portlet:actionURL name="editPublicRenderParameters" var="editPublicRenderParametersURL">
 	<portlet:param name="mvcPath" value="/edit_public_render_parameters.jsp" />
 	<portlet:param name="portletConfiguration" value="<%= Boolean.TRUE.toString() %>" />
@@ -149,7 +148,7 @@ Set<PublicRenderParameter> publicRenderParameters = (Set<PublicRenderParameter>)
 		);
 
 		if (ignoreInput && mappingInput) {
-			mappingInput.disabled = true && ignoreInput.checked;
+			mappingInput.disabled = ignoreInput.checked;
 
 			ignoreInput.addEventListener('click', () => {
 				Liferay.Util.toggleDisabled(mappingInput, !mappingInput.disabled);

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_public_render_parameters.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_public_render_parameters.jsp
@@ -23,6 +23,7 @@ List<PublicRenderParameterConfiguration> publicRenderParameterConfigurations = (
 Set<PublicRenderParameter> publicRenderParameters = (Set<PublicRenderParameter>)request.getAttribute(WebKeys.PUBLIC_RENDER_PARAMETERS);
 %>
 
+<h1>edit_public_render_parameters</h1>
 <portlet:actionURL name="editPublicRenderParameters" var="editPublicRenderParametersURL">
 	<portlet:param name="mvcPath" value="/edit_public_render_parameters.jsp" />
 	<portlet:param name="portletConfiguration" value="<%= Boolean.TRUE.toString() %>" />
@@ -140,11 +141,20 @@ Set<PublicRenderParameter> publicRenderParameters = (Set<PublicRenderParameter>)
 	for (PublicRenderParameterConfiguration publicRenderParameterConfiguration : publicRenderParameterConfigurations) {
 	%>
 
-		Liferay.Util.disableToggleBoxes(
-			'<portlet:namespace /><%= PublicRenderParameterConfiguration.IGNORE_PREFIX + HtmlUtil.escapeJS(publicRenderParameterConfiguration.getPublicRenderParameterName()) %>',
-			'<portlet:namespace /><%= PublicRenderParameterConfiguration.MAPPING_PREFIX + HtmlUtil.escapeJS(publicRenderParameterConfiguration.getPublicRenderParameterName()) %>',
-			true
+		var ignoreInput = document.getElementById(
+			'<portlet:namespace /><%= PublicRenderParameterConfiguration.IGNORE_PREFIX + HtmlUtil.escapeJS(publicRenderParameterConfiguration.getPublicRenderParameterName()) %>'
 		);
+		var mappingInput = document.getElementById(
+			'<portlet:namespace /><%= PublicRenderParameterConfiguration.MAPPING_PREFIX + HtmlUtil.escapeJS(publicRenderParameterConfiguration.getPublicRenderParameterName()) %>'
+		);
+
+		if (ignoreInput && mappingInput) {
+			mappingInput.disabled = true && ignoreInput.checked;
+
+			ignoreInput.addEventListener('click', () => {
+				Liferay.Util.toggleDisabled(mappingInput, !mappingInput.disabled);
+			});
+		}
 
 	<%
 	}


### PR DESCRIPTION
After careful investigation I've come to the conclusion that this utility was a more specific variant of our [toggleDisabled](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_disabled.js) util. I've changed usages of this util to reflect that conclusion.

## 🧪 Testing

I've tested only one of three usages, I couldn't find the other 2 usages. I've tested the one inside `edit_feed.jsp` that can be tested by enabling Feeds first: System settings -> Web Content -> Administration -> Show feeds. Then go to Web Content > Feeds and create a new Feed. 

### 😕 Confusion

The given example above has the elements in question set as hidden, so the functionality should be able to be removed in that example, but I wanted to play it safe and keep everything as it was. Due to this, in order to test it, you will need to replace the `type="hidden"` with `type="text"` and `type="checkbox"`, respectively ([in this part](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp#L149-L150)).