### PR TITLE
Revert: LPS-155297 - Remove hardcoded paths to clay icon pack (2f2f6b…

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
@@ -15,7 +15,17 @@
 import ClayIcon from '@clayui/icon';
 import React from 'react';
 
-export const spritemap = Liferay.Icons.spritemap;
+const contextPath = window.location.pathname.substring(
+	0,
+	window.location.pathname.indexOf('/o/')
+);
+
+export const spritemap =
+	window.location.protocol +
+	'//' +
+	window.location.host +
+	contextPath +
+	'/o/icons/pack/clay.svg';
 
 const Icon = (props) => {
 	const {symbol, ...otherProps} = props;


### PR DESCRIPTION
…43) Partial revert to make /o/api work

@bryceosterhaus is out of the office today, I'd like @izaera or @kresimir-coko to take a quick look before sending to BChan as a quick fix for the headless-discovery-web app served from `/o/api` as the `Liferay` object is not available there.

cc @LuismiBarcos @ccorreagg 