### PR TITLE
LPS-154689 Fix React warning when selectedItemsKey is missing in FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/model/UserEntry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/model/UserEntry.java
@@ -19,9 +19,12 @@ package com.liferay.frontend.data.set.sample.web.internal.model;
  */
 public class UserEntry {
 
-	public UserEntry(String emailAddress, String firstName, String lastName) {
+	public UserEntry(
+		String emailAddress, String firstName, Long id, String lastName) {
+
 		_emailAddress = emailAddress;
 		_firstName = firstName;
+		_id = id;
 		_lastName = lastName;
 	}
 
@@ -33,12 +36,17 @@ public class UserEntry {
 		return _firstName;
 	}
 
+	public Long getId() {
+		return _id;
+	}
+
 	public String getLastName() {
 		return _lastName;
 	}
 
 	private final String _emailAddress;
 	private final String _firstName;
+	private final Long _id;
 	private final String _lastName;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/provider/ClassicFDSDataProvider.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/provider/ClassicFDSDataProvider.java
@@ -65,7 +65,7 @@ public class ClassicFDSDataProvider implements FDSDataProvider<UserEntry> {
 					fdsPagination.getStartPosition(),
 					fdsPagination.getEndPosition(), sort)),
 			user -> new UserEntry(
-				user.getEmailAddress(), user.getFirstName(),
+				user.getEmailAddress(), user.getFirstName(), user.getUserId(),
 				user.getLastName()));
 	}
 


### PR DESCRIPTION
[Jira task](https://issues.liferay.com/browse/LPS-154689)

### The problem
When the attribute `selectedItemsKey` is not specified in a FDS instance and the items rendered have no an `id` property, the FE fails to assign a proper key throwing a warning in browser console.

`Warning: Each child in a list should have a unique "key" prop.`

 
### Proposed solution

In addition to the `id` used as a fallback, in case this one fails, the FE will generate an unique identifier for each item