### PR TITLE
LPS-152235 Modernize `toggleBoxes`

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/js/blogs.js
@@ -13,6 +13,7 @@
  */
 
 import {State} from '@liferay/frontend-js-state-web';
+import {toggleBoxes} from 'frontend-js-web';
 import {
 	STR_NULL_IMAGE_FILE_ENTRY_ID,
 	imageSelectorImageAtom,
@@ -88,7 +89,7 @@ export default class Blogs {
 			this._shortenDescription = !customDescriptionEnabled;
 
 			if (emailEntryUpdatedEnabled) {
-				Liferay.Util.toggleBoxes(
+				toggleBoxes(
 					`${namespace}sendEmailEntryUpdated`,
 					`${namespace}emailEntryUpdatedCommentWrapper`
 				);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -734,45 +734,6 @@
 			return parseInt(value, 10) || 0;
 		},
 
-		toggleBoxes(
-			checkBoxId,
-			toggleBoxId,
-			displayWhenUnchecked,
-			toggleChildCheckboxes
-		) {
-			const checkBox = document.getElementById(checkBoxId);
-			const toggleBox = document.getElementById(toggleBoxId);
-
-			if (checkBox && toggleBox) {
-				let checked = checkBox.checked;
-
-				if (displayWhenUnchecked) {
-					checked = !checked;
-				}
-
-				if (checked) {
-					toggleBox.classList.remove('hide');
-				}
-				else {
-					toggleBox.classList.add('hide');
-				}
-
-				checkBox.addEventListener(EVENT_CLICK, () => {
-					toggleBox.classList.toggle('hide');
-
-					if (toggleChildCheckboxes) {
-						const childCheckboxes = toggleBox.querySelectorAll(
-							'input[type=checkbox]'
-						);
-
-						childCheckboxes.forEach((childCheckbox) => {
-							childCheckbox.checked = checkBox.checked;
-						});
-					}
-				});
-			}
-		},
-
 		toggleRadio(radioId, showBoxIds, hideBoxIds) {
 			const radioButton = document.getElementById(radioId);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -668,3 +668,10 @@ export function openToast({
 }): void;
 
 export function fetch(resource: string | Request, init?: Object): Promise<any>;
+
+export function toggleBoxes(
+	checkBoxId: string,
+	toggleBoxId: string,
+	displayWhenUnchecked?: boolean,
+	toggleChildCheckboxes?: boolean
+): void;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -112,5 +112,6 @@ export {default as removeEntitySelection} from './liferay/util/remove_entity_sel
 export {default as showCapsLock} from './liferay/util/show_caps_lock';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';
 export {default as selectFolder} from './liferay/util/select_folder';
+export {default as toggleBoxes} from './liferay/util/toggle_boxes';
 export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -87,6 +87,7 @@ import {getSessionValue, setSessionValue} from './util/session.es';
 import showCapsLock from './util/show_caps_lock';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
+import toggleBoxes from './util/toggle_boxes';
 import toggleControls from './util/toggle_controls';
 import toggleDisabled from './util/toggle_disabled';
 import zIndex from './zIndex';
@@ -326,6 +327,7 @@ Liferay.Util.Session = {
 	set: setSessionValue,
 };
 
+Liferay.Util.toggleBoxes = toggleBoxes;
 Liferay.Util.toggleControls = toggleControls;
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -496,6 +496,13 @@ declare module Liferay {
 		 */
 		export function toCharCode(name: string): string;
 
+		export function toggleBoxes(
+			checkBoxId: string,
+			toggleBoxId: string,
+			displayWhenUnchecked?: boolean,
+			toggleChildCheckboxes?: boolean
+		): void;
+
 		/**
 		 * Unescapes HTML from the given string.
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_boxes.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_boxes.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function toggleBoxes(
+	checkBoxId,
+	toggleBoxId,
+	displayWhenUnchecked,
+	toggleChildCheckboxes
+) {
+	const checkBox = document.getElementById(checkBoxId);
+	const toggleBox = document.getElementById(toggleBoxId);
+
+	if (checkBox && toggleBox) {
+		let checked = checkBox.checked;
+
+		if (displayWhenUnchecked) {
+			checked = !checked;
+		}
+
+		if (checked) {
+			toggleBox.classList.remove('hide');
+		}
+		else {
+			toggleBox.classList.add('hide');
+		}
+
+		checkBox.addEventListener('click', () => {
+			toggleBox.classList.toggle('hide');
+
+			if (toggleChildCheckboxes) {
+				const childCheckboxes = toggleBox.querySelectorAll(
+					'input[type=checkbox]'
+				);
+
+				childCheckboxes.forEach((childCheckbox) => {
+					childCheckbox.checked = checkBox.checked;
+				});
+			}
+		});
+	}
+}


### PR DESCRIPTION
This PR moves `toggleBoxes` utility to frontend-js-web so we can export it and adapt it to our modern workflow.

The only usage that I could modernize is the one in blogs-web, as others are in JSP files.

## 🧪 Testing

Can be tested by going to Content & Data > Web Content > Templates > New Template > Click on Cacheable.

The warning above the textarea input should be hidden if the checkbox is ticked off.

<img width="950" alt="image" src="https://user-images.githubusercontent.com/24564752/170674291-63dd51f5-0839-4a3a-8709-4d4a2ca39f8a.png">
