### PR TITLE
LPS-145457 Add validation to avoid batch generation/VulcanBatchEngineImportTaskResource implementation if the schema is in the disabledBatchSchemaNames list

### DIFF
--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -98,10 +98,14 @@ public class FreeMarkerTool {
 
 	public boolean generateBatch(
 		ConfigYAML configYAML, String javaDataType,
-		List<JavaMethodSignature> javaMethodSignatures) {
+		List<JavaMethodSignature> javaMethodSignatures, String schemaName) {
 
-		if (!configYAML.isGenerateBatch() || (javaDataType == null) ||
-			javaDataType.isEmpty()) {
+		List<String> disabledBatchSchemaNames =
+			configYAML.getDisabledBatchSchemaNames();
+
+		if (!configYAML.isGenerateBatch() ||
+			disabledBatchSchemaNames.contains(schemaName) ||
+			(javaDataType == null) || javaDataType.isEmpty()) {
 
 			return false;
 		}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_impl.ftl
@@ -77,7 +77,7 @@ public abstract class Base${schemaName}ResourceImpl
 	<#assign
 		javaDataType = freeMarkerTool.getJavaDataType(configYAML, openAPIYAML, schemaName)!""
 		javaMethodSignatures = freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
-		generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures)
+		generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures, schemaName)
 	/>
 
 	<#if generateBatch>

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/graphql_mutation.ftl
@@ -117,7 +117,7 @@ public class Mutation {
 	<#list schemaNames as schemaName>
 		<#assign
 			javaDataType = freeMarkerTool.getJavaDataType(configYAML, openAPIYAML, schemaName)!""
-			generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName))
+			generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName), schemaName)
 		/>
 
 		private void _populateResourceContext(${schemaName}Resource ${freeMarkerTool.getSchemaVarName(schemaName)}Resource) throws Exception {

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/properties.ftl
@@ -6,7 +6,7 @@ api.version=${openAPIYAML.info.version}
 <#assign
 	javaDataType = freeMarkerTool.getJavaDataType(configYAML, openAPIYAML, schemaName)!""
 	javaMethodSignatures = freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
-	generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures)
+	generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures, schemaName)
 />
 <#if !stringUtil.equals(schemaName, "openapi") && generateBatch>
 batch.engine.entity.class.name=${javaDataType}

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/resource.ftl
@@ -59,7 +59,7 @@ public interface ${schemaName}Resource {
 	<#assign
 		javaDataType = freeMarkerTool.getJavaDataType(configYAML, openAPIYAML, schemaName)!""
 		javaMethodSignatures = freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName)
-		generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures)
+		generateBatch = freeMarkerTool.generateBatch(configYAML, javaDataType, javaMethodSignatures, schemaName)
 	/>
 
 	<#list javaMethodSignatures as javaMethodSignature>


### PR DESCRIPTION
This PR contains the code to avoid all the batch generation (included the `VulcanBatchEngineImportTaskResource` implementation) if the current schema is included in the `disabledBatchSchemaNames` list of the `rest-config.yaml` file.

---

Given a schema, called `Schema`, if the schema is included in the `disabledBatchSchemaNames`, in the `rest-openapi.yaml`is not defined any POST either any PUT, but it is defined a GET:

**Before the PR:**

The VulcanBatchEngineImportTaskResource is implemented as the validation that contains a getSchemaPages is passed even though the Batch endpoints are not created.

**After the PR:**

The VulcanBatchEngineImportTaskResource is not implemented as the validation regarding the `disabledBatchSchemaNames` list is indicating that nothing from Batch functionality should be implemented