### PR TITLE
LPS-154940 Take into account if the restContextPath contains a portal context path

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/jaxrs/context/provider/ObjectDefinitionContextProvider.java
@@ -49,6 +49,9 @@ public class ObjectDefinitionContextProvider
 		String restContextPath = (String)message.getContextualProperty(
 			"org.apache.cxf.message.Message.BASE_PATH");
 
+		int indexOf = restContextPath.indexOf("/o/");
+
+		restContextPath = restContextPath.substring(indexOf);
 		restContextPath = StringUtil.removeFirst(restContextPath, "/o");
 		restContextPath = StringUtil.replaceLast(restContextPath, '/', "");
 


### PR DESCRIPTION
Related ticket -> [LPS-154940](https://issues.liferay.com/browse/LPS-154940)
______
When there is a portal with a context path, the context provider of the object definition in the Object REST APIs does not take it into account and fails to retrieve the Object, which causes a NullPointerException.

This PR takes into account this context path and handles that URL.

Steps to reproduce copied from the related ticket

1. Change the ROOT folder name, under `{LIFERAY_HOME}/tomcat-9.0.17/webapps/ROOT) to 'myportal'`
2. Change the ROOT.xml file name, under `{LIFERAY_HOME}/tomcat-9.0.17/conf/Catalina/localhost/) to 'myportal.xml'`
5. Change the ROOT to 'myportal' in the `tomcat-9.0.53\conf\catalina.properties` file
6. Clear temp and work directories under `TOMCAT_HOME`
7. Start the server and log in as admin
8. Navigate to http://localhost:8080/myportal/
9. Create and Object definition and publish it
10. Go to http://localhost:8080/myportal/o/api
11. Select the Object APIs
12. Do a request

To test this solution just deploy the module `object-rest-impl`