### PR TITLE
LPS-155631 Adapt FDS to only render with items when CurrentViewComponent is ready

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -450,9 +450,10 @@ const FrontendDataSet = ({
 					value={selectedItemsValue.join(',')}
 				/>
 
-				{items?.length ||
-				overrideEmptyResultView ||
-				inlineAddingSettings ? (
+				{(items?.length ||
+					overrideEmptyResultView ||
+					inlineAddingSettings) &&
+				CurrentViewComponent ? (
 					<CurrentViewComponent
 						frontendDataSetContext={FrontendDataSetContext}
 						items={items}


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-155631

Hello guys, hope you are all doing well!

I'm from Bravo team and we are working with FDS to make a story as you can see [here](https://issues.liferay.com/browse/LPS-152180). The good news is that we managed to render the `FrontendDataSet` without using the explicit render method, looking like this:

```
<Card title={Liferay.Language.get('predefined-values')}>
		<div id="lfr-object-web__predefined-values-render-fds" >
				<FrontendDataSet {...props} />
		</div>
</Card>
```

But we faced some issues where the items inside the table wouldn't render, it actually breaks the whole page. After some investigation we realized that the problem was the `<CurrentViewComponent />` wasn't ready to be rendered since the `useEffect` that brings the table hasn't been called yet. So our proposal is to add a verification on the condition to only render the `<CurrentViewComponent />` when the component is ready.

If you have any concerns about this please let me know, thanks a lot!

fyi: @markocikos
