### PR TITLE
LPS-145305 Add a sample for FDS `classic-display` tag

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/model/UserEntry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/model/UserEntry.java
@@ -12,20 +12,33 @@
  * details.
  */
 
-package com.liferay.frontend.data.set.sample.web.internal.constants;
+package com.liferay.frontend.data.set.sample.web.internal.model;
 
 /**
  * @author Marko Cikos
  */
-public class FDSSampleFDSNames {
+public class UserEntry {
 
-	public static final String CLASSIC =
-		FDSSamplePortletKeys.FDS_SAMPLE + "-classic";
+	public UserEntry(String emailAddress, String firstName, String lastName) {
+		_emailAddress = emailAddress;
+		_firstName = firstName;
+		_lastName = lastName;
+	}
 
-	public static final String CUSTOMIZED =
-		FDSSamplePortletKeys.FDS_SAMPLE + "-customized";
+	public String getEmailAddress() {
+		return _emailAddress;
+	}
 
-	public static final String MINIMUM =
-		FDSSamplePortletKeys.FDS_SAMPLE + "-minimum";
+	public String getFirstName() {
+		return _firstName;
+	}
+
+	public String getLastName() {
+		return _lastName;
+	}
+
+	private final String _emailAddress;
+	private final String _firstName;
+	private final String _lastName;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/provider/ClassicFDSDataProvider.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/provider/ClassicFDSDataProvider.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.provider;
+
+import com.liferay.frontend.data.set.provider.FDSDataProvider;
+import com.liferay.frontend.data.set.provider.search.FDSKeywords;
+import com.liferay.frontend.data.set.provider.search.FDSPagination;
+import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
+import com.liferay.frontend.data.set.sample.web.internal.model.UserEntry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.users.admin.kernel.util.UsersAdmin;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	immediate = true,
+	property = "fds.data.provider.key=" + FDSSampleFDSNames.CLASSIC,
+	service = FDSDataProvider.class
+)
+public class ClassicFDSDataProvider implements FDSDataProvider<UserEntry> {
+
+	@Override
+	public List<UserEntry> getItems(
+			FDSKeywords fdsKeywords, FDSPagination fdsPagination,
+			HttpServletRequest httpServletRequest, Sort sort)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		List<User> users = _usersAdmin.getUsers(
+			_userLocalService.search(
+				themeDisplay.getCompanyId(), fdsKeywords.getKeywords(),
+				WorkflowConstants.STATUS_APPROVED,
+				new LinkedHashMap<String, Object>(),
+				fdsPagination.getStartPosition(),
+				fdsPagination.getEndPosition(), sort));
+
+		List<UserEntry> userEntries = new ArrayList<>();
+
+		for (User user : users) {
+			UserEntry userEntry = new UserEntry(
+				user.getEmailAddress(), user.getFirstName(),
+				user.getLastName());
+
+			userEntries.add(userEntry);
+		}
+
+		return userEntries;
+	}
+
+	@Override
+	public int getItemsCount(
+			FDSKeywords fdsKeywords, HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return _userLocalService.searchCount(
+			themeDisplay.getCompanyId(), fdsKeywords.getKeywords(),
+			WorkflowConstants.STATUS_APPROVED, null);
+	}
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	@Reference
+	private UsersAdmin _usersAdmin;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/ClassicTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/ClassicTableFDSView.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.sample.web.internal.view;
+
+import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
+import com.liferay.frontend.data.set.view.FDSView;
+import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
+import com.liferay.frontend.data.set.view.table.FDSTableSchema;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
+import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	enabled = true,
+	property = "frontend.data.set.name=" + FDSSampleFDSNames.CLASSIC,
+	service = FDSView.class
+)
+public class ClassicTableFDSView extends BaseTableFDSView {
+
+	@Override
+	public FDSTableSchema getFDSTableSchema(Locale locale) {
+		FDSTableSchemaBuilder fdsTableSchemaBuilder =
+			_fdsTableSchemaBuilderFactory.create();
+
+		return fdsTableSchemaBuilder.add(
+			"firstName", "first-name"
+		).add(
+			"lastName", "last-name",
+			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
+		).add(
+			"emailAddress", "email-address"
+		).build();
+	}
+
+	@Reference
+	private FDSTableSchemaBuilderFactory _fdsTableSchemaBuilderFactory;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/classic.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/classic.jsp
@@ -1,3 +1,4 @@
+<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -11,21 +12,12 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+--%>
 
-package com.liferay.frontend.data.set.sample.web.internal.constants;
+<%@ include file="/init.jsp" %>
 
-/**
- * @author Marko Cikos
- */
-public class FDSSampleFDSNames {
-
-	public static final String CLASSIC =
-		FDSSamplePortletKeys.FDS_SAMPLE + "-classic";
-
-	public static final String CUSTOMIZED =
-		FDSSamplePortletKeys.FDS_SAMPLE + "-customized";
-
-	public static final String MINIMUM =
-		FDSSamplePortletKeys.FDS_SAMPLE + "-minimum";
-
-}
+<frontend-data-set:classic-display
+	dataProviderKey="<%= FDSSampleFDSNames.CLASSIC %>"
+	id="<%= FDSSampleFDSNames.CLASSIC %>"
+	style="fluid"
+/>

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -28,7 +28,7 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 
 <clay:container-fluid>
 	<liferay-ui:tabs
-		names="customized,minimum"
+		names="customized,minimum,classic"
 		url="<%= portletURL.toString() %>"
 	>
 		<liferay-ui:section>
@@ -40,6 +40,12 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 		<liferay-ui:section>
 			<c:if test='<%= tabs1.equals("minimum") %>'>
 				<liferay-util:include page="/partials/minimum.jsp" servletContext="<%= pageContext.getServletContext() %>" />
+			</c:if>
+		</liferay-ui:section>
+
+		<liferay-ui:section>
+			<c:if test='<%= tabs1.equals("classic") %>'>
+				<liferay-util:include page="/partials/classic.jsp" servletContext="<%= pageContext.getServletContext() %>" />
 			</c:if>
 		</liferay-ui:section>
 	</liferay-ui:tabs>


### PR DESCRIPTION
### References

- [LPS-145305 Create a sample for FDS classic-display tag](https://issues.liferay.com/browse/LPS-145305)

### What is the goal of this PR?

We are adding a showcase of `classic-display` tag, in which FDS can be used without headless API. The key part is implementation of `FDSDataProvider`, where we fetch DXP users through standard `LocalService`.

Notes:
- We cannot set `List<User>` directly, because `User` cannot be serialized. That is why we are using `UserEntry` POJO.
- We are using `_usersAdmin.getUsers` because of the weird signature of `_userLocalService.search`. In its overloads, some return `List<User>` and some `Hits`. The one that is interesting to FDS is [the one including `Sort` argument](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java#L2092-L2099), and that one returns `Hits`.
- We can extend this tab with other FDS features in future PRs, for the features that have different implementations in two tags. An example for this is sorting, that we are adding is this PR. 
- We can now add CI tests for this tag, starting with simple 'is it rendering' sanity check @Esther-OC 

cc @dsanz 

### What does it look like?

![screen](https://user-images.githubusercontent.com/5435511/169321432-a0c46993-9c19-4aa1-820b-31ef0b181be9.png)