### PR TITLE
LPS-149283 Fix API Explorer for Objects relationships

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -93,13 +93,15 @@ public class OpenAPIResourceImpl {
 					StringUtil.replace(
 						key,
 						new String[] {
-							"currentObjectEntryId", "{objectRelationshipName}",
-							"relatedObjectEntryId"
+							"currentObjectEntry", "{objectRelationshipName}",
+							"relatedObjectEntry"
 						},
 						new String[] {
-							_currentObjectDefinition.getPKObjectFieldName(),
+							StringUtil.lowerCaseFirstLetter(
+								_currentObjectDefinition.getShortName()),
 							objectRelationship.getName(),
-							relatedObjectDefinition.getPKObjectFieldName()
+							StringUtil.lowerCaseFirstLetter(
+								relatedObjectDefinition.getShortName())
 						}),
 					_createPathItem(
 						objectRelationship, paths.get(key),
@@ -146,10 +148,16 @@ public class OpenAPIResourceImpl {
 			}
 
 			if (Objects.equals(parameterName, "currentObjectEntryId")) {
-				parameterName = _currentObjectDefinition.getPKObjectFieldName();
+				parameterName = StringUtil.replace(
+					parameterName, "currentObjectEntry",
+					StringUtil.lowerCaseFirstLetter(
+						_currentObjectDefinition.getShortName()));
 			}
 			else if (Objects.equals(parameterName, "relatedObjectEntryId")) {
-				parameterName = relatedObjectDefinition.getPKObjectFieldName();
+				parameterName = StringUtil.replace(
+					parameterName, "relatedObjectEntry",
+					StringUtil.lowerCaseFirstLetter(
+						relatedObjectDefinition.getShortName()));
 			}
 
 			String finalParameterName = parameterName;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -78,7 +78,7 @@ public class OpenAPIResourceImpl {
 
 		Paths paths = openAPI.getPaths();
 
-		for (String key : paths.keySet()) {
+		for (String key : new ArrayList<>(paths.keySet())) {
 			if (!key.contains("objectRelationshipName")) {
 				continue;
 			}


### PR DESCRIPTION
This PR fixes an error in the API Explorer. 
When an Object with some relationships is published and the user goes to the API Explorer to consult that endpoints, the API Explorer breaks with a `ConcurrentModificationException`

This PR fixes the code to avoid that crush and make the API Explorer consistent. Also, it changes the names of some endpoint parameters to follow the convention that we used in the Object REST APIs.