### PR TITLE
LRQA-74676 Update tests from RemoteApps file.

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -202,7 +202,7 @@ definition {
 		PortletEntry.publish();
 	}
 
-	macro getRemoteAppEntryIdValue {
+	macro getClientExtensionEntryIdValue {
 		WaitForSPARefresh();
 
 		RemoteApps.goToRemoteAppsPortlet();
@@ -213,10 +213,10 @@ definition {
 
 		var currentURL = Navigator.getCurrentURL();
 
-		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "remoteAppEntryId=");
-		var remoteAppEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
+		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "clientExtensionEntryId=");
+		var clientExtensionEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
 
-		return "${remoteAppEntryIdValue}";
+		return "${clientExtensionEntryIdValue}";
 	}
 
 	macro getRemoteAppEntryName {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -362,12 +362,12 @@ definition {
 		}
 
 		task ("Obtain Vanilla Counter's remoteAppEntryId") {
-			var remoteAppEntryIdValue = RemoteApps.getRemoteAppEntryIdValue();
+			var clientExtensionEntryIdValue = RemoteApps.getClientExtensionEntryIdValue();
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Guest",
 				layoutName = "Test Page",
-				remoteAppEntryId = "${remoteAppEntryIdValue}",
+				remoteAppEntryId = "${clientExtensionEntryIdValue}",
 				widgetName = "Vanilla Counter");
 		}
 
@@ -434,12 +434,12 @@ definition {
 		}
 
 		task ("Add Vanilla Counter to Test Page") {
-			var remoteAppEntryIdValue = RemoteApps.getRemoteAppEntryIdValue();
+			var clientExtensionEntryIdValue = RemoteApps.getClientExtensionEntryIdValue();
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Guest",
 				layoutName = "Test Page",
-				remoteAppEntryId = "${remoteAppEntryIdValue}",
+				remoteAppEntryId = "${clientExtensionEntryIdValue}",
 				widgetName = "Vanilla Counter");
 		}
 


### PR DESCRIPTION
**Background:**
Tests were failing because a change occurred with `remoteAppEntryId` needed to be updated to `clientExtensionEntryId` .

**Affected Cases:**
RemoteApps#CustomElementCanConfigurePortletName
RemoteApps#CustomElementCanInjectHTMLProperties

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-74676