### PR TITLE
LPS-153811 Allow to retrieve related objects from the relationship endpoint (GET operation)

### DIFF
--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 4.3.1
+Bundle-Version: 4.4.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.manager.v1_0,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/manager/v1_0/ObjectEntryManager.java
@@ -95,6 +95,12 @@ public interface ObjectEntryManager {
 			ObjectDefinition objectDefinition, String scopeKey)
 		throws Exception;
 
+	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
+			DTOConverterContext dtoConverterContext, Long objectEntryId,
+			ObjectDefinition objectDefinition, String objectRelationshipName,
+			Pagination pagination)
+		throws Exception;
+
 	public ObjectEntry updateObjectEntry(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition, long objectEntryId,

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/resource/v1_0/ObjectEntryResource.java
@@ -90,6 +90,11 @@ public interface ObjectEntryResource {
 			ObjectEntry objectEntry)
 		throws Exception;
 
+	public Page<ObjectEntry> getCurrentObjectEntriesObjectRelationshipNamePage(
+			Long currentObjectEntryId, String objectRelationshipName,
+			Pagination pagination)
+		throws Exception;
+
 	public ObjectEntry putCurrentObjectEntry(
 			Long currentObjectEntryId, String objectRelationshipName,
 			Long relatedObjectEntryId)

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/manager/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -272,6 +272,42 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ObjectEntry"
             tags: ["ObjectEntry"]
+    "/{currentObjectEntryId}/{objectRelationshipName}":
+        get:
+            parameters:
+                - in: path
+                  name: currentObjectEntryId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+                - in: path
+                  name: objectRelationshipName
+                  required: true
+                  schema:
+                      type: string
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/ObjectEntry"
+                                type: array
+            tags: ["ObjectEntry"]
     "/{currentObjectEntryId}/{objectRelationshipName}/{relatedObjectEntryId}":
         put:
             operationId: putCurrentObjectEntry

--- a/modules/apps/object/object-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-rest-impl/rest-openapi.yaml
@@ -274,6 +274,7 @@ paths:
             tags: ["ObjectEntry"]
     "/{currentObjectEntryId}/{objectRelationshipName}":
         get:
+            operationId: getCurrentObjectEntriesObjectRelationshipNamePage
             parameters:
                 - in: path
                   name: currentObjectEntryId

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -17,6 +17,7 @@ package com.liferay.object.rest.internal.manager.v1_0;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.object.constants.ObjectConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.NoSuchObjectEntryException;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
@@ -29,9 +30,11 @@ import com.liferay.object.rest.internal.resource.v1_0.ObjectEntryResourceImpl;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectRelationshipService;
 import com.liferay.petra.sql.dsl.expression.Predicate;
 import com.liferay.petra.string.StringPool;
@@ -420,6 +423,55 @@ public class DefaultObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	@Override
+	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
+			DTOConverterContext dtoConverterContext, Long objectEntryId,
+			ObjectDefinition objectDefinition, String objectRelationshipName,
+			Pagination pagination)
+		throws Exception {
+
+		ObjectRelationship objectRelationship =
+			_objectRelationshipService.getObjectRelationship(
+				objectDefinition.getObjectDefinitionId(),
+				objectRelationshipName);
+
+		com.liferay.object.model.ObjectEntry objectEntry =
+			_objectEntryService.getObjectEntry(objectEntryId);
+
+		List<ObjectEntry> objectEntries = new ArrayList<>();
+
+		if (Objects.equals(
+				objectRelationship.getType(),
+				ObjectRelationshipConstants.TYPE_MANY_TO_MANY)) {
+
+			objectEntries = _getManyToManyRelationshipObjectEntries(
+				dtoConverterContext, objectRelationship, objectEntry,
+				pagination);
+		}
+		else if (Objects.equals(
+					objectRelationship.getType(),
+					ObjectRelationshipConstants.TYPE_ONE_TO_MANY)) {
+
+			objectEntries = _getOneToManyRelationshipObjectEntries(
+				dtoConverterContext, objectRelationship, objectEntry,
+				pagination);
+		}
+
+		return Page.of(
+			HashMapBuilder.put(
+				"get",
+				ActionUtil.addAction(
+					ActionKeys.VIEW, ObjectEntryResourceImpl.class,
+					objectEntry.getObjectEntryId(),
+					"getCurrentObjectEntriesObjectRelationshipNamePage", null,
+					objectEntry.getUserId(),
+					_getObjectEntryPermissionName(
+						objectEntry.getObjectDefinitionId()),
+					objectEntry.getGroupId(), dtoConverterContext.getUriInfo())
+			).build(),
+			objectEntries);
+	}
+
+	@Override
 	public ObjectEntry updateObjectEntry(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition, long objectEntryId,
@@ -477,12 +529,58 @@ public class DefaultObjectEntryManagerImpl implements ObjectEntryManager {
 		return 0;
 	}
 
+	private List<ObjectEntry> _getManyToManyRelationshipObjectEntries(
+			DTOConverterContext dtoConverterContext,
+			ObjectRelationship objectRelationship,
+			com.liferay.object.model.ObjectEntry objectEntry,
+			Pagination pagination)
+		throws Exception {
+
+		boolean reverse = objectRelationship.isReverse();
+
+		if (reverse) {
+			objectRelationship =
+				_objectRelationshipLocalService.fetchReverseObjectRelationship(
+					objectRelationship, false);
+		}
+
+		List<com.liferay.object.model.ObjectEntry>
+			manyToManyRelatedObjectEntries =
+				_objectEntryLocalService.getManyToManyRelatedObjectEntries(
+					objectEntry.getGroupId(),
+					objectRelationship.getObjectRelationshipId(),
+					objectEntry.getObjectEntryId(), reverse,
+					pagination.getStartPosition(), pagination.getEndPosition());
+
+		return _toObjectEntries(
+			dtoConverterContext, manyToManyRelatedObjectEntries);
+	}
+
 	private String _getObjectEntriesPermissionName(long objectDefinitionId) {
 		return ObjectConstants.RESOURCE_NAME + "#" + objectDefinitionId;
 	}
 
 	private String _getObjectEntryPermissionName(long objectDefinitionId) {
 		return ObjectDefinition.class.getName() + "#" + objectDefinitionId;
+	}
+
+	private List<ObjectEntry> _getOneToManyRelationshipObjectEntries(
+			DTOConverterContext dtoConverterContext,
+			ObjectRelationship objectRelationship,
+			com.liferay.object.model.ObjectEntry objectEntry,
+			Pagination pagination)
+		throws Exception {
+
+		List<com.liferay.object.model.ObjectEntry>
+			oneToManyRelatedObjectEntries =
+				_objectEntryLocalService.getOneToManyRelatedObjectEntries(
+					objectEntry.getGroupId(),
+					objectRelationship.getObjectRelationshipId(),
+					objectEntry.getObjectEntryId(),
+					pagination.getStartPosition(), pagination.getEndPosition());
+
+		return _toObjectEntries(
+			dtoConverterContext, oneToManyRelatedObjectEntries);
 	}
 
 	private void _processVulcanAggregation(
@@ -563,6 +661,26 @@ public class DefaultObjectEntryManagerImpl implements ObjectEntryManager {
 		}
 
 		return null;
+	}
+
+	private List<ObjectEntry> _toObjectEntries(
+			DTOConverterContext dtoConverterContext,
+			List<com.liferay.object.model.ObjectEntry> objectEntries)
+		throws Exception {
+
+		List<ObjectEntry> finalObjectEntries = new ArrayList<>();
+
+		for (com.liferay.object.model.ObjectEntry objectEntry : objectEntries) {
+			ObjectDefinition objectDefinition =
+				_objectDefinitionLocalService.getObjectDefinition(
+					objectEntry.getObjectDefinitionId());
+
+			finalObjectEntries.add(
+				_toObjectEntry(
+					dtoConverterContext, objectDefinition, objectEntry));
+		}
+
+		return finalObjectEntries;
 	}
 
 	private ObjectEntry _toObjectEntry(
@@ -685,6 +803,9 @@ public class DefaultObjectEntryManagerImpl implements ObjectEntryManager {
 	private GroupLocalService _groupLocalService;
 
 	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
 	private ObjectEntryDTOConverter _objectEntryDTOConverter;
 
 	@Reference
@@ -695,6 +816,9 @@ public class DefaultObjectEntryManagerImpl implements ObjectEntryManager {
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
 	@Reference
 	private ObjectRelationshipService _objectRelationshipService;

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SalesforceObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/SalesforceObjectEntryManagerImpl.java
@@ -142,6 +142,16 @@ public class SalesforceObjectEntryManagerImpl implements ObjectEntryManager {
 	}
 
 	@Override
+	public Page<ObjectEntry> getObjectEntryRelatedObjectEntries(
+			DTOConverterContext dtoConverterContext, Long objectEntryId,
+			ObjectDefinition objectDefinition, String objectRelationshipName,
+			Pagination pagination)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
 	public ObjectEntry updateObjectEntry(
 			DTOConverterContext dtoConverterContext,
 			ObjectDefinition objectDefinition, long objectEntryId,

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/BaseObjectEntryResourceImpl.java
@@ -365,6 +365,48 @@ public abstract class BaseObjectEntryResourceImpl
 				name = "objectRelationshipName"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "ObjectEntry")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/{currentObjectEntryId}/{objectRelationshipName}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<ObjectEntry> getCurrentObjectEntriesObjectRelationshipNamePage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("currentObjectEntryId")
+			Long currentObjectEntryId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("objectRelationshipName")
+			String objectRelationshipName,
+			@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "currentObjectEntryId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "objectRelationshipName"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
 				name = "relatedObjectEntryId"
 			)

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java
@@ -145,6 +145,21 @@ public class ObjectEntryResourceImpl extends BaseObjectEntryResourceImpl {
 	}
 
 	@Override
+	public Page<ObjectEntry> getCurrentObjectEntriesObjectRelationshipNamePage(
+			Long currentObjectEntryId, String objectRelationshipName,
+			Pagination pagination)
+		throws Exception {
+
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerServicesTracker.getObjectEntryManager(
+				_objectDefinition.getStorageType());
+
+		return objectEntryManager.getObjectEntryRelatedObjectEntries(
+			_getDTOConverterContext(currentObjectEntryId), currentObjectEntryId,
+			_objectDefinition, objectRelationshipName, pagination);
+	}
+
+	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return new ObjectEntryEntityModel(
 			_objectFieldLocalService.getObjectFields(


### PR DESCRIPTION
Related ticket -> [LPS-153811](https://issues.liferay.com/browse/LPS-153811)
Related documentation -> [Internal documentation](https://liferay.atlassian.net/wiki/spaces/DXPL/pages/1998749744/LPS-149282+-+Allow+Many+to+many+relationships+between+objects+in+a+headless+API)
____

This PR is a follow-up of [this one](https://github.com/liferay-frontend/liferay-portal/pull/2235).

## New Endpoints
With this PR we are adding new endpoints to retrieve the relations of a specific object. There will be as many endpoints as relationships an object has. For example, if an object `University` exists with have relations among `subjects` and `students`, there will be two endpoints, each for each relationship.
![imagen](https://user-images.githubusercontent.com/17163902/170463868-f3fa1b16-51a2-4c70-a58a-141ff5e20e2e.png)

Also, the endpoints support pagination. In our previous example, if the university has a large number of students or subjects, it is possible to retrieve all this information paginated.
![imagen](https://user-images.githubusercontent.com/17163902/170464614-7b751a3b-f0f3-4aee-a1ab-eb868fad8db3.png)

This functionality supports BOTH types of relationships: one-to-many and many-to-many.
The way to use it is just to make a GET request to the endpoint indicating the id of the object that wants to know their relations. For example: 
`curl http://localhost:8080/o/c/universities/<your-id>/universityStudents -u <your-credentials>`

Will return something like:
![imagen](https://user-images.githubusercontent.com/17163902/170465364-c5b2562f-301b-4ccf-b0cb-9873dbadf8be.png)

_NOTE: The previous example use a basic auth for developing purposes. Should not use in production_

These endpoints also support the new nested fields introduced in [the previous PR](https://github.com/liferay-frontend/liferay-portal/pull/2235).

