### PR TITLE
LPS-153229 | StructuredContent can be sorted with a set priority

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -88,6 +88,41 @@ definition {
 		return "${articleId}";
 	}
 
+	macro _createStructuredContent {
+		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority}");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/structured-contents/ \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+            -d
+					{
+    "contentFields": [{
+        "contentFieldValue": {
+            "data": "${data}"
+        },
+        "dataType": "string",
+        "label": "${label}",
+        "name": "${name}",
+        "nestedContentFields": [],
+        "repeatable": false
+    }],
+    "contentStructureId": "${ddmStructureId}",
+    "title": "${title}",
+	"priority": "${priority}"
+	}
+		''';
+
+		var curl = JSONCurlUtil.post("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _createStructuredContentDraft {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title}");
 
@@ -122,7 +157,7 @@ definition {
 		return "${curl}";
 	}
 
-	macro _editStructuredContentWithPriority {
+	macro _editStructuredContent {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority},${structuredContentId}");
 
 		var portalURL = JSONCompany.getDefaultPortalURL();
@@ -157,7 +192,7 @@ definition {
 		return "${curl}";
 	}
 
-	macro _filterStructuredContentWithPriority {
+	macro _filterStructuredContent {
 		Variables.assertDefined(parameterList = "${filtervalue}");
 
 		var portalURL = JSONCompany.getDefaultPortalURL();
@@ -166,7 +201,26 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue} \
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
+	macro _sortStructureContent {
+		Variables.assertDefined(parameterList = "${sortvalue}");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/structured-contents?sort=${sortvalue} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
@@ -182,6 +236,14 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualPriorityValue}",
 			expected = "${expectedPriorityValue}");
+	}
+
+	macro assertPriorityFieldIsSortedWithCorrectValue {
+		var actualPriorityValueList = JSONUtil.getWithJSONPath("${responseToParse}", "$..['priority']");
+
+		TestUtils.assertEquals(
+			actual = "${actualPriorityValueList}",
+			expected = "${expectedPriorityValueList}");
 	}
 
 	macro assertPriorityFieldWithDefaultValue {
@@ -209,6 +271,22 @@ definition {
 			expected = "${editStructuredContentId}");
 	}
 
+	macro createStructuredContent {
+		if (!(isSet(priority))) {
+			var priority = "";
+		}
+
+		var response = HeadlessWebcontentAPI._createStructuredContent(
+			data = "${data}",
+			ddmStructureId = "${ddmStructureId}",
+			label = "${label}",
+			name = "${name}",
+			priority = "${priority}",
+			title = "${title}");
+
+		return "${response}";
+	}
+
 	macro createStructuredContentDraft {
 		var response = HeadlessWebcontentAPI._createStructuredContentDraft(
 			data = "${data}",
@@ -220,12 +298,16 @@ definition {
 		return "${response}";
 	}
 
-	macro editStructuredContentWithPriority {
+	macro editStructuredContent {
 		Variables.assertDefined(parameterList = "${responseToParse},${data},${ddmStructureId},${label},${name},${priority},${title}");
 
 		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
 
-		var response = HeadlessWebcontentAPI._editStructuredContentWithPriority(
+		if (!(isSet(priority))) {
+			var priority = "";
+		}
+
+		var response = HeadlessWebcontentAPI._editStructuredContent(
 			data = "${data}",
 			ddmStructureId = "${ddmStructureId}",
 			label = "${label}",
@@ -237,8 +319,14 @@ definition {
 		return "${response}";
 	}
 
-	macro filterStructuredContentWithPriority {
-		var response = HeadlessWebcontentAPI._filterStructuredContentWithPriority(filtervalue = "${filtervalue}");
+	macro filterStructuredContent {
+		var response = HeadlessWebcontentAPI._filterStructuredContent(filtervalue = "${filtervalue}");
+
+		return "${response}";
+	}
+
+	macro sortStructureContent {
+		var response = HeadlessWebcontentAPI._sortStructureContent(sortvalue = "${sortvalue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
@@ -38,6 +38,48 @@ definition {
 		}
 	}
 
+	@description = "StructuredContent can be sorted with a set priority"
+	@priority = "5"
+	test CanSortDescendingStructuredContentsByPriority {
+		property portal.acceptance = "true";
+
+		task ("Given three web contents are created with different priorities") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse1 = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1.2",
+				title = "WC WebContent Title 1");
+			var responseToParse2 = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1.3",
+				title = "WC WebContent Title 2");
+			var responseToParse3 = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1.4",
+				title = "WC WebContent Title 3");
+		}
+
+		task ("When web contents are sorted with descending priority") {
+			var response = HeadlessWebcontentAPI.sortStructureContent(sortvalue = "priority%3Adesc");
+		}
+
+		task ("Then the response body includes a list with descending priority") {
+			HeadlessWebcontentAPI.assertPriorityFieldIsSortedWithCorrectValue(
+				expectedPriorityValueList = "1.4,1.3,1.2",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "StructuredContent can be filtered with default priority"
 	@priority = "5"
 	test StructuredContentContainsPriorityField {
@@ -46,7 +88,7 @@ definition {
 		task ("Given a web content are created with default priority") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
-			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = "${ddmStructureId}",
 				label = "Text",
@@ -55,7 +97,7 @@ definition {
 		}
 
 		task ("When web contents are filtered with default priority") {
-			var responseToParse = HeadlessWebcontentAPI.filterStructuredContentWithPriority(filtervalue = "priority%20eq%200.0");
+			var responseToParse = HeadlessWebcontentAPI.filterStructuredContent(filtervalue = "priority%20eq%200.0");
 		}
 
 		task ("Then the response body includes the default priority field") {
@@ -73,19 +115,19 @@ definition {
 		task ("Given three web contents are created with default priority") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
-			var responseToParse1 = HeadlessWebcontentAPI.createStructuredContentDraft(
+			var responseToParse1 = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = "${ddmStructureId}",
 				label = "Text",
 				name = "Text",
 				title = "WC WebContent Title 1");
-			var responseToParse2 = HeadlessWebcontentAPI.createStructuredContentDraft(
+			var responseToParse2 = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = "${ddmStructureId}",
 				label = "Text",
 				name = "Text",
 				title = "WC WebContent Title 2");
-			var responseToParse3 = HeadlessWebcontentAPI.createStructuredContentDraft(
+			var responseToParse3 = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = "${ddmStructureId}",
 				label = "Text",
@@ -94,7 +136,7 @@ definition {
 		}
 
 		task ("Given edit a web content with different priorities") {
-			var editStructuredContentId = HeadlessWebcontentAPI.editStructuredContentWithPriority(
+			var editStructuredContentId = HeadlessWebcontentAPI.editStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = "${ddmStructureId}",
 				label = "Text",
@@ -105,7 +147,7 @@ definition {
 		}
 
 		task ("When web contents are filtered with 1.3 priority") {
-			var response = HeadlessWebcontentAPI.filterStructuredContentWithPriority(filtervalue = "priority%20eq%201.3");
+			var response = HeadlessWebcontentAPI.filterStructuredContent(filtervalue = "priority%20eq%201.3");
 		}
 
 		task ("Then the response body only includes items with priority 1.3") {


### PR DESCRIPTION
**Background**
StructuredContent can be sorted with a set priority

**Test Plan**
Given three web content is created with different priorities (eg: 1.2, 1.3, 1.4)
When with GET request I sort priority:desc web content by the field priority with "/v1.0/site/{siteId}/structured-contents"
Then you can see the web content sorted by the descending priority in the body response

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-153229