### PR TITLE
LPS-152232 Modernize `Liferay.Util.openWindow`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -550,16 +550,6 @@
 			Liferay.Util.openWindow(config);
 		},
 
-		openWindow(config, callback) {
-			config.openingWindow = window;
-
-			var top = Util.getTop();
-
-			var topUtil = top.Liferay.Util;
-
-			topUtil._openWindowProvider(config, callback);
-		},
-
 		/**
 		 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
 		 */

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1297,6 +1297,10 @@
 		['aui-base', 'liferay-util-window']
 	);
 
+	/**
+	 * Used in `modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/open_window.js`
+	 * which will need to be migrated over to `openModal`.
+	 */
 	Liferay.provide(
 		Util,
 		'_openWindowProvider',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -667,6 +667,8 @@ export function openToast({
 	variant?: string;
 }): void;
 
+export function openWindow(config: object, callback?: Function): void;
+
 export function fetch(resource: string | Request, init?: Object): Promise<any>;
 
 export function getCheckedCheckboxes(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -108,6 +108,7 @@ export {default as isTablet} from './liferay/util/is_tablet';
 export {default as getSelectedOptionValues} from './liferay/util/get_selected_option_values';
 export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
+export {default as openWindow} from './liferay/util/open_window';
 export {default as removeEntitySelection} from './liferay/util/remove_entity_selection';
 export {default as showCapsLock} from './liferay/util/show_caps_lock';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -81,6 +81,7 @@ import navigate from './util/navigate.es';
 import normalizeFriendlyURL from './util/normalize_friendly_url';
 import ns from './util/ns.es';
 import objectToURLSearchParams from './util/object_to_url_search_params.es';
+import openWindow from './util/open_window';
 import createActionURL from './util/portlet_url/create_action_url.es';
 import createPortletURL from './util/portlet_url/create_portlet_url.es';
 import createRenderURL from './util/portlet_url/create_render_url.es';
@@ -325,6 +326,7 @@ Liferay.Util.openToast = (...args) => {
 	);
 };
 
+Liferay.Util.openWindow = openWindow;
 Liferay.Util.removeEntitySelection = removeEntitySelection;
 Liferay.Util.selectFolder = selectFolder;
 Liferay.Util.showCapsLock = showCapsLock;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -453,6 +453,8 @@ declare module Liferay {
 			variant?: string;
 		}): void;
 
+		export function openWindow(config: object, callback?: Function): void;
+
 		/**
 		 * Submits the form, with optional setting of form elements.
 		 */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/open_window.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/open_window.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getTop from './get_top';
+
+export default function openWindow(config, callback) {
+	const topUtil = getTop();
+
+	config.openingWindow = window;
+
+	topUtil.Liferay.Util._openWindowProvider(config, callback);
+}


### PR DESCRIPTION
I've decided to "modernize" this util by moving it to frontend-js-web, keeping the ancient `topUtil.Liferay.Util._openWindowProvider(config, callback);` line because we can't modernize that without modernizing `Liferay.provide`, which we will do some time in the future.

## 🧪 Testing
Can be tested by dragging a Calendar portlet onto landing page and clicking on `Add Event`  button, which will invoke the function and open the modal if it works properly.