### PR TITLE
LPS-153134 Test Autom. StructuredContentAssetPriority#StructuredContentDraftContainsModifiedPriorityValue

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -34,6 +34,44 @@ definition {
 	}
 
 	@priority = "5"
+	test StructuredContentDraftContainsModifiedPriorityValue {
+		property portal.acceptance = "true";
+
+		task ("When in Headless Admin Content i create a structuredContent draft with with a priority field set") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1",
+				title = "Title");
+		}
+
+		task ("Given edit a web content with different priorities") {
+			var editStructuredContentId = HeadlessWebcontentAPI.editStructuredContent(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "3.0",
+				responseToParse = "${responseToParse}",
+				title = "Title");
+		}
+
+		task ("When web contents are filtered with 3.0 priority") {
+			var response = HeadlessWebcontentAPI.filterStructuredContent(filtervalue = "priority%20eq%203.0");
+		}
+
+		task ("Then I should see in response content1 with the updated priority value") {
+			HeadlessWebcontentAPI.assertStructuredContentIdIsFilteredWithCorrectValue(
+				editStructuredContentId = "${editStructuredContentId}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "5"
 	test StructuredContentDraftContainsPriorityField {
 		property portal.acceptance = "true";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -37,7 +37,7 @@ definition {
 	test StructuredContentDraftContainsModifiedPriorityValue {
 		property portal.acceptance = "true";
 
-		task ("Given in Headless Admin Content I create a structuredContent draft with with a priority field set") {
+		task ("Given in Headless Admin Content I create a structuredContent draft with a priority field set") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -37,7 +37,7 @@ definition {
 	test StructuredContentDraftContainsModifiedPriorityValue {
 		property portal.acceptance = "true";
 
-		task ("When in Headless Admin Content i create a structuredContent draft with with a priority field set") {
+		task ("Given in Headless Admin Content I create a structuredContent draft with with a priority field set") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
@@ -49,7 +49,7 @@ definition {
 				title = "Title");
 		}
 
-		task ("Given edit a web content with different priorities") {
+		task ("When edit a web content with different priorities") {
 			var editStructuredContentId = HeadlessWebcontentAPI.editStructuredContent(
 				data = "Text",
 				ddmStructureId = "${ddmStructureId}",
@@ -65,9 +65,9 @@ definition {
 		}
 
 		task ("Then I should see in response content1 with the updated priority value") {
-			HeadlessWebcontentAPI.assertStructuredContentIdIsFilteredWithCorrectValue(
-				editStructuredContentId = "${editStructuredContentId}",
-				responseToParse = "${response}");
+			HeadlessWebcontentAPI.assertPriorityFieldIsFilteredWithCorrectValue(
+				expectedPriorityValue = "3.0",
+				responseToParse = "${responseToParse}");
 		}
 	}
 
@@ -97,7 +97,7 @@ definition {
 	test StructuredContentDraftContainsSetPriorityValue {
 		property portal.acceptance = "true";
 
-		task ("When in Headless Admin Content i create a structuredContent draft with with a priority field set") {
+		task ("When in Headless Admin Content I create a structuredContent draft with with a priority field set") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -49,7 +49,7 @@ definition {
 				title = "Title");
 		}
 
-		task ("When edit a web content with different priorities") {
+		task ("When a structured content draft priority is modified") {
 			var editStructuredContentId = HeadlessWebcontentAPI.editStructuredContent(
 				data = "Text",
 				ddmStructureId = "${ddmStructureId}",
@@ -97,7 +97,7 @@ definition {
 	test StructuredContentDraftContainsSetPriorityValue {
 		property portal.acceptance = "true";
 
-		task ("When in Headless Admin Content I create a structuredContent draft with with a priority field set") {
+		task ("When in Headless Admin Content I create a structuredContent draft with a priority field set") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -65,9 +65,9 @@ definition {
 		}
 
 		task ("Then I should see in response content1 with the updated priority value") {
-			HeadlessWebcontentAPI.assertPriorityFieldIsFilteredWithCorrectValue(
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
 				expectedPriorityValue = "3.0",
-				responseToParse = "${responseToParse}");
+				responseToParse = "${response}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automation test StructuredContentAssetPriority#StructuredContentDraftContainsModifiedPriorityValue

**Test Plan**
**Given** a content structure with a content-field of dataType "string" and label "content" and name "content" created in the portal
**And Given** with Headless Admin Content POST "/v1.0/sites/{siteId}/structured-contents/draft" a structured content draft "content1" with a priority 1.0 set is created
**When** with Headless Delivery PUT "/v1.0/structured-contents/{structuredContentId}" a structured content draft "content1" priority is modified to 3.0
**And When** with Headless Admin Content GET "/v1.0/sites/{siteId}/structured-contents" and filter set to "priority eq 3.0"
**Then** I should see in response "content1" with the updated priority value

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-153134