### PR TITLE
LPS-155104 Handle entityFields with date type

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/odata/entity/v1_0/ObjectEntryEntityModel.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.odata.entity.BooleanEntityField;
 import com.liferay.portal.odata.entity.CollectionEntityField;
-import com.liferay.portal.odata.entity.DateEntityField;
 import com.liferay.portal.odata.entity.DateTimeEntityField;
 import com.liferay.portal.odata.entity.DoubleEntityField;
 import com.liferay.portal.odata.entity.EntityField;
@@ -168,7 +167,7 @@ public class ObjectEntryEntityModel implements EntityModel {
 					ObjectFieldConstants.DB_TYPE_DATE)) {
 
 			return Optional.of(
-				new DateEntityField(
+				new DateTimeEntityField(
 					objectField.getName(),
 					locale ->
 						"nestedFieldArray.value_date#" + objectField.getName(),


### PR DESCRIPTION
Related ticket -> [LPS-155104](https://issues.liferay.com/browse/LPS-155104)
____
When exists a custom object with a custom field of type Date, the REST API related to the custom object does not support the date format sent by the API and used in the Liferay REST APIs.

This PR changes this behavior and makes it consistent with the Liferay APIs.
