### PR TITLE
LPS-154004 Change type of entityFieldMap

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -90,10 +90,11 @@ public class ObjectEntryEntityModel implements EntityModel {
 
 				_entityFieldsMap.put(
 					relationshipIdName,
-					new IntegerEntityField(
+					new IdEntityField(
 						relationshipIdName,
 						locale ->
-							"nestedFieldArray.value_long#" + objectFieldName));
+							"nestedFieldArray.value_long#" + objectFieldName,
+						String::valueOf));
 			}
 			else {
 				_getEntityField(


### PR DESCRIPTION
Related ticket -> [LPS-154004](https://issues.liferay.com/browse/LPS-154004)
____
Copying the description of the ticket with the steps to reproduce the bug:
```
When using the operator in through Object headless APIs, a  400 bad request is returned.

Steps to reproduce

1. Create 2 Objects definitions: University and Student

2. Create a field for each object definition (like "University name" and "Student name")

3. Create a One to Many relationship between them

4. Populate the objects with some data (create two or more universities and assign to those universities some students)

5. Send a request from Students REST APIs using the filter universityId in ('41226', '41227') (make sure that only one id is from one university)

Example of request:
http://localhost:8080/o/c/students?filter=universityId in ('41226', '41227')

Expected result

The API returns the students of the universities that are in the in operator

Actual result

The API returns a 400 response.

{
"status": "BAD_REQUEST",
"title": "Incompatible types."
}
```

The PR changes the type of the relationships Id in the one-to-many relationships inside the ObjectEntryEntityModel.

To prove the code, just download the code of this branch and deploy the module `object-rest-impl` 
After the changes, the REST API should return something like this
![image](https://user-images.githubusercontent.com/17163902/169161947-6f153ef2-9e2a-4138-aa0c-d5a63a90c56c.png)
