### PR TITLE
LPS-152224 Deprecate `disableElements`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -247,6 +247,9 @@
 			}
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
+		 */
 		disableElements(element) {
 			const currentElement = Util.getElement(element);
 

--- a/portal-web/docroot/html/taglib/portlet/preview/page.jsp
+++ b/portal-web/docroot/html/taglib/portlet/preview/page.jsp
@@ -50,5 +50,30 @@ if (Validator.isNull(width)) {
 </div>
 
 <aui:script>
-	Liferay.Util.disableElements('#<%= randomNamespace %>');
+	var randomElement = document.getElementById('<%= randomNamespace %>');
+
+	if (randomElement) {
+		var children = randomElement.getElementsByTagName('*');
+
+		var emptyFnFalse = function () {
+			return false;
+		};
+
+		for (var i = children.length - 1; i >= 0; i--) {
+			var item = children[i];
+
+			item.style.cursor = 'default';
+
+			item.onclick = emptyFnFalse;
+			item.onmouseover = emptyFnFalse;
+			item.onmouseout = emptyFnFalse;
+			item.onmouseenter = emptyFnFalse;
+			item.onmouseleave = emptyFnFalse;
+
+			item.action = '';
+			item.disabled = true;
+			item.href = 'javascript:;';
+			item.onsubmit = emptyFnFalse;
+		}
+	}
 </aui:script>


### PR DESCRIPTION
This PR deprecates the util and just adds the implementation directly to where the util was used.

It can be tested by dragging a Breadcrumbs portlet onto your landing page and going into its Configuration. At that point, the util should be invoked.