### PR TITLE
LPS-153657 Fix modal visibility and modal-full-screen scale

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -102,6 +102,10 @@ html#{$cadmin-selector} {
 			width: 1em;
 		}
 
+		&.modal-open .modal {
+			display: block;
+		}
+
 		.user-icon-color-0 {
 			color: $user-icon-color-0;
 		}


### PR DESCRIPTION
Hi Team,

could you please review my fix?
The solution id discussed on Slack here: https://liferay.slack.com/archives/CNBG06JS3/p1652437746029029

**Issue**
In the Import/Export modal of several widgets, clicking on the "Change" link leads to the modal locking up, when we expected the configuration screen to load up.

**Steps to Reproduce**

1. Start up Liferay DXP
2. Sign in as administrator
3. Go to the Product Menu > Content & Data > Web Content
4. Create a new Basic Web Content article and publish it
5. Go back to the Content & Data > Web Content
6. Click on the more options (⁝) on the top right hand corner of the screen
7. Click Export / Import
8. On the Export tab, under Configuration > Setup, click the Change link

**Actual Result**
The modal window locks up and is unresponsive to mouse clicks. No errors are reported in the console.

**Expected Behavior**
The modal window displays the Setup configuration screen, and is responsive to mouse clicks.

Thanks, Roland

https://issues.liferay.com/browse/LPS-153657

cc @pat270 