### PR TITLE
LPS-154738 Fix missing notifications for Document Folder's subscribers by including themeDisplay in ServiceContext

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.internal.dto.v1_0.util;
+
+import com.liferay.portal.events.ServicePreAction;
+import com.liferay.portal.events.ThemeServicePreAction;
+import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class DocumentUtil {
+
+	public static ThemeDisplay getThemeDisplay(
+			HttpServletRequest httpServletRequest, long groupId)
+		throws Exception {
+
+		ServicePreAction servicePreAction = new ServicePreAction();
+
+		HttpServletResponse httpServletResponse =
+			new DummyHttpServletResponse();
+
+		servicePreAction.servicePre(
+			httpServletRequest, httpServletResponse, false);
+
+		ThemeServicePreAction themeServicePreAction =
+			new ThemeServicePreAction();
+
+		themeServicePreAction.run(httpServletRequest, httpServletResponse);
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		themeDisplay.setScopeGroupId(groupId);
+		themeDisplay.setSiteGroupId(groupId);
+
+		return themeDisplay;
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
@@ -28,8 +28,8 @@ import javax.servlet.http.HttpServletResponse;
 public class DocumentUtil {
 
 	public static void addThemeDisplay(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse, long groupId)
+			long groupId, HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
 		throws Exception {
 
 		ServicePreAction servicePreAction = new ServicePreAction();

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
@@ -16,7 +16,6 @@ package com.liferay.headless.delivery.internal.dto.v1_0.util;
 
 import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.events.ThemeServicePreAction;
-import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -29,13 +28,11 @@ import javax.servlet.http.HttpServletResponse;
 public class DocumentUtil {
 
 	public static ThemeDisplay getThemeDisplay(
-			HttpServletRequest httpServletRequest, long groupId)
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, long groupId)
 		throws Exception {
 
 		ServicePreAction servicePreAction = new ServicePreAction();
-
-		HttpServletResponse httpServletResponse =
-			new DummyHttpServletResponse();
 
 		servicePreAction.servicePre(
 			httpServletRequest, httpServletResponse, false);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/DocumentUtil.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class DocumentUtil {
 
-	public static ThemeDisplay getThemeDisplay(
+	public static void addThemeDisplay(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, long groupId)
 		throws Exception {
@@ -48,8 +48,6 @@ public class DocumentUtil {
 
 		themeDisplay.setScopeGroupId(groupId);
 		themeDisplay.setSiteGroupId(groupId);
-
-		return themeDisplay;
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.headless.delivery.dto.v1_0.util.CustomFieldsUtil;
 import com.liferay.headless.delivery.dto.v1_0.util.DDMFormValuesUtil;
 import com.liferay.headless.delivery.internal.dto.v1_0.converter.DocumentDTOConverter;
 import com.liferay.headless.delivery.internal.dto.v1_0.util.DisplayPageRendererUtil;
+import com.liferay.headless.delivery.internal.dto.v1_0.util.DocumentUtil;
 import com.liferay.headless.delivery.internal.dto.v1_0.util.RatingUtil;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.DocumentEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.DocumentResource;
@@ -72,9 +73,11 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.search.aggregation.Aggregations;
 import com.liferay.portal.search.expando.ExpandoBridgeIndexer;
@@ -323,7 +326,7 @@ public class DocumentResourceImpl
 					() -> _assetTagLocalService.getTagNames(
 						DLFileEntry.class.getName(), documentId),
 					existingFileEntry.getFolderId(), documentOptional,
-					existingFileEntry.getGroupId())));
+					existingFileEntry.getGroupId(), Constants.UPDATE)));
 	}
 
 	@Override
@@ -462,7 +465,7 @@ public class DocumentResourceImpl
 				null,
 				_createServiceContext(
 					() -> new Long[0], () -> new String[0], documentFolderId,
-					documentOptional, groupId)));
+					documentOptional, groupId, Constants.ADD)));
 	}
 
 	private UnsafeConsumer<BooleanQuery, Exception>
