### PR TITLE
LPS-152608 Server Response Error 404 when trying to access Blueprints, Objects, Remote Apps, Workflow Metrics using a portal with context path

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
@@ -29,19 +29,6 @@ export default function defaultFetch(resource, init = {}) {
 	let resourceLocation = resource.url ? resource.url : resource.toString();
 
 	if (resourceLocation.startsWith('/')) {
-		const pathContext = Liferay.ThemeDisplay.getPathContext();
-
-		if (pathContext && !resourceLocation.startsWith(pathContext)) {
-			resourceLocation = pathContext + resourceLocation;
-
-			if (typeof resource === 'string') {
-				resource = resourceLocation;
-			}
-			else {
-				resource = {...resource, url: resourceLocation};
-			}
-		}
-
 		resourceLocation = window.location.origin + resourceLocation;
 	}
 
@@ -59,6 +46,12 @@ export default function defaultFetch(resource, init = {}) {
 		headers.set(key, value);
 	});
 
+	const pathContext = Liferay.ThemeDisplay.getPathContext();
+
+	if (pathContext && !resourceURL.pathname.startsWith(pathContext)) {
+		resourceURL.pathname = pathContext + resourceURL.pathname;
+	}
+
 	// eslint-disable-next-line @liferay/portal/no-global-fetch
-	return fetch(resource, {...config, ...init, headers});
+	return fetch(resourceURL, {...config, ...init, headers});
 }


### PR DESCRIPTION
### References

- [LPS-152608 Server Response Error 404 when trying to access Blueprints, Objects, Remote Apps, Workflow Metrics using a portal with context path](https://issues.liferay.com/browse/LPS-152608)
- [LPS-152729 Data Engine (Web Content) missing context path in headless calls](https://issues.liferay.com/browse/LPS-152729)
- Related to #2190 
- Related to #2178

### What is the goal of this PR?

We are fixing path context URL mutation, relevant when portal is not located in the default `ROOT` context.

The problem with current solution is that we are only modifying URLs starting with `/`, while they can take shape of either starting with `https`, or be a `URL` object.

Notes:
- @bryceosterhaus please check if the solution clashes with the origin check in any way 
I kinda feel dirty writing this code, as this URL shenanigans should ideally be always set in backend. It may be ok to have this as a sefeguard, for some edge cases, bot not as a normal practice.
- There is a problem with this solution and FDS sample module, see [slack discussion](https://liferay.slack.com/archives/C02CH9Q6Q21/p1653661755734479). I believe this is caused by the special hardcoded way of generating sample data. It is limited to the case where sample module is in different context than default, so it should be safe to move forward with the solution as it is, and deal with the sample module in a seperate task.

/cc @dsanz @mbowerman @diegonvs 

### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/170735647-1990fbd7-6bfb-47e6-8cda-39de93e3880a.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/170735635-5ff9d476-7798-4050-b723-bbcb889f85cb.gif)

### Steps to reproduce

See steps to reproduce in the linked JIRA tickets.