### PR TITLE
LPS-155507 Fix API Explorer

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
@@ -15,7 +15,17 @@
 import ClayIcon from '@clayui/icon';
 import React from 'react';
 
-export const spritemap = Liferay.Icons.spritemap;
+const contextPath = window.location.pathname.substring(
+	0,
+	window.location.pathname.indexOf('/o/')
+);
+
+export const spritemap =
+	window.location.protocol +
+	'//' +
+	window.location.host +
+	contextPath +
+	'/o/classic-theme/images/clay/icons.svg';
 
 const Icon = (props) => {
 	const {symbol, ...otherProps} = props;


### PR DESCRIPTION
Related ticket -> [LPS-155507](https://issues.liferay.com/browse/LPS-155507)

Fix API Explorer getting access to the spritemap without the Liferay JS Object as the API Explorer does not have access to the Liferay Object.

To try this, just get this branch and deploy the module `modules/apps/headless/headless-discovery/headless-discovery-web`