### PR TITLE
[TS] LPS-153271 Use the 'realUserId' so that the sessions are tied together when impersonating a user and the user is not logged out if not performing actions as the original user

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -324,7 +324,7 @@ AUI.add(
 					var instance = this;
 
 					instance._cookieKey =
-						'LFR_SESSION_STATE_' + themeDisplay.getUserId();
+						'LFR_SESSION_STATE_' + themeDisplay.getRealUserId();
 
 					instance._cookieOptions = {
 						path: '/',

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -272,6 +272,9 @@
 			getPortalURL: function() {
 				return '<%= themeDisplay.getPortalURL() %>';
 			},
+			getRealUserId: function() {
+				return '<%= themeDisplay.getRealUserId() %>';
+			},
 			getScopeGroupId: function() {
 				return '<%= scopeGroup.getGroupId() %>';
 			},


### PR DESCRIPTION
### References

- [LPS-153271 Session key is incorrect when impersonating user leading to an expired session and logged out of both](https://issues.liferay.com/browse/LPS-153271)

### What is the goal of this PR?

The goal of this PR is to use the correct `userId` as part of the session cookie's key.

Currently, the user's ID is appended to `LFR_SESSION_STATE_` in order to create a key for the session cookie. This does not work as expected when impersonating a user since we now have two session cookies but there is only one true session tied to the original user.

With the changes in this pull the `realUserId` is fetched so that the same cookie key is used between the original and impersonated user tabs. Now, when an action is performed in one tab the session is updated for both.

This is needed because the true session is tied to the original user. If that session expires then both the original and impersonated user tabs will be logged out. This is unexpected because the user is performing actions and should not need to switch between tabs to keep both users' sessions alive.

### What does it look like?

No changes in the UI.

### Steps to reproduce

1. In _ROOT/WEB-INF/web.xml_ update the _session-timeout_ to _2_
2. In _portal-ext.properties_ add _session.timeout=2_
3. Start up the portal
4. Create a new user
5. Impersonate the new user
6. Wait 1 minute and assert the original tab shows the session timeout warning
7. Perform an action on the second tab (impersonated user)
8. Wait 1 more minute
9. Assert that the user is logged out of both tabs