### PR TITLE
LPS-153237 | StructuredContent is created with priority field

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
@@ -165,4 +165,27 @@ definition {
 		}
 	}
 
+	@description = "StructuredContent is created with priority field"
+	@priority = "5"
+	test StructuredContentIsCreatedWithPriorityField {
+		property portal.acceptance = "true";
+
+		task ("When a web contents is created with default priority") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("Then the response body includes the default priority field") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithDefaultValue(
+				expectedPriorityDefaultValue = "0.0",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
StructuredContent is created with priority field

**Test Plan**
Given a content structure with a content-field of dataType "string" and label "content" and name "content" created in the portal
And Given that web content is created with default priority
When with POST request with "/v1.0/site/{siteId}/structured-contents"
Then you can see the response body includes the set default priority value

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-153237