### PR TITLE
LPS-154696 Create ObjectValidationExceptionMapper and send the error message type by the user in the validation definition

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -18,6 +18,7 @@ import com.liferay.object.deployer.ObjectDefinitionDeployer;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.internal.graphql.dto.v1_0.ObjectDefinitionGraphQLDTOContributor;
 import com.liferay.object.rest.internal.jaxrs.context.provider.ObjectDefinitionContextProvider;
+import com.liferay.object.rest.internal.jaxrs.exception.mapper.ObjectValidationExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectFieldExceptionMapper;
 import com.liferay.object.rest.internal.jaxrs.exception.mapper.RequiredObjectRelationshipExceptionMapper;
 import com.liferay.object.rest.internal.resource.v1_0.BaseObjectEntryResourceImpl;
@@ -157,6 +158,19 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 						"osgi.jaxrs.name",
 						objectDefinition.getName() +
 							"RequiredObjectRelationshipExceptionMapper"
+					).build()),
+				_bundleContext.registerService(
+					ExceptionMapper.class,
+					new ObjectValidationExceptionMapper(),
+					HashMapDictionaryBuilder.<String, Object>put(
+						"osgi.jaxrs.application.select",
+						"(osgi.jaxrs.name=" + objectDefinition.getName() + ")"
+					).put(
+						"osgi.jaxrs.extension", "true"
+					).put(
+						"osgi.jaxrs.name",
+						objectDefinition.getName() +
+							"ObjectValidationExceptionMapper"
 					).build()));
 		}
 

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectValidationExceptionMapper.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/exception/mapper/ObjectValidationExceptionMapper.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.rest.internal.jaxrs.exception.mapper;
+
+import com.liferay.object.exception.ObjectValidationRuleEngineException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * @author luismiguel barcos
+ */
+public class ObjectValidationExceptionMapper
+	extends BaseExceptionMapper<ObjectValidationRuleEngineException> {
+
+	@Override
+	public Response toResponse(
+		ObjectValidationRuleEngineException
+			objectValidationRuleEngineException) {
+
+		Problem problem = getProblem(objectValidationRuleEngineException);
+
+		return Response.status(
+			problem.getStatus()
+		).entity(
+			problem
+		).type(
+			getMediaType()
+		).build();
+	}
+
+	@Override
+	protected Problem getProblem(
+		ObjectValidationRuleEngineException
+			objectValidationRuleEngineException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST,
+			objectValidationRuleEngineException.getMessage());
+	}
+
+}


### PR DESCRIPTION
Related ticket -> [LPS-154696](https://issues.liferay.com/browse/LPS-154696)
___

Due to [this PR](https://github.com/brianchandotcom/liferay-portal/pull/117690), the REST APIs do not respond with `title` information which is used to provide information about the validation in Objects.

This PR creates an exception mapper to handle that exception throw by the validator in case it fails and makes the REST API respond with the error provided by the user in the validation definition.

So now, if the user does not pass the validation, the error shown will be shown like this (_Error message_ is the message introduced by the user in the validation definition)
![imagen](https://user-images.githubusercontent.com/17163902/170593562-3c51b482-ebc1-4fc4-a26f-3a02ef8b14b0.png)
