### PR TITLE
LPS-155297 - Remove hardcoded paths to clay icon pack

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon.js
@@ -24,7 +24,7 @@ export default function getLexiconIcon(icon, cssClass = '') {
 				focusable="false"
 				role="presentation"
 			>
-				<use href="/o/icons/pack/clay.svg#${iconName}" />
+				<use href="${Liferay.Icons.spritemap}#${iconName}" />
 			</svg>`;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_lexicon_icon_template.js
@@ -15,7 +15,7 @@
 export default function getLexiconIconTpl(icon, cssClass = '') {
 	return (
 		`<svg aria-hidden="true" class="lexicon-icon lexicon-icon-${icon} ${cssClass}" focusable="false" role="presentation">` +
-		`<use href="/o/icons/pack/clay.svg#${icon}" />` +
+		`<use href="${Liferay.Icons.spritemap}#${icon}" />` +
 		'</svg>'
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/mock/setup.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portlet/mock/setup.es.js
@@ -252,4 +252,11 @@ const portlet = {
 	},
 };
 
+window.Liferay = {
+	...(window.Liferay || {}),
+	Icons: {
+		spritemap: '/o/icons/pack/clay.svg',
+	},
+};
+
 global.portlet = portlet;

--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
@@ -15,17 +15,7 @@
 import ClayIcon from '@clayui/icon';
 import React from 'react';
 
-const contextPath = window.location.pathname.substring(
-	0,
-	window.location.pathname.indexOf('/o/')
-);
-
-export const spritemap =
-	window.location.protocol +
-	'//' +
-	window.location.host +
-	contextPath +
-	'/o/icons/pack/clay.svg';
+export const spritemap = Liferay.Icons.spritemap;
 
 const Icon = (props) => {
 	const {symbol, ...otherProps} = props;


### PR DESCRIPTION
Not sure why I originally added these hardcoded paths, but they shouldn't exist. Replacing them with the proper globals will ensure that the icon pack path won't be referenced without the feature flag