### PR TITLE
LPS-153224 | StructuredContentContainsPriorityField

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -122,6 +122,33 @@ definition {
 		return "${curl}";
 	}
 
+	macro _filterStructuredContentWithPriority {
+		Variables.assertDefined(parameterList = "${filtervalue}");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
+	macro assertPriorityFieldIsFilterWithDefaultValue {
+		var actualPriorityDefaultValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..['priority']");
+
+		TestUtils.assertEquals(
+			actual = "${actualPriorityDefaultValue}",
+			expected = "${expectedPriorityDefaultValue}");
+	}
+
 	macro assertPriorityFieldWithDefaultValue {
 		var actualPriorityDefaultValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.priority");
 
@@ -137,6 +164,12 @@ definition {
 			label = "${label}",
 			name = "${name}",
 			title = "${title}");
+
+		return "${response}";
+	}
+
+	macro filterStructuredContentWithPriority {
+		var response = HeadlessWebcontentAPI._filterStructuredContentWithPriority(filtervalue = "${filtervalue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/template/WebContentStructures.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/template/WebContentStructures.macro
@@ -311,7 +311,7 @@ definition {
 			Alert.viewSuccessMessage();
 		}
 
-		Portlet.viewEmptyMessage(message = "There are no results.");
+		Portlet.viewEmptyMessage(message = "No structures were found.");
 	}
 
 	macro viewCP {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
@@ -1,0 +1,68 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			WebContent.tearDownCP();
+
+			WebContentStructures.tearDownCP();
+		}
+	}
+
+	@description = "StructuredContent can be filtered with default priority"
+	@priority = "5"
+	test StructuredContentContainsPriorityField {
+		property portal.acceptance = "true";
+
+		task ("Given a web content are created with default priority") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When web contents are filtered with default priority") {
+			var responseToParse = HeadlessWebcontentAPI.filterStructuredContentWithPriority(filtervalue = "priority%20eq%200.0");
+		}
+
+		task ("Then the response body includes the default priority field") {
+			HeadlessWebcontentAPI.assertPriorityFieldIsFilterWithDefaultValue(
+				expectedPriorityDefaultValue = "0.0",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
StructuredContent can be filtered with default priority

**Test Plan**
Given three web content is created with default priority
When with GET request I filter web content by the field priority with "/v1.0/sites/{siteId}/structured-contents"
Then you can see the web content filtered by the default in the body response

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-153224