@@ -492,7 +495,7 @@ public class DocumentResourceImpl
 	private ServiceContext _createServiceContext(
 			Supplier<Long[]> defaultCategoriesSupplier,
 			Supplier<String[]> defaultKeywordsSupplier, Long documentFolderId,
-			Optional<Document> documentOptional, Long groupId)
+			Optional<Document> documentOptional, Long groupId, String command)
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -559,6 +562,14 @@ public class DocumentResourceImpl
 					_ddmBeanTranslator.translate(ddmFormValues));
 			}
 		}
+
+		serviceContext.setCompanyId(contextCompany.getCompanyId());
+		contextHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY,
+			DocumentUtil.getThemeDisplay(contextHttpServletRequest, groupId));
+
+		serviceContext.setRequest(contextHttpServletRequest);
+		serviceContext.setCommand(command);
 
 		return serviceContext;
 	}
@@ -820,7 +831,7 @@ public class DocumentResourceImpl
 				_createServiceContext(
 					() -> new Long[0], () -> new String[0],
 					fileEntry.getFolderId(), documentOptional,
-					fileEntry.getGroupId())));
+					fileEntry.getGroupId(), Constants.UPDATE)));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -525,8 +525,10 @@ public class DocumentResourceImpl
 		serviceContext.setRequest(contextHttpServletRequest);
 		serviceContext.setUserId(contextUser.getUserId());
 
-		DocumentUtil.addThemeDisplay(
-			groupId, contextHttpServletRequest, contextHttpServletResponse);
+		if (contextHttpServletRequest != null) {
+			DocumentUtil.addThemeDisplay(
+				groupId, contextHttpServletRequest, contextHttpServletResponse);
+		}
 
 		Optional<DLFileEntryType> dlFileEntryTypeOptional =
 			_getDLFileEntryTypeOptional(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -566,7 +566,9 @@ public class DocumentResourceImpl
 		serviceContext.setCompanyId(contextCompany.getCompanyId());
 		contextHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY,
-			DocumentUtil.getThemeDisplay(contextHttpServletRequest, groupId));
+			DocumentUtil.getThemeDisplay(
+				contextHttpServletRequest, contextHttpServletResponse,
+				groupId));
 
 		serviceContext.setRequest(contextHttpServletRequest);
 		serviceContext.setCommand(command);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -319,13 +319,14 @@ public class DocumentResourceImpl
 				existingFileEntry.getExpirationDate(),
 				existingFileEntry.getReviewDate(),
 				_createServiceContext(
+					Constants.UPDATE,
 					() -> ArrayUtil.toArray(
 						_assetCategoryLocalService.getCategoryIds(
 							DLFileEntry.class.getName(), documentId)),
 					() -> _assetTagLocalService.getTagNames(
 						DLFileEntry.class.getName(), documentId),
 					existingFileEntry.getFolderId(), documentOptional,
-					existingFileEntry.getGroupId(), Constants.UPDATE)));
+					existingFileEntry.getGroupId())));
 	}
 
 	@Override
@@ -463,8 +464,8 @@ public class DocumentResourceImpl
 				null, binaryFile.getInputStream(), binaryFile.getSize(), null,
 				null,
 				_createServiceContext(
-					() -> new Long[0], () -> new String[0], documentFolderId,
-					documentOptional, groupId, Constants.ADD)));
+					Constants.ADD, () -> new Long[0], () -> new String[0],
+					documentFolderId, documentOptional, groupId)));
 	}
 
 	private UnsafeConsumer<BooleanQuery, Exception>
@@ -492,9 +493,9 @@ public class DocumentResourceImpl
 	}
 
 	private ServiceContext _createServiceContext(
-			Supplier<Long[]> defaultCategoriesSupplier,
+			String command, Supplier<Long[]> defaultCategoriesSupplier,
 			Supplier<String[]> defaultKeywordsSupplier, Long documentFolderId,
-			Optional<Document> documentOptional, Long groupId, String command)
+			Optional<Document> documentOptional, Long groupId)
 		throws Exception {
 
 		ServiceContext serviceContext =
@@ -517,7 +518,15 @@ public class DocumentResourceImpl
 					Document.ViewableBy.OWNER.getValue()
 				));
 
+		serviceContext.setCommand(command);
+		serviceContext.setCompanyId(contextCompany.getCompanyId());
+		serviceContext.setPlid(
+			_portal.getControlPanelPlid(contextCompany.getCompanyId()));
+		serviceContext.setRequest(contextHttpServletRequest);
 		serviceContext.setUserId(contextUser.getUserId());
+
+		DocumentUtil.addThemeDisplay(
+			groupId, contextHttpServletRequest, contextHttpServletResponse);
 
 		Optional<DLFileEntryType> dlFileEntryTypeOptional =
 			_getDLFileEntryTypeOptional(
@@ -561,16 +570,6 @@ public class DocumentResourceImpl
 					_ddmBeanTranslator.translate(ddmFormValues));
 			}
 		}
-
-		serviceContext.setCompanyId(contextCompany.getCompanyId());
-
-		DocumentUtil.addThemeDisplay(
-			contextHttpServletRequest, contextHttpServletResponse, groupId);
-
-		serviceContext.setRequest(contextHttpServletRequest);
-		serviceContext.setCommand(command);
-		serviceContext.setPlid(
-			_portal.getControlPanelPlid(contextCompany.getCompanyId()));
 
 		return serviceContext;
 	}
@@ -830,9 +829,9 @@ public class DocumentResourceImpl
 				binaryFile.getInputStream(), binaryFile.getSize(),
 				fileEntry.getExpirationDate(), fileEntry.getReviewDate(),
 				_createServiceContext(
-					() -> new Long[0], () -> new String[0],
+					Constants.UPDATE, () -> new Long[0], () -> new String[0],
 					fileEntry.getFolderId(), documentOptional,
-					fileEntry.getGroupId(), Constants.UPDATE)));
+					fileEntry.getGroupId())));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -570,6 +570,8 @@ public class DocumentResourceImpl
 
 		serviceContext.setRequest(contextHttpServletRequest);
 		serviceContext.setCommand(command);
+		serviceContext.setPlid(
+			_portal.getControlPanelPlid(contextCompany.getCompanyId()));
 
 		return serviceContext;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -77,7 +77,6 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.search.aggregation.Aggregations;
 import com.liferay.portal.search.expando.ExpandoBridgeIndexer;
@@ -564,11 +563,9 @@ public class DocumentResourceImpl
 		}
 
 		serviceContext.setCompanyId(contextCompany.getCompanyId());
-		contextHttpServletRequest.setAttribute(
-			WebKeys.THEME_DISPLAY,
-			DocumentUtil.getThemeDisplay(
-				contextHttpServletRequest, contextHttpServletResponse,
-				groupId));
+
+		DocumentUtil.addThemeDisplay(
+			contextHttpServletRequest, contextHttpServletResponse, groupId);
 
 		serviceContext.setRequest(contextHttpServletRequest);
 		serviceContext.setCommand(command);


### PR DESCRIPTION
Related PRs from Support team: https://github.com/liferay-frontend/liferay-portal/pull/2270

---

After subscribing to a folder, when a user uploads a document via Headless Delivery API, there's no notification sent to the subscriptor.
 
**How to reproduce it:**

- Log in with test user (_test@liferay.com_) and create a new folder, use the api to subscribe to it.
- Create a new user _prueba@liferay.com_ and provide a proper role, for example, Admin.
- Log in with _prueba@liferay.com_
- Create a new document from UI with _prueba@liferay.com_
- A new notification pops up in test user _test@liferay.com_
- Create a new document via API with _prueba@liferay.com_ with a request similar to the following:

```
curl \
    -F "file=@image.png" \
    -F 'document={"viewableBy":"Anyone"}'  \
    -H "Content-Type: multipart/form-data"  \
    -X POST "http://localhost:8080/o/headless-delivery/v1.0/document-folders/42816/documents" \
    -u "prueba@liferay.com:prueba"
```

**Expected result:**

A new notification is sent about the upload of the new document

 **Current result:**

There's no new notification in test user notification menu