### PR TITLE
LPS-155332 - Icon pack names should be normalized to uppercase

### DIFF
--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/configuration/FrontendIconsPacksConfiguration.java
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/configuration/FrontendIconsPacksConfiguration.java
@@ -32,7 +32,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface FrontendIconsPacksConfiguration {
 
-	@Meta.AD(deflt = "clay", name = "selected-icon-packs", required = false)
+	@Meta.AD(deflt = "CLAY", name = "selected-icon-packs", required = false)
 	public String[] selectedIconPacks();
 
 }

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/display/context/FrontendIconsSiteSettingsConfigurationDisplayContext.java
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/display/context/FrontendIconsSiteSettingsConfigurationDisplayContext.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -102,7 +103,7 @@ public class FrontendIconsSiteSettingsConfigurationDisplayContext {
 				JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 				for (String selectedIconPack : _selectedIconPacks) {
-					jsonArray.put(selectedIconPack);
+					jsonArray.put(StringUtil.toUpperCase(selectedIconPack));
 				}
 
 				return jsonArray;

--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/portlet/action/SaveSiteFrontendIconsPacksMVCActionCommand.java
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/java/com/liferay/frontend/icons/web/internal/portlet/action/SaveSiteFrontendIconsPacksMVCActionCommand.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.portlet.ActionRequest;
@@ -58,6 +59,10 @@ public class SaveSiteFrontendIconsPacksMVCActionCommand
 
 		String[] selectedIconPacks = ParamUtil.getStringValues(
 			actionRequest, "selectedIconPacks");
+
+		for (int i = 0; i < selectedIconPacks.length; i++) {
+			selectedIconPacks[i] = StringUtil.toUpperCase(selectedIconPacks[i]);
+		}
 
 		try {
 			_configurationProvider.saveGroupConfiguration(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155332

We weren't previously normalizing all icon packs to be uppercase, this meant that if you checked site settings then the clay icon pack would be missing. Clay should be the default pack for all sites and can only be removed if a different icon pack is added.