### PR TITLE
LPS-152237 Modernize `toggleSelectBox`

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {delegate, toggleSelectBox} from 'frontend-js-web';
 
 export default function ({classTypes, namespace}) {
 	const mapDDMStructures = {};
@@ -224,7 +224,7 @@ export default function ({classTypes, namespace}) {
 	};
 
 	classTypes.forEach(({className, classSubtypes}) => {
-		Liferay.Util.toggleSelectBox(
+		toggleSelectBox(
 			`${namespace}anyClassType${className}`,
 			'false',
 			`${namespace}${className}Boxes`
@@ -417,7 +417,7 @@ export default function ({classTypes, namespace}) {
 
 	eventDelegates.push(clickOpenModal);
 
-	Liferay.Util.toggleSelectBox(
+	toggleSelectBox(
 		`${namespace}anyAssetType`,
 		'false',
 		`${namespace}classNamesBoxes`

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/Source.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {delegate, toggleSelectBox} from 'frontend-js-web';
 
 const ANY = 'any';
 const SELECT_MORE_THAN_ONE = 'select-more-than-one';
@@ -208,7 +208,7 @@ export default function ({assetPublisherNamespace, classTypes, namespace}) {
 	};
 
 	classTypes.forEach(({className, classSubtypes}) => {
-		Liferay.Util.toggleSelectBox(
+		toggleSelectBox(
 			`${namespace}anyClassType${className}`,
 			SELECT_MORE_THAN_ONE,
 			`${namespace}${className}Boxes`
@@ -407,7 +407,7 @@ export default function ({assetPublisherNamespace, classTypes, namespace}) {
 
 	eventDelegates.push(clickOpenModal);
 
-	Liferay.Util.toggleSelectBox(
+	toggleSelectBox(
 		`${namespace}anyAssetType`,
 		SELECT_MORE_THAN_ONE,
 		`${namespace}classNamesBoxes`

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -763,36 +763,6 @@
 				'input[type=checkbox]'
 			);
 		},
-
-		toggleSelectBox(selectBoxId, value, toggleBoxId) {
-			var selectBox = document.getElementById(selectBoxId);
-			var toggleBox = document.getElementById(toggleBoxId);
-
-			if (selectBox && toggleBox) {
-				var dynamicValue = typeof value === 'function';
-
-				var toggle = function () {
-					var currentValue = selectBox.value;
-
-					var visible = value === currentValue;
-
-					if (dynamicValue) {
-						visible = value(currentValue, value);
-					}
-
-					if (visible) {
-						toggleBox.classList.remove('hide');
-					}
-					else {
-						toggleBox.classList.add('hide');
-					}
-				};
-
-				toggle();
-
-				selectBox.addEventListener('change', toggle);
-			}
-		},
 	};
 
 	Liferay.provide(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -693,3 +693,9 @@ export function toggleRadio(
 	showBoxIds: string | string[],
 	hideBoxIds?: string | string[]
 ): void;
+
+export function toggleSelectBox(
+	selectBoxId: string,
+	value: any,
+	toggleBoxId: string
+): void;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -116,6 +116,7 @@ export {default as toggleBoxes} from './liferay/util/toggle_boxes';
 export {default as toggleControls} from './liferay/util/toggle_controls';
 export {default as toggleDisabled} from './liferay/util/toggle_disabled';
 export {default as toggleRadio} from './liferay/util/toggle_radio';
+export {default as toggleSelectBox} from './liferay/util/toggle_select_box';
 export {
 	getCheckedCheckboxes,
 	getUncheckedCheckboxes,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -95,6 +95,7 @@ import toggleBoxes from './util/toggle_boxes';
 import toggleControls from './util/toggle_controls';
 import toggleDisabled from './util/toggle_disabled';
 import toggleRadio from './util/toggle_radio';
+import toggleSelectBox from './util/toggle_select_box';
 import zIndex from './zIndex';
 
 Liferay = window.Liferay || {};
@@ -337,6 +338,7 @@ Liferay.Util.Session = {
 Liferay.Util.toggleBoxes = toggleBoxes;
 Liferay.Util.toggleControls = toggleControls;
 Liferay.Util.toggleRadio = toggleRadio;
+Liferay.Util.toggleSelectBox = toggleSelectBox;
 Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -521,6 +521,12 @@ declare module Liferay {
 			hideBoxIds?: string | string[]
 		): void;
 
+		export function toggleSelectBox(
+			selectBoxId: string,
+			value: any,
+			toggleBoxId: string
+		): void;
+
 		/**
 		 * Unescapes HTML from the given string.
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_select_box.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/toggle_select_box.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const toggle = (selectBox, toggleBox, dynamicValue, value) => {
+	const currentValue = selectBox.value;
+
+	const visible = dynamicValue
+		? value(currentValue, value)
+		: value === currentValue;
+
+	toggleBox.classList.toggle('hide', !visible);
+};
+
+export default function toggleSelectBox(selectBoxId, value, toggleBoxId) {
+	const selectBox = document.getElementById(selectBoxId);
+	const toggleBox = document.getElementById(toggleBoxId);
+
+	if (!selectBox || !toggleBox) {
+		return;
+	}
+
+	const dynamicValue = typeof value === 'function';
+
+	toggle(selectBox, toggleBox, dynamicValue, value);
+
+	selectBox.addEventListener('change', () =>
+		toggle(selectBox, toggleBox, dynamicValue, value)
+	);
+}


### PR DESCRIPTION
This PR modernizes the `Liferay.Util.toggleSelectBox` utility. The utility accepts 2 elements and a value, where the 1st element is used to change the state of the 2nd element depending on the value.

## 🧪 Testing
In the sidebar of Web Content, under Display Page, switching between Specific, Default, and None will trigger the `change` event specified inside the utility.
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/24564752/171386646-2c09c246-5237-4db8-a594-cd5c21339668.png">
