### PR TITLE
LPS-152234 Deprecate `submitForm` and replace usages

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -720,6 +720,9 @@
 
 		submitCountdown: 0,
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `form.submit()`
+		 */
 		submitForm(form) {
 			form.submit();
 		},


### PR DESCRIPTION
The initial PR caused some regressions but I think I have fixed them now. The problem was with the `events.js` changes, where I relied on the `form` to be a regular HTML element, not a YUI element.

After consulting with Meg, she gave me a bunch of additional CI checks to run to make sure the teams that reported the regressions are covered.