### PR TITLE
LPS-140372 Include example key value in @Schema java annotation

### DIFF
--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Account.java
@@ -66,7 +66,9 @@ public class Account implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Account.class, json);
 	}
 
-	@Schema
+	@Schema(
+		example = "[{city=Diamond Bar, countryISOCode=US, defaultBilling=true, defaultShipping=true, description=right stairs, first room on the left, id=31130, latitude=33.9976884, longitude=-117.8144595, name=Alessio Antonio Rendina, phoneNumber=(123) 456 7890, regionISOCode=CA, street1=1400 Montefino Ave, street2=1st floor, street3=suite 200, zip=91765}]"
+	)
 	@Valid
 	public AccountAddress[] getAccountAddresses() {
 		return accountAddresses;
@@ -96,7 +98,9 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected AccountAddress[] accountAddresses;
 
-	@Schema
+	@Schema(
+		example = "[{description={en_US=Account Administrator Description US, hr_HR=Account Administrator Description HR, hu_HU=Account Administrator Description HU}}, {id=31256, name=Alessio Antonio Rendina, roles=null}]"
+	)
 	@Valid
 	public AccountMember[] getAccountMembers() {
 		return accountMembers;
@@ -126,7 +130,9 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected AccountMember[] accountMembers;
 
-	@Schema
+	@Schema(
+		example = "[{id=20546, name=Liferay Italy, organizationId=20433, treePath=/Liferay/Liferay Italy}]"
+	)
 	@Valid
 	public AccountOrganization[] getAccountOrganizations() {
 		return accountOrganizations;
@@ -158,7 +164,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected AccountOrganization[] accountOrganizations;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -272,7 +278,7 @@ public class Account implements Serializable {
 	protected Date dateModified;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "10130")
 	public Long getDefaultBillingAccountAddressId() {
 		return defaultBillingAccountAddressId;
 	}
@@ -305,7 +311,7 @@ public class Account implements Serializable {
 	protected Long defaultBillingAccountAddressId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "10131")
 	public Long getDefaultShippingAccountAddressId() {
 		return defaultShippingAccountAddressId;
 	}
@@ -337,7 +343,9 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long defaultShippingAccountAddressId;
 
-	@Schema
+	@Schema(
+		example = "[joe.1@commerce.com, joe.2@commerce.com, joe.3@commerce.com]"
+	)
 	public String[] getEmailAddresses() {
 		return emailAddresses;
 	}
@@ -365,7 +373,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String[] emailAddresses;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -395,7 +403,7 @@ public class Account implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -422,7 +430,7 @@ public class Account implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20078")
 	public Long getLogoId() {
 		return logoId;
 	}
@@ -450,7 +458,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long logoId;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getLogoURL() {
 		return logoURL;
 	}
@@ -478,7 +486,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String logoURL;
 
-	@Schema
+	@Schema(example = "Account Name")
 	public String getName() {
 		return name;
 	}
@@ -505,7 +513,7 @@ public class Account implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getRoot() {
 		return root;
 	}
@@ -531,7 +539,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean root;
 
-	@Schema
+	@Schema(example = "Abcd1234")
 	public String getTaxId() {
 		return taxId;
 	}
@@ -561,7 +569,7 @@ public class Account implements Serializable {
 
 	@DecimalMax("2")
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getType() {
 		return type;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountAddress.java
@@ -61,7 +61,7 @@ public class AccountAddress implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(AccountAddress.class, json);
 	}
 
-	@Schema
+	@Schema(example = "Diamond Bar")
 	public String getCity() {
 		return city;
 	}
@@ -88,7 +88,7 @@ public class AccountAddress implements Serializable {
 	@NotEmpty
 	protected String city;
 
-	@Schema
+	@Schema(example = "US")
 	public String getCountryISOCode() {
 		return countryISOCode;
 	}
@@ -117,7 +117,7 @@ public class AccountAddress implements Serializable {
 	@NotEmpty
 	protected String countryISOCode;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDefaultBilling() {
 		return defaultBilling;
 	}
@@ -145,7 +145,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean defaultBilling;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDefaultShipping() {
 		return defaultShipping;
 	}
@@ -173,7 +173,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean defaultShipping;
 
-	@Schema
+	@Schema(example = "right stairs, first room on the left")
 	public String getDescription() {
 		return description;
 	}
@@ -201,7 +201,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -230,7 +230,7 @@ public class AccountAddress implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -256,7 +256,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "33.9976884")
 	public Double getLatitude() {
 		return latitude;
 	}
@@ -284,7 +284,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double latitude;
 
-	@Schema
+	@Schema(example = "-117.8144595")
 	public Double getLongitude() {
 		return longitude;
 	}
@@ -312,7 +312,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double longitude;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}
@@ -339,7 +339,7 @@ public class AccountAddress implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "(123) 456 7890")
 	public String getPhoneNumber() {
 		return phoneNumber;
 	}
@@ -367,7 +367,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String phoneNumber;
 
-	@Schema
+	@Schema(example = "CA")
 	public String getRegionISOCode() {
 		return regionISOCode;
 	}
@@ -395,7 +395,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String regionISOCode;
 
-	@Schema
+	@Schema(example = "1400 Montefino Ave")
 	public String getStreet1() {
 		return street1;
 	}
@@ -424,7 +424,7 @@ public class AccountAddress implements Serializable {
 	@NotEmpty
 	protected String street1;
 
-	@Schema
+	@Schema(example = "1st floor")
 	public String getStreet2() {
 		return street2;
 	}
@@ -452,7 +452,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street2;
 
-	@Schema
+	@Schema(example = "suite 200")
 	public String getStreet3() {
 		return street3;
 	}
@@ -482,7 +482,7 @@ public class AccountAddress implements Serializable {
 
 	@DecimalMax("3")
 	@DecimalMin("1")
-	@Schema
+	@Schema(example = "1")
 	public Integer getType() {
 		return type;
 	}
@@ -508,7 +508,7 @@ public class AccountAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer type;
 
-	@Schema
+	@Schema(example = "91765")
 	public String getZip() {
 		return zip;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountGroup.java
@@ -90,7 +90,7 @@ public class AccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -119,7 +119,7 @@ public class AccountGroup implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -145,7 +145,7 @@ public class AccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "AccountGroup Name")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountMember.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountMember.java
@@ -62,7 +62,7 @@ public class AccountMember implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -90,7 +90,9 @@ public class AccountMember implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long accountId;
 
-	@Schema
+	@Schema(
+		example = "[{description={en_US=Account Administrator Description US, hr_HR=Account Administrator Description HR, hu_HU=Account Administrator Description HU}}, {description={en_US=Order Manager Description US, hr_HR=Order Manager Description HR, hu_HU=Order Manager Description HU}}]"
+	)
 	@Valid
 	public AccountRole[] getAccountRoles() {
 		return accountRoles;
@@ -119,7 +121,7 @@ public class AccountMember implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected AccountRole[] accountRoles;
 
-	@Schema
+	@Schema(example = "joe.1@commerce.com")
 	public String getEmail() {
 		return email;
 	}
@@ -148,7 +150,7 @@ public class AccountMember implements Serializable {
 	@NotEmpty
 	protected String email;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -176,7 +178,7 @@ public class AccountMember implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@Schema
+	@Schema(example = "User Name")
 	public String getName() {
 		return name;
 	}
@@ -202,7 +204,7 @@ public class AccountMember implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(example = "UAB-34098-789-N")
 	public String getUserExternalReferenceCode() {
 		return userExternalReferenceCode;
 	}
@@ -233,7 +235,7 @@ public class AccountMember implements Serializable {
 	protected String userExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30002")
 	public Long getUserId() {
 		return userId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountOrganization.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountOrganization.java
@@ -60,7 +60,7 @@ public class AccountOrganization implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -88,7 +88,7 @@ public class AccountOrganization implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long accountId;
 
-	@Schema
+	@Schema(example = "Organization Name")
 	public String getName() {
 		return name;
 	}
@@ -114,7 +114,7 @@ public class AccountOrganization implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(example = "UAB-34098-789-N")
 	public String getOrganizationExternalReferenceCode() {
 		return organizationExternalReferenceCode;
 	}
@@ -148,7 +148,7 @@ public class AccountOrganization implements Serializable {
 	protected String organizationExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30002")
 	public Long getOrganizationId() {
 		return organizationId;
 	}
@@ -176,7 +176,7 @@ public class AccountOrganization implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long organizationId;
 
-	@Schema
+	@Schema(example = "/Parent Organization/Organization Name")
 	public String getTreePath() {
 		return treePath;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountRole.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/AccountRole.java
@@ -61,7 +61,9 @@ public class AccountRole implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(AccountRole.class, json);
 	}
 
-	@Schema
+	@Schema(
+		example = "{en_US=Role Description US, hr_HR=Role Description HR, hu_HU=Role Description HU}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -91,7 +93,7 @@ public class AccountRole implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "Role Name")
 	public String getName() {
 		return name;
 	}
@@ -119,7 +121,7 @@ public class AccountRole implements Serializable {
 	protected String name;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getRoleId() {
 		return roleId;
 	}
@@ -147,7 +149,9 @@ public class AccountRole implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long roleId;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Role Title US, hr_HR=Role Title HR, hu_HU=Role Title HU}"
+	)
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/User.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/java/com/liferay/headless/commerce/admin/account/dto/v1_0/User.java
@@ -60,7 +60,7 @@ public class User implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(User.class, json);
 	}
 
-	@Schema
+	@Schema(example = "joe.1@commerce.com")
 	public String getEmail() {
 		return email;
 	}
@@ -89,7 +89,7 @@ public class User implements Serializable {
 	@NotEmpty
 	protected String email;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -147,7 +147,7 @@ public class User implements Serializable {
 	protected String firstName;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -230,7 +230,7 @@ public class User implements Serializable {
 	@NotEmpty
 	protected String lastName;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getMale() {
 		return male;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/resources/com/liferay/headless/commerce/admin/account/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-api/src/main/resources/com/liferay/headless/commerce/admin/account/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.2.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Attachment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Attachment.java
@@ -119,7 +119,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean cdnEnabled;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getCdnURL() {
 		return cdnURL;
 	}
@@ -204,7 +204,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected CustomField[] customFields;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -232,7 +232,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -260,7 +260,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -289,7 +289,7 @@ public class Attachment implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -315,7 +315,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -343,7 +343,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@Schema
+	@Schema(example = "{color=yellow, optionKey=optionValueKey, size=xs}")
 	@Valid
 	public Map<String, String> getOptions() {
 		return options;
@@ -372,7 +372,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> options;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -426,7 +426,9 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String src;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Attachment Title HR, hu_HU=Attachment Title HU}"
+	)
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentBase64.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentBase64.java
@@ -148,7 +148,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected CustomField[] customFields;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -176,7 +176,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -204,7 +204,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -233,7 +233,7 @@ public class AttachmentBase64 implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -259,7 +259,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -287,7 +287,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@Schema
+	@Schema(example = "{color=yellow, optionKey=optionValueKey, size=xs}")
 	@Valid
 	public Map<String, String> getOptions() {
 		return options;
@@ -316,7 +316,7 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> options;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -370,7 +370,9 @@ public class AttachmentBase64 implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String src;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Attachment Title HR, hu_HU=Attachment Title HU}"
+	)
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentUrl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/AttachmentUrl.java
@@ -120,7 +120,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected CustomField[] customFields;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -148,7 +148,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -176,7 +176,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -205,7 +205,7 @@ public class AttachmentUrl implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -231,7 +231,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -259,7 +259,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@Schema
+	@Schema(example = "{color=yellow, optionKey=optionValueKey, size=xs}")
 	@Valid
 	public Map<String, String> getOptions() {
 		return options;
@@ -288,7 +288,7 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> options;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -342,7 +342,9 @@ public class AttachmentUrl implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String src;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Attachment Title HR, hu_HU=Attachment Title HU}"
+	)
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Catalog.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Catalog.java
@@ -91,7 +91,7 @@ public class Catalog implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "USD")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -119,7 +119,7 @@ public class Catalog implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String currencyCode;
 
-	@Schema
+	@Schema(example = "en_US")
 	public String getDefaultLanguageId() {
 		return defaultLanguageId;
 	}
@@ -147,7 +147,7 @@ public class Catalog implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String defaultLanguageId;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -176,7 +176,7 @@ public class Catalog implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -229,7 +229,7 @@ public class Catalog implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "false")
 	public Boolean getSystem() {
 		return system;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Category.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Category.java
@@ -60,7 +60,7 @@ public class Category implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Category.class, json);
 	}
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -89,7 +89,7 @@ public class Category implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -170,7 +170,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long siteId;
 
-	@Schema
+	@Schema(example = "Default Vocabulary")
 	public String getVocabulary() {
 		return vocabulary;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Diagram.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Diagram.java
@@ -89,7 +89,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected AttachmentBase64 attachmentBase64;
 
-	@Schema
+	@Schema(example = "black")
 	public String getColor() {
 		return color;
 	}
@@ -118,7 +118,7 @@ public class Diagram implements Serializable {
 	protected String color;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -145,7 +145,7 @@ public class Diagram implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33132")
 	public Long getImageId() {
 		return imageId;
 	}
@@ -173,7 +173,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long imageId;
 
-	@Schema
+	@Schema(example = "Name 1")
 	public String getImageURL() {
 		return imageURL;
 	}
@@ -201,7 +201,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String imageURL;
 
-	@Schema
+	@Schema(example = "exampleERC")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -234,7 +234,7 @@ public class Diagram implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;
 	}
@@ -262,7 +262,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long productId;
 
-	@Schema
+	@Schema(example = "33.54")
 	public Double getRadius() {
 		return radius;
 	}
@@ -290,7 +290,7 @@ public class Diagram implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double radius;
 
-	@Schema
+	@Schema(example = "default")
 	public String getType() {
 		return type;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {catalogId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/MappedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/MappedProduct.java
@@ -121,7 +121,7 @@ public class MappedProduct implements Serializable {
 	protected CustomField[] customFields;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33130")
 	public Long getId() {
 		return id;
 	}
@@ -147,7 +147,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "exampleERC")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -180,7 +180,7 @@ public class MappedProduct implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;
 	}
@@ -208,7 +208,9 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getProductName() {
 		return productName;
@@ -239,7 +241,7 @@ public class MappedProduct implements Serializable {
 	protected Map<String, String> productName;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
 	}
@@ -267,7 +269,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer quantity;
 
-	@Schema
+	@Schema(example = "1")
 	public String getSequence() {
 		return sequence;
 	}
@@ -295,7 +297,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sequence;
 
-	@Schema
+	@Schema(example = "SKU01")
 	public String getSku() {
 		return sku;
 	}
@@ -321,7 +323,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "SKU0111")
 	public String getSkuExternalReferenceCode() {
 		return skuExternalReferenceCode;
 	}
@@ -352,7 +354,7 @@ public class MappedProduct implements Serializable {
 	protected String skuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33135")
 	public Long getSkuId() {
 		return skuId;
 	}
@@ -378,7 +380,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long skuId;
 
-	@Schema
+	@Schema(example = "sku")
 	@Valid
 	public Type getType() {
 		return type;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Option.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Option.java
@@ -122,7 +122,9 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long catalogId;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Description HU, hr_HR=Description HR, en_US=Description}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -152,7 +154,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -180,7 +182,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getFacetable() {
 		return facetable;
 	}
@@ -208,7 +210,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean facetable;
 
-	@Schema
+	@Schema(example = "select")
 	@Valid
 	public FieldType getFieldType() {
 		return fieldType;
@@ -248,7 +250,7 @@ public class Option implements Serializable {
 	protected FieldType fieldType;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -274,7 +276,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "color")
 	public String getKey() {
 		return key;
 	}
@@ -301,7 +303,7 @@ public class Option implements Serializable {
 	@NotEmpty
 	protected String key;
 
-	@Schema
+	@Schema(example = "{en_US=Color, hr_HR=Color HR, hu_HU=Color HU}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -360,7 +362,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected OptionValue[] optionValues;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -388,7 +390,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getRequired() {
 		return required;
 	}
@@ -416,7 +418,7 @@ public class Option implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean required;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getSkuContributor() {
 		return skuContributor;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionCategory.java
@@ -62,7 +62,7 @@ public class OptionCategory implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(OptionCategory.class, json);
 	}
 
-	@Schema
+	@Schema(example = "{hu_HU=Horvatorszag, hr_HR=Hrvatska, en_US=Croatia}")
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -93,7 +93,7 @@ public class OptionCategory implements Serializable {
 	protected Map<String, String> description;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -119,7 +119,7 @@ public class OptionCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "oprion-category-key")
 	public String getKey() {
 		return key;
 	}
@@ -147,7 +147,7 @@ public class OptionCategory implements Serializable {
 	protected String key;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -175,7 +175,7 @@ public class OptionCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionValue.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/OptionValue.java
@@ -92,7 +92,7 @@ public class OptionValue implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -121,7 +121,7 @@ public class OptionValue implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -147,7 +147,7 @@ public class OptionValue implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "black")
 	public String getKey() {
 		return key;
 	}
@@ -174,7 +174,7 @@ public class OptionValue implements Serializable {
 	@NotEmpty
 	protected String key;
 
-	@Schema
+	@Schema(example = "{en_US=Black, hr_HR=Black HR, hu_HU=Black HU}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -204,7 +204,7 @@ public class OptionValue implements Serializable {
 	@NotNull
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Pin.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Pin.java
@@ -60,7 +60,7 @@ public class Pin implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33130")
 	public Long getId() {
 		return id;
 	}
@@ -115,7 +115,7 @@ public class Pin implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected MappedProduct mappedProduct;
 
-	@Schema
+	@Schema(example = "33.54")
 	public Double getPositionX() {
 		return positionX;
 	}
@@ -143,7 +143,7 @@ public class Pin implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double positionX;
 
-	@Schema
+	@Schema(example = "33.54")
 	public Double getPositionY() {
 		return positionY;
 	}
@@ -171,7 +171,7 @@ public class Pin implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double positionY;
 
-	@Schema
+	@Schema(example = "1")
 	public String getSequence() {
 		return sequence;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Product.java
@@ -96,7 +96,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -184,7 +184,7 @@ public class Product implements Serializable {
 	protected Catalog catalog;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30054")
 	public Long getCatalogId() {
 		return catalogId;
 	}
@@ -272,7 +272,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductConfiguration configuration;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -329,7 +329,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected CustomField[] customFields;
 
-	@Schema
+	@Schema(example = "Blue handle, 00001l, 70cm, lifetime warranty")
 	public String getDefaultSku() {
 		return defaultSku;
 	}
@@ -357,7 +357,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String defaultSku;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Product Description HU, hr_HR=Product Description HR, en_US=Professional hand stainless steel saw for wood. Made to last and saw forever. Made of best steel}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -416,7 +418,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Diagram diagram;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -473,7 +475,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> expando;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -501,7 +503,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -530,7 +532,7 @@ public class Product implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -615,7 +617,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected MappedProduct[] mappedProducts;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Meta description HU, hr_HR=Meta description HU, hu_HU=Meta description HU}"
+	)
 	@Valid
 	public Map<String, String> getMetaDescription() {
 		return metaDescription;
@@ -645,7 +649,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> metaDescription;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Meta keyword HU, hr_HR=Meta keyword HU, hu_HU=Meta keyword HU}"
+	)
 	@Valid
 	public Map<String, String> getMetaKeyword() {
 		return metaKeyword;
@@ -675,7 +681,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> metaKeyword;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Meta title HU, hr_HR=Meta title HU, hu_HU=Meta title HU}"
+	)
 	@Valid
 	public Map<String, String> getMetaTitle() {
 		return metaTitle;
@@ -705,7 +713,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> metaTitle;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getModifiedDate() {
 		return modifiedDate;
 	}
@@ -733,7 +741,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date modifiedDate;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -763,7 +773,7 @@ public class Product implements Serializable {
 	@NotNull
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -818,7 +828,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Pin[] pins;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getProductAccountGroupFilter() {
 		return productAccountGroupFilter;
 	}
@@ -882,7 +892,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductAccountGroup[] productAccountGroups;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getProductChannelFilter() {
 		return productChannelFilter;
 	}
@@ -1090,7 +1100,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer productStatus;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getProductType() {
 		return productType;
 	}
@@ -1119,7 +1129,7 @@ public class Product implements Serializable {
 	@NotEmpty
 	protected String productType;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getProductTypeI18n() {
 		return productTypeI18n;
 	}
@@ -1209,7 +1219,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductShippingConfiguration shippingConfiguration;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand stainless steel saw for wood, hr_HR=Product Short Description HR, hu_HU=Product Short Description HU}"
+	)
 	@Valid
 	public Map<String, String> getShortDescription() {
 		return shortDescription;
@@ -1239,7 +1251,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> shortDescription;
 
-	@Schema
+	@Schema(example = "default")
 	public String getSkuFormatted() {
 		return skuFormatted;
 	}
@@ -1327,7 +1339,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductSubscriptionConfiguration subscriptionConfiguration;
 
-	@Schema
+	@Schema(example = "[tag1, tag2, tag3]")
 	public String[] getTags() {
 		return tags;
 	}
@@ -1385,7 +1397,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductTaxConfiguration taxConfiguration;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getThumbnail() {
 		return thumbnail;
 	}
@@ -1413,7 +1425,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String thumbnail;
 
-	@Schema
+	@Schema(
+		example = "{en_US=product-url-us, hr_HR=product-url-hr, hu_HU=product-url-hu}"
+	)
 	@Valid
 	public Map<String, String> getUrls() {
 		return urls;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductAccountGroup.java
@@ -62,7 +62,7 @@ public class ProductAccountGroup implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getAccountGroupId() {
 		return accountGroupId;
 	}
@@ -90,7 +90,7 @@ public class ProductAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long accountGroupId;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -119,7 +119,7 @@ public class ProductAccountGroup implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -146,7 +146,7 @@ public class ProductAccountGroup implements Serializable {
 	@NotNull
 	protected Long id;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductChannel.java
@@ -61,7 +61,7 @@ public class ProductChannel implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -89,7 +89,7 @@ public class ProductChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long channelId;
 
-	@Schema
+	@Schema(example = "USD")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -117,7 +117,7 @@ public class ProductChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String currencyCode;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -146,7 +146,7 @@ public class ProductChannel implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -173,7 +173,7 @@ public class ProductChannel implements Serializable {
 	@NotNull
 	protected Long id;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductConfiguration.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductConfiguration.java
@@ -57,7 +57,7 @@ public class ProductConfiguration implements Serializable {
 			ProductConfiguration.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getAllowBackOrder() {
 		return allowBackOrder;
 	}
@@ -85,7 +85,7 @@ public class ProductConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean allowBackOrder;
 
-	@Schema
+	@Schema(example = "[10, 20, 30, 40]")
 	public Integer[] getAllowedOrderQuantities() {
 		return allowedOrderQuantities;
 	}
@@ -114,7 +114,7 @@ public class ProductConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer[] allowedOrderQuantities;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDisplayAvailability() {
 		return displayAvailability;
 	}
@@ -142,7 +142,7 @@ public class ProductConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean displayAvailability;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDisplayStockQuantity() {
 		return displayStockQuantity;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroup.java
@@ -88,7 +88,9 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Description HU, hr_HR=Description HR, en_US=Description}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -118,7 +120,7 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -147,7 +149,7 @@ public class ProductGroup implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -204,7 +206,7 @@ public class ProductGroup implements Serializable {
 	protected ProductGroupProduct[] products;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	public Integer getProductsCount() {
 		return productsCount;
 	}
@@ -232,7 +234,7 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer productsCount;
 
-	@Schema
+	@Schema(example = "{en_US=Title, hr_HR=Title HR, hu_HU=Title HU}")
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroupProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductGroupProduct.java
@@ -60,7 +60,7 @@ public class ProductGroupProduct implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -86,7 +86,7 @@ public class ProductGroupProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -118,7 +118,7 @@ public class ProductGroupProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String productExternalReferenceCode;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getProductGroupExternalReferenceCode() {
 		return productGroupExternalReferenceCode;
 	}
@@ -152,7 +152,7 @@ public class ProductGroupProduct implements Serializable {
 	protected String productGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getProductGroupId() {
 		return productGroupId;
 	}
@@ -181,7 +181,7 @@ public class ProductGroupProduct implements Serializable {
 	protected Long productGroupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;
 	}
@@ -237,7 +237,7 @@ public class ProductGroupProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String productName;
 
-	@Schema
+	@Schema(example = "BL500IC")
 	public String getSku() {
 		return sku;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOption.java
@@ -90,7 +90,9 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long catalogId;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Description HU, hr_HR=Description HR, en_US=Description}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -120,7 +122,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getFacetable() {
 		return facetable;
 	}
@@ -148,7 +150,9 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean facetable;
 
-	@Schema
+	@Schema(
+		example = "checkbox, checkbox_multiple, date, numeric, radio, select"
+	)
 	public String getFieldType() {
 		return fieldType;
 	}
@@ -178,7 +182,7 @@ public class ProductOption implements Serializable {
 	protected String fieldType;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -204,7 +208,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "color")
 	public String getKey() {
 		return key;
 	}
@@ -231,7 +235,7 @@ public class ProductOption implements Serializable {
 	@NotEmpty
 	protected String key;
 
-	@Schema
+	@Schema(example = "{en_US=Color, hr_HR=Color HR, hu_HU=Color HU}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -262,7 +266,7 @@ public class ProductOption implements Serializable {
 	protected Map<String, String> name;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30080")
 	public Long getOptionId() {
 		return optionId;
 	}
@@ -291,7 +295,7 @@ public class ProductOption implements Serializable {
 	@NotNull
 	protected Long optionId;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -351,7 +355,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductOptionValue[] productOptionValues;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getRequired() {
 		return required;
 	}
@@ -379,7 +383,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean required;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getSkuContributor() {
 		return skuContributor;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOptionValue.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductOptionValue.java
@@ -63,7 +63,7 @@ public class ProductOptionValue implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -89,7 +89,7 @@ public class ProductOptionValue implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "black")
 	public String getKey() {
 		return key;
 	}
@@ -116,7 +116,7 @@ public class ProductOptionValue implements Serializable {
 	@NotEmpty
 	protected String key;
 
-	@Schema
+	@Schema(example = "{en_US=Black, hr_HR=Black HR, hu_HU=Black HU}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -146,7 +146,7 @@ public class ProductOptionValue implements Serializable {
 	@NotNull
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductShippingConfiguration.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductShippingConfiguration.java
@@ -64,7 +64,7 @@ public class ProductShippingConfiguration implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "202")
 	@Valid
 	public BigDecimal getDepth() {
 		return depth;
@@ -93,7 +93,7 @@ public class ProductShippingConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal depth;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getFreeShipping() {
 		return freeShipping;
 	}
@@ -122,7 +122,7 @@ public class ProductShippingConfiguration implements Serializable {
 	protected Boolean freeShipping;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "202")
 	@Valid
 	public BigDecimal getHeight() {
 		return height;
@@ -151,7 +151,7 @@ public class ProductShippingConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal height;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getShippable() {
 		return shippable;
 	}
@@ -180,7 +180,7 @@ public class ProductShippingConfiguration implements Serializable {
 	protected Boolean shippable;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "202")
 	@Valid
 	public BigDecimal getShippingExtraPrice() {
 		return shippingExtraPrice;
@@ -210,7 +210,7 @@ public class ProductShippingConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal shippingExtraPrice;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getShippingSeparately() {
 		return shippingSeparately;
 	}
@@ -239,7 +239,7 @@ public class ProductShippingConfiguration implements Serializable {
 	protected Boolean shippingSeparately;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "202")
 	@Valid
 	public BigDecimal getWeight() {
 		return weight;
@@ -269,7 +269,7 @@ public class ProductShippingConfiguration implements Serializable {
 	protected BigDecimal weight;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "202")
 	@Valid
 	public BigDecimal getWidth() {
 		return width;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductSpecification.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductSpecification.java
@@ -64,7 +64,7 @@ public class ProductSpecification implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -90,7 +90,9 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getLabel() {
 		return label;
@@ -120,7 +122,7 @@ public class ProductSpecification implements Serializable {
 	protected Map<String, String> label;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getOptionCategoryId() {
 		return optionCategoryId;
 	}
@@ -149,7 +151,7 @@ public class ProductSpecification implements Serializable {
 	protected Long optionCategoryId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -178,7 +180,7 @@ public class ProductSpecification implements Serializable {
 	protected Double priority;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
 	}
@@ -207,7 +209,7 @@ public class ProductSpecification implements Serializable {
 	protected Long productId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getSpecificationId() {
 		return specificationId;
 	}
@@ -235,7 +237,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long specificationId;
 
-	@Schema
+	@Schema(example = "specification-key")
 	public String getSpecificationKey() {
 		return specificationKey;
 	}
@@ -264,7 +266,7 @@ public class ProductSpecification implements Serializable {
 	@NotEmpty
 	protected String specificationKey;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getValue() {
 		return value;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductSubscriptionConfiguration.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductSubscriptionConfiguration.java
@@ -62,7 +62,7 @@ public class ProductSubscriptionConfiguration implements Serializable {
 			ProductSubscriptionConfiguration.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getEnable() {
 		return enable;
 	}
@@ -90,7 +90,7 @@ public class ProductSubscriptionConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean enable;
 
-	@Schema
+	@Schema(example = "2")
 	public Integer getLength() {
 		return length;
 	}
@@ -118,7 +118,7 @@ public class ProductSubscriptionConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer length;
 
-	@Schema
+	@Schema(example = "12")
 	public Long getNumberOfLength() {
 		return numberOfLength;
 	}
@@ -146,7 +146,7 @@ public class ProductSubscriptionConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long numberOfLength;
 
-	@Schema
+	@Schema(example = "month")
 	@Valid
 	public SubscriptionType getSubscriptionType() {
 		return subscriptionType;
@@ -185,7 +185,7 @@ public class ProductSubscriptionConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected SubscriptionType subscriptionType;
 
-	@Schema
+	@Schema(example = "{monthDay=1, monthlyMode=0}")
 	@Valid
 	public Map<String, String> getSubscriptionTypeSettings() {
 		return subscriptionTypeSettings;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductTaxConfiguration.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/ProductTaxConfiguration.java
@@ -60,7 +60,7 @@ public class ProductTaxConfiguration implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -86,7 +86,7 @@ public class ProductTaxConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "taxCategoryName")
 	public String getTaxCategory() {
 		return taxCategory;
 	}
@@ -114,7 +114,7 @@ public class ProductTaxConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String taxCategory;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getTaxable() {
 		return taxable;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/RelatedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/RelatedProduct.java
@@ -62,7 +62,7 @@ public class RelatedProduct implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -88,7 +88,7 @@ public class RelatedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -116,7 +116,7 @@ public class RelatedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -149,7 +149,7 @@ public class RelatedProduct implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
 	}
@@ -178,7 +178,7 @@ public class RelatedProduct implements Serializable {
 	@NotNull
 	protected Long productId;
 
-	@Schema
+	@Schema(example = "cross-sell")
 	public String getType() {
 		return type;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Sku.java
@@ -68,7 +68,7 @@ public class Sku implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getCost() {
 		return cost;
@@ -98,7 +98,7 @@ public class Sku implements Serializable {
 	protected BigDecimal cost;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.1")
 	public Double getDepth() {
 		return depth;
 	}
@@ -126,7 +126,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double depth;
 
-	@Schema
+	@Schema(example = "false")
 	public Boolean getDiscontinued() {
 		return discontinued;
 	}
@@ -154,7 +154,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean discontinued;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDiscontinuedDate() {
 		return discontinuedDate;
 	}
@@ -182,7 +182,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date discontinuedDate;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -210,7 +210,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -238,7 +238,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -266,7 +266,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getGtin() {
 		return gtin;
 	}
@@ -293,7 +293,7 @@ public class Sku implements Serializable {
 	protected String gtin;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20.2")
 	public Double getHeight() {
 		return height;
 	}
@@ -322,7 +322,7 @@ public class Sku implements Serializable {
 	protected Double height;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -348,7 +348,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "29")
 	public Integer getInventoryLevel() {
 		return inventoryLevel;
 	}
@@ -376,7 +376,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer inventoryLevel;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getManufacturerPartNumber() {
 		return manufacturerPartNumber;
 	}
@@ -405,7 +405,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String manufacturerPartNumber;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -434,7 +434,7 @@ public class Sku implements Serializable {
 	protected Boolean neverExpire;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getPrice() {
 		return price;
@@ -464,7 +464,7 @@ public class Sku implements Serializable {
 	protected BigDecimal price;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
 	}
@@ -492,7 +492,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long productId;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getProductName() {
 		return productName;
@@ -523,7 +523,7 @@ public class Sku implements Serializable {
 	protected Map<String, String> productName;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "202")
 	@Valid
 	public BigDecimal getPromoPrice() {
 		return promoPrice;
@@ -552,7 +552,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal promoPrice;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPublished() {
 		return published;
 	}
@@ -580,7 +580,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean published;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPurchasable() {
 		return purchasable;
 	}
@@ -608,7 +608,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean purchasable;
 
-	@Schema
+	@Schema(example = "SKU0111")
 	public String getReplacementSkuExternalReferenceCode() {
 		return replacementSkuExternalReferenceCode;
 	}
@@ -642,7 +642,7 @@ public class Sku implements Serializable {
 	protected String replacementSkuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33135")
 	public Long getReplacementSkuId() {
 		return replacementSkuId;
 	}
@@ -670,7 +670,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long replacementSkuId;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getSku() {
 		return sku;
 	}
@@ -726,7 +726,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected SkuOption[] skuOptions;
 
-	@Schema
+	@Schema(example = "1234567890")
 	public String getUnspsc() {
 		return unspsc;
 	}
@@ -755,7 +755,7 @@ public class Sku implements Serializable {
 	protected String unspsc;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.1")
 	public Double getWeight() {
 		return weight;
 	}
@@ -784,7 +784,7 @@ public class Sku implements Serializable {
 	protected Double weight;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20.2")
 	public Double getWidth() {
 		return width;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/SkuOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/SkuOption.java
@@ -59,7 +59,7 @@ public class SkuOption implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getKey() {
 		return key;
 	}
@@ -86,7 +86,7 @@ public class SkuOption implements Serializable {
 	protected Long key;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getValue() {
 		return value;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Specification.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Specification.java
@@ -62,7 +62,7 @@ public class Specification implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Specification.class, json);
 	}
 
-	@Schema
+	@Schema(example = "{hu_HU=Horvatorszag, hr_HR=Hrvatska, en_US=Croatia}")
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -92,7 +92,7 @@ public class Specification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getFacetable() {
 		return facetable;
 	}
@@ -121,7 +121,7 @@ public class Specification implements Serializable {
 	protected Boolean facetable;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -147,7 +147,7 @@ public class Specification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "specification-key")
 	public String getKey() {
 		return key;
 	}
@@ -204,7 +204,7 @@ public class Specification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected OptionCategory optionCategory;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Status.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/java/com/liferay/headless/commerce/admin/catalog/dto/v1_0/Status.java
@@ -82,7 +82,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer code;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel() {
 		return label;
 	}
@@ -110,7 +110,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel_i18n() {
 		return label_i18n;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/resources/com/liferay/headless/commerce/admin/catalog/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-api/src/main/resources/com/liferay/headless/commerce/admin/catalog/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.0.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/OrderType.java
@@ -60,7 +60,7 @@ public class OrderType implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -86,7 +86,9 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelOrderType.java
@@ -122,7 +122,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected OrderType orderType;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -155,7 +155,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -185,7 +185,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	protected Long orderTypeId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPaymentMethodGroupRelId() {
 		return paymentMethodGroupRelId;
 	}
@@ -216,7 +216,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	protected Long paymentMethodGroupRelId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPaymentMethodGroupRelOrderTypeId() {
 		return paymentMethodGroupRelOrderTypeId;
 	}
@@ -250,7 +250,7 @@ public class PaymentMethodGroupRelOrderType implements Serializable {
 	protected Long paymentMethodGroupRelOrderTypeId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelTerm.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/PaymentMethodGroupRelTerm.java
@@ -94,7 +94,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getPaymentMethodGroupRelId() {
 		return paymentMethodGroupRelId;
 	}
@@ -125,7 +125,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	protected Long paymentMethodGroupRelId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPaymentMethodGroupRelTermId() {
 		return paymentMethodGroupRelTermId;
 	}
@@ -184,7 +184,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Term term;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getTermExternalReferenceCode() {
 		return termExternalReferenceCode;
 	}
@@ -215,7 +215,7 @@ public class PaymentMethodGroupRelTerm implements Serializable {
 	protected String termExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getTermId() {
 		return termId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionOrderType.java
@@ -122,7 +122,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected OrderType orderType;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -155,7 +155,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -185,7 +185,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	protected Long orderTypeId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;
 	}
@@ -214,7 +214,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	protected Integer priority;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getShippingFixedOptionId() {
 		return shippingFixedOptionId;
 	}
@@ -244,7 +244,7 @@ public class ShippingFixedOptionOrderType implements Serializable {
 	protected Long shippingFixedOptionId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getShippingFixedOptionOrderTypeId() {
 		return shippingFixedOptionOrderTypeId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionTerm.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingFixedOptionTerm.java
@@ -93,7 +93,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getShippingFixedOptionId() {
 		return shippingFixedOptionId;
 	}
@@ -123,7 +123,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	protected Long shippingFixedOptionId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getShippingFixedOptionTermId() {
 		return shippingFixedOptionTermId;
 	}
@@ -180,7 +180,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Term term;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getTermExternalReferenceCode() {
 		return termExternalReferenceCode;
 	}
@@ -211,7 +211,7 @@ public class ShippingFixedOptionTerm implements Serializable {
 	protected String termExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getTermId() {
 		return termId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingMethod.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingMethod.java
@@ -59,7 +59,7 @@ public class ShippingMethod implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ShippingMethod.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -87,7 +87,9 @@ public class ShippingMethod implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Product Description HU, hr_HR=Product Description HR, en_US=Professional hand stainless steel saw for wood. Made to last and saw forever. Made of best steel}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -117,7 +119,7 @@ public class ShippingMethod implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getEngineKey() {
 		return engineKey;
 	}
@@ -146,7 +148,7 @@ public class ShippingMethod implements Serializable {
 	protected String engineKey;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getId() {
 		return id;
 	}
@@ -172,7 +174,9 @@ public class ShippingMethod implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Professional hand stainless steel saw for wood. Made to last and saw forever. Made of best steel, hr_HR=Product Description HR, hu_HU=Product Description HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -201,7 +205,7 @@ public class ShippingMethod implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/ShippingOption.java
@@ -59,7 +59,7 @@ public class ShippingOption implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ShippingOption.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -87,7 +87,7 @@ public class ShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getAmount() {
 		return amount;
 	}
@@ -115,7 +115,9 @@ public class ShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double amount;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Product Description HU, hr_HR=Product Description HR, en_US=Professional hand stainless steel saw for wood. Made to last and saw forever. Made of best steel}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -146,7 +148,7 @@ public class ShippingOption implements Serializable {
 	protected Map<String, String> description;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getId() {
 		return id;
 	}
@@ -172,7 +174,9 @@ public class ShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Professional hand stainless steel saw for wood. Made to last and saw forever. Made of best steel, hr_HR=Product Description HR, hu_HU=Product Description HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -201,7 +205,7 @@ public class ShippingOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/TaxCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/TaxCategory.java
@@ -61,7 +61,7 @@ public class TaxCategory implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(TaxCategory.class, json);
 	}
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -92,7 +92,7 @@ public class TaxCategory implements Serializable {
 	protected Map<String, String> description;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
 	}
@@ -121,7 +121,7 @@ public class TaxCategory implements Serializable {
 	protected Long groupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -147,7 +147,7 @@ public class TaxCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/Term.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/java/com/liferay/headless/commerce/admin/channel/dto/v1_0/Term.java
@@ -59,7 +59,7 @@ public class Term implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -85,7 +85,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/resources/com/liferay/headless/commerce/admin/channel/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-api/src/main/resources/com/liferay/headless/commerce/admin/channel/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.5.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/Warehouse.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/Warehouse.java
@@ -59,7 +59,7 @@ public class Warehouse implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Warehouse.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -87,7 +87,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "Diamond Bar")
 	public String getCity() {
 		return city;
 	}
@@ -113,7 +113,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String city;
 
-	@Schema
+	@Schema(example = "US")
 	public String getCountryISOCode() {
 		return countryISOCode;
 	}
@@ -141,7 +141,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String countryISOCode;
 
-	@Schema
+	@Schema(example = "right stairs, first room on the left")
 	public String getDescription() {
 		return description;
 	}
@@ -169,7 +169,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -198,7 +198,7 @@ public class Warehouse implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -224,7 +224,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "33.9976884")
 	public Double getLatitude() {
 		return latitude;
 	}
@@ -252,7 +252,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double latitude;
 
-	@Schema
+	@Schema(example = "-117.8144595")
 	public Double getLongitude() {
 		return longitude;
 	}
@@ -280,7 +280,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double longitude;
 
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public Number getMvccVersion() {
 		return mvccVersion;
@@ -309,7 +309,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Number mvccVersion;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}
@@ -335,7 +335,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(example = "CA")
 	public String getRegionISOCode() {
 		return regionISOCode;
 	}
@@ -363,7 +363,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String regionISOCode;
 
-	@Schema
+	@Schema(example = "1400 Montefino Ave")
 	public String getStreet1() {
 		return street1;
 	}
@@ -391,7 +391,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street1;
 
-	@Schema
+	@Schema(example = "1st floor")
 	public String getStreet2() {
 		return street2;
 	}
@@ -419,7 +419,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street2;
 
-	@Schema
+	@Schema(example = "suite 200")
 	public String getStreet3() {
 		return street3;
 	}
@@ -503,7 +503,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected WarehouseItem[] warehouseItems;
 
-	@Schema
+	@Schema(example = "91765")
 	public String getZip() {
 		return zip;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/java/com/liferay/headless/commerce/admin/inventory/dto/v1_0/WarehouseItem.java
@@ -62,7 +62,7 @@ public class WarehouseItem implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(WarehouseItem.class, json);
 	}
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -91,7 +91,7 @@ public class WarehouseItem implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -146,7 +146,7 @@ public class WarehouseItem implements Serializable {
 	protected Date modifiedDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
 	}
@@ -175,7 +175,7 @@ public class WarehouseItem implements Serializable {
 	protected Integer quantity;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "2")
 	public Integer getReservedQuantity() {
 		return reservedQuantity;
 	}
@@ -203,7 +203,7 @@ public class WarehouseItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer reservedQuantity;
 
-	@Schema
+	@Schema(example = "SKU")
 	public String getSku() {
 		return sku;
 	}
@@ -229,7 +229,7 @@ public class WarehouseItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getWarehouseExternalReferenceCode() {
 		return warehouseExternalReferenceCode;
 	}
@@ -262,7 +262,7 @@ public class WarehouseItem implements Serializable {
 	protected String warehouseExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30030")
 	public Long getWarehouseId() {
 		return warehouseId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/resources/com/liferay/headless/commerce/admin/inventory/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-api/src/main/resources/com/liferay/headless/commerce/admin/inventory/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.4.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
@@ -9,11 +9,11 @@ components:
                     readOnly: true
                     type: integer
                 errorDescription:
-                    example: "Unable to find currency. Currency code should be expressed with\n3-letter ISO 4217 format."
+                    example: "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
                     readOnly: true
                     type: string
                 message:
-                    example: "No CommerceCurrency exists with the key {groupId=41811, code=US\nDollar}"
+                    example: "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
                     readOnly: true
                     type: string
                 status:

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Account.java
@@ -117,7 +117,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String emailAddress;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -146,7 +146,7 @@ public class Account implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -173,7 +173,7 @@ public class Account implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20078")
 	public Long getLogoId() {
 		return logoId;
 	}
@@ -201,7 +201,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long logoId;
 
-	@Schema
+	@Schema(example = "Account Name")
 	public String getName() {
 		return name;
 	}
@@ -227,7 +227,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getRoot() {
 		return root;
 	}
@@ -253,7 +253,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean root;
 
-	@Schema
+	@Schema(example = "Abcd1234")
 	public String getTaxId() {
 		return taxId;
 	}
@@ -283,7 +283,7 @@ public class Account implements Serializable {
 
 	@DecimalMax("2")
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getType() {
 		return type;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/AccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/AccountGroup.java
@@ -59,7 +59,7 @@ public class AccountGroup implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -85,7 +85,7 @@ public class AccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "AccountGroup Name")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/BillingAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/BillingAddress.java
@@ -60,7 +60,7 @@ public class BillingAddress implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(BillingAddress.class, json);
 	}
 
-	@Schema
+	@Schema(example = "Diamond Bar")
 	public String getCity() {
 		return city;
 	}
@@ -87,7 +87,7 @@ public class BillingAddress implements Serializable {
 	@NotEmpty
 	protected String city;
 
-	@Schema
+	@Schema(example = "US")
 	public String getCountryISOCode() {
 		return countryISOCode;
 	}
@@ -116,7 +116,7 @@ public class BillingAddress implements Serializable {
 	@NotEmpty
 	protected String countryISOCode;
 
-	@Schema
+	@Schema(example = "right stairs, first room on the left")
 	public String getDescription() {
 		return description;
 	}
@@ -144,7 +144,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -173,7 +173,7 @@ public class BillingAddress implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -199,7 +199,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "33.9976884")
 	public Double getLatitude() {
 		return latitude;
 	}
@@ -227,7 +227,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double latitude;
 
-	@Schema
+	@Schema(example = "-117.8144595")
 	public Double getLongitude() {
 		return longitude;
 	}
@@ -255,7 +255,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double longitude;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}
@@ -282,7 +282,7 @@ public class BillingAddress implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "(123) 456 7890")
 	public String getPhoneNumber() {
 		return phoneNumber;
 	}
@@ -310,7 +310,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String phoneNumber;
 
-	@Schema
+	@Schema(example = "CA")
 	public String getRegionISOCode() {
 		return regionISOCode;
 	}
@@ -338,7 +338,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String regionISOCode;
 
-	@Schema
+	@Schema(example = "1400 Montefino Ave")
 	public String getStreet1() {
 		return street1;
 	}
@@ -367,7 +367,7 @@ public class BillingAddress implements Serializable {
 	@NotEmpty
 	protected String street1;
 
-	@Schema
+	@Schema(example = "1st floor")
 	public String getStreet2() {
 		return street2;
 	}
@@ -395,7 +395,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street2;
 
-	@Schema
+	@Schema(example = "suite 200")
 	public String getStreet3() {
 		return street3;
 	}
@@ -423,7 +423,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street3;
 
-	@Schema
+	@Schema(example = "353246836565")
 	public String getVatNumber() {
 		return vatNumber;
 	}
@@ -451,7 +451,7 @@ public class BillingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String vatNumber;
 
-	@Schema
+	@Schema(example = "91765")
 	public String getZip() {
 		return zip;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Channel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Channel.java
@@ -58,7 +58,7 @@ public class Channel implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Channel.class, json);
 	}
 
-	@Schema
+	@Schema(example = "USD")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -86,7 +86,7 @@ public class Channel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String currencyCode;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -115,7 +115,7 @@ public class Channel implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -141,7 +141,7 @@ public class Channel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Order.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Order.java
@@ -97,7 +97,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Account account;
 
-	@Schema
+	@Schema(example = "AAB-34098-789-N")
 	public String getAccountExternalReferenceCode() {
 		return accountExternalReferenceCode;
 	}
@@ -130,7 +130,7 @@ public class Order implements Serializable {
 	protected String accountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -188,7 +188,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "trasmitted")
 	public String getAdvanceStatus() {
 		return advanceStatus;
 	}
@@ -247,7 +247,7 @@ public class Order implements Serializable {
 	protected BillingAddress billingAddress;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getBillingAddressId() {
 		return billingAddressId;
 	}
@@ -304,7 +304,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Channel channel;
 
-	@Schema
+	@Schema(example = "AAB-34098-789-N")
 	public String getChannelExternalReferenceCode() {
 		return channelExternalReferenceCode;
 	}
@@ -337,7 +337,7 @@ public class Order implements Serializable {
 	protected String channelExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -366,7 +366,7 @@ public class Order implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@Schema
+	@Schema(example = "save20")
 	public String getCouponCode() {
 		return couponCode;
 	}
@@ -394,7 +394,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String couponCode;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -422,7 +422,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date createDate;
 
-	@Schema
+	@Schema(example = "USD")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -480,7 +480,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "Orders delivery terms description")
 	public String getDeliveryTermDescription() {
 		return deliveryTermDescription;
 	}
@@ -511,7 +511,7 @@ public class Order implements Serializable {
 	protected String deliveryTermDescription;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getDeliveryTermId() {
 		return deliveryTermId;
 	}
@@ -539,7 +539,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long deliveryTermId;
 
-	@Schema
+	@Schema(example = "Orders delivery terms name")
 	public String getDeliveryTermName() {
 		return deliveryTermName;
 	}
@@ -567,7 +567,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String deliveryTermName;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -596,7 +596,7 @@ public class Order implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -622,7 +622,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getLastPriceUpdateDate() {
 		return lastPriceUpdateDate;
 	}
@@ -650,7 +650,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date lastPriceUpdateDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getModifiedDate() {
 		return modifiedDate;
 	}
@@ -678,7 +678,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date modifiedDate;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getOrderDate() {
 		return orderDate;
 	}
@@ -736,7 +736,7 @@ public class Order implements Serializable {
 	protected OrderItem[] orderItems;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getOrderStatus() {
 		return orderStatus;
 	}
@@ -793,7 +793,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Status orderStatusInfo;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -826,7 +826,7 @@ public class Order implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -854,7 +854,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long orderTypeId;
 
-	@Schema
+	@Schema(example = "paypal")
 	public String getPaymentMethod() {
 		return paymentMethod;
 	}
@@ -883,7 +883,7 @@ public class Order implements Serializable {
 	protected String paymentMethod;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getPaymentStatus() {
 		return paymentStatus;
 	}
@@ -940,7 +940,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Status paymentStatusInfo;
 
-	@Schema
+	@Schema(example = "Orders payment terms description")
 	public String getPaymentTermDescription() {
 		return paymentTermDescription;
 	}
@@ -970,7 +970,7 @@ public class Order implements Serializable {
 	protected String paymentTermDescription;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPaymentTermId() {
 		return paymentTermId;
 	}
@@ -998,7 +998,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long paymentTermId;
 
-	@Schema
+	@Schema(example = "Orders payment terms name")
 	public String getPaymentTermName() {
 		return paymentTermName;
 	}
@@ -1026,7 +1026,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String paymentTermName;
 
-	@Schema
+	@Schema(example = "Order printed note")
 	public String getPrintedNote() {
 		return printedNote;
 	}
@@ -1054,7 +1054,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String printedNote;
 
-	@Schema
+	@Schema(example = "Abcd1234")
 	public String getPurchaseOrderNumber() {
 		return purchaseOrderNumber;
 	}
@@ -1082,7 +1082,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String purchaseOrderNumber;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getRequestedDeliveryDate() {
 		return requestedDeliveryDate;
 	}
@@ -1141,7 +1141,7 @@ public class Order implements Serializable {
 	protected ShippingAddress shippingAddress;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;
 	}
@@ -1170,7 +1170,7 @@ public class Order implements Serializable {
 	protected Long shippingAddressId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "12")
 	@Valid
 	public BigDecimal getShippingAmount() {
 		return shippingAmount;
@@ -1230,7 +1230,7 @@ public class Order implements Serializable {
 	protected String shippingAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "12")
 	public Double getShippingAmountValue() {
 		return shippingAmountValue;
 	}
@@ -1353,7 +1353,7 @@ public class Order implements Serializable {
 	protected Double shippingDiscountAmountValue;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel1() {
 		return shippingDiscountPercentageLevel1;
@@ -1388,7 +1388,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel1WithTaxAmount() {
 		return shippingDiscountPercentageLevel1WithTaxAmount;
@@ -1424,7 +1424,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel1WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel2() {
 		return shippingDiscountPercentageLevel2;
@@ -1459,7 +1459,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel2WithTaxAmount() {
 		return shippingDiscountPercentageLevel2WithTaxAmount;
@@ -1495,7 +1495,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel2WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel3() {
 		return shippingDiscountPercentageLevel3;
@@ -1530,7 +1530,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel3WithTaxAmount() {
 		return shippingDiscountPercentageLevel3WithTaxAmount;
@@ -1566,7 +1566,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel3WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel4() {
 		return shippingDiscountPercentageLevel4;
@@ -1601,7 +1601,7 @@ public class Order implements Serializable {
 	protected BigDecimal shippingDiscountPercentageLevel4;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getShippingDiscountPercentageLevel4WithTaxAmount() {
 		return shippingDiscountPercentageLevel4WithTaxAmount;
@@ -1702,7 +1702,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String shippingDiscountWithTaxAmountFormatted;
 
-	@Schema
+	@Schema(example = "fixed")
 	public String getShippingMethod() {
 		return shippingMethod;
 	}
@@ -1730,7 +1730,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String shippingMethod;
 
-	@Schema
+	@Schema(example = "by Air")
 	public String getShippingOption() {
 		return shippingOption;
 	}
@@ -1759,7 +1759,7 @@ public class Order implements Serializable {
 	protected String shippingOption;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "12")
 	@Valid
 	public BigDecimal getShippingWithTaxAmount() {
 		return shippingWithTaxAmount;
@@ -1822,7 +1822,7 @@ public class Order implements Serializable {
 	protected String shippingWithTaxAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "12")
 	public Double getShippingWithTaxAmountValue() {
 		return shippingWithTaxAmountValue;
 	}
@@ -1974,7 +1974,7 @@ public class Order implements Serializable {
 	protected String subtotalDiscountAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel1() {
 		return subtotalDiscountPercentageLevel1;
@@ -2009,7 +2009,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel1WithTaxAmount() {
 		return subtotalDiscountPercentageLevel1WithTaxAmount;
@@ -2045,7 +2045,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel1WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel2() {
 		return subtotalDiscountPercentageLevel2;
@@ -2080,7 +2080,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel2WithTaxAmount() {
 		return subtotalDiscountPercentageLevel2WithTaxAmount;
@@ -2116,7 +2116,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel2WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel3() {
 		return subtotalDiscountPercentageLevel3;
@@ -2151,7 +2151,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel3WithTaxAmount() {
 		return subtotalDiscountPercentageLevel3WithTaxAmount;
@@ -2187,7 +2187,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel3WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel4() {
 		return subtotalDiscountPercentageLevel4;
@@ -2222,7 +2222,7 @@ public class Order implements Serializable {
 	protected BigDecimal subtotalDiscountPercentageLevel4;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getSubtotalDiscountPercentageLevel4WithTaxAmount() {
 		return subtotalDiscountPercentageLevel4WithTaxAmount;
@@ -2446,7 +2446,7 @@ public class Order implements Serializable {
 	protected Double subtotalWithTaxAmountValue;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "11")
 	@Valid
 	public BigDecimal getTaxAmount() {
 		return taxAmount;
@@ -2504,7 +2504,7 @@ public class Order implements Serializable {
 	protected String taxAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "12")
 	public Double getTaxAmountValue() {
 		return taxAmountValue;
 	}
@@ -2533,7 +2533,7 @@ public class Order implements Serializable {
 	protected Double taxAmountValue;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "113")
 	@Valid
 	public BigDecimal getTotal() {
 		return total;
@@ -2563,7 +2563,7 @@ public class Order implements Serializable {
 	protected BigDecimal total;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "113")
 	public Double getTotalAmount() {
 		return totalAmount;
 	}
@@ -2592,7 +2592,7 @@ public class Order implements Serializable {
 	protected Double totalAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "11")
 	@Valid
 	public BigDecimal getTotalDiscountAmount() {
 		return totalDiscountAmount;
@@ -2655,7 +2655,7 @@ public class Order implements Serializable {
 	protected String totalDiscountAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "11")
 	public Double getTotalDiscountAmountValue() {
 		return totalDiscountAmountValue;
 	}
@@ -2686,7 +2686,7 @@ public class Order implements Serializable {
 	protected Double totalDiscountAmountValue;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel1() {
 		return totalDiscountPercentageLevel1;
@@ -2720,7 +2720,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel1WithTaxAmount() {
 		return totalDiscountPercentageLevel1WithTaxAmount;
@@ -2755,7 +2755,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel1WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel2() {
 		return totalDiscountPercentageLevel2;
@@ -2789,7 +2789,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel2WithTaxAmount() {
 		return totalDiscountPercentageLevel2WithTaxAmount;
@@ -2824,7 +2824,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel2WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel3() {
 		return totalDiscountPercentageLevel3;
@@ -2858,7 +2858,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel3WithTaxAmount() {
 		return totalDiscountPercentageLevel3WithTaxAmount;
@@ -2893,7 +2893,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel3WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel4() {
 		return totalDiscountPercentageLevel4;
@@ -2927,7 +2927,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel4;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getTotalDiscountPercentageLevel4WithTaxAmount() {
 		return totalDiscountPercentageLevel4WithTaxAmount;
@@ -2962,7 +2962,7 @@ public class Order implements Serializable {
 	protected BigDecimal totalDiscountPercentageLevel4WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "11")
 	@Valid
 	public BigDecimal getTotalDiscountWithTaxAmount() {
 		return totalDiscountWithTaxAmount;
@@ -3029,7 +3029,7 @@ public class Order implements Serializable {
 	protected String totalDiscountWithTaxAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "11")
 	public Double getTotalDiscountWithTaxAmountValue() {
 		return totalDiscountWithTaxAmountValue;
 	}
@@ -3090,7 +3090,7 @@ public class Order implements Serializable {
 	protected String totalFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "113")
 	@Valid
 	public BigDecimal getTotalWithTaxAmount() {
 		return totalWithTaxAmount;
@@ -3153,7 +3153,7 @@ public class Order implements Serializable {
 	protected String totalWithTaxAmountFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "113")
 	public Double getTotalWithTaxAmountValue() {
 		return totalWithTaxAmountValue;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderItem.java
@@ -66,7 +66,7 @@ public class OrderItem implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "32144")
 	public Long getBookedQuantityId() {
 		return bookedQuantityId;
 	}
@@ -124,7 +124,7 @@ public class OrderItem implements Serializable {
 	protected Map<String, ?> customFields;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "10.1")
 	@Valid
 	public BigDecimal getDecimalQuantity() {
 		return decimalQuantity;
@@ -153,7 +153,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal decimalQuantity;
 
-	@Schema
+	@Schema(example = "separate package")
 	public String getDeliveryGroup() {
 		return deliveryGroup;
 	}
@@ -182,7 +182,7 @@ public class OrderItem implements Serializable {
 	protected String deliveryGroup;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "2")
 	@Valid
 	public BigDecimal getDiscountAmount() {
 		return discountAmount;
@@ -212,7 +212,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel1() {
 		return discountPercentageLevel1;
@@ -246,7 +246,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel1WithTaxAmount() {
 		return discountPercentageLevel1WithTaxAmount;
@@ -281,7 +281,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel1WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel2() {
 		return discountPercentageLevel2;
@@ -315,7 +315,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel2WithTaxAmount() {
 		return discountPercentageLevel2WithTaxAmount;
@@ -350,7 +350,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel2WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel3() {
 		return discountPercentageLevel3;
@@ -384,7 +384,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel3WithTaxAmount() {
 		return discountPercentageLevel3WithTaxAmount;
@@ -419,7 +419,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel3WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel4() {
 		return discountPercentageLevel4;
@@ -453,7 +453,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel4;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getDiscountPercentageLevel4WithTaxAmount() {
 		return discountPercentageLevel4WithTaxAmount;
@@ -488,7 +488,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal discountPercentageLevel4WithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "2")
 	@Valid
 	public BigDecimal getDiscountWithTaxAmount() {
 		return discountWithTaxAmount;
@@ -518,7 +518,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal discountWithTaxAmount;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -547,7 +547,7 @@ public class OrderItem implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "200")
 	@Valid
 	public BigDecimal getFinalPrice() {
 		return finalPrice;
@@ -577,7 +577,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal finalPrice;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "200")
 	@Valid
 	public BigDecimal getFinalPriceWithTaxAmount() {
 		return finalPriceWithTaxAmount;
@@ -637,7 +637,7 @@ public class OrderItem implements Serializable {
 	protected String formattedQuantity;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -663,7 +663,9 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -720,7 +722,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String options;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getOrderExternalReferenceCode() {
 		return orderExternalReferenceCode;
 	}
@@ -753,7 +755,7 @@ public class OrderItem implements Serializable {
 	protected String orderExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30128")
 	public Long getOrderId() {
 		return orderId;
 	}
@@ -781,7 +783,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long orderId;
 
-	@Schema
+	@Schema(example = "Order item printed note")
 	public String getPrintedNote() {
 		return printedNote;
 	}
@@ -810,7 +812,7 @@ public class OrderItem implements Serializable {
 	protected String printedNote;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getPromoPrice() {
 		return promoPrice;
@@ -840,7 +842,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal promoPrice;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getPromoPriceWithTaxAmount() {
 		return promoPriceWithTaxAmount;
@@ -872,7 +874,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal promoPriceWithTaxAmount;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "2")
 	public Integer getQuantity() {
 		return quantity;
 	}
@@ -900,7 +902,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer quantity;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getRequestedDeliveryDate() {
 		return requestedDeliveryDate;
 	}
@@ -929,7 +931,7 @@ public class OrderItem implements Serializable {
 	protected Date requestedDeliveryDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getShippedQuantity() {
 		return shippedQuantity;
 	}
@@ -988,7 +990,7 @@ public class OrderItem implements Serializable {
 	protected ShippingAddress shippingAddress;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;
 	}
@@ -1016,7 +1018,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long shippingAddressId;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getSku() {
 		return sku;
 	}
@@ -1042,7 +1044,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getSkuExternalReferenceCode() {
 		return skuExternalReferenceCode;
 	}
@@ -1073,7 +1075,7 @@ public class OrderItem implements Serializable {
 	protected String skuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30128")
 	public Long getSkuId() {
 		return skuId;
 	}
@@ -1099,7 +1101,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long skuId;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getSubscription() {
 		return subscription;
 	}
@@ -1127,7 +1129,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean subscription;
 
-	@Schema
+	@Schema(example = "pc")
 	public String getUnitOfMeasure() {
 		return unitOfMeasure;
 	}
@@ -1156,7 +1158,7 @@ public class OrderItem implements Serializable {
 	protected String unitOfMeasure;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getUnitPrice() {
 		return unitPrice;
@@ -1186,7 +1188,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal unitPrice;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getUnitPriceWithTaxAmount() {
 		return unitPriceWithTaxAmount;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderNote.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderNote.java
@@ -58,7 +58,7 @@ public class OrderNote implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(OrderNote.class, json);
 	}
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getAuthor() {
 		return author;
 	}
@@ -86,7 +86,7 @@ public class OrderNote implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String author;
 
-	@Schema
+	@Schema(example = "This order will be shipped separately")
 	public String getContent() {
 		return content;
 	}
@@ -114,7 +114,7 @@ public class OrderNote implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String content;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -143,7 +143,7 @@ public class OrderNote implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -169,7 +169,7 @@ public class OrderNote implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getOrderExternalReferenceCode() {
 		return orderExternalReferenceCode;
 	}
@@ -202,7 +202,7 @@ public class OrderNote implements Serializable {
 	protected String orderExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30128")
 	public Long getOrderId() {
 		return orderId;
 	}
@@ -230,7 +230,7 @@ public class OrderNote implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long orderId;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getRestricted() {
 		return restricted;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRule.java
@@ -95,7 +95,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -123,7 +123,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "admin")
 	public String getAuthor() {
 		return author;
 	}
@@ -151,7 +151,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String author;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -179,7 +179,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date createDate;
 
-	@Schema
+	@Schema(example = "Laptops, Beverages")
 	public String getDescription() {
 		return description;
 	}
@@ -207,7 +207,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -235,7 +235,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -263,7 +263,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -292,7 +292,7 @@ public class OrderRule implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -318,7 +318,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "Laptops, Beverages")
 	public String getName() {
 		return name;
 	}
@@ -345,7 +345,7 @@ public class OrderRule implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -495,7 +495,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected OrderRuleOrderType[] orderRuleOrderType;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -523,7 +523,7 @@ public class OrderRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "order-limit")
 	public String getType() {
 		return type;
 	}
@@ -550,7 +550,7 @@ public class OrderRule implements Serializable {
 	@NotEmpty
 	protected String type;
 
-	@Schema
+	@Schema(example = "22.50")
 	public String getTypeSettings() {
 		return typeSettings;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccount.java
@@ -90,7 +90,7 @@ public class OrderRuleAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Account account;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getAccountExternalReferenceCode() {
 		return accountExternalReferenceCode;
 	}
@@ -123,7 +123,7 @@ public class OrderRuleAccount implements Serializable {
 	protected String accountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -183,7 +183,7 @@ public class OrderRuleAccount implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getOrderRuleAccountId() {
 		return orderRuleAccountId;
 	}
@@ -211,7 +211,7 @@ public class OrderRuleAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long orderRuleAccountId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getOrderRuleExternalReferenceCode() {
 		return orderRuleExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class OrderRuleAccount implements Serializable {
 	protected String orderRuleExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleAccountGroup.java
@@ -91,7 +91,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected AccountGroup accountGroup;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getAccountGroupExternalReferenceCode() {
 		return accountGroupExternalReferenceCode;
 	}
@@ -125,7 +125,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	protected String accountGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getAccountGroupId() {
 		return accountGroupId;
 	}
@@ -185,7 +185,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getOrderRuleAccountGroupId() {
 		return orderRuleAccountGroupId;
 	}
@@ -214,7 +214,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long orderRuleAccountGroupId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getOrderRuleExternalReferenceCode() {
 		return orderRuleExternalReferenceCode;
 	}
@@ -247,7 +247,7 @@ public class OrderRuleAccountGroup implements Serializable {
 	protected String orderRuleExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleChannel.java
@@ -120,7 +120,7 @@ public class OrderRuleChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Channel channel;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getChannelExternalReferenceCode() {
 		return channelExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class OrderRuleChannel implements Serializable {
 	protected String channelExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -183,7 +183,7 @@ public class OrderRuleChannel implements Serializable {
 	protected Long channelId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getOrderRuleChannelId() {
 		return orderRuleChannelId;
 	}
@@ -211,7 +211,7 @@ public class OrderRuleChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long orderRuleChannelId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getOrderRuleExternalReferenceCode() {
 		return orderRuleExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class OrderRuleChannel implements Serializable {
 	protected String orderRuleExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderRuleOrderType.java
@@ -91,7 +91,7 @@ public class OrderRuleOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getOrderRuleExternalReferenceCode() {
 		return orderRuleExternalReferenceCode;
 	}
@@ -124,7 +124,7 @@ public class OrderRuleOrderType implements Serializable {
 	protected String orderRuleExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderRuleId() {
 		return orderRuleId;
 	}
@@ -154,7 +154,7 @@ public class OrderRuleOrderType implements Serializable {
 	protected Long orderRuleId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getOrderRuleOrderTypeId() {
 		return orderRuleOrderTypeId;
 	}
@@ -211,7 +211,7 @@ public class OrderRuleOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected OrderType orderType;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class OrderRuleOrderType implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderType.java
@@ -95,7 +95,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -152,7 +152,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "{en_US=Title, hr_HR=Title HR, hu_HU=Title HU}")
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -182,7 +182,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -211,7 +211,7 @@ public class OrderType implements Serializable {
 	protected Date displayDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getDisplayOrder() {
 		return displayOrder;
 	}
@@ -239,7 +239,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer displayOrder;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -267,7 +267,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -296,7 +296,7 @@ public class OrderType implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -322,7 +322,7 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "{en_US=Title, hr_HR=Title HR, hu_HU=Title HU}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -352,7 +352,7 @@ public class OrderType implements Serializable {
 	@NotNull
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderTypeChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/OrderTypeChannel.java
@@ -120,7 +120,7 @@ public class OrderTypeChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Channel channel;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getChannelExternalReferenceCode() {
 		return channelExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class OrderTypeChannel implements Serializable {
 	protected String channelExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -183,7 +183,7 @@ public class OrderTypeChannel implements Serializable {
 	protected Long channelId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getOrderTypeChannelId() {
 		return orderTypeChannelId;
 	}
@@ -211,7 +211,7 @@ public class OrderTypeChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long orderTypeChannelId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class OrderTypeChannel implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/ShippingAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/ShippingAddress.java
@@ -60,7 +60,7 @@ public class ShippingAddress implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ShippingAddress.class, json);
 	}
 
-	@Schema
+	@Schema(example = "Diamond Bar")
 	public String getCity() {
 		return city;
 	}
@@ -87,7 +87,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String city;
 
-	@Schema
+	@Schema(example = "US")
 	public String getCountryISOCode() {
 		return countryISOCode;
 	}
@@ -116,7 +116,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String countryISOCode;
 
-	@Schema
+	@Schema(example = "right stairs, first room on the left")
 	public String getDescription() {
 		return description;
 	}
@@ -144,7 +144,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -173,7 +173,7 @@ public class ShippingAddress implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -199,7 +199,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "33.9976884")
 	public Double getLatitude() {
 		return latitude;
 	}
@@ -227,7 +227,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double latitude;
 
-	@Schema
+	@Schema(example = "-117.8144595")
 	public Double getLongitude() {
 		return longitude;
 	}
@@ -255,7 +255,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double longitude;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}
@@ -282,7 +282,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "(123) 456 7890")
 	public String getPhoneNumber() {
 		return phoneNumber;
 	}
@@ -310,7 +310,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String phoneNumber;
 
-	@Schema
+	@Schema(example = "CA")
 	public String getRegionISOCode() {
 		return regionISOCode;
 	}
@@ -338,7 +338,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String regionISOCode;
 
-	@Schema
+	@Schema(example = "1400 Montefino Ave")
 	public String getStreet1() {
 		return street1;
 	}
@@ -367,7 +367,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String street1;
 
-	@Schema
+	@Schema(example = "1st floor")
 	public String getStreet2() {
 		return street2;
 	}
@@ -395,7 +395,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street2;
 
-	@Schema
+	@Schema(example = "suite 200")
 	public String getStreet3() {
 		return street3;
 	}
@@ -423,7 +423,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street3;
 
-	@Schema
+	@Schema(example = "91765")
 	public String getZip() {
 		return zip;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Status.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Status.java
@@ -82,7 +82,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer code;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel() {
 		return label;
 	}
@@ -110,7 +110,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel_i18n() {
 		return label_i18n;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Term.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/Term.java
@@ -95,7 +95,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -123,7 +123,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -151,7 +151,9 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date createDate;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Term Description US, hr_HR=Term Description HR, hu_HU=Term Description HU}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -181,7 +183,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -209,7 +211,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -237,7 +239,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -266,7 +268,7 @@ public class Term implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -292,7 +294,9 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Term Label US, hr_HR=Term Label HR, hu_HU=Term Label HU}"
+	)
 	@Valid
 	public Map<String, String> getLabel() {
 		return label;
@@ -321,7 +325,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> label;
 
-	@Schema
+	@Schema(example = "Laptops, Beverages")
 	public String getName() {
 		return name;
 	}
@@ -348,7 +352,7 @@ public class Term implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -376,7 +380,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -434,7 +438,7 @@ public class Term implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected TermOrderType[] termOrderType;
 
-	@Schema
+	@Schema(example = "payment-terms")
 	public String getType() {
 		return type;
 	}
@@ -461,7 +465,7 @@ public class Term implements Serializable {
 	@NotEmpty
 	protected String type;
 
-	@Schema
+	@Schema(example = "Payment Terms")
 	public String getTypeLocalized() {
 		return typeLocalized;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/TermOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/java/com/liferay/headless/commerce/admin/order/dto/v1_0/TermOrderType.java
@@ -120,7 +120,7 @@ public class TermOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected OrderType orderType;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class TermOrderType implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -182,7 +182,7 @@ public class TermOrderType implements Serializable {
 	@NotNull
 	protected Long orderTypeId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getTermExternalReferenceCode() {
 		return termExternalReferenceCode;
 	}
@@ -213,7 +213,7 @@ public class TermOrderType implements Serializable {
 	protected String termExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getTermId() {
 		return termId;
 	}
@@ -243,7 +243,7 @@ public class TermOrderType implements Serializable {
 	protected Long termId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getTermOrderTypeId() {
 		return termOrderTypeId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/resources/com/liferay/headless/commerce/admin/order/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-api/src/main/resources/com/liferay/headless/commerce/admin/order/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.0.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Discount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Discount.java
@@ -67,7 +67,7 @@ public class Discount implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Discount.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -95,7 +95,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "SAVE20")
 	public String getCouponCode() {
 		return couponCode;
 	}
@@ -329,7 +329,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -358,7 +358,7 @@ public class Discount implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -385,7 +385,7 @@ public class Discount implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getLimitationTimes() {
 		return limitationTimes;
 	}
@@ -413,7 +413,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer limitationTimes;
 
-	@Schema
+	@Schema(example = "unlimited")
 	public String getLimitationType() {
 		return limitationType;
 	}
@@ -443,7 +443,7 @@ public class Discount implements Serializable {
 	protected String limitationType;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "25")
 	@Valid
 	public BigDecimal getMaximumDiscountAmount() {
 		return maximumDiscountAmount;
@@ -473,7 +473,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal maximumDiscountAmount;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -502,7 +502,7 @@ public class Discount implements Serializable {
 	protected Boolean neverExpire;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "5")
 	public Integer getNumberOfUse() {
 		return numberOfUse;
 	}
@@ -531,7 +531,7 @@ public class Discount implements Serializable {
 	protected Integer numberOfUse;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getPercentageLevel1() {
 		return percentageLevel1;
@@ -561,7 +561,7 @@ public class Discount implements Serializable {
 	protected BigDecimal percentageLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getPercentageLevel2() {
 		return percentageLevel2;
@@ -591,7 +591,7 @@ public class Discount implements Serializable {
 	protected BigDecimal percentageLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getPercentageLevel3() {
 		return percentageLevel3;
@@ -621,7 +621,7 @@ public class Discount implements Serializable {
 	protected BigDecimal percentageLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getPercentageLevel4() {
 		return percentageLevel4;
@@ -650,7 +650,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal percentageLevel4;
 
-	@Schema
+	@Schema(example = "subtotal")
 	public String getTarget() {
 		return target;
 	}
@@ -679,7 +679,7 @@ public class Discount implements Serializable {
 	@NotEmpty
 	protected String target;
 
-	@Schema
+	@Schema(example = "20% Off")
 	public String getTitle() {
 		return title;
 	}
@@ -708,7 +708,7 @@ public class Discount implements Serializable {
 	@NotEmpty
 	protected String title;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getUseCouponCode() {
 		return useCouponCode;
 	}
@@ -736,7 +736,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean useCouponCode;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getUsePercentage() {
 		return usePercentage;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountAccountGroup.java
@@ -59,7 +59,7 @@ public class DiscountAccountGroup implements Serializable {
 			DiscountAccountGroup.class, json);
 	}
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getAccountGroupExternalReferenceCode() {
 		return accountGroupExternalReferenceCode;
 	}
@@ -93,7 +93,7 @@ public class DiscountAccountGroup implements Serializable {
 	protected String accountGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountGroupId() {
 		return accountGroupId;
 	}
@@ -121,7 +121,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long accountGroupId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -154,7 +154,7 @@ public class DiscountAccountGroup implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -183,7 +183,7 @@ public class DiscountAccountGroup implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getId() {
 		return id;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountCategory.java
@@ -58,7 +58,7 @@ public class DiscountCategory implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(DiscountCategory.class, json);
 	}
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getCategoryExternalReferenceCode() {
 		return categoryExternalReferenceCode;
 	}
@@ -91,7 +91,7 @@ public class DiscountCategory implements Serializable {
 	protected String categoryExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getCategoryId() {
 		return categoryId;
 	}
@@ -119,7 +119,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long categoryId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -152,7 +152,7 @@ public class DiscountCategory implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -181,7 +181,7 @@ public class DiscountCategory implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getId() {
 		return id;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountProduct.java
@@ -58,7 +58,7 @@ public class DiscountProduct implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(DiscountProduct.class, json);
 	}
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -91,7 +91,7 @@ public class DiscountProduct implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -120,7 +120,7 @@ public class DiscountProduct implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getId() {
 		return id;
 	}
@@ -146,7 +146,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -179,7 +179,7 @@ public class DiscountProduct implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/DiscountRule.java
@@ -61,7 +61,7 @@ public class DiscountRule implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -90,7 +90,7 @@ public class DiscountRule implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getId() {
 		return id;
 	}
@@ -116,7 +116,7 @@ public class DiscountRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "cart-total")
 	public String getType() {
 		return type;
 	}
@@ -143,7 +143,7 @@ public class DiscountRule implements Serializable {
 	@NotEmpty
 	protected String type;
 
-	@Schema
+	@Schema(example = "22.50")
 	public String getTypeSettings() {
 		return typeSettings;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceEntry.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceEntry.java
@@ -92,7 +92,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -120,7 +120,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getHasTierPrice() {
 		return hasTierPrice;
 	}
@@ -149,7 +149,7 @@ public class PriceEntry implements Serializable {
 	protected Boolean hasTierPrice;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -176,7 +176,7 @@ public class PriceEntry implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getPrice() {
 		return price;
@@ -206,7 +206,7 @@ public class PriceEntry implements Serializable {
 	@NotNull
 	protected BigDecimal price;
 
-	@Schema
+	@Schema(example = "PLAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -239,7 +239,7 @@ public class PriceEntry implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20078")
 	public Long getPriceListId() {
 		return priceListId;
 	}
@@ -268,7 +268,7 @@ public class PriceEntry implements Serializable {
 	protected Long priceListId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getPromoPrice() {
 		return promoPrice;
@@ -297,7 +297,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal promoPrice;
 
-	@Schema
+	@Schema(example = "BL500IC")
 	public String getSku() {
 		return sku;
 	}
@@ -323,7 +323,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getSkuExternalReferenceCode() {
 		return skuExternalReferenceCode;
 	}
@@ -354,7 +354,7 @@ public class PriceEntry implements Serializable {
 	protected String skuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getSkuId() {
 		return skuId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceList.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceList.java
@@ -65,7 +65,7 @@ public class PriceList implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(PriceList.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -94,7 +94,7 @@ public class PriceList implements Serializable {
 	protected Boolean active;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getCatalogId() {
 		return catalogId;
 	}
@@ -122,7 +122,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long catalogId;
 
-	@Schema
+	@Schema(example = "EUR")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -236,7 +236,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -265,7 +265,7 @@ public class PriceList implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -291,7 +291,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "Laptops, Beverages")
 	public String getName() {
 		return name;
 	}
@@ -318,7 +318,7 @@ public class PriceList implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -407,7 +407,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PriceListAccountGroup[] priceListAccountGroups;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceListAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/PriceListAccountGroup.java
@@ -59,7 +59,7 @@ public class PriceListAccountGroup implements Serializable {
 			PriceListAccountGroup.class, json);
 	}
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getAccountGroupExternalReferenceCode() {
 		return accountGroupExternalReferenceCode;
 	}
@@ -93,7 +93,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected String accountGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getAccountGroupId() {
 		return accountGroupId;
 	}
@@ -122,7 +122,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected Long accountGroupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getId() {
 		return id;
 	}
@@ -149,7 +149,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
 	}
@@ -177,7 +177,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer order;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -210,7 +210,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/TierPrice.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v1_0/TierPrice.java
@@ -90,7 +90,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -119,7 +119,7 @@ public class TierPrice implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -146,7 +146,7 @@ public class TierPrice implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "5")
 	public Integer getMinimumQuantity() {
 		return minimumQuantity;
 	}
@@ -175,7 +175,7 @@ public class TierPrice implements Serializable {
 	protected Integer minimumQuantity;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "25")
 	@Valid
 	public BigDecimal getPrice() {
 		return price;
@@ -204,7 +204,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal price;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getPriceEntryExternalReferenceCode() {
 		return priceEntryExternalReferenceCode;
 	}
@@ -237,7 +237,7 @@ public class TierPrice implements Serializable {
 	protected String priceEntryExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceEntryId() {
 		return priceEntryId;
 	}
@@ -266,7 +266,7 @@ public class TierPrice implements Serializable {
 	protected Long priceEntryId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getPromoPrice() {
 		return promoPrice;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Account.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Account.java
@@ -59,7 +59,7 @@ public class Account implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -86,7 +86,7 @@ public class Account implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20078")
 	public Long getLogoId() {
 		return logoId;
 	}
@@ -114,7 +114,7 @@ public class Account implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long logoId;
 
-	@Schema
+	@Schema(example = "Account Name")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/AccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/AccountGroup.java
@@ -59,7 +59,7 @@ public class AccountGroup implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -85,7 +85,7 @@ public class AccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "AccountGroup Name")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Category.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Category.java
@@ -59,7 +59,7 @@ public class Category implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -85,7 +85,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getName() {
 		return name;
 	}
@@ -111,7 +111,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String name;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getPath() {
 		return path;
 	}
@@ -137,7 +137,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String path;
 
-	@Schema
+	@Schema(example = "Default Vocabulary")
 	public String getVocabulary() {
 		return vocabulary;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Discount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Discount.java
@@ -102,7 +102,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -158,7 +158,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String amountFormatted;
 
-	@Schema
+	@Schema(example = "SAVE20")
 	public String getCouponCode() {
 		return couponCode;
 	}
@@ -458,7 +458,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected DiscountRule[] discountRules;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -486,7 +486,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -514,7 +514,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -543,7 +543,7 @@ public class Discount implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -569,7 +569,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "L1")
 	public String getLevel() {
 		return level;
 	}
@@ -599,7 +599,7 @@ public class Discount implements Serializable {
 	protected String level;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getLimitationTimes() {
 		return limitationTimes;
 	}
@@ -628,7 +628,7 @@ public class Discount implements Serializable {
 	protected Integer limitationTimes;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getLimitationTimesPerAccount() {
 		return limitationTimesPerAccount;
 	}
@@ -660,7 +660,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer limitationTimesPerAccount;
 
-	@Schema
+	@Schema(example = "unlimited")
 	public String getLimitationType() {
 		return limitationType;
 	}
@@ -690,7 +690,7 @@ public class Discount implements Serializable {
 	protected String limitationType;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "25")
 	@Valid
 	public BigDecimal getMaximumDiscountAmount() {
 		return maximumDiscountAmount;
@@ -720,7 +720,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal maximumDiscountAmount;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -749,7 +749,7 @@ public class Discount implements Serializable {
 	protected Boolean neverExpire;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "5")
 	public Integer getNumberOfUse() {
 		return numberOfUse;
 	}
@@ -778,7 +778,7 @@ public class Discount implements Serializable {
 	protected Integer numberOfUse;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	@Valid
 	public BigDecimal getPercentageLevel1() {
 		return percentageLevel1;
@@ -808,7 +808,7 @@ public class Discount implements Serializable {
 	protected BigDecimal percentageLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getPercentageLevel2() {
 		return percentageLevel2;
@@ -838,7 +838,7 @@ public class Discount implements Serializable {
 	protected BigDecimal percentageLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getPercentageLevel3() {
 		return percentageLevel3;
@@ -868,7 +868,7 @@ public class Discount implements Serializable {
 	protected BigDecimal percentageLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public BigDecimal getPercentageLevel4() {
 		return percentageLevel4;
@@ -897,7 +897,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal percentageLevel4;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getRulesConjunction() {
 		return rulesConjunction;
 	}
@@ -925,7 +925,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean rulesConjunction;
 
-	@Schema
+	@Schema(example = "subtotal")
 	public String getTarget() {
 		return target;
 	}
@@ -954,7 +954,7 @@ public class Discount implements Serializable {
 	@NotEmpty
 	protected String target;
 
-	@Schema
+	@Schema(example = "20% Off")
 	public String getTitle() {
 		return title;
 	}
@@ -983,7 +983,7 @@ public class Discount implements Serializable {
 	@NotEmpty
 	protected String title;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getUseCouponCode() {
 		return useCouponCode;
 	}
@@ -1011,7 +1011,7 @@ public class Discount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean useCouponCode;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getUsePercentage() {
 		return usePercentage;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccount.java
@@ -90,7 +90,7 @@ public class DiscountAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Account account;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getAccountExternalReferenceCode() {
 		return accountExternalReferenceCode;
 	}
@@ -123,7 +123,7 @@ public class DiscountAccount implements Serializable {
 	protected String accountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -183,7 +183,7 @@ public class DiscountAccount implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountAccountId() {
 		return discountAccountId;
 	}
@@ -211,7 +211,7 @@ public class DiscountAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountAccountId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class DiscountAccount implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountAccountGroup.java
@@ -91,7 +91,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected AccountGroup accountGroup;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getAccountGroupExternalReferenceCode() {
 		return accountGroupExternalReferenceCode;
 	}
@@ -125,7 +125,7 @@ public class DiscountAccountGroup implements Serializable {
 	protected String accountGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountGroupId() {
 		return accountGroupId;
 	}
@@ -185,7 +185,7 @@ public class DiscountAccountGroup implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountAccountGroupId() {
 		return discountAccountGroupId;
 	}
@@ -213,7 +213,7 @@ public class DiscountAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountAccountGroupId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -246,7 +246,7 @@ public class DiscountAccountGroup implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountCategory.java
@@ -120,7 +120,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Category category;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getCategoryExternalReferenceCode() {
 		return categoryExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class DiscountCategory implements Serializable {
 	protected String categoryExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getCategoryId() {
 		return categoryId;
 	}
@@ -183,7 +183,7 @@ public class DiscountCategory implements Serializable {
 	protected Long categoryId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountCategoryId() {
 		return discountCategoryId;
 	}
@@ -211,7 +211,7 @@ public class DiscountCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountCategoryId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class DiscountCategory implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountChannel.java
@@ -120,7 +120,7 @@ public class DiscountChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Channel channel;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getChannelExternalReferenceCode() {
 		return channelExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class DiscountChannel implements Serializable {
 	protected String channelExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -183,7 +183,7 @@ public class DiscountChannel implements Serializable {
 	protected Long channelId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountChannelId() {
 		return discountChannelId;
 	}
@@ -211,7 +211,7 @@ public class DiscountChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long discountChannelId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class DiscountChannel implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountOrderType.java
@@ -91,7 +91,7 @@ public class DiscountOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -124,7 +124,7 @@ public class DiscountOrderType implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -154,7 +154,7 @@ public class DiscountOrderType implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountOrderTypeId() {
 		return discountOrderTypeId;
 	}
@@ -211,7 +211,7 @@ public class DiscountOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected OrderType orderType;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class DiscountOrderType implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -274,7 +274,7 @@ public class DiscountOrderType implements Serializable {
 	protected Long orderTypeId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProduct.java
@@ -91,7 +91,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -124,7 +124,7 @@ public class DiscountProduct implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -154,7 +154,7 @@ public class DiscountProduct implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountProductId() {
 		return discountProductId;
 	}
@@ -211,7 +211,7 @@ public class DiscountProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Product product;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -244,7 +244,7 @@ public class DiscountProduct implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountProductGroup.java
@@ -92,7 +92,7 @@ public class DiscountProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -125,7 +125,7 @@ public class DiscountProductGroup implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -155,7 +155,7 @@ public class DiscountProductGroup implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountProductGroupId() {
 		return discountProductGroupId;
 	}
@@ -212,7 +212,7 @@ public class DiscountProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ProductGroup productGroup;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getProductGroupExternalReferenceCode() {
 		return productGroupExternalReferenceCode;
 	}
@@ -246,7 +246,7 @@ public class DiscountProductGroup implements Serializable {
 	protected String productGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getProductGroupId() {
 		return productGroupId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountRule.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountRule.java
@@ -92,7 +92,7 @@ public class DiscountRule implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -121,7 +121,7 @@ public class DiscountRule implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getId() {
 		return id;
 	}
@@ -173,7 +173,7 @@ public class DiscountRule implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(example = "cart-total")
 	public String getType() {
 		return type;
 	}
@@ -200,7 +200,7 @@ public class DiscountRule implements Serializable {
 	@NotEmpty
 	protected String type;
 
-	@Schema
+	@Schema(example = "22.50")
 	public String getTypeSettings() {
 		return typeSettings;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountSku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/DiscountSku.java
@@ -91,7 +91,7 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -124,7 +124,7 @@ public class DiscountSku implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -154,7 +154,7 @@ public class DiscountSku implements Serializable {
 	protected Long discountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getDiscountSkuId() {
 		return discountSkuId;
 	}
@@ -183,7 +183,7 @@ public class DiscountSku implements Serializable {
 	protected Long discountSkuId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getProductId() {
 		return productId;
 	}
@@ -211,7 +211,9 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getProductName() {
 		return productName;
@@ -268,7 +270,7 @@ public class DiscountSku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Sku sku;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getSkuExternalReferenceCode() {
 		return skuExternalReferenceCode;
 	}
@@ -299,7 +301,7 @@ public class DiscountSku implements Serializable {
 	protected String skuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getSkuId() {
 		return skuId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/OrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/OrderType.java
@@ -60,7 +60,7 @@ public class OrderType implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -86,7 +86,9 @@ public class OrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceEntry.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceEntry.java
@@ -97,7 +97,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -125,7 +125,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getBulkPricing() {
 		return bulkPricing;
 	}
@@ -182,7 +182,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDiscountDiscovery() {
 		return discountDiscovery;
 	}
@@ -211,7 +211,7 @@ public class PriceEntry implements Serializable {
 	protected Boolean discountDiscovery;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel1() {
 		return discountLevel1;
@@ -241,7 +241,7 @@ public class PriceEntry implements Serializable {
 	protected BigDecimal discountLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel2() {
 		return discountLevel2;
@@ -271,7 +271,7 @@ public class PriceEntry implements Serializable {
 	protected BigDecimal discountLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel3() {
 		return discountLevel3;
@@ -301,7 +301,7 @@ public class PriceEntry implements Serializable {
 	protected BigDecimal discountLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel4() {
 		return discountLevel4;
@@ -330,7 +330,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal discountLevel4;
 
-	@Schema
+	@Schema(example = "10 | 10 | 10 | 10")
 	public String getDiscountLevelsFormatted() {
 		return discountLevelsFormatted;
 	}
@@ -360,7 +360,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String discountLevelsFormatted;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -388,7 +388,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -416,7 +416,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -444,7 +444,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getHasTierPrice() {
 		return hasTierPrice;
 	}
@@ -472,7 +472,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean hasTierPrice;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -530,7 +530,7 @@ public class PriceEntry implements Serializable {
 	protected Double price;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceEntryId() {
 		return priceEntryId;
 	}
@@ -586,7 +586,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String priceFormatted;
 
-	@Schema
+	@Schema(example = "PLAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -619,7 +619,7 @@ public class PriceEntry implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20078")
 	public Long getPriceListId() {
 		return priceListId;
 	}
@@ -704,7 +704,7 @@ public class PriceEntry implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Sku sku;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getSkuExternalReferenceCode() {
 		return skuExternalReferenceCode;
 	}
@@ -735,7 +735,7 @@ public class PriceEntry implements Serializable {
 	protected String skuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getSkuId() {
 		return skuId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceList.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceList.java
@@ -98,7 +98,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -126,7 +126,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "admin")
 	public String getAuthor() {
 		return author;
 	}
@@ -154,7 +154,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String author;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getCatalogBasePriceList() {
 		return catalogBasePriceList;
 	}
@@ -183,7 +183,7 @@ public class PriceList implements Serializable {
 	protected Boolean catalogBasePriceList;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getCatalogId() {
 		return catalogId;
 	}
@@ -212,7 +212,7 @@ public class PriceList implements Serializable {
 	@NotNull
 	protected Long catalogId;
 
-	@Schema
+	@Schema(example = "catalog")
 	public String getCatalogName() {
 		return catalogName;
 	}
@@ -240,7 +240,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String catalogName;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -268,7 +268,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date createDate;
 
-	@Schema
+	@Schema(example = "EUR")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -326,7 +326,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -354,7 +354,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -382,7 +382,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -411,7 +411,7 @@ public class PriceList implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -437,7 +437,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "Laptops, Beverages")
 	public String getName() {
 		return name;
 	}
@@ -464,7 +464,7 @@ public class PriceList implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNetPrice() {
 		return netPrice;
 	}
@@ -492,7 +492,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean netPrice;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -521,7 +521,7 @@ public class PriceList implements Serializable {
 	protected Boolean neverExpire;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getParentPriceListId() {
 		return parentPriceListId;
 	}
@@ -762,7 +762,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PriceModifier[] priceModifiers;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -790,7 +790,7 @@ public class PriceList implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "price-list, promotion, contract")
 	@Valid
 	public Type getType() {
 		return type;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccount.java
@@ -90,7 +90,7 @@ public class PriceListAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Account account;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getAccountExternalReferenceCode() {
 		return accountExternalReferenceCode;
 	}
@@ -123,7 +123,7 @@ public class PriceListAccount implements Serializable {
 	protected String accountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -183,7 +183,7 @@ public class PriceListAccount implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
 	}
@@ -212,7 +212,7 @@ public class PriceListAccount implements Serializable {
 	protected Integer order;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceListAccountId() {
 		return priceListAccountId;
 	}
@@ -240,7 +240,7 @@ public class PriceListAccount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long priceListAccountId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -273,7 +273,7 @@ public class PriceListAccount implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccountGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListAccountGroup.java
@@ -91,7 +91,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected AccountGroup accountGroup;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getAccountGroupExternalReferenceCode() {
 		return accountGroupExternalReferenceCode;
 	}
@@ -125,7 +125,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected String accountGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getAccountGroupId() {
 		return accountGroupId;
 	}
@@ -185,7 +185,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected Map<String, Map<String, String>> actions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
 	}
@@ -214,7 +214,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected Integer order;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceListAccountGroupId() {
 		return priceListAccountGroupId;
 	}
@@ -243,7 +243,7 @@ public class PriceListAccountGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long priceListAccountGroupId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -276,7 +276,7 @@ public class PriceListAccountGroup implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListChannel.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListChannel.java
@@ -120,7 +120,7 @@ public class PriceListChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Channel channel;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getChannelExternalReferenceCode() {
 		return channelExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class PriceListChannel implements Serializable {
 	protected String channelExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -183,7 +183,7 @@ public class PriceListChannel implements Serializable {
 	protected Long channelId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
 	}
@@ -212,7 +212,7 @@ public class PriceListChannel implements Serializable {
 	protected Integer order;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceListChannelId() {
 		return priceListChannelId;
 	}
@@ -240,7 +240,7 @@ public class PriceListChannel implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long priceListChannelId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -273,7 +273,7 @@ public class PriceListChannel implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListDiscount.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListDiscount.java
@@ -60,7 +60,7 @@ public class PriceListDiscount implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(PriceListDiscount.class, json);
 	}
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getDiscountExternalReferenceCode() {
 		return discountExternalReferenceCode;
 	}
@@ -93,7 +93,7 @@ public class PriceListDiscount implements Serializable {
 	protected String discountExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getDiscountId() {
 		return discountId;
 	}
@@ -151,7 +151,7 @@ public class PriceListDiscount implements Serializable {
 	protected String discountName;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getOrder() {
 		return order;
 	}
@@ -180,7 +180,7 @@ public class PriceListDiscount implements Serializable {
 	protected Integer order;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceListDiscountId() {
 		return priceListDiscountId;
 	}
@@ -208,7 +208,7 @@ public class PriceListDiscount implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long priceListDiscountId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -241,7 +241,7 @@ public class PriceListDiscount implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListOrderType.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceListOrderType.java
@@ -120,7 +120,7 @@ public class PriceListOrderType implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected OrderType orderType;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -153,7 +153,7 @@ public class PriceListOrderType implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -182,7 +182,7 @@ public class PriceListOrderType implements Serializable {
 	@NotNull
 	protected Long orderTypeId;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -215,7 +215,7 @@ public class PriceListOrderType implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceListId() {
 		return priceListId;
 	}
@@ -245,7 +245,7 @@ public class PriceListOrderType implements Serializable {
 	protected Long priceListId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceListOrderTypeId() {
 		return priceListOrderTypeId;
 	}
@@ -274,7 +274,7 @@ public class PriceListOrderType implements Serializable {
 	protected Long priceListOrderTypeId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifier.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifier.java
@@ -100,7 +100,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -128,7 +128,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -156,7 +156,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -184,7 +184,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -213,7 +213,7 @@ public class PriceModifier implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -239,7 +239,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "25")
 	@Valid
 	public BigDecimal getModifierAmount() {
 		return modifierAmount;
@@ -269,7 +269,7 @@ public class PriceModifier implements Serializable {
 	@NotNull
 	protected BigDecimal modifierAmount;
 
-	@Schema
+	@Schema(example = "percentage")
 	public String getModifierType() {
 		return modifierType;
 	}
@@ -298,7 +298,7 @@ public class PriceModifier implements Serializable {
 	@NotEmpty
 	protected String modifierType;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -326,7 +326,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@Schema
+	@Schema(example = "PLAB-34098-789-N")
 	public String getPriceListExternalReferenceCode() {
 		return priceListExternalReferenceCode;
 	}
@@ -359,7 +359,7 @@ public class PriceModifier implements Serializable {
 	protected String priceListExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20078")
 	public Long getPriceListId() {
 		return priceListId;
 	}
@@ -485,7 +485,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PriceModifierProduct[] priceModifierProducts;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -513,7 +513,7 @@ public class PriceModifier implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "product")
 	public String getTarget() {
 		return target;
 	}
@@ -542,7 +542,7 @@ public class PriceModifier implements Serializable {
 	@NotEmpty
 	protected String target;
 
-	@Schema
+	@Schema(example = "20% Off")
 	public String getTitle() {
 		return title;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierCategory.java
@@ -121,7 +121,7 @@ public class PriceModifierCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Category category;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getCategoryExternalReferenceCode() {
 		return categoryExternalReferenceCode;
 	}
@@ -154,7 +154,7 @@ public class PriceModifierCategory implements Serializable {
 	protected String categoryExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getCategoryId() {
 		return categoryId;
 	}
@@ -184,7 +184,7 @@ public class PriceModifierCategory implements Serializable {
 	protected Long categoryId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceModifierCategoryId() {
 		return priceModifierCategoryId;
 	}
@@ -213,7 +213,7 @@ public class PriceModifierCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long priceModifierCategoryId;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getPriceModifierExternalReferenceCode() {
 		return priceModifierExternalReferenceCode;
 	}
@@ -247,7 +247,7 @@ public class PriceModifierCategory implements Serializable {
 	protected String priceModifierExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getPriceModifierId() {
 		return priceModifierId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProduct.java
@@ -92,7 +92,7 @@ public class PriceModifierProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getPriceModifierExternalReferenceCode() {
 		return priceModifierExternalReferenceCode;
 	}
@@ -126,7 +126,7 @@ public class PriceModifierProduct implements Serializable {
 	protected String priceModifierExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getPriceModifierId() {
 		return priceModifierId;
 	}
@@ -156,7 +156,7 @@ public class PriceModifierProduct implements Serializable {
 	protected Long priceModifierId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceModifierProductId() {
 		return priceModifierProductId;
 	}
@@ -213,7 +213,7 @@ public class PriceModifierProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Product product;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -246,7 +246,7 @@ public class PriceModifierProduct implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getProductId() {
 		return productId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/PriceModifierProductGroup.java
@@ -93,7 +93,7 @@ public class PriceModifierProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "DAB-34098-789-N")
 	public String getPriceModifierExternalReferenceCode() {
 		return priceModifierExternalReferenceCode;
 	}
@@ -127,7 +127,7 @@ public class PriceModifierProductGroup implements Serializable {
 	protected String priceModifierExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30324")
 	public Long getPriceModifierId() {
 		return priceModifierId;
 	}
@@ -157,7 +157,7 @@ public class PriceModifierProductGroup implements Serializable {
 	protected Long priceModifierId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30643")
 	public Long getPriceModifierProductGroupId() {
 		return priceModifierProductGroupId;
 	}
@@ -218,7 +218,7 @@ public class PriceModifierProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected ProductGroup productGroup;
 
-	@Schema
+	@Schema(example = "PAB-34098-789-N")
 	public String getProductGroupExternalReferenceCode() {
 		return productGroupExternalReferenceCode;
 	}
@@ -252,7 +252,7 @@ public class PriceModifierProductGroup implements Serializable {
 	protected String productGroupExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getProductGroupId() {
 		return productGroupId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Product.java
@@ -60,7 +60,7 @@ public class Product implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -86,7 +86,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -115,7 +117,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getSku() {
 		return sku;
 	}
@@ -141,7 +143,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getThumbnail() {
 		return thumbnail;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/ProductGroup.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/ProductGroup.java
@@ -60,7 +60,7 @@ public class ProductGroup implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -87,7 +87,7 @@ public class ProductGroup implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20")
 	public Integer getProductsCount() {
 		return productsCount;
 	}
@@ -115,7 +115,7 @@ public class ProductGroup implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer productsCount;
 
-	@Schema
+	@Schema(example = "{en_US=Title, hr_HR=Title HR, hu_HU=Title HU}")
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Sku.java
@@ -173,7 +173,7 @@ public class Sku implements Serializable {
 	protected String basePromoPriceFormatted;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -199,7 +199,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getName() {
 		return name;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Status.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/Status.java
@@ -82,7 +82,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer code;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel() {
 		return label;
 	}
@@ -110,7 +110,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel_i18n() {
 		return label_i18n;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/TierPrice.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/java/com/liferay/headless/commerce/admin/pricing/dto/v2_0/TierPrice.java
@@ -97,7 +97,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -154,7 +154,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDiscountDiscovery() {
 		return discountDiscovery;
 	}
@@ -183,7 +183,7 @@ public class TierPrice implements Serializable {
 	protected Boolean discountDiscovery;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel1() {
 		return discountLevel1;
@@ -213,7 +213,7 @@ public class TierPrice implements Serializable {
 	protected BigDecimal discountLevel1;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel2() {
 		return discountLevel2;
@@ -243,7 +243,7 @@ public class TierPrice implements Serializable {
 	protected BigDecimal discountLevel2;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel3() {
 		return discountLevel3;
@@ -273,7 +273,7 @@ public class TierPrice implements Serializable {
 	protected BigDecimal discountLevel3;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	@Valid
 	public BigDecimal getDiscountLevel4() {
 		return discountLevel4;
@@ -302,7 +302,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BigDecimal discountLevel4;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -330,7 +330,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -358,7 +358,7 @@ public class TierPrice implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -387,7 +387,7 @@ public class TierPrice implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -414,7 +414,7 @@ public class TierPrice implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "5")
 	public Integer getMinimumQuantity() {
 		return minimumQuantity;
 	}
@@ -443,7 +443,7 @@ public class TierPrice implements Serializable {
 	@NotNull
 	protected Integer minimumQuantity;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -500,7 +500,7 @@ public class TierPrice implements Serializable {
 	@NotNull
 	protected Double price;
 
-	@Schema
+	@Schema(example = "CAB-34098-789-N")
 	public String getPriceEntryExternalReferenceCode() {
 		return priceEntryExternalReferenceCode;
 	}
@@ -533,7 +533,7 @@ public class TierPrice implements Serializable {
 	protected String priceEntryExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getPriceEntryId() {
 		return priceEntryId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.3.0
+version 5.3.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v2_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-api/src/main/resources/com/liferay/headless/commerce/admin/pricing/dto/v2_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 6.1.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Shipment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Shipment.java
@@ -64,7 +64,7 @@ public class Shipment implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -122,7 +122,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Map<String, Map<String, String>> actions;
 
-	@Schema
+	@Schema(example = "FedEx")
 	public String getCarrier() {
 		return carrier;
 	}
@@ -235,7 +235,7 @@ public class Shipment implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -290,7 +290,7 @@ public class Shipment implements Serializable {
 	protected Date modifiedDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderId() {
 		return orderId;
 	}
@@ -378,7 +378,7 @@ public class Shipment implements Serializable {
 	protected ShippingAddress shippingAddress;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getShippingAddressId() {
 		return shippingAddressId;
 	}
@@ -435,7 +435,7 @@ public class Shipment implements Serializable {
 	protected Date shippingDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getShippingMethodId() {
 		return shippingMethodId;
 	}
@@ -463,7 +463,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long shippingMethodId;
 
-	@Schema
+	@Schema(example = "Standard Delivery")
 	public String getShippingOptionName() {
 		return shippingOptionName;
 	}
@@ -520,7 +520,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Status status;
 
-	@Schema
+	@Schema(example = "123AD-asd")
 	public String getTrackingNumber() {
 		return trackingNumber;
 	}
@@ -548,7 +548,7 @@ public class Shipment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String trackingNumber;
 
-	@Schema
+	@Schema(example = "John")
 	public String getUserName() {
 		return userName;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShipmentItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShipmentItem.java
@@ -152,7 +152,7 @@ public class ShipmentItem implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -207,7 +207,7 @@ public class ShipmentItem implements Serializable {
 	protected Date modifiedDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderItemId() {
 		return orderItemId;
 	}
@@ -237,7 +237,7 @@ public class ShipmentItem implements Serializable {
 	protected Long orderItemId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
 	}
@@ -299,7 +299,7 @@ public class ShipmentItem implements Serializable {
 	protected String shipmentExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getShipmentId() {
 		return shipmentId;
 	}
@@ -327,7 +327,7 @@ public class ShipmentItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long shipmentId;
 
-	@Schema
+	@Schema(example = "John")
 	public String getUserName() {
 		return userName;
 	}
@@ -355,7 +355,7 @@ public class ShipmentItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String userName;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getValidateInventory() {
 		return validateInventory;
 	}
@@ -384,7 +384,7 @@ public class ShipmentItem implements Serializable {
 	protected Boolean validateInventory;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getWarehouseId() {
 		return warehouseId;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShippingAddress.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/ShippingAddress.java
@@ -60,7 +60,7 @@ public class ShippingAddress implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(ShippingAddress.class, json);
 	}
 
-	@Schema
+	@Schema(example = "Diamond Bar")
 	public String getCity() {
 		return city;
 	}
@@ -87,7 +87,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String city;
 
-	@Schema
+	@Schema(example = "US")
 	public String getCountryISOCode() {
 		return countryISOCode;
 	}
@@ -116,7 +116,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String countryISOCode;
 
-	@Schema
+	@Schema(example = "right stairs, first room on the left")
 	public String getDescription() {
 		return description;
 	}
@@ -144,7 +144,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -173,7 +173,7 @@ public class ShippingAddress implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -199,7 +199,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "33.9976884")
 	public Double getLatitude() {
 		return latitude;
 	}
@@ -227,7 +227,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double latitude;
 
-	@Schema
+	@Schema(example = "-117.8144595")
 	public Double getLongitude() {
 		return longitude;
 	}
@@ -255,7 +255,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double longitude;
 
-	@Schema
+	@Schema(example = "Alessio Antonio Rendina")
 	public String getName() {
 		return name;
 	}
@@ -282,7 +282,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "(123) 456 7890")
 	public String getPhoneNumber() {
 		return phoneNumber;
 	}
@@ -310,7 +310,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String phoneNumber;
 
-	@Schema
+	@Schema(example = "CA")
 	public String getRegionISOCode() {
 		return regionISOCode;
 	}
@@ -338,7 +338,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String regionISOCode;
 
-	@Schema
+	@Schema(example = "1400 Montefino Ave")
 	public String getStreet1() {
 		return street1;
 	}
@@ -367,7 +367,7 @@ public class ShippingAddress implements Serializable {
 	@NotEmpty
 	protected String street1;
 
-	@Schema
+	@Schema(example = "1st floor")
 	public String getStreet2() {
 		return street2;
 	}
@@ -395,7 +395,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street2;
 
-	@Schema
+	@Schema(example = "suite 200")
 	public String getStreet3() {
 		return street3;
 	}
@@ -423,7 +423,7 @@ public class ShippingAddress implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street3;
 
-	@Schema
+	@Schema(example = "91765")
 	public String getZip() {
 		return zip;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Status.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/java/com/liferay/headless/commerce/admin/shipment/dto/v1_0/Status.java
@@ -82,7 +82,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer code;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel() {
 		return label;
 	}
@@ -110,7 +110,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel_i18n() {
 		return label_i18n;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/resources/com/liferay/headless/commerce/admin/shipment/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-api/src/main/resources/com/liferay/headless/commerce/admin/shipment/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.1
+version 1.3.2

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/AvailabilityEstimate.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/AvailabilityEstimate.java
@@ -63,7 +63,7 @@ public class AvailabilityEstimate implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
 	}
@@ -92,7 +92,7 @@ public class AvailabilityEstimate implements Serializable {
 	protected Long groupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -119,7 +119,7 @@ public class AvailabilityEstimate implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.1")
 	public Double getPriority() {
 		return priority;
 	}
@@ -147,7 +147,7 @@ public class AvailabilityEstimate implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double priority;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getTitle() {
 		return title;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/MeasurementUnit.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/MeasurementUnit.java
@@ -64,7 +64,7 @@ public class MeasurementUnit implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
 	}
@@ -93,7 +93,7 @@ public class MeasurementUnit implements Serializable {
 	protected Long groupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -119,7 +119,7 @@ public class MeasurementUnit implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "kg")
 	public String getKey() {
 		return key;
 	}
@@ -146,7 +146,7 @@ public class MeasurementUnit implements Serializable {
 	@NotEmpty
 	protected String key;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -176,7 +176,7 @@ public class MeasurementUnit implements Serializable {
 	@NotNull
 	protected Map<String, String> name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPrimary() {
 		return primary;
 	}
@@ -205,7 +205,7 @@ public class MeasurementUnit implements Serializable {
 	protected Boolean primary;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.1")
 	public Double getPriority() {
 		return priority;
 	}
@@ -234,7 +234,7 @@ public class MeasurementUnit implements Serializable {
 	protected Double priority;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Double getRate() {
 		return rate;
 	}
@@ -262,7 +262,7 @@ public class MeasurementUnit implements Serializable {
 
 	@DecimalMax("1")
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getType() {
 		return type;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/TaxCategory.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/TaxCategory.java
@@ -61,7 +61,7 @@ public class TaxCategory implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(TaxCategory.class, json);
 	}
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -92,7 +92,7 @@ public class TaxCategory implements Serializable {
 	protected Map<String, String> description;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
 	}
@@ -121,7 +121,7 @@ public class TaxCategory implements Serializable {
 	protected Long groupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -147,7 +147,7 @@ public class TaxCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "{en_US=Croatia, hr_HR=Hrvatska, hu_HU=Horvatorszag}")
 	@Valid
 	public Map<String, String> getName() {
 		return name;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/Warehouse.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/java/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/Warehouse.java
@@ -62,7 +62,7 @@ public class Warehouse implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Warehouse.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getActive() {
 		return active;
 	}
@@ -90,7 +90,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean active;
 
-	@Schema
+	@Schema(example = "Diamond Bar")
 	public String getCity() {
 		return city;
 	}
@@ -117,7 +117,7 @@ public class Warehouse implements Serializable {
 	protected String city;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getCommerceCountryId() {
 		return commerceCountryId;
 	}
@@ -147,7 +147,7 @@ public class Warehouse implements Serializable {
 	protected Long commerceCountryId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30234")
 	public Long getCommerceRegionId() {
 		return commerceRegionId;
 	}
@@ -175,7 +175,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long commerceRegionId;
 
-	@Schema
+	@Schema(example = "right stairs, first room on the left")
 	public String getDescription() {
 		return description;
 	}
@@ -204,7 +204,7 @@ public class Warehouse implements Serializable {
 	protected String description;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "23130")
 	public Long getGroupId() {
 		return groupId;
 	}
@@ -233,7 +233,7 @@ public class Warehouse implements Serializable {
 	protected Long groupId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -259,7 +259,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "33.9976884")
 	public Double getLatitude() {
 		return latitude;
 	}
@@ -287,7 +287,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double latitude;
 
-	@Schema
+	@Schema(example = "-117.8144595")
 	public Double getLongitude() {
 		return longitude;
 	}
@@ -315,7 +315,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double longitude;
 
-	@Schema
+	@Schema(example = "0")
 	@Valid
 	public Number getMvccVersion() {
 		return mvccVersion;
@@ -344,7 +344,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Number mvccVersion;
 
-	@Schema
+	@Schema(example = "Warehouse Name")
 	public String getName() {
 		return name;
 	}
@@ -371,7 +371,7 @@ public class Warehouse implements Serializable {
 	@NotEmpty
 	protected String name;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPrimary() {
 		return primary;
 	}
@@ -399,7 +399,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean primary;
 
-	@Schema
+	@Schema(example = "1400 Montefino Ave")
 	public String getStreet1() {
 		return street1;
 	}
@@ -427,7 +427,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street1;
 
-	@Schema
+	@Schema(example = "1st floor")
 	public String getStreet2() {
 		return street2;
 	}
@@ -455,7 +455,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street2;
 
-	@Schema
+	@Schema(example = "suite 200")
 	public String getStreet3() {
 		return street3;
 	}
@@ -483,7 +483,7 @@ public class Warehouse implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String street3;
 
-	@Schema
+	@Schema(example = "91765")
 	public String getZip() {
 		return zip;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/resources/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-api/src/main/resources/com/liferay/headless/commerce/admin/site/setting/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.5.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Cart.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Cart.java
@@ -541,7 +541,7 @@ public class Cart implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Status orderStatusInfo;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/CartItem.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/CartItem.java
@@ -337,7 +337,9 @@ public class CartItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@Schema
+	@Schema(
+		example = "{en_US=product-url-us, hr_HR=product-url-hr, hu_HU=product-url-hu}"
+	)
 	@Valid
 	public Map<String, String> getProductURLs() {
 		return productURLs;
@@ -476,7 +478,7 @@ public class CartItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long skuId;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getSubscription() {
 		return subscription;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Status.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/java/com/liferay/headless/commerce/delivery/cart/dto/v1_0/Status.java
@@ -82,7 +82,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Integer code;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel() {
 		return label;
 	}
@@ -110,7 +110,7 @@ public class Status implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
-	@Schema
+	@Schema(example = "black")
 	public String getLabel_i18n() {
 		return label_i18n;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/resources/com/liferay/headless/commerce/delivery/cart/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-api/src/main/resources/com/liferay/headless/commerce/delivery/cart/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.2.1

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Attachment.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Attachment.java
@@ -92,7 +92,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String attachment;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -120,7 +120,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -149,7 +149,7 @@ public class Attachment implements Serializable {
 	protected Date expirationDate;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -175,7 +175,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -203,7 +203,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean neverExpire;
 
-	@Schema
+	@Schema(example = "{color=yellow, optionKey=optionValueKey, size=xs}")
 	@Valid
 	public Map<String, String> getOptions() {
 		return options;
@@ -232,7 +232,7 @@ public class Attachment implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> options;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Availability.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Availability.java
@@ -56,7 +56,7 @@ public class Availability implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Availability.class, json);
 	}
 
-	@Schema
+	@Schema(example = "available")
 	public String getLabel() {
 		return label;
 	}
@@ -84,7 +84,7 @@ public class Availability implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String label;
 
-	@Schema
+	@Schema(example = "Available")
 	public String getLabel_i18n() {
 		return label_i18n;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Category.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Category.java
@@ -59,7 +59,7 @@ public class Category implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -139,7 +139,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long siteId;
 
-	@Schema
+	@Schema(example = "Default Vocabulary")
 	public String getVocabulary() {
 		return vocabulary;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Error.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/MappedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/MappedProduct.java
@@ -155,7 +155,7 @@ public class MappedProduct implements Serializable {
 	protected MappedProduct firstAvailableReplacementMappedProduct;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33130")
 	public Long getId() {
 		return id;
 	}
@@ -240,7 +240,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductConfiguration productConfiguration;
 
-	@Schema
+	@Schema(example = "exampleERC")
 	public String getProductExternalReferenceCode() {
 		return productExternalReferenceCode;
 	}
@@ -273,7 +273,7 @@ public class MappedProduct implements Serializable {
 	protected String productExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33131")
 	public Long getProductId() {
 		return productId;
 	}
@@ -301,7 +301,9 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getProductName() {
 		return productName;
@@ -361,7 +363,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductOption[] productOptions;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPurchasable() {
 		return purchasable;
 	}
@@ -390,7 +392,7 @@ public class MappedProduct implements Serializable {
 	protected Boolean purchasable;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getQuantity() {
 		return quantity;
 	}
@@ -451,7 +453,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected MappedProduct replacementMappedProduct;
 
-	@Schema
+	@Schema(example = "MIN3123 has been replaced by MIN1289")
 	public String getReplacementMessage() {
 		return replacementMessage;
 	}
@@ -479,7 +481,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String replacementMessage;
 
-	@Schema
+	@Schema(example = "1")
 	public String getSequence() {
 		return sequence;
 	}
@@ -507,7 +509,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sequence;
 
-	@Schema
+	@Schema(example = "SKU01")
 	public String getSku() {
 		return sku;
 	}
@@ -533,7 +535,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "SKU0111")
 	public String getSkuExternalReferenceCode() {
 		return skuExternalReferenceCode;
 	}
@@ -564,7 +566,7 @@ public class MappedProduct implements Serializable {
 	protected String skuExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33135")
 	public Long getSkuId() {
 		return skuId;
 	}
@@ -619,7 +621,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected SkuOption[] skuOptions;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getThumbnail() {
 		return thumbnail;
 	}
@@ -647,7 +649,7 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected String thumbnail;
 
-	@Schema
+	@Schema(example = "sku")
 	@Valid
 	public Type getType() {
 		return type;
@@ -683,7 +685,9 @@ public class MappedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Type type;
 
-	@Schema
+	@Schema(
+		example = "{en_US=product-url-us, hr_HR=product-url-hr, hu_HU=product-url-hu}"
+	)
 	@Valid
 	public Map<String, String> getUrls() {
 		return urls;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Pin.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Pin.java
@@ -60,7 +60,7 @@ public class Pin implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "33130")
 	public Long getId() {
 		return id;
 	}
@@ -115,7 +115,7 @@ public class Pin implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected MappedProduct mappedProduct;
 
-	@Schema
+	@Schema(example = "33.54")
 	public Double getPositionX() {
 		return positionX;
 	}
@@ -143,7 +143,7 @@ public class Pin implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double positionX;
 
-	@Schema
+	@Schema(example = "33.54")
 	public Double getPositionY() {
 		return positionY;
 	}
@@ -171,7 +171,7 @@ public class Pin implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double positionY;
 
-	@Schema
+	@Schema(example = "1")
 	public String getSequence() {
 		return sequence;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Product.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Product.java
@@ -207,7 +207,7 @@ public class Product implements Serializable {
 	protected Map<String, ?> expando;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -551,7 +551,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductSpecification[] productSpecifications;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getProductType() {
 		return productType;
 	}
@@ -690,7 +690,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String slug;
 
-	@Schema
+	@Schema(example = "[tag1, tag2, tag3]")
 	public String[] getTags() {
 		return tags;
 	}
@@ -746,7 +746,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String urlImage;
 
-	@Schema
+	@Schema(
+		example = "{en_US=product-url-us, hr_HR=product-url-hr, hu_HU=product-url-hu}"
+	)
 	@Valid
 	public Map<String, String> getUrls() {
 		return urls;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductConfiguration.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductConfiguration.java
@@ -57,7 +57,7 @@ public class ProductConfiguration implements Serializable {
 			ProductConfiguration.class, json);
 	}
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getAllowBackOrder() {
 		return allowBackOrder;
 	}
@@ -85,7 +85,7 @@ public class ProductConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean allowBackOrder;
 
-	@Schema
+	@Schema(example = "[10, 20, 30, 40]")
 	public Integer[] getAllowedOrderQuantities() {
 		return allowedOrderQuantities;
 	}
@@ -114,7 +114,7 @@ public class ProductConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer[] allowedOrderQuantities;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDisplayAvailability() {
 		return displayAvailability;
 	}
@@ -142,7 +142,7 @@ public class ProductConfiguration implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean displayAvailability;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getDisplayStockQuantity() {
 		return displayStockQuantity;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOption.java
@@ -115,7 +115,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String description;
 
-	@Schema
+	@Schema(example = "select")
 	public String getFieldType() {
 		return fieldType;
 	}
@@ -144,7 +144,7 @@ public class ProductOption implements Serializable {
 	protected String fieldType;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -170,7 +170,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "color")
 	public String getKey() {
 		return key;
 	}
@@ -223,7 +223,7 @@ public class ProductOption implements Serializable {
 	protected String name;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30080")
 	public Long getOptionId() {
 		return optionId;
 	}
@@ -251,7 +251,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long optionId;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOptionValue.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductOptionValue.java
@@ -59,7 +59,7 @@ public class ProductOptionValue implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -85,7 +85,7 @@ public class ProductOptionValue implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "black")
 	public String getKey() {
 		return key;
 	}
@@ -137,7 +137,7 @@ public class ProductOptionValue implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductSpecification.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/ProductSpecification.java
@@ -60,7 +60,7 @@ public class ProductSpecification implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -87,7 +87,7 @@ public class ProductSpecification implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getOptionCategoryId() {
 		return optionCategoryId;
 	}
@@ -116,7 +116,7 @@ public class ProductSpecification implements Serializable {
 	protected Long optionCategoryId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -145,7 +145,7 @@ public class ProductSpecification implements Serializable {
 	protected Double priority;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
 	}
@@ -174,7 +174,7 @@ public class ProductSpecification implements Serializable {
 	protected Long productId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getSpecificationId() {
 		return specificationId;
 	}
@@ -202,7 +202,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long specificationId;
 
-	@Schema
+	@Schema(example = "specification-key")
 	public String getSpecificationKey() {
 		return specificationKey;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/RelatedProduct.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/RelatedProduct.java
@@ -59,7 +59,7 @@ public class RelatedProduct implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -85,7 +85,7 @@ public class RelatedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "1.2")
 	public Double getPriority() {
 		return priority;
 	}
@@ -114,7 +114,7 @@ public class RelatedProduct implements Serializable {
 	protected Double priority;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getProductId() {
 		return productId;
 	}
@@ -142,7 +142,7 @@ public class RelatedProduct implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long productId;
 
-	@Schema
+	@Schema(example = "cross-sell")
 	public String getType() {
 		return type;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Sku.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/Sku.java
@@ -63,7 +63,7 @@ public class Sku implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Sku.class, json);
 	}
 
-	@Schema
+	@Schema(example = "[10, 20, 30, 40]")
 	public String[] getAllowedOrderQuantities() {
 		return allowedOrderQuantities;
 	}
@@ -122,7 +122,7 @@ public class Sku implements Serializable {
 	protected Availability availability;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.1")
 	public Double getDepth() {
 		return depth;
 	}
@@ -150,7 +150,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Double depth;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -178,7 +178,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -206,7 +206,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getGtin() {
 		return gtin;
 	}
@@ -233,7 +233,7 @@ public class Sku implements Serializable {
 	protected String gtin;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20.2")
 	public Double getHeight() {
 		return height;
 	}
@@ -262,7 +262,7 @@ public class Sku implements Serializable {
 	protected Double height;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -288,7 +288,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getManufacturerPartNumber() {
 		return manufacturerPartNumber;
 	}
@@ -373,7 +373,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer minOrderQuantity;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getNeverExpire() {
 		return neverExpire;
 	}
@@ -428,7 +428,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Price price;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPublished() {
 		return published;
 	}
@@ -456,7 +456,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean published;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPurchasable() {
 		return purchasable;
 	}
@@ -540,7 +540,7 @@ public class Sku implements Serializable {
 	protected SkuOption[] skuOptions;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1.1")
 	public Double getWeight() {
 		return weight;
 	}
@@ -569,7 +569,7 @@ public class Sku implements Serializable {
 	protected Double weight;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "20.2")
 	public Double getWidth() {
 		return width;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/SkuOption.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/java/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/SkuOption.java
@@ -59,7 +59,7 @@ public class SkuOption implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getKey() {
 		return key;
 	}
@@ -86,7 +86,7 @@ public class SkuOption implements Serializable {
 	protected Long key;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getValue() {
 		return value;
 	}

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/resources/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/packageinfo
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-api/src/main/resources/com/liferay/headless/commerce/delivery/catalog/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.0.1

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
@@ -85,7 +85,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.address.client', and version '1.0.3'."
+        'com.liferay.headless.admin.address.client', and version '1.0.4'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.address.client', and version '1.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Address", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.address.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Address", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ExportTask.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ExportTask.java
@@ -66,7 +66,8 @@ public class ExportTask implements Serializable {
 	}
 
 	@Schema(
-		description = "The item class name for which data will be exported in batch."
+		description = "The item class name for which data will be exported in batch.",
+		example = "com.liferay.headless.delivery.dto.v1_0.BlogPosting"
 	)
 	public String getClassName() {
 		return className;
@@ -97,7 +98,7 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String className;
 
-	@Schema(description = "The file content type.")
+	@Schema(description = "The file content type.", example = "JSON")
 	public String getContentType() {
 		return contentType;
 	}
@@ -125,7 +126,10 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String contentType;
 
-	@Schema(description = "The end time of export task operation.")
+	@Schema(
+		description = "The end time of export task operation.",
+		example = "2019-27-09'T'08:33:33'Z'"
+	)
 	public Date getEndTime() {
 		return endTime;
 	}
@@ -154,7 +158,8 @@ public class ExportTask implements Serializable {
 	protected Date endTime;
 
 	@Schema(
-		description = "The error message in case of export task's failed execution."
+		description = "The error message in case of export task's failed execution.",
+		example = "File import failed"
 	)
 	public String getErrorMessage() {
 		return errorMessage;
@@ -185,7 +190,10 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String errorMessage;
 
-	@Schema(description = "The status of export task's execution.")
+	@Schema(
+		description = "The status of export task's execution.",
+		example = "INITIALIZED"
+	)
 	@Valid
 	public ExecuteStatus getExecuteStatus() {
 		return executeStatus;
@@ -252,7 +260,7 @@ public class ExportTask implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema(description = "The task's ID.")
+	@Schema(description = "The task's ID.", example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -279,7 +287,10 @@ public class ExportTask implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema(description = "Number of items processed by export task opeartion.")
+	@Schema(
+		description = "Number of items processed by export task opeartion.",
+		example = "100"
+	)
 	public Integer getProcessedItemsCount() {
 		return processedItemsCount;
 	}
@@ -309,7 +320,10 @@ public class ExportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer processedItemsCount;
 
-	@Schema(description = "The start time of export task operation.")
+	@Schema(
+		description = "The start time of export task operation.",
+		example = "2019-27-09'T'08:23:33'Z'"
+	)
 	public Date getStartTime() {
 		return startTime;
 	}
@@ -339,7 +353,8 @@ public class ExportTask implements Serializable {
 
 	@DecimalMin("0")
 	@Schema(
-		description = "Total number of items that will be processed by export task operation."
+		description = "Total number of items that will be processed by export task operation.",
+		example = "1000"
 	)
 	public Integer getTotalItemsCount() {
 		return totalItemsCount;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ImportTask.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/java/com/liferay/headless/batch/engine/dto/v1_0/ImportTask.java
@@ -66,7 +66,8 @@ public class ImportTask implements Serializable {
 	}
 
 	@Schema(
-		description = "The item class name for which data will be processed in batch."
+		description = "The item class name for which data will be processed in batch.",
+		example = "com.liferay.headless.delivery.dto.v1_0.BlogPosting"
 	)
 	public String getClassName() {
 		return className;
@@ -97,7 +98,7 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String className;
 
-	@Schema(description = "The file content type.")
+	@Schema(description = "The file content type.", example = "JSON")
 	public String getContentType() {
 		return contentType;
 	}
@@ -125,7 +126,10 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String contentType;
 
-	@Schema(description = "The end time of import task operation.")
+	@Schema(
+		description = "The end time of import task operation.",
+		example = "2019-27-09'T'08:33:33'Z'"
+	)
 	public Date getEndTime() {
 		return endTime;
 	}
@@ -154,7 +158,8 @@ public class ImportTask implements Serializable {
 	protected Date endTime;
 
 	@Schema(
-		description = "The error message in case of import task's failed execution."
+		description = "The error message in case of import task's failed execution.",
+		example = "File import failed"
 	)
 	public String getErrorMessage() {
 		return errorMessage;
@@ -185,7 +190,10 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String errorMessage;
 
-	@Schema(description = "The status of import task's execution.")
+	@Schema(
+		description = "The status of import task's execution.",
+		example = "INITIALIZED"
+	)
 	@Valid
 	public ExecuteStatus getExecuteStatus() {
 		return executeStatus;
@@ -281,7 +289,7 @@ public class ImportTask implements Serializable {
 	protected FailedItem[] failedItems;
 
 	@DecimalMin("0")
-	@Schema(description = "The task's ID.")
+	@Schema(description = "The task's ID.", example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -350,7 +358,7 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ImportStrategy importStrategy;
 
-	@Schema(description = "The operation of import task.")
+	@Schema(description = "The operation of import task.", example = "CREATE")
 	@Valid
 	public Operation getOperation() {
 		return operation;
@@ -389,7 +397,10 @@ public class ImportTask implements Serializable {
 	protected Operation operation;
 
 	@DecimalMin("0")
-	@Schema(description = "Number of items processed by import task opeartion.")
+	@Schema(
+		description = "Number of items processed by import task opeartion.",
+		example = "100"
+	)
 	public Integer getProcessedItemsCount() {
 		return processedItemsCount;
 	}
@@ -419,7 +430,10 @@ public class ImportTask implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer processedItemsCount;
 
-	@Schema(description = "The start time of import task operation.")
+	@Schema(
+		description = "The start time of import task operation.",
+		example = "2019-27-09'T'08:23:33'Z'"
+	)
 	public Date getStartTime() {
 		return startTime;
 	}
@@ -449,7 +463,8 @@ public class ImportTask implements Serializable {
 
 	@DecimalMin("0")
 	@Schema(
-		description = "Total number of items that will be processed by import task operation."
+		description = "Total number of items that will be processed by import task operation.",
+		example = "1000"
 	)
 	public Integer getTotalItemsCount() {
 		return totalItemsCount;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-api/src/main/resources/com/liferay/headless/batch/engine/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.6.0
+version 2.6.1

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -449,7 +449,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.23'."
+        'com.liferay.object.admin.rest.client', and version '1.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/CartItem.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/CartItem.java
@@ -309,7 +309,7 @@ public class CartItem implements Serializable {
 	protected Settings settings;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "1")
 	public Integer getShippedQuantity() {
 		return shippedQuantity;
 	}
@@ -389,7 +389,7 @@ public class CartItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long skuId;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getSubscription() {
 		return subscription;
 	}

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/User.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/java/com/liferay/headless/commerce/punchout/dto/v1_0/User.java
@@ -60,7 +60,7 @@ public class User implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(User.class, json);
 	}
 
-	@Schema
+	@Schema(example = "joe.1@commerce.com")
 	public String getEmail() {
 		return email;
 	}
@@ -89,7 +89,7 @@ public class User implements Serializable {
 	@NotEmpty
 	protected String email;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -146,7 +146,7 @@ public class User implements Serializable {
 	protected String firstName;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -228,7 +228,7 @@ public class User implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String lastName;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getMale() {
 		return male;
 	}

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/resources/com/liferay/headless/commerce/punchout/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-api/src/main/resources/com/liferay/headless/commerce/punchout/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.2
+version 2.2.3

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Category.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Category.java
@@ -60,7 +60,7 @@ public class Category implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Category.class, json);
 	}
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -89,7 +89,7 @@ public class Category implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -170,7 +170,7 @@ public class Category implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long siteId;
 
-	@Schema
+	@Schema(example = "Default Vocabulary")
 	public String getVocabulary() {
 		return vocabulary;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Error.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Error.java
@@ -62,7 +62,7 @@ public class Error implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(Error.class, json);
 	}
 
-	@Schema(description = "Internal error code mapping")
+	@Schema(description = "Internal error code mapping", example = "996")
 	public Integer getErrorCode() {
 		return errorCode;
 	}
@@ -91,7 +91,9 @@ public class Error implements Serializable {
 	@NotNull
 	protected Integer errorCode;
 
-	@Schema
+	@Schema(
+		example = "Unable to find currency. Currency code should be expressed with 3-letter ISO 4217 format."
+	)
 	public String getErrorDescription() {
 		return errorDescription;
 	}
@@ -120,7 +122,9 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String errorDescription;
 
-	@Schema
+	@Schema(
+		example = "No CommerceCurrency exists with the key {groupId=41811, code=US Dollar}"
+	)
 	public String getMessage() {
 		return message;
 	}
@@ -149,7 +153,7 @@ public class Error implements Serializable {
 	@NotEmpty
 	protected String message;
 
-	@Schema(description = "HTTP Status code")
+	@Schema(description = "HTTP Status code", example = "404")
 	public Integer getStatus() {
 		return status;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/FrequentPatternRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/FrequentPatternRecommendation.java
@@ -120,7 +120,7 @@ public class FrequentPatternRecommendation implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long antecedentIdsLength;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Order.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Order.java
@@ -69,7 +69,7 @@ public class Order implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getAccountId() {
 		return accountId;
 	}
@@ -98,7 +98,7 @@ public class Order implements Serializable {
 	protected Long accountId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getChannelId() {
 		return channelId;
 	}
@@ -127,7 +127,7 @@ public class Order implements Serializable {
 	@NotNull
 	protected Long channelId;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -155,7 +155,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date createDate;
 
-	@Schema
+	@Schema(example = "USD")
 	public String getCurrencyCode() {
 		return currencyCode;
 	}
@@ -213,7 +213,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -242,7 +242,7 @@ public class Order implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -268,7 +268,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getModifiedDate() {
 		return modifiedDate;
 	}
@@ -296,7 +296,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date modifiedDate;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getOrderDate() {
 		return orderDate;
 	}
@@ -354,7 +354,7 @@ public class Order implements Serializable {
 	protected OrderItem[] orderItems;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getOrderStatus() {
 		return orderStatus;
 	}
@@ -382,7 +382,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer orderStatus;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getOrderTypeExternalReferenceCode() {
 		return orderTypeExternalReferenceCode;
 	}
@@ -415,7 +415,7 @@ public class Order implements Serializable {
 	protected String orderTypeExternalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getOrderTypeId() {
 		return orderTypeId;
 	}
@@ -443,7 +443,7 @@ public class Order implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long orderTypeId;
 
-	@Schema
+	@Schema(example = "paypal")
 	public String getPaymentMethod() {
 		return paymentMethod;
 	}
@@ -472,7 +472,7 @@ public class Order implements Serializable {
 	protected String paymentMethod;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "0")
 	public Integer getPaymentStatus() {
 		return paymentStatus;
 	}
@@ -529,7 +529,7 @@ public class Order implements Serializable {
 	protected Integer status;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "113")
 	@Valid
 	public BigDecimal getTotal() {
 		return total;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/OrderItem.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/OrderItem.java
@@ -93,7 +93,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long cpDefinitionId;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -150,7 +150,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -179,7 +179,7 @@ public class OrderItem implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "200")
 	@Valid
 	public BigDecimal getFinalPrice() {
 		return finalPrice;
@@ -209,7 +209,7 @@ public class OrderItem implements Serializable {
 	protected BigDecimal finalPrice;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -235,7 +235,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getModifiedDate() {
 		return modifiedDate;
 	}
@@ -263,7 +263,9 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date modifiedDate;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -321,7 +323,7 @@ public class OrderItem implements Serializable {
 	protected String options;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30128")
 	public Long getOrderId() {
 		return orderId;
 	}
@@ -350,7 +352,7 @@ public class OrderItem implements Serializable {
 	protected Long orderId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30128")
 	public Long getParentOrderItemId() {
 		return parentOrderItemId;
 	}
@@ -379,7 +381,7 @@ public class OrderItem implements Serializable {
 	protected Long parentOrderItemId;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "2")
 	public Integer getQuantity() {
 		return quantity;
 	}
@@ -407,7 +409,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Integer quantity;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getSku() {
 		return sku;
 	}
@@ -433,7 +435,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String sku;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getSubscription() {
 		return subscription;
 	}
@@ -461,7 +463,7 @@ public class OrderItem implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean subscription;
 
-	@Schema
+	@Schema(example = "pc")
 	public String getUnitOfMeasure() {
 		return unitOfMeasure;
 	}
@@ -490,7 +492,7 @@ public class OrderItem implements Serializable {
 	protected String unitOfMeasure;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getUnitPrice() {
 		return unitPrice;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Product.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Product.java
@@ -67,7 +67,7 @@ public class Product implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30054")
 	public Long getCatalogId() {
 		return catalogId;
 	}
@@ -124,7 +124,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long[] categoryIds;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}
@@ -181,7 +181,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, ?> customFields;
 
-	@Schema
+	@Schema(
+		example = "{hu_HU=Product Description HU, hr_HR=Product Description HR, en_US=Professional hand stainless steel saw for wood. Made to last and saw forever. Made of best steel}"
+	)
 	@Valid
 	public Map<String, String> getDescription() {
 		return description;
@@ -211,7 +213,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> description;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -239,7 +241,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -267,7 +269,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -296,7 +298,7 @@ public class Product implements Serializable {
 	protected String externalReferenceCode;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -322,7 +324,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Meta description HU, hr_HR=Meta description HU, hu_HU=Meta description HU}"
+	)
 	@Valid
 	public Map<String, String> getMetaDescription() {
 		return metaDescription;
@@ -352,7 +356,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> metaDescription;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Meta keyword HU, hr_HR=Meta keyword HU, hu_HU=Meta keyword HU}"
+	)
 	@Valid
 	public Map<String, String> getMetaKeyword() {
 		return metaKeyword;
@@ -382,7 +388,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> metaKeyword;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Meta title HU, hr_HR=Meta title HU, hu_HU=Meta title HU}"
+	)
 	@Valid
 	public Map<String, String> getMetaTitle() {
 		return metaTitle;
@@ -412,7 +420,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Map<String, String> metaTitle;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getModifiedDate() {
 		return modifiedDate;
 	}
@@ -440,7 +448,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date modifiedDate;
 
-	@Schema
+	@Schema(
+		example = "{en_US=Hand Saw, hr_HR=Product Name HR, hu_HU=Product Name HU}"
+	)
 	@Valid
 	public Map<String, String> getName() {
 		return name;
@@ -588,7 +598,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ProductSpecification[] productSpecifications;
 
-	@Schema
+	@Schema(example = "simple")
 	public String getProductType() {
 		return productType;
 	}
@@ -700,7 +710,7 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean subscriptionEnabled;
 
-	@Schema
+	@Schema(example = "[tag1, tag2, tag3]")
 	public String[] getTags() {
 		return tags;
 	}
@@ -728,7 +738,9 @@ public class Product implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String[] tags;
 
-	@Schema
+	@Schema(
+		example = "{en_US=product-url-us, hr_HR=product-url-hr, hu_HU=product-url-hu}"
+	)
 	@Valid
 	public Map<String, String> getUrls() {
 		return urls;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductContentRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductContentRecommendation.java
@@ -64,7 +64,7 @@ public class ProductContentRecommendation implements Serializable {
 			ProductContentRecommendation.class, json);
 	}
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductInteractionRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductInteractionRecommendation.java
@@ -64,7 +64,7 @@ public class ProductInteractionRecommendation implements Serializable {
 			ProductInteractionRecommendation.class, json);
 	}
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductOption.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductOption.java
@@ -84,7 +84,7 @@ public class ProductOption implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String key;
 
-	@Schema
+	@Schema(example = "option-key")
 	public String getOptionKey() {
 		return optionKey;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductSpecification.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/ProductSpecification.java
@@ -64,7 +64,7 @@ public class ProductSpecification implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "31130")
 	public Long getId() {
 		return id;
 	}
@@ -91,7 +91,7 @@ public class ProductSpecification implements Serializable {
 	protected Long id;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30129")
 	public Long getOptionCategoryId() {
 		return optionCategoryId;
 	}
@@ -119,7 +119,7 @@ public class ProductSpecification implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long optionCategoryId;
 
-	@Schema
+	@Schema(example = "specification-key")
 	public String getSpecificationKey() {
 		return specificationKey;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Sku.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/Sku.java
@@ -68,7 +68,7 @@ public class Sku implements Serializable {
 	}
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "101")
 	@Valid
 	public BigDecimal getCost() {
 		return cost;
@@ -125,7 +125,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean discontinued;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getDisplayDate() {
 		return displayDate;
 	}
@@ -153,7 +153,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date displayDate;
 
-	@Schema
+	@Schema(example = "2017-08-21")
 	public Date getExpirationDate() {
 		return expirationDate;
 	}
@@ -181,7 +181,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Date expirationDate;
 
-	@Schema
+	@Schema(example = "AB-34098-789-N")
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
 	}
@@ -209,7 +209,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String externalReferenceCode;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getGtin() {
 		return gtin;
 	}
@@ -236,7 +236,7 @@ public class Sku implements Serializable {
 	protected String gtin;
 
 	@DecimalMin("0")
-	@Schema
+	@Schema(example = "30130")
 	public Long getId() {
 		return id;
 	}
@@ -262,7 +262,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
 	protected Long id;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getManufacturerPartNumber() {
 		return manufacturerPartNumber;
 	}
@@ -291,7 +291,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String manufacturerPartNumber;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPublished() {
 		return published;
 	}
@@ -319,7 +319,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean published;
 
-	@Schema
+	@Schema(example = "true")
 	public Boolean getPurchasable() {
 		return purchasable;
 	}
@@ -347,7 +347,7 @@ public class Sku implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Boolean purchasable;
 
-	@Schema
+	@Schema(example = "12341234")
 	public String getSku() {
 		return sku;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/UserRecommendation.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/java/com/liferay/headless/commerce/machine/learning/dto/v1_0/UserRecommendation.java
@@ -90,7 +90,7 @@ public class UserRecommendation implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected Long[] assetCategoryIds;
 
-	@Schema
+	@Schema(example = "2017-07-21")
 	public Date getCreateDate() {
 		return createDate;
 	}

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/resources/com/liferay/headless/commerce/machine/learning/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-api/src/main/resources/com/liferay/headless/commerce/machine/learning/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.5.1

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -15,9 +15,11 @@
 package com.liferay.portal.tools.rest.builder.internal.freemarker.tool;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodParameter;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.JavaMethodSignature;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.DTOOpenAPIParser;
@@ -39,9 +41,13 @@ import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.RequestBody;
 import com.liferay.portal.tools.rest.builder.internal.yaml.openapi.Schema;
 import com.liferay.portal.vulcan.graphql.util.GraphQLNamingUtil;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -561,6 +567,18 @@ public class FreeMarkerTool {
 		);
 	}
 
+	public String getObjectFieldStringValue(String type, Object value) {
+		if (value instanceof Date) {
+			if (type.equals("Date")) {
+				return _dateFormat.format(value);
+			}
+
+			return _dateTimeFormat.format(value);
+		}
+
+		return value.toString();
+	}
+
 	public List<JavaMethodSignature>
 			getParentGraphQLRelationJavaMethodSignatures(
 				ConfigYAML configYAML, String graphQLType,
@@ -933,6 +951,14 @@ public class FreeMarkerTool {
 		return false;
 	}
 
+	private static DateFormat _getDateFormat(String format) {
+		DateFormat dateFormat = new SimpleDateFormat(format);
+
+		dateFormat.setTimeZone(TimeZoneUtil.GMT);
+
+		return dateFormat;
+	}
+
 	private FreeMarkerTool() {
 	}
 
@@ -1241,6 +1267,9 @@ public class FreeMarkerTool {
 		return parameterName;
 	}
 
+	private static final DateFormat _dateFormat = _getDateFormat("yyyy-MM-dd");
+	private static final DateFormat _dateTimeFormat = _getDateFormat(
+		DateUtil.ISO_8601_PATTERN);
 	private static final FreeMarkerTool _freeMarkerTool = new FreeMarkerTool();
 
 }

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/yaml/openapi/Schema.java
@@ -14,8 +14,6 @@
 
 package com.liferay.portal.tools.rest.builder.internal.yaml.openapi;
 
-import java.beans.Transient;
-
 import java.util.List;
 import java.util.Map;
 
@@ -57,12 +55,7 @@ public class Schema {
 		return _enumValues;
 	}
 
-	/**
-	 * @deprecated As of Mueller (7.2.x)
-	 */
-	@Deprecated
-	@Transient
-	public String getExample() {
+	public Object getExample() {
 		return _example;
 	}
 
@@ -154,12 +147,7 @@ public class Schema {
 		_enumValues = enumValues;
 	}
 
-	/**
-	 * @deprecated As of Mueller (7.2.x)
-	 */
-	@Deprecated
-	@Transient
-	public void setExample(String example) {
+	public void setExample(Object example) {
 		_example = example;
 	}
 
@@ -228,7 +216,7 @@ public class Schema {
 	private boolean _deprecated;
 	private String _description;
 	private List<String> _enumValues;
-	private String _example;
+	private Object _example;
 	private String _format;
 	private Items _items;
 	private boolean _jsonMap;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/dto.ftl
@@ -164,7 +164,7 @@ public class ${schemaName} <#if dtoParentClassName?has_content>extends ${dtoPare
 					,
 				</#if>
 
-				example = "${propertySchema.example}"
+				example = "${freeMarkerTool.getObjectFieldStringValue(propertyType, propertySchema.example)}"
 			</#if>
 		)
 


### PR DESCRIPTION
This PR contains the code to parse and include the value of the `example` field from the `rest-openapi.yaml` file into the @Schema java annotation of the Java DTOs.

---

Given a schema, for example:
```
        Attachment:
            properties:
                [...]
                cdnURL:
                    example: AB-34098-789-N
                    type: string
                displayDate:
                    example: 2017-07-21
                    format: date
                    type: string
                expirationDate:
                    example: 2017-08-21
                    format: date
                    type: string
                [...]
```

**Before the PR:**

The DTO was created without including the example values:

```
[...]
@Generated("")
@GraphQLName("Attachment")
@JsonFilter("Liferay.Vulcan")
@XmlRootElement(name = "Attachment")
public class Attachment implements Serializable {

	[...]

	@Schema
	public String getCdnURL() {
		return cdnURL;
	}

	[...]

	@Schema
	public Date getDisplayDate() {
		return displayDate;
	}

	[...]
	
	@Schema
	public Date getExpirationDate() {
		return expirationDate;
	}

	[...]
}
```

**After the PR:**

The DTO is created with the example parameter in the @Schema annotation:

```
[...]
@Generated("")
@GraphQLName("Attachment")
@JsonFilter("Liferay.Vulcan")
@XmlRootElement(name = "Attachment")
public class Attachment implements Serializable {

	[...]

	@Schema(example = "AB-34098-789-N")
	public String getCdnURL() {
		return cdnURL;
	}

	[...]

	@Schema(example = "Fri Jul 21 02:00:00 CEST 2017")
	public Date getDisplayDate() {
		return displayDate;
	}

	[...]
	
	@Schema(example = "Mon Aug 21 02:00:00 CEST 2017")
	public Date getExpirationDate() {
		return expirationDate;
	}

	[...]
}
```