### PR TITLE
LPS-152231 Deprecate `openInDialog`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -509,6 +509,9 @@
 			return Util.listCheckboxesExcept(form, except, name, false);
 		},
 
+		/**
+		 * @deprecated As of Cavanaugh (7.4.x), replaced by `Liferay.Util.openWindow()`
+		 */
 		openInDialog(event, config) {
 			event.preventDefault();
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments_segments_entry.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_assignments_segments_entry.jsp
@@ -109,7 +109,9 @@
 
 <aui:script>
 	function <portlet:namespace />openViewMembersDialog(event) {
-		Liferay.Util.openInDialog(event, {
+		event.preventDefault();
+
+		Liferay.Util.openWindow({
 			dialog: {
 				constrain: true,
 				destroyOnHide: true,

--- a/portal-web/docroot/html/taglib/aui/button/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/button/end.jsp
@@ -102,13 +102,12 @@
 		Liferay.delegateClick(
 			'<%= namespace + name %>',
 			function(event) {
-				Liferay.Util.openInDialog(
-					event,
-					{
-						dialogIframe: {
-							bodyCssClass: 'dialog-with-footer'
-						}
-					}
+				event.preventDefault();
+
+				Liferay.Util.openWindow({
+					dialogIframe: {
+						bodyCssClass: 'dialog-with-footer'
+					}}
 				);
 			}
 		);


### PR DESCRIPTION
This PR goes the simple route and replaces `openInDialog` usages with `openWindow` which is also an AUI utility. `openInDialog` is a very thin wrapper around `openInDialog` and for simplicity's sake I decided to first replace it with `openWindow` which will be deprecated at a later date.

You can test it by enabling `Roles by Segments`, go to Roles and under the Segments tab. When you add one, click on the kebab menu on the right and click on "View People" (or something like that)