### PR TITLE
LPS-152820 | Nested fields in oneToMany relationship after object deletion

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -35,7 +35,7 @@ definition {
 	}
 
 	macro _createEmployee {
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/c/employees \
@@ -54,7 +54,7 @@ definition {
 	}
 
 	macro _createManager {
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/c/managers \
@@ -74,7 +74,7 @@ definition {
 	macro _createObjectDefinition {
 		Variables.assertDefined(parameterList = "${en_US_label},${name},${requiredStringFieldName},${en_US_plural_label}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions \
@@ -115,7 +115,7 @@ definition {
 	macro _createRelationship {
 		Variables.assertDefined(parameterList = "${deletionType},${en_US_label},${name},${objectDefinitionId1},${objectDefinitionId2},${type}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId1}/object-relationships \
@@ -141,7 +141,7 @@ definition {
 	macro _deleteEmployee {
 		Variables.assertDefined(parameterList = "${employeeId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/c/employees/${employeeId} \
@@ -157,9 +157,10 @@ definition {
 	macro _getEmployeeFirstnameById {
 		Variables.assertDefined(parameterList = "${employeeId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
+
 		var curl = '''
-        	http://localhost:8080/o/c/employees/${employeeId} \
+        	${portalURL}/o/c/employees/${employeeId} \
 			-u test@liferay.com:test
 		''';
 
@@ -171,9 +172,10 @@ definition {
 	macro _getManagerFirstnameById {
 		Variables.assertDefined(parameterList = "${managerId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
+
 		var curl = '''
-        	http://localhost:8080/o/c/managers/${managerId} \
+        	${portalURL}/o/c/managers/${managerId} \
 			-u test@liferay.com:test
 		''';
 
@@ -197,7 +199,7 @@ definition {
 	macro _getObjectDefinitionStatusById {
 		Variables.assertDefined(parameterList = "${objectDefinitionId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
         	${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId} \
@@ -218,7 +220,7 @@ definition {
 	macro _getObjectsWithNestedField {
 		Variables.assertDefined(parameterList = "${nestedField}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
         	${portalURL}/o/c/${objects}?nestedFields=${nestedField} \
@@ -233,9 +235,10 @@ definition {
 	macro _getRelationshipNameById {
 		Variables.assertDefined(parameterList = "${relationshipId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
+
 		var curl = '''
-        	http://localhost:8080/o/object-admin/v1.0/object-relationships/${relationshipId} \
+        	${portalURL}/o/object-admin/v1.0/object-relationships/${relationshipId} \
 			-u test@liferay.com:test
 		''';
 
@@ -247,7 +250,7 @@ definition {
 	macro _publishObjectDefinition {
 		Variables.assertDefined(parameterList = "${objectDefinitionId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
         	${portalURL}/o/object-admin/v1.0/object-definitions/${objectDefinitionId}/publish \
@@ -262,7 +265,7 @@ definition {
 	macro _updateEmployee {
 		Variables.assertDefined(parameterList = "${employeeId},${firstname},${managerId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/c/employees/${employeeId} \

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -138,6 +138,22 @@ definition {
 		return "${relationshipId}";
 	}
 
+	macro _deleteEmployee {
+		Variables.assertDefined(parameterList = "${employeeId}");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/employees/${employeeId} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var response = JSONCurlUtil.delete("${curl}");
+
+		return "${response}";
+	}
+
 	macro _getEmployeeFirstnameById {
 		Variables.assertDefined(parameterList = "${employeeId}");
 
@@ -287,6 +303,34 @@ definition {
 			responseToParse = "${responseToParse}");
 	}
 
+	macro assertResponseIncludesDetailsOfNotDeletedEmployee {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..items[?(@.id==${employeeId2} && @.r_supervisor_c_managerId==${managerId2})].r_supervisor_c_managerId");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${managerId2}");
+	}
+
+	macro assertResponseNotIncludesDetailsOfDeletedEmployee {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..items[?(@.id==${employeeId1} && @.r_supervisor_c_managerId==${managerId1})].r_supervisor_c_managerId");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "");
+	}
+
+	macro assertResponseOnlyIncludesDetailsOfNotDeletedEmployee {
+		ObjectDefinitionAPI.assertResponseNotIncludesDetailsOfDeletedEmployee(
+			employeeId1 = "${employeeId1}",
+			managerId1 = "${managerId1}",
+			responseToParse = "${responseToParse}");
+
+		ObjectDefinitionAPI.assertResponseIncludesDetailsOfNotDeletedEmployee(
+			employeeId2 = "${employeeId2}",
+			managerId2 = "${managerId2}",
+			responseToParse = "${responseToParse}");
+	}
+
 	macro createAndPublishObjectDefinition {
 		var objectDefinitionId = ObjectDefinitionAPI._createObjectDefinition(
 			en_US_label = "${en_US_label}",
@@ -347,6 +391,10 @@ definition {
 			expected = "${name}");
 
 		return "${relationshipName}";
+	}
+
+	macro deleteEmployee {
+		ObjectDefinitionAPI._deleteEmployee(employeeId = "${employeeId}");
 	}
 
 	macro getObjectsWithNestedField {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -76,6 +76,45 @@ definition {
 		}
 	}
 
+	@description = "Nested fields in oneToMany relationship after object deletion"
+	@priority = "5"
+	test CanReturnNestedFieldsDetailsInOneToManyRelationshipAfterObjectDeletion {
+		property portal.acceptance = "true";
+
+		task ("Given two manager accounts created") {
+			var managerId1 = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
+			var managerId2 = ObjectDefinitionAPI.createManager(managerFirstname = "Aaron");
+		}
+
+		task ("Given two employee accounts created") {
+			var employeeId1 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Bruce",
+				managerId = "${managerId1}");
+			var employeeId2 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Riley",
+				managerId = "${managerId2}");
+		}
+
+		task ("Given deleting one of the employees") {
+			ObjectDefinitionAPI.deleteEmployee(employeeId = "${employeeId1}");
+		}
+
+		task ("When calling for 'employees' with a 'manager' as nestedFields parameter") {
+			var responseToParse = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedObject = "manager",
+				objects = "employees");
+		}
+
+		task ("Then 'employee' information should not include 'manager' information assigned to the deleted employee") {
+			ObjectDefinitionAPI.assertResponseOnlyIncludesDetailsOfNotDeletedEmployee(
+				employeeId1 = "${employeeId1}",
+				employeeId2 = "${employeeId2}",
+				managerId1 = "${managerId1}",
+				managerId2 = "${managerId2}",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
 	@description = "Nested fields in oneToMany Updated relationship"
 	@priority = "5"
 	test CanReturnNestedFieldsDetailsInOneToManyUpdatedRelationship {


### PR DESCRIPTION
**Background**
Nested fields in oneToMany relationship after object deletion

**Test Plan**
Given active object definitions created
And Given a relationship between two object definitions created
And Given two manager accounts created
And Given two employee accounts created with different managed assigned
And Given deleting one of the employees
When calling for employees with "manager" as nestedFields parameter
Then "employee" information should not include manager information assigned to the deleted employee

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-152820