### PR TITLE
LPS-155079 Use different filterable function in localized String fields to allow "contains" filter type

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataDefinitionEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataDefinitionEntityModel.java
@@ -15,7 +15,6 @@
 package com.liferay.data.engine.rest.internal.odata.entity.v2_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -41,9 +40,8 @@ public class DataDefinitionEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_name_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_name")),
+				locale -> Field.getLocalizedName(locale, "localized_name")));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataDefinitionEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataDefinitionEntityModel.java
@@ -41,8 +41,9 @@ public class DataDefinitionEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_name_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataLayoutEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataLayoutEntityModel.java
@@ -15,7 +15,6 @@
 package com.liferay.data.engine.rest.internal.odata.entity.v2_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -41,9 +40,8 @@ public class DataLayoutEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_name_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_name")),
+				locale -> Field.getLocalizedName(locale, "localized_name")));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataLayoutEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataLayoutEntityModel.java
@@ -41,8 +41,9 @@ public class DataLayoutEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_name_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataListViewEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataListViewEntityModel.java
@@ -15,7 +15,6 @@
 package com.liferay.data.engine.rest.internal.odata.entity.v2_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -41,9 +40,8 @@ public class DataListViewEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_name_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_name")),
+				locale -> Field.getLocalizedName(locale, "localized_name")));
 	}
 
 	@Override

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataListViewEntityModel.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/odata/entity/v2_0/DataListViewEntityModel.java
@@ -41,8 +41,9 @@ public class DataListViewEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_name_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -64,12 +64,14 @@ public class StructuredContentEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(
 					StringBundler.concat(
 						"urlTitle_", LocaleUtil.toLanguageId(locale),
-						"_String"))),
+						"_String")),
+				locale -> "urlTitle_".concat(LocaleUtil.toLanguageId(locale))),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -15,9 +15,7 @@
 package com.liferay.headless.admin.content.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.DoubleEntityField;
@@ -62,16 +60,13 @@ public class StructuredContentEntityModel implements EntityModel {
 			new StringEntityField(
 				"friendlyUrlPath",
 				locale -> Field.getSortableFieldName(
-					StringBundler.concat(
-						"urlTitle_", LocaleUtil.toLanguageId(locale),
-						"_String")),
-				locale -> "urlTitle_".concat(LocaleUtil.toLanguageId(locale))),
+					Field.getLocalizedName(locale, "urlTitle") + "_String"),
+				locale -> Field.getLocalizedName(locale, "urlTitle")),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/odata/entity/v1_0/ListTypeEntryEntityModel.java
@@ -43,7 +43,8 @@ public class ListTypeEntryEntityModel implements EntityModel {
 			new StringEntityField(
 				Field.NAME,
 				locale -> Field.getSortableFieldName(
-					Field.getLocalizedName(locale, "localized_name"))));
+					Field.getLocalizedName(locale, "localized_name")),
+				locale -> Field.getLocalizedName(locale, "localized_name")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -42,9 +41,8 @@ public class CategoryEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale)),
-				locale ->
-					"localized_title_" + LocaleUtil.toLanguageId(locale)));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/CategoryEntityModel.java
@@ -42,7 +42,9 @@ public class CategoryEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale))));
+					"localized_title_" + LocaleUtil.toLanguageId(locale)),
+				locale ->
+					"localized_title_" + LocaleUtil.toLanguageId(locale)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.admin.taxonomy.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -42,9 +41,8 @@ public class VocabularyEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale)),
-				locale ->
-					"localized_title_" + LocaleUtil.toLanguageId(locale)));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/odata/entity/v1_0/VocabularyEntityModel.java
@@ -42,7 +42,9 @@ public class VocabularyEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_" + LocaleUtil.toLanguageId(locale))));
+					"localized_title_" + LocaleUtil.toLanguageId(locale)),
+				locale ->
+					"localized_title_" + LocaleUtil.toLanguageId(locale)));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
@@ -51,8 +51,9 @@ public class BlogPostingImageEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/BlogPostingImageEntityModel.java
@@ -17,7 +17,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -51,9 +50,8 @@ public class BlogPostingImageEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.DoubleEntityField;
@@ -65,9 +64,8 @@ public class ContentElementEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentElementEntityModel.java
@@ -65,8 +65,9 @@ public class ContentElementEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
@@ -42,8 +42,9 @@ public class ContentStructureEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_name_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/ContentStructureEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -42,9 +41,8 @@ public class ContentStructureEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_name_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_name_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
@@ -17,7 +17,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
@@ -71,9 +70,8 @@ public class DocumentEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/DocumentEntityModel.java
@@ -71,8 +71,9 @@ public class DocumentEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -56,9 +55,8 @@ public class KnowledgeBaseArticleEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/KnowledgeBaseArticleEntityModel.java
@@ -56,8 +56,9 @@ public class KnowledgeBaseArticleEntityModel implements EntityModel {
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
@@ -77,9 +76,8 @@ public class MessageBoardMessageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/MessageBoardMessageEntityModel.java
@@ -77,8 +77,9 @@ public class MessageBoardMessageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -15,9 +15,7 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.CollectionEntityField;
 import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
@@ -72,16 +70,13 @@ public class StructuredContentEntityModel implements EntityModel {
 			new StringEntityField(
 				"friendlyUrlPath",
 				locale -> Field.getSortableFieldName(
-					StringBundler.concat(
-						"urlTitle_", LocaleUtil.toLanguageId(locale),
-						"_String")),
-				locale -> "urlTitle_".concat(LocaleUtil.toLanguageId(locale))),
+					Field.getLocalizedName(locale, "urlTitle") + "_String"),
+				locale -> Field.getLocalizedName(locale, "urlTitle")),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentEntityModel.java
@@ -74,12 +74,14 @@ public class StructuredContentEntityModel implements EntityModel {
 				locale -> Field.getSortableFieldName(
 					StringBundler.concat(
 						"urlTitle_", LocaleUtil.toLanguageId(locale),
-						"_String"))),
+						"_String")),
+				locale -> "urlTitle_".concat(LocaleUtil.toLanguageId(locale))),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
@@ -16,7 +16,6 @@ package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.headless.common.spi.odata.entity.EntityFieldsMapFactory;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -47,9 +46,8 @@ public class StructuredContentFolderEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/StructuredContentFolderEntityModel.java
@@ -47,8 +47,9 @@ public class StructuredContentFolderEntityModel implements EntityModel {
 			new StringEntityField(
 				"name",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
@@ -15,7 +15,6 @@
 package com.liferay.headless.delivery.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.ComplexEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -44,9 +43,8 @@ public class WikiPageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "localized_title_".concat(
-					LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, "localized_title")),
+				locale -> Field.getLocalizedName(locale, "localized_title")));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/odata/entity/v1_0/WikiPageEntityModel.java
@@ -44,8 +44,9 @@ public class WikiPageEntityModel implements EntityModel {
 			new StringEntityField(
 				"headline",
 				locale -> Field.getSortableFieldName(
-					"localized_title_".concat(
-						LocaleUtil.toLanguageId(locale)))));
+					"localized_title_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "localized_title_".concat(
+					LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java
+++ b/modules/apps/portal-odata/portal-odata-api/src/main/java/com/liferay/portal/odata/entity/StringEntityField.java
@@ -44,4 +44,25 @@ public class StringEntityField extends EntityField {
 			filterableAndSortableFieldNameFunction, String::valueOf);
 	}
 
+	/**
+	 * Creates a new {@code StringEntityField} with a {@code Function} to
+	 * convert the entity field's name to a filterable/sortable field name for a
+	 * locale.
+	 *
+	 * @param  name the entity field's name
+	 * @param  sortableFieldNameFunction the sortable field name {@code
+	 *         Function}
+	 * @param  filterableFieldNameFunction the filterable field name {@code
+	 *         Function}
+	 * @review
+	 */
+	public StringEntityField(
+		String name, Function<Locale, String> sortableFieldNameFunction,
+		Function<Locale, String> filterableFieldNameFunction) {
+
+		super(
+			name, Type.STRING, sortableFieldNameFunction,
+			filterableFieldNameFunction, String::valueOf);
+	}
+
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/odata/entity/v1_0/InstanceEntityModel.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/odata/entity/v1_0/InstanceEntityModel.java
@@ -36,7 +36,8 @@ public class InstanceEntityModel implements EntityModel {
 			new StringEntityField(
 				"assetType",
 				locale -> Field.getSortableFieldName(
-					"assetType_".concat(LocaleUtil.toLanguageId(locale)))),
+					"assetType_".concat(LocaleUtil.toLanguageId(locale))),
+				locale -> "assetType_".concat(LocaleUtil.toLanguageId(locale))),
 			new StringEntityField("assigneeName", locale -> "assigneeName"),
 			new DateTimeEntityField(
 				"dateCreated", locale -> "createDate", locale -> "createDate"),

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/odata/entity/v1_0/InstanceEntityModel.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/odata/entity/v1_0/InstanceEntityModel.java
@@ -15,7 +15,6 @@
 package com.liferay.portal.workflow.metrics.rest.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -36,8 +35,8 @@ public class InstanceEntityModel implements EntityModel {
 			new StringEntityField(
 				"assetType",
 				locale -> Field.getSortableFieldName(
-					"assetType_".concat(LocaleUtil.toLanguageId(locale))),
-				locale -> "assetType_".concat(LocaleUtil.toLanguageId(locale))),
+					Field.getLocalizedName(locale, "assetType")),
+				locale -> Field.getLocalizedName(locale, "assetType")),
 			new StringEntityField("assigneeName", locale -> "assigneeName"),
 			new DateTimeEntityField(
 				"dateCreated", locale -> "createDate", locale -> "createDate"),

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
@@ -15,8 +15,6 @@
 package com.liferay.search.experiences.rest.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -44,17 +42,13 @@ public class SXPBlueprintEntityModel implements EntityModel {
 			new StringEntityField(
 				"description",
 				locale -> Field.getSortableFieldName(
-					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
-				locale -> LocalizationUtil.getLocalizedName(
-					Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+					Field.getLocalizedName(locale, Field.DESCRIPTION)),
+				locale -> Field.getLocalizedName(locale, Field.DESCRIPTION)),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale))),
-				locale -> LocalizationUtil.getLocalizedName(
-					Field.TITLE, LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, Field.TITLE)),
+				locale -> Field.getLocalizedName(locale, Field.TITLE)));
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPBlueprintEntityModel.java
@@ -45,12 +45,16 @@ public class SXPBlueprintEntityModel implements EntityModel {
 				"description",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale)))),
+						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+				locale -> LocalizationUtil.getLocalizedName(
+					Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale)))));
+						Field.TITLE, LocaleUtil.toLanguageId(locale))),
+				locale -> LocalizationUtil.getLocalizedName(
+					Field.TITLE, LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
@@ -15,8 +15,6 @@
 package com.liferay.search.experiences.rest.internal.odata.entity.v1_0;
 
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -45,17 +43,13 @@ public class SXPElementEntityModel implements EntityModel {
 			new StringEntityField(
 				"description",
 				locale -> Field.getSortableFieldName(
-					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
-				locale -> LocalizationUtil.getLocalizedName(
-					Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+					Field.getLocalizedName(locale, Field.DESCRIPTION)),
+				locale -> Field.getLocalizedName(locale, Field.DESCRIPTION)),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
-					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale))),
-				locale -> LocalizationUtil.getLocalizedName(
-					Field.TITLE, LocaleUtil.toLanguageId(locale))));
+					Field.getLocalizedName(locale, Field.TITLE)),
+				locale -> Field.getLocalizedName(locale, Field.TITLE)));
 	}
 
 	@Override

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/odata/entity/v1_0/SXPElementEntityModel.java
@@ -46,12 +46,16 @@ public class SXPElementEntityModel implements EntityModel {
 				"description",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale)))),
+						Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
+				locale -> LocalizationUtil.getLocalizedName(
+					Field.DESCRIPTION, LocaleUtil.toLanguageId(locale))),
 			new StringEntityField(
 				"title",
 				locale -> Field.getSortableFieldName(
 					LocalizationUtil.getLocalizedName(
-						Field.TITLE, LocaleUtil.toLanguageId(locale)))));
+						Field.TITLE, LocaleUtil.toLanguageId(locale))),
+				locale -> LocalizationUtil.getLocalizedName(
+					Field.TITLE, LocaleUtil.toLanguageId(locale))));
 	}
 
 	@Override


### PR DESCRIPTION
This PR contains the code to allow passing a different function to filter a field for the String field type different from the function passed to Sort them.

For the cases than a field is localizable, the document inserted into ElasticSearch contains a field for each localization, whose sorteable field is of the type `icu_collation_keyword`, for example for Journal Articles (see the field `title` and the different localizations):

```
      {
          [...]
          "title_en_US" : "jfehlglm",
          [...]
          "urlTitle_en_US" : "k5yidght",
          [...]
          "latest" : "true",
          "entryClassName" : "com.liferay.journal.model.JournalArticle",
          "roleId" : "20107",
          "articleId" : "44062",
          "contentLength_en_US_sortable" : 10,
          "userName" : "test test",
          "userId" : "20126",
          "urlTitle_en_US_String_sortable" : "k5yidght",
          "assetEntryId" : "44068",
          "localized_title_zh_CN" : "jfehlglm",
          "localized_title_zh_CN_sortable" : "jfehlglm",
          "localized_title_es_ES" : "jfehlglm",
          "localized_title_es_ES_sortable" : "jfehlglm",
          "localized_title_sv_SE" : "jfehlglm",
          "localized_title_sv_SE_sortable" : "jfehlglm",
          "localized_title_ja_JP" : "jfehlglm",
          "localized_title_ja_JP_sortable" : "jfehlglm",
          "localized_title_nl_NL" : "jfehlglm",
          "localized_title_nl_NL_sortable" : "jfehlglm",
          "localized_title_hu_HU" : "jfehlglm",
          "localized_title_hu_HU_sortable" : "jfehlglm",
          "localized_title_ar_SA" : "jfehlglm",
          "localized_title_ar_SA_sortable" : "jfehlglm",
          "localized_title_pt_BR" : "jfehlglm",
          "localized_title_pt_BR_sortable" : "jfehlglm",
          "localized_title_de_DE" : "jfehlglm",
          "localized_title_de_DE_sortable" : "jfehlglm",
          "localized_title_ca_ES" : "jfehlglm",
          "localized_title_ca_ES_sortable" : "jfehlglm",
          "localized_title_fi_FI" : "jfehlglm",
          "localized_title_fi_FI_sortable" : "jfehlglm",
          "localized_title_fr_FR" : "jfehlglm",
          "localized_title_fr_FR_sortable" : "jfehlglm",
          "localized_title" : "jfehlglm",
          "localized_title_en_US" : "jfehlglm",
          "localized_title_en_US_sortable" : "jfehlglm",
          [...]
        }
      }
```

If the GET endpoint is called with the contains filter over the `title` field with the following request:

```
curl -X GET -u 'test@liferay.com:test' http://localhost:8080/o/headless-delivery/v1.0/sites/20123/structured-contents?filter=contains(title,'eh')
```

**Before the PR:**

The Search engine throws an error and no values are returned. The following trace is printed:

```
Suppressed: org.elasticsearch.client.ResponseException: method [POST], host [http://127.0.0.1:9201/], URI [/liferay-20098/_search?typed_keys=true&max_concurrent_shard_requests=5&search_type=query_then_fetch&batched_reduce_size=512], status line [HTTP/1.1 400 Bad Request]
{"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: [wildcard] queries are not supported on [icu_collation_keyword] fields.","index_uuid":"63WoM56XR5CTZRAcprW7yg","index":"liferay-20098"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"liferay-20098","node":"ohdaYE72SIaqWUfboqrPrw","reason":{"type":"query_shard_exception","reason":"failed to create query: [wildcard] queries are not supported on [icu_collation_keyword] fields.","index_uuid":"63WoM56XR5CTZRAcprW7yg","index":"liferay-20098","caused_by":{"type":"unsupported_operation_exception","reason":"[wildcard] queries are not supported on [icu_collation_keyword] fields."}}}]},"status":400}
```

**After the PR:**

The Structured Content is returned successfully if applies
