### PR TITLE
LPS-154813 - Update alloy-ui to 3.1.0-deprecated.95

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.94"
+String alloyUIVersion = "3.1.0-deprecated.95"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.94"
+String alloyUIVersion = "3.1.0-deprecated.95"
 
 String fontAwesomeVersion = "3.2.1"
 


### PR DESCRIPTION
The previous updated missed a commit range that was needed. This newest release includes the latest commits on master of alloy-ui