### PR TITLE
LPS-153133 StructuredContentAssetPriority#StructuredContentDraftContainsSetPriorityValue

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -159,7 +159,7 @@ definition {
 	}
 
 	macro createStructuredContentDraft {
-		if(!(isSet(priority))){
+		if (!(isSet(priority))) {
 			var priority = "";
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -89,7 +89,7 @@ definition {
 	}
 
 	macro _createStructuredContentDraft {
-		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title}");
+		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${priority},${title}");
 
 		var portalURL = JSONCompany.getDefaultPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
@@ -113,6 +113,7 @@ definition {
         "repeatable": false
     }],
     "contentStructureId": "${ddmStructureId}",
+	"priority": "${priority}",
     "title": "${title}"
 	}
 		''';
@@ -158,11 +159,16 @@ definition {
 	}
 
 	macro createStructuredContentDraft {
+		if(!(isSet(priority))){
+			var priority = "";
+		}
+
 		var response = HeadlessWebcontentAPI._createStructuredContentDraft(
 			data = "${data}",
 			ddmStructureId = "${ddmStructureId}",
 			label = "${label}",
 			name = "${name}",
+			priority = "${priority}",
 			title = "${title}");
 
 		return "${response}";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -55,4 +55,27 @@ definition {
 		}
 	}
 
+	@priority = "5"
+	test StructuredContentDraftContainsSetPriorityValue {
+		property portal.acceptance = "true";
+
+		task ("When create a structuredContent draft with Headless Admin Content POST '/v1.0/sites/{siteId}/structured-contents/draft' with a priority field set (as in the json example attached)") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1",
+				title = "Title");
+		}
+
+		task ("Then the response body includes the set priority") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithDefaultValue(
+				expectedPriorityDefaultValue = "1.0",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -59,7 +59,7 @@ definition {
 	test StructuredContentDraftContainsSetPriorityValue {
 		property portal.acceptance = "true";
 
-		task ("When create a structuredContent draft with Headless Admin Content POST '/v1.0/sites/{siteId}/structured-contents/draft' with a priority field set (as in the json example attached)") {
+		task ("When in Headless Admin Content i create a structuredContent draft with with a priority field set") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(


### PR DESCRIPTION
Background
Create automation tests for StructuredContentAssetPriority

Test Plan
**Given** a content structure with a content-field of dataType "string" and label "content" and name "content" created in the portal
**When** I create a structuredContent draft with Headless Admin Content POST "/v1.0/sites/{siteId}/structured-contents/draft" with a priority field set (as in the json example attached)
**Then** the response body includes the set priority

JIRA Ticket:
https://issues.liferay.com/browse/LPS-153133