### PR TITLE
LPS-152236 Modernize `toggleRadio`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -743,54 +743,7 @@
 			return parseInt(value, 10) || 0;
 		},
 
-		toggleRadio(radioId, showBoxIds, hideBoxIds) {
-			const radioButton = document.getElementById(radioId);
-
-			if (radioButton) {
-				let showBoxes;
-
-				if (showBoxIds) {
-					if (Array.isArray(showBoxIds)) {
-						showBoxIds = showBoxIds.join(',#');
-					}
-
-					showBoxes = document.querySelectorAll('#' + showBoxIds);
-
-					showBoxes.forEach((showBox) => {
-						if (radioButton.checked) {
-							showBox.classList.remove('hide');
-						}
-						else {
-							showBox.classList.add('hide');
-						}
-					});
-				}
-
-				radioButton.addEventListener('change', () => {
-					if (showBoxes) {
-						showBoxes.forEach((showBox) => {
-							showBox.classList.remove('hide');
-						});
-					}
-
-					if (hideBoxIds) {
-						if (Array.isArray(hideBoxIds)) {
-							hideBoxIds = hideBoxIds.join(',#');
-						}
-
-						const hideBoxes = document.querySelectorAll(
-							'#' + hideBoxIds
-						);
-
-						hideBoxes.forEach((hideBox) => {
-							hideBox.classList.add('hide');
-						});
-					}
-				});
-			}
-		},
-
-		/*
+		/**
 		 * @deprecated As of Athanasius (7.3.x), with no direct replacement
 		 */
 		toggleSearchContainerButton(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -675,3 +675,9 @@ export function toggleBoxes(
 	displayWhenUnchecked?: boolean,
 	toggleChildCheckboxes?: boolean
 ): void;
+
+export function toggleRadio(
+	radioId: string,
+	showBoxIds: string | string[],
+	hideBoxIds?: string | string[]
+): void;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -115,6 +115,7 @@ export {default as selectFolder} from './liferay/util/select_folder';
 export {default as toggleBoxes} from './liferay/util/toggle_boxes';
 export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';
+export {default as toggleRadio} from './liferay/util/toggle_radio';
 export {
 	getCheckedCheckboxes,
 	getUncheckedCheckboxes,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -94,6 +94,7 @@ import toCharCode from './util/to_char_code.es';
 import toggleBoxes from './util/toggle_boxes';
 import toggleControls from './util/toggle_controls';
 import toggleDisabled from './util/toggle_disabled';
+import toggleRadio from './util/toggle_radio';
 import zIndex from './zIndex';
 
 Liferay = window.Liferay || {};
@@ -335,6 +336,7 @@ Liferay.Util.Session = {
 
 Liferay.Util.toggleBoxes = toggleBoxes;
 Liferay.Util.toggleControls = toggleControls;
+Liferay.Util.toggleRadio = toggleRadio;
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -515,6 +515,12 @@ declare module Liferay {
 			toggleChildCheckboxes?: boolean
 		): void;
 
+		export function toggleRadio(
+			radioId: string,
+			showBoxIds: string | string[],
+			hideBoxIds?: string | string[]
+		): void;
+
 		/**
 		 * Unescapes HTML from the given string.
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_radio.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_radio.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function toggleRadio(radioId, showBoxIds, hideBoxIds) {
+	const radioButton = document.getElementById(radioId);
+
+	if (radioButton) {
+		let showBoxes;
+
+		if (showBoxIds) {
+			if (Array.isArray(showBoxIds)) {
+				showBoxIds = showBoxIds.join(',#');
+			}
+
+			showBoxes = document.querySelectorAll(`#${showBoxIds}`);
+
+			showBoxes.forEach((showBox) => {
+				if (radioButton.checked) {
+					showBox.classList.remove('hide');
+				}
+				else {
+					showBox.classList.add('hide');
+				}
+			});
+		}
+
+		radioButton.addEventListener('change', () => {
+			if (showBoxes) {
+				showBoxes.forEach((showBox) => {
+					showBox.classList.remove('hide');
+				});
+			}
+
+			if (hideBoxIds) {
+				if (Array.isArray(hideBoxIds)) {
+					hideBoxIds = hideBoxIds.join(',#');
+				}
+
+				const hideBoxes = document.querySelectorAll(`#${hideBoxIds}`);
+
+				hideBoxes.forEach((hideBox) => {
+					hideBox.classList.add('hide');
+				});
+			}
+		});
+	}
+}

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/JournalTemplate.js
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/JournalTemplate.js
@@ -18,6 +18,7 @@ import {
 	fetch,
 	openSelectionModal,
 	openToast,
+	toggleRadio,
 } from 'frontend-js-web';
 
 export default function ({
@@ -127,13 +128,13 @@ export default function ({
 		),
 	];
 
-	Liferay.Util.toggleRadio(
+	toggleRadio(
 		`${namespace}ddmTemplateTypeCustom`,
 		`${namespace}customDDMTemplateContainer`,
 		null
 	);
 
-	Liferay.Util.toggleRadio(
+	toggleRadio(
 		`${namespace}ddmTemplateTypeDefault`,
 		null,
 		`${namespace}customDDMTemplateContainer`


### PR DESCRIPTION
This PR moves the `toggleRadio`  util from `frontend-js-aui-web` to `frontend-js-web`, adds the types for the util and exports it.

## 🧪 Testing
Can be tested by going to Content & Data > Documents & Media > Edit Folder

<img width="671" alt="image" src="https://user-images.githubusercontent.com/24564752/170691796-ed4b090d-88b5-4c74-bc5f-e89d3546f9f3.png">

