### PR TITLE
[TS] LPS-155136 Gather all of the available checkboxes and consturction an add/remove list from that

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -130,20 +130,44 @@ function AssetTagsSelector({
 
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
+			getSelectedItemsOnly: false,
 			multiple: true,
 			onSelect: (dialogSelectedItems) => {
 				if (!dialogSelectedItems?.length) {
 					return;
 				}
 
-				const newValues = dialogSelectedItems.map((item) => {
-					return {
-						label: item.value,
-						value: item.value,
-					};
-				});
+				let [newValues, removedValues] = dialogSelectedItems.reduce(
+					([checked, unchecked], item) => {
+						if (item.checked) {
+							return [
+								[
+									...checked,
+									{
+										label: item.value,
+										value: item.value,
+									},
+								],
+								unchecked,
+							];
+						}
+						else {
+							return [
+								checked,
+								[
+									...unchecked,
+									{
+										label: item.value,
+										value: item.value,
+									},
+								],
+							];
+						}
+					},
+					[[], []]
+				);
 
-				const addedItems = newValues.filter(
+				newValues = newValues.filter(
 					(newValue) =>
 						!selectedItems.find(
 							(selectedItem) =>
@@ -151,20 +175,24 @@ function AssetTagsSelector({
 						)
 				);
 
-				const removedItems = selectedItems.filter(
-					(selectedItem) =>
-						!newValues.find(
-							(newValue) => newValue.label === selectedItem.label
-						)
+				removedValues = selectedItems.filter((selectedItem) =>
+					removedValues.find(
+						(removedValue) =>
+							removedValue.label === selectedItem.label
+					)
 				);
 
-				onSelectedItemsChange(newValues);
+				const allSelectedItems = selectedItems
+					.concat(newValues)
+					.filter((item) => !removedValues.includes(item));
 
-				addedItems.forEach((item) =>
+				onSelectedItemsChange(allSelectedItems);
+
+				newValues.forEach((item) =>
 					callGlobalCallback(addCallback, item)
 				);
 
-				removedItems.forEach((item) =>
+				removedValues.forEach((item) =>
 					callGlobalCallback(removeCallback, item)
 				);
 			},


### PR DESCRIPTION
### References

- [LPS-155136 Tags can be lost if the page they are on is not accessed in the selection modal](https://issues.liferay.com/browse/LPS-155136)

### What is the goal of this PR?

The goal of this PR is to maintain previously selected tags even if the results page they reside upon is not loaded.

Currently, the list of selected tags is only populated with the tags that have been rendered in the modal window. If some tags on page 2 of the results were previously selected but page 2 is never accessed then those selected tags will be removed.

What the changes in this pull do is to fetch all of the potential tags from the search container. Then we are able to create add and remove arrays which contain everyone, not just what was rendered. Finally, those added and removed values are merged with the previously selected tags to create the full list of selected tags.

### What does it look like?

No changes in the UI.

### Steps to reproduce

1. Set search.container.page.default.delta=5 for easier testing.
2. Create at least 6 tags (more can make testing clearer to see, but this is the bare minimum).
3. Go to Documents & Media > Upload File.
4. In the "Categorization" section, find the tags selector. Open the selection modal with the "Select" button. There should be at least two pages of tags in this modal. If there isn't, either set the property in step 1 or create more tags as necessary.
5. Select one tag on the first page and one tag on the second page. Save.
6. The tags should properly appear in the selector.  Open the selection modal again.
7. You should see the tag on the first page still selected. Select another tag on the first page. Save *without* accessing the second page.

*Expected:*
There are three tags selected, two from the first page and the one from the second page.

*Actual:*
Only two tags now appear: the two from the first page.