### PR TITLE
LPS-154005 Adapt FDS table to use items without needing an API URL

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DataSet.js
@@ -73,7 +73,7 @@ const DataSet = ({
 	id,
 	inlineAddingSettings,
 	inlineEditingSettings,
-	items: itemsProp = [],
+	items: itemsProp,
 	itemsActions,
 	namespace,
 	nestedItemsKey,
@@ -200,12 +200,10 @@ const DataSet = ({
 	}
 
 	useEffect(() => {
-		const itemsAreInjected = !apiURL && itemsProp?.length !== items.length;
-
-		if (itemsAreInjected) {
+		if (itemsProp) {
 			updateDataSetItems({items: itemsProp});
 		}
-	}, [items, apiURL, itemsProp]);
+	}, [itemsProp]);
 
 	function selectItems(value) {
 		if (Array.isArray(value)) {
@@ -338,6 +336,10 @@ const DataSet = ({
 	};
 
 	useEffect(() => {
+		if (!apiURL) {
+			return;
+		}
+
 		setDataLoading(true);
 
 		requestData().then(({data, ok, status: statusCode}) => {
@@ -351,7 +353,7 @@ const DataSet = ({
 				setDataLoading(false);
 			}
 		});
-	}, [isMounted, requestData, setDataLoading]);
+	}, [apiURL, isMounted, requestData, setDataLoading]);
 
 	useEffect(() => {
 		function handleRefreshFromTheOutside(event) {


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-154005

### Motivation

We have the need to use the FDS table as a pivot table based on a Select above, with data that we have to modulate in the parent component, we make the requests in the parent component, add new data in the list that does not come from the API and send it to the FDS table ready to be displayed. So for this specific case we don't need the `apiURL` attribute of the FDS, just pass the `items` attribute. For this specific case, the parent component has the responsibility to modulate the state of the `items` and render the table again when there is any change.

My proposal for this PR is to make the `apiURL` an optional attribute, when we have it, the table just does the things it did before, but when we don't have the `apiURL`, we use the `items` attribute to display the data, and the person responsible for those items is the parent component.

Here is a gif, with the FDS implementation as React Component, using only the `items` modulated by the parent component, without passing the `apiURL`

![FDSDynamic](https://user-images.githubusercontent.com/46692326/169311022-fe1c652e-ed48-4d90-9f37-5199afcbefe6.gif)


