### PR TITLE
LPS-153228 | StructuredContent can be filtered with a set priority

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -122,6 +122,41 @@ definition {
 		return "${curl}";
 	}
 
+	macro _editStructuredContentWithPriority {
+		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority},${structuredContentId}");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+			-H accept: application/json \
+			-d
+					{
+    "contentFields": [{
+        "contentFieldValue": {
+            "data": "${data}"
+        },
+        "dataType": "string",
+        "label": "${label}",
+        "name": "${name}",
+        "nestedContentFields": [],
+        "repeatable": false
+    }],
+    "contentStructureId": "${ddmStructureId}",
+    "title": "${title}",
+	"priority": "${priority}"
+	}
+		''';
+
+		var curl = JSONCurlUtil.put("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _filterStructuredContentWithPriority {
 		Variables.assertDefined(parameterList = "${filtervalue}");
 
@@ -141,12 +176,12 @@ definition {
 		return "${curl}";
 	}
 
-	macro assertPriorityFieldIsFilterWithDefaultValue {
-		var actualPriorityDefaultValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..['priority']");
+	macro assertPriorityFieldIsFilteredWithCorrectValue {
+		var actualPriorityValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..['priority']");
 
 		TestUtils.assertEquals(
-			actual = "${actualPriorityDefaultValue}",
-			expected = "${expectedPriorityDefaultValue}");
+			actual = "${actualPriorityValue}",
+			expected = "${expectedPriorityValue}");
 	}
 
 	macro assertPriorityFieldWithDefaultValue {
@@ -157,12 +192,46 @@ definition {
 			expected = "${expectedPriorityDefaultValue}");
 	}
 
+	macro assertProperNumberOfItems {
+		var actualTotalElement = JSONUtil.getWithJSONPath("${responseToParse}", "$..['totalCount']");
+
+		TestUtils.assertEquals(
+			actual = "${actualTotalElement}",
+			expected = "${expectedTotalElement}");
+	}
+
+	macro assertStructuredContentIdIsFilteredWithCorrectValue {
+		var editStructuredContentId = JSONUtil.getWithJSONPath("${editStructuredContentId}", "$.['id']");
+		var filterStructuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$..['items'][0].id");
+
+		TestUtils.assertEquals(
+			actual = "${filterStructuredContentId}",
+			expected = "${editStructuredContentId}");
+	}
+
 	macro createStructuredContentDraft {
 		var response = HeadlessWebcontentAPI._createStructuredContentDraft(
 			data = "${data}",
 			ddmStructureId = "${ddmStructureId}",
 			label = "${label}",
 			name = "${name}",
+			title = "${title}");
+
+		return "${response}";
+	}
+
+	macro editStructuredContentWithPriority {
+		Variables.assertDefined(parameterList = "${responseToParse},${data},${ddmStructureId},${label},${name},${priority},${title}");
+
+		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
+
+		var response = HeadlessWebcontentAPI._editStructuredContentWithPriority(
+			data = "${data}",
+			ddmStructureId = "${ddmStructureId}",
+			label = "${label}",
+			name = "${name}",
+			priority = "${priority}",
+			structuredContentId = "${structuredContentId}",
 			title = "${title}");
 
 		return "${response}";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
@@ -59,9 +59,67 @@ definition {
 		}
 
 		task ("Then the response body includes the default priority field") {
-			HeadlessWebcontentAPI.assertPriorityFieldIsFilterWithDefaultValue(
-				expectedPriorityDefaultValue = "0.0",
+			HeadlessWebcontentAPI.assertPriorityFieldIsFilteredWithCorrectValue(
+				expectedPriorityValue = "0.0",
 				responseToParse = "${responseToParse}");
+		}
+	}
+
+	@description = "StructuredContent can be filtered with a set priority"
+	@priority = "5"
+	test StructuredContentContainsUpdatedPriorityValueFilteredByEqualTo {
+		property portal.acceptance = "true";
+
+		task ("Given three web contents are created with default priority") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse1 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title 1");
+			var responseToParse2 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title 2");
+			var responseToParse3 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title 3");
+		}
+
+		task ("Given edit a web content with different priorities") {
+			var editStructuredContentId = HeadlessWebcontentAPI.editStructuredContentWithPriority(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1.3",
+				responseToParse = "${responseToParse2}",
+				title = "WC WebContent Title 2");
+		}
+
+		task ("When web contents are filtered with 1.3 priority") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentWithPriority(filtervalue = "priority%20eq%201.3");
+		}
+
+		task ("Then the response body only includes items with priority 1.3") {
+			HeadlessWebcontentAPI.assertPriorityFieldIsFilteredWithCorrectValue(
+				expectedPriorityValue = "1.3",
+				responseToParse = "${response}");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "1",
+				responseToParse = "${response}");
+
+			HeadlessWebcontentAPI.assertStructuredContentIdIsFilteredWithCorrectValue(
+				editStructuredContentId = "${editStructuredContentId}",
+				responseToParse = "${response}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
StructuredContent can be filtered with a set priority

**Test Plan**
Given three web content is created with default priority
Then edit three web content with different priorities (eg: 1.2, 1.3, 1.4)
When with GET request I filter priority eq 1.3 web content by the field priority with "/v1.0/site/{siteId}/structured-contents"
Then you can see the web content filtered by the priority 1.3 in the body response

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-153228