### PR TITLE
LPS-154746 Support mainFieldValue in SimpleInputModal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
@@ -51,6 +51,7 @@ function openSimpleInputModalImplementation({
 	idFieldValue,
 	mainFieldLabel,
 	mainFieldName,
+	mainFieldValue,
 	namespace,
 	onFormSuccess,
 	placeholder,
@@ -71,6 +72,7 @@ function openSimpleInputModalImplementation({
 			initialVisible="true"
 			mainFieldLabel={mainFieldLabel}
 			mainFieldName={mainFieldName}
+			mainFieldValue={mainFieldValue}
 			namespace={namespace}
 			onFormSuccess={onFormSuccess}
 			placeholder={placeholder}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -39,6 +39,7 @@ const SimpleInputModal = ({
 	initialVisible,
 	mainFieldLabel,
 	mainFieldName,
+	mainFieldValue = '',
 	namespace,
 	onFormSuccess,
 	placeholder,
@@ -47,11 +48,21 @@ const SimpleInputModal = ({
 	const [errorMessage, setErrorMessage] = useState();
 	const [loadingResponse, setLoadingResponse] = useState(false);
 	const [visible, setVisible] = useState(initialVisible);
-	const [inputValue, setInputValue] = useState('');
+	const [inputValue, setInputValue] = useState(mainFieldValue);
 	const [isChecked, setChecked] = useState(checkboxFieldValue);
 
 	const handleFormError = (responseContent) => {
 		setErrorMessage(responseContent.error || '');
+	};
+
+	const handleMainFieldRef = (mainFieldElement) => {
+		if (
+			mainFieldElement &&
+			mainFieldValue &&
+			mainFieldValue === inputValue
+		) {
+			mainFieldElement.setSelectionRange(0, inputValue.length);
+		}
 	};
 
 	const _handleSubmit = (event) => {
@@ -156,6 +167,7 @@ const SimpleInputModal = ({
 									setInputValue(event.target.value)
 								}
 								placeholder={placeholder}
+								ref={handleMainFieldRef}
 								required
 								type="text"
 								value={inputValue}


### PR DESCRIPTION
Hey there!

I have fixed an issue in SimpleInputModal component, which was not supporting `mainFieldValue` property (it did when it was implemented in Soy :sweat_smile:). This property is used to improve renaming use cases, when the old item name is being shown to keep context:

![image](https://user-images.githubusercontent.com/800645/170489210-e9f10cfa-885e-4041-958a-6b99522938f6.png)
