### PR TITLE
LPS-152608 Fix FDS URLs when path context is not default

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -69,7 +69,8 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		try {
 			_appURL =
 				PortalUtil.getPortalURL(httpServletRequest) +
-					"/o/frontend-data-set-taglib/app";
+					PortalUtil.getPathContext() +
+						"/o/frontend-data-set-taglib/app";
 
 			StringBundler sb = new StringBundler(
 				11 + (_contextParams.size() * 4));

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -228,7 +228,12 @@ export async function loadData(
 	page = 1,
 	sorting = []
 ) {
-	const url = new URL(apiURL, themeDisplay.getPortalURL());
+	const fullUrl = apiURL.startsWith('/')
+		? themeDisplay.getPortalURL() + themeDisplay.getPathContext() + apiURL
+		: apiURL;
+
+	const url = new URL(fullUrl);
+
 	const providedFilters = url.searchParams.get('filter');
 
 	url.searchParams.delete('filter');


### PR DESCRIPTION
### References

- [LPS-152608 Server Response Error 404 when trying to access Blueprints, Objects, Remote Apps, Workflow Metrics using a portal with context path](https://issues.liferay.com/browse/LPS-152608)
- [LPS-152729 Data Engine (Web Content) missing context path in headless calls](https://issues.liferay.com/browse/LPS-152729)
- Related to #2190 
- Related to #2178
- Followup on #2281

### What is the goal of this PR?

The solution in this PR only partially fixes the issue. We are fixing FDS handling of non-default path context, but there are still rest clients in `search-experiences` and `portal-workflow-metrics` that need fixing.

There is a lot going on here:
- In an ideal world, we would not need to modify anything in frontend. A full URL would be passed to the `fetch` utility, and we make requests to that URL. 
- In #2190 we introduced support for relative paths. If `fetch` utils gets a relative path, we append domain and path context.
- The problem in this ticket is that we incorrectly building URLs in several places in DXP. We are setting domain and path, but  not adding path context. See changes in this PR, where we were missing path context in FDS URLs.
- in #2281 I tried to compensate this, with a quick & dirty patch in the `fetch` util. I basically split the incorrect URL and added path context in the middle. I used `URL` API for this. Unfortunately, that approach has one big problem: it breaks the `fetch-mock` library. We are using it in many places in DXP. The problem is that `URL` API changes URL, adding `/` on end and changing it to lower case. `fetch-mock` library requires URL to stay the same.
- There is an alternative to using `URL`, we can add path context with only string manipulation, using few complex regexes. The whole concept of compensating bad URLs in frontend is ugly enough, but adding another layer of ugliness and fragile code, I think would be just too much.
- The more I worked on this, the more I became convinced that we should fix this not in `fetch` utility, but in original building of URL. This is what we are doing in this PR. We are fixing URL building in FDS. This covers some cases in the original ticket, but not all.
- Rest clients in `search-experiences` and `portal-workflow-metrics` are still broken. I'm hoping product teams can fix these in separate tasks. Here is, for example, how [we are building url in portal-workflow-metrics](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/SLAResource.java#L246-L249).  I'm guessing we need to add something like `+ _builder._pathContext`. I am not sure what else needs to done here.
- In my opinion, something we should consider is to drop support for relative URLs in the `fetch` util, and completely rely on backend to build full URLs. But, I do understand this would require a lot of changes, it might not be worth the effort. But, we should be extremely careful about adding any additional logic to `fetch` utility. It is suppose to be a thin wrapper on vanilla `fetch`, not a convenient method of compensating backend inadequacies.

/cc @dsanz @mbowerman @diegonvs

### Steps to reproduce
See steps to reproduce in the JIRA ticket. Out of the cases there, this PR fixes the ones with :heavy_check_mark:

:x: Go to Open Menu -> Workflow -> Metrics
:x: Go to Open Menu -> Search Experiences -> Blueprints. The main FDS works, but Edit Blueprint causes an error.
:heavy_check_mark: Go to Open Menu -> Custom Apps -> Remote Apps
:heavy_check_mark: Go to Open Menu -> Control Panel -> Object -> Objects

I could not reproduce:
- Go to Open Menu -> Workflow -> Process Builder -> Single Approver
- Go to Open Menu -> Workflow -> Process Builder -> Add a new Workflow > Add a connection between start and end node and try do save or publish