### PR TITLE
LPS-153239 | StructuredContent can be modified priority value

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -231,28 +231,12 @@ definition {
 		return "${curl}";
 	}
 
-	macro assertPriorityFieldIsFilteredWithCorrectValue {
-		var actualPriorityValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..['priority']");
+	macro assertPriorityFieldWithCorrectValue {
+		var actualPriorityValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..priority");
 
 		TestUtils.assertEquals(
 			actual = "${actualPriorityValue}",
 			expected = "${expectedPriorityValue}");
-	}
-
-	macro assertPriorityFieldIsSortedWithCorrectValue {
-		var actualPriorityValueList = JSONUtil.getWithJSONPath("${responseToParse}", "$..['priority']");
-
-		TestUtils.assertEquals(
-			actual = "${actualPriorityValueList}",
-			expected = "${expectedPriorityValueList}");
-	}
-
-	macro assertPriorityFieldWithDefaultValue {
-		var actualPriorityDefaultValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.priority");
-
-		TestUtils.assertEquals(
-			actual = "${actualPriorityDefaultValue}",
-			expected = "${expectedPriorityDefaultValue}");
 	}
 
 	macro assertProperNumberOfItems {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -49,8 +49,8 @@ definition {
 		}
 
 		task ("Then the response body includes the default priority field") {
-			HeadlessWebcontentAPI.assertPriorityFieldWithDefaultValue(
-				expectedPriorityDefaultValue = "0.0",
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "0.0",
 				responseToParse = "${responseToParse}");
 		}
 	}
@@ -72,8 +72,8 @@ definition {
 		}
 
 		task ("Then the response body includes the set priority") {
-			HeadlessWebcontentAPI.assertPriorityFieldWithDefaultValue(
-				expectedPriorityDefaultValue = "1.0",
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "1.0",
 				responseToParse = "${responseToParse}");
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliveryStructuredContent.testcase
@@ -38,6 +38,40 @@ definition {
 		}
 	}
 
+	@description = "StructuredContent can be modified priority value"
+	@priority = "5"
+	test CanModifyStructuredContentPriorityValue {
+		property portal.acceptance = "true";
+
+		task ("Given a web content is created with default priority") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("when edit priority value is modified to 3.0") {
+			var response = HeadlessWebcontentAPI.editStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "3.0",
+				responseToParse = "${responseToParse}",
+				title = "WC WebContent Title");
+		}
+
+		task ("Then the response body includes the modified priority value") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "3.0",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "StructuredContent can be sorted with a set priority"
 	@priority = "5"
 	test CanSortDescendingStructuredContentsByPriority {
@@ -74,8 +108,8 @@ definition {
 		}
 
 		task ("Then the response body includes a list with descending priority") {
-			HeadlessWebcontentAPI.assertPriorityFieldIsSortedWithCorrectValue(
-				expectedPriorityValueList = "1.4,1.3,1.2",
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "1.4,1.3,1.2",
 				responseToParse = "${response}");
 		}
 	}
@@ -97,13 +131,13 @@ definition {
 		}
 
 		task ("When web contents are filtered with default priority") {
-			var responseToParse = HeadlessWebcontentAPI.filterStructuredContent(filtervalue = "priority%20eq%200.0");
+			var response = HeadlessWebcontentAPI.filterStructuredContent(filtervalue = "priority%20eq%200.0");
 		}
 
 		task ("Then the response body includes the default priority field") {
-			HeadlessWebcontentAPI.assertPriorityFieldIsFilteredWithCorrectValue(
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
 				expectedPriorityValue = "0.0",
-				responseToParse = "${responseToParse}");
+				responseToParse = "${response}");
 		}
 	}
 
@@ -151,7 +185,7 @@ definition {
 		}
 
 		task ("Then the response body only includes items with priority 1.3") {
-			HeadlessWebcontentAPI.assertPriorityFieldIsFilteredWithCorrectValue(
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
 				expectedPriorityValue = "1.3",
 				responseToParse = "${response}");
 
@@ -173,7 +207,7 @@ definition {
 		task ("When a web contents is created with default priority") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
-			var responseToParse = HeadlessWebcontentAPI.createStructuredContent(
+			var response = HeadlessWebcontentAPI.createStructuredContent(
 				data = "<p>My content</p>",
 				ddmStructureId = "${ddmStructureId}",
 				label = "Text",
@@ -182,9 +216,9 @@ definition {
 		}
 
 		task ("Then the response body includes the default priority field") {
-			HeadlessWebcontentAPI.assertPriorityFieldWithDefaultValue(
-				expectedPriorityDefaultValue = "0.0",
-				responseToParse = "${responseToParse}");
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "0.0",
+				responseToParse = "${response}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
StructuredContent can be modified priority value

**Test Plan**
Given a web content is created with default priority
when edit priority value is modified to 3.0
Then the response body includes the modified priority value

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-153239