### PR TITLE
LPS-152608 Add pathContext parameter in REST Builder to generate it in the resource client

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/FieldResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/FieldResource.java
@@ -87,6 +87,12 @@ public interface FieldResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface FieldResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -196,7 +203,7 @@ public interface FieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/batch-planner/v1.0/plans/{internalClassName}/fields");
 
 			httpInvoker.path("internalClassName", internalClassName);

--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/PlanResource.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/resource/v1_0/PlanResource.java
@@ -112,6 +112,12 @@ public interface PlanResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -135,6 +141,7 @@ public interface PlanResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -219,7 +226,8 @@ public interface PlanResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/batch-planner/v1.0/plans");
+					_builder._port + _builder._pathContext +
+						"/o/batch-planner/v1.0/plans");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -295,7 +303,8 @@ public interface PlanResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/batch-planner/v1.0/plans");
+					_builder._port + _builder._pathContext +
+						"/o/batch-planner/v1.0/plans");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -360,7 +369,7 @@ public interface PlanResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/batch-planner/v1.0/plans/{internalClassName}/template");
 
 			httpInvoker.path("internalClassName", internalClassName);
@@ -438,7 +447,8 @@ public interface PlanResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/batch-planner/v1.0/plans/{planId}");
+					_builder._port + _builder._pathContext +
+						"/o/batch-planner/v1.0/plans/{planId}");
 
 			httpInvoker.path("planId", planId);
 
@@ -514,7 +524,8 @@ public interface PlanResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/batch-planner/v1.0/plans/{planId}");
+					_builder._port + _builder._pathContext +
+						"/o/batch-planner/v1.0/plans/{planId}");
 
 			httpInvoker.path("planId", planId);
 
@@ -594,7 +605,8 @@ public interface PlanResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/batch-planner/v1.0/plans/{planId}");
+					_builder._port + _builder._pathContext +
+						"/o/batch-planner/v1.0/plans/{planId}");
 
 			httpInvoker.path("planId", planId);
 

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/KeywordResource.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/KeywordResource.java
@@ -102,6 +102,12 @@ public interface KeywordResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -125,6 +131,7 @@ public interface KeywordResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -207,7 +214,8 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/keywords/batch");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/keywords/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -288,7 +296,8 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/keywords/batch");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/keywords/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -370,7 +379,8 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/keywords/common");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/keywords/common");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/SelectionResource.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/SelectionResource.java
@@ -85,6 +85,12 @@ public interface SelectionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface SelectionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -192,7 +199,8 @@ public interface SelectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/bulk-selection");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/bulk-selection");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/StatusResource.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/StatusResource.java
@@ -80,6 +80,12 @@ public interface StatusResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -103,6 +109,7 @@ public interface StatusResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -179,7 +186,8 @@ public interface StatusResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/status");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/status");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/TaxonomyCategoryResource.java
@@ -92,6 +92,12 @@ public interface TaxonomyCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -115,6 +121,7 @@ public interface TaxonomyCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -200,7 +207,8 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/taxonomy-categories/batch");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/taxonomy-categories/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -283,7 +291,8 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/bulk/v1.0/taxonomy-categories/batch");
+					_builder._port + _builder._pathContext +
+						"/o/bulk/v1.0/taxonomy-categories/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/resource/v1_0/TaxonomyVocabularyResource.java
@@ -88,6 +88,12 @@ public interface TaxonomyVocabularyResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -111,6 +117,7 @@ public interface TaxonomyVocabularyResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -197,7 +204,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/bulk/v1.0/sites/{siteId}/taxonomy-vocabularies/common");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountAddressResource.java
@@ -193,6 +193,12 @@ public interface AccountAddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -216,6 +222,7 @@ public interface AccountAddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -288,7 +295,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -372,7 +379,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -447,7 +454,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -515,7 +522,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/{id}");
 
 			httpInvoker.path("id", id);
@@ -593,7 +600,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/batch");
 
 			httpInvoker.path("id", id);
@@ -671,7 +678,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/{id}");
 
 			httpInvoker.path("id", id);
@@ -755,7 +762,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/{id}");
 
 			httpInvoker.path("id", id);
@@ -839,7 +846,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/{id}");
 
 			httpInvoker.path("id", id);
@@ -917,7 +924,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountAddresses/batch");
 
 			httpInvoker.path("id", id);
@@ -1009,7 +1016,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountAddresses");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1095,7 +1102,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountAddresses");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1185,7 +1192,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountAddresses");
 
 			httpInvoker.path("id", id);
@@ -1269,7 +1276,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountAddresses");
 
 			httpInvoker.path("id", id);
@@ -1349,7 +1356,7 @@ public interface AccountAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/accountAddresses/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountGroupResource.java
@@ -171,6 +171,12 @@ public interface AccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -194,6 +200,7 @@ public interface AccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -291,7 +298,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups");
 
 			httpInvoker.userNameAndPassword(
@@ -372,7 +379,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups");
 
 			httpInvoker.userNameAndPassword(
@@ -447,7 +454,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -518,7 +525,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -602,7 +609,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -677,7 +684,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -744,7 +751,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/{id}");
 
 			httpInvoker.path("id", id);
@@ -822,7 +829,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/batch");
 
 			httpInvoker.path("id", id);
@@ -900,7 +907,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/{id}");
 
 			httpInvoker.path("id", id);
@@ -972,7 +979,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/{id}");
 
 			httpInvoker.path("id", id);
@@ -1064,7 +1071,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountGroups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1154,7 +1161,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountGroups");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountMemberResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountMemberResource.java
@@ -173,6 +173,12 @@ public interface AccountMemberResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -196,6 +202,7 @@ public interface AccountMemberResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -287,7 +294,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountMembers");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -373,7 +380,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountMembers");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -446,7 +453,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountMembers/{userId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -531,7 +538,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountMembers/{userId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -609,7 +616,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountMembers/{userId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -700,7 +707,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountMembers");
 
 			httpInvoker.path("id", id);
@@ -784,7 +791,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountMembers");
 
 			httpInvoker.path("id", id);
@@ -864,7 +871,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/accountMembers/batch");
 
 			httpInvoker.path("id", id);
@@ -934,7 +941,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountMembers/{userId}");
 
 			httpInvoker.path("id", id);
@@ -1016,7 +1023,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountMembers/{userId}");
 
 			httpInvoker.path("id", id);
@@ -1091,7 +1098,7 @@ public interface AccountMemberResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountMembers/{userId}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountOrganizationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountOrganizationResource.java
@@ -163,6 +163,12 @@ public interface AccountOrganizationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -186,6 +192,7 @@ public interface AccountOrganizationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -277,7 +284,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountOrganizations");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -367,7 +374,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountOrganizations");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -440,7 +447,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountOrganizations/{organizationId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -526,7 +533,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountOrganizations/{organizationId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -618,7 +625,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountOrganizations");
 
 			httpInvoker.path("id", id);
@@ -705,7 +712,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountOrganizations");
 
 			httpInvoker.path("id", id);
@@ -785,7 +792,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/accountOrganizations/batch");
 
 			httpInvoker.path("id", id);
@@ -858,7 +865,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountOrganizations/{organizationId}");
 
 			httpInvoker.path("id", id);
@@ -942,7 +949,7 @@ public interface AccountOrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/accountOrganizations/{organizationId}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/AccountResource.java
@@ -191,6 +191,12 @@ public interface AccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -214,6 +220,7 @@ public interface AccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -287,7 +294,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/by-externalReferenceCode/{externalReferenceCode}/accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -362,7 +369,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accountGroups/by-externalReferenceCode/{externalReferenceCode}/accounts/{accountExternalReferenceCode}");
 
 			httpInvoker.path(
@@ -467,7 +474,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts");
 
 			httpInvoker.userNameAndPassword(
@@ -545,7 +552,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts");
 
 			httpInvoker.userNameAndPassword(
@@ -620,7 +627,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -691,7 +698,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -775,7 +782,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -850,7 +857,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -933,7 +940,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/logo");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1000,7 +1007,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -1078,7 +1085,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/batch");
 
 			httpInvoker.path("id", id);
@@ -1155,7 +1162,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -1225,7 +1232,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -1304,7 +1311,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/{id}/logo");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/UserResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/resource/v1_0/UserResource.java
@@ -85,6 +85,12 @@ public interface UserResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface UserResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -193,7 +200,7 @@ public interface UserResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-account/v1.0/accounts/by-externalReferenceCode/{externalReferenceCode}/accountMembers/createUser");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/AttachmentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/AttachmentResource.java
@@ -223,6 +223,12 @@ public interface AttachmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -246,6 +252,7 @@ public interface AttachmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -336,7 +343,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/attachments");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -422,7 +429,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/attachments");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -509,7 +516,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/attachments/by-base64");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -595,7 +602,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/attachments/by-url");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -686,7 +693,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/images");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -772,7 +779,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/images");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -859,7 +866,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/images/by-base64");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -945,7 +952,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/images/by-url");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1034,7 +1041,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/attachments");
 
 			httpInvoker.path("id", id);
@@ -1118,7 +1125,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/attachments");
 
 			httpInvoker.path("id", id);
@@ -1198,7 +1205,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/attachments/batch");
 
 			httpInvoker.path("id", id);
@@ -1284,7 +1291,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/attachments/by-base64");
 
 			httpInvoker.path("id", id);
@@ -1369,7 +1376,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/attachments/by-url");
 
 			httpInvoker.path("id", id);
@@ -1458,7 +1465,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/images");
 
 			httpInvoker.path("id", id);
@@ -1541,7 +1548,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/images");
 
 			httpInvoker.path("id", id);
@@ -1625,7 +1632,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/images/by-base64");
 
 			httpInvoker.path("id", id);
@@ -1709,7 +1716,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/images/by-url");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/CatalogResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/CatalogResource.java
@@ -167,6 +167,12 @@ public interface CatalogResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -190,6 +196,7 @@ public interface CatalogResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -261,7 +268,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -345,7 +352,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -420,7 +427,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -487,7 +494,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/{id}");
 
 			httpInvoker.path("id", id);
@@ -565,7 +572,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/batch");
 
 			httpInvoker.path("id", id);
@@ -642,7 +649,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/{id}");
 
 			httpInvoker.path("id", id);
@@ -712,7 +719,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalog/{id}");
 
 			httpInvoker.path("id", id);
@@ -815,7 +822,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalogs");
 
 			httpInvoker.userNameAndPassword(
@@ -893,7 +900,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalogs");
 
 			httpInvoker.userNameAndPassword(
@@ -968,7 +975,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/catalogs/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1057,7 +1064,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/catalog");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1145,7 +1152,7 @@ public interface CatalogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/catalog");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/CategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/CategoryResource.java
@@ -114,6 +114,12 @@ public interface CategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -137,6 +143,7 @@ public interface CategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -226,7 +233,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/categories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -309,7 +316,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/categories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -398,7 +405,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/categories");
 
 			httpInvoker.path("id", id);
@@ -478,7 +485,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/categories");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/DiagramResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/DiagramResource.java
@@ -114,6 +114,12 @@ public interface DiagramResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -137,6 +143,7 @@ public interface DiagramResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -219,7 +226,7 @@ public interface DiagramResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/diagrams/{diagramId}");
 
 			httpInvoker.path("diagramId", diagramId);
@@ -304,7 +311,7 @@ public interface DiagramResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/diagrams");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -391,7 +398,7 @@ public interface DiagramResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/diagrams");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -471,7 +478,7 @@ public interface DiagramResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/diagrams");
 
 			httpInvoker.path("productId", productId);
@@ -555,7 +562,7 @@ public interface DiagramResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/diagrams");
 
 			httpInvoker.path("productId", productId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/MappedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/MappedProductResource.java
@@ -158,6 +158,12 @@ public interface MappedProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -181,6 +187,7 @@ public interface MappedProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -259,7 +266,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/mapped-products/{mappedProductId}");
 
 			httpInvoker.path("mappedProductId", mappedProductId);
@@ -336,7 +343,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/mapped-products/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -418,7 +425,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/mapped-products/{mappedProductId}");
 
 			httpInvoker.path("mappedProductId", mappedProductId);
@@ -520,7 +527,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/mapped-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -606,7 +613,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/mapped-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -691,7 +698,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/mapped-products/by-sequence/{sequence}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -793,7 +800,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/mapped-products");
 
 			httpInvoker.path("productId", productId);
@@ -878,7 +885,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/mapped-products");
 
 			httpInvoker.path("productId", productId);
@@ -962,7 +969,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/mapped-products/by-sequence/{sequence}");
 
 			httpInvoker.path("productId", productId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/OptionCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/OptionCategoryResource.java
@@ -126,6 +126,12 @@ public interface OptionCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -149,6 +155,7 @@ public interface OptionCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -246,7 +253,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories");
 
 			httpInvoker.userNameAndPassword(
@@ -327,7 +334,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories");
 
 			httpInvoker.userNameAndPassword(
@@ -402,7 +409,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -468,7 +475,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories/{id}");
 
 			httpInvoker.path("id", id);
@@ -546,7 +553,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories/batch");
 
 			httpInvoker.path("id", id);
@@ -624,7 +631,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories/{id}");
 
 			httpInvoker.path("id", id);
@@ -696,7 +703,7 @@ public interface OptionCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionCategories/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/OptionResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/OptionResource.java
@@ -150,6 +150,12 @@ public interface OptionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -173,6 +179,7 @@ public interface OptionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -274,7 +281,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options");
 
 			httpInvoker.userNameAndPassword(
@@ -352,7 +359,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options");
 
 			httpInvoker.userNameAndPassword(
@@ -427,7 +434,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -498,7 +505,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -582,7 +589,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -657,7 +664,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -724,7 +731,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/{id}");
 
 			httpInvoker.path("id", id);
@@ -802,7 +809,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/batch");
 
 			httpInvoker.path("id", id);
@@ -879,7 +886,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/{id}");
 
 			httpInvoker.path("id", id);
@@ -949,7 +956,7 @@ public interface OptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/OptionValueResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/OptionValueResource.java
@@ -174,6 +174,12 @@ public interface OptionValueResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -197,6 +203,7 @@ public interface OptionValueResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -268,7 +275,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -352,7 +359,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -427,7 +434,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -494,7 +501,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/{id}");
 
 			httpInvoker.path("id", id);
@@ -572,7 +579,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/batch");
 
 			httpInvoker.path("id", id);
@@ -650,7 +657,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/{id}");
 
 			httpInvoker.path("id", id);
@@ -722,7 +729,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/optionValues/{id}");
 
 			httpInvoker.path("id", id);
@@ -824,7 +831,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/by-externalReferenceCode/{externalReferenceCode}/optionValues");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -910,7 +917,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/by-externalReferenceCode/{externalReferenceCode}/optionValues");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1010,7 +1017,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/{id}/optionValues");
 
 			httpInvoker.path("id", id);
@@ -1094,7 +1101,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/{id}/optionValues");
 
 			httpInvoker.path("id", id);
@@ -1174,7 +1181,7 @@ public interface OptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/options/optionValues/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/PinResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/PinResource.java
@@ -132,6 +132,12 @@ public interface PinResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -155,6 +161,7 @@ public interface PinResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -231,7 +238,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/pins/{pinId}");
 
 			httpInvoker.path("pinId", pinId);
@@ -308,7 +315,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/pins/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -387,7 +394,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/pins/{pinId}");
 
 			httpInvoker.path("pinId", pinId);
@@ -488,7 +495,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/pins");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -574,7 +581,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/pins");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -674,7 +681,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/pins");
 
 			httpInvoker.path("productId", productId);
@@ -755,7 +762,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{productId}/pins");
 
 			httpInvoker.path("productId", productId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductAccountGroupResource.java
@@ -117,6 +117,12 @@ public interface ProductAccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -140,6 +146,7 @@ public interface ProductAccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -218,7 +225,7 @@ public interface ProductAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-account-groups/{id}");
 
 			httpInvoker.path("id", id);
@@ -298,7 +305,7 @@ public interface ProductAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-account-groups/batch");
 
 			httpInvoker.path("id", id);
@@ -379,7 +386,7 @@ public interface ProductAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-account-groups/{id}");
 
 			httpInvoker.path("id", id);
@@ -471,7 +478,7 @@ public interface ProductAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/product-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -562,7 +569,7 @@ public interface ProductAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/product-account-groups");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductChannelResource.java
@@ -115,6 +115,12 @@ public interface ProductChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -138,6 +144,7 @@ public interface ProductChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -216,7 +223,7 @@ public interface ProductChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-channels/{id}");
 
 			httpInvoker.path("id", id);
@@ -294,7 +301,7 @@ public interface ProductChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-channels/batch");
 
 			httpInvoker.path("id", id);
@@ -372,7 +379,7 @@ public interface ProductChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-channels/{id}");
 
 			httpInvoker.path("id", id);
@@ -464,7 +471,7 @@ public interface ProductChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/product-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -554,7 +561,7 @@ public interface ProductChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/product-channels");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductConfigurationResource.java
@@ -111,6 +111,12 @@ public interface ProductConfigurationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -134,6 +140,7 @@ public interface ProductConfigurationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -219,7 +226,7 @@ public interface ProductConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/configuration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -297,7 +304,7 @@ public interface ProductConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/configuration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -379,7 +386,7 @@ public interface ProductConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/configuration");
 
 			httpInvoker.path("id", id);
@@ -454,7 +461,7 @@ public interface ProductConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/configuration");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductGroupProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductGroupProductResource.java
@@ -142,6 +142,12 @@ public interface ProductGroupProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -165,6 +171,7 @@ public interface ProductGroupProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -243,7 +250,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-group-products/{id}");
 
 			httpInvoker.path("id", id);
@@ -323,7 +330,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-group-products/batch");
 
 			httpInvoker.path("id", id);
@@ -415,7 +422,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/by-externalReferenceCode/{externalReferenceCode}/product-group-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -505,7 +512,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/by-externalReferenceCode/{externalReferenceCode}/product-group-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -597,7 +604,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/{id}/product-group-products");
 
 			httpInvoker.path("id", id);
@@ -684,7 +691,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/{id}/product-group-products");
 
 			httpInvoker.path("id", id);
@@ -764,7 +771,7 @@ public interface ProductGroupProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/product-group-products/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductGroupResource.java
@@ -155,6 +155,12 @@ public interface ProductGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -178,6 +184,7 @@ public interface ProductGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -281,7 +288,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups");
 
 			httpInvoker.userNameAndPassword(
@@ -362,7 +369,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups");
 
 			httpInvoker.userNameAndPassword(
@@ -437,7 +444,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -519,7 +526,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -603,7 +610,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -678,7 +685,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -756,7 +763,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/{id}");
 
 			httpInvoker.path("id", id);
@@ -834,7 +841,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/batch");
 
 			httpInvoker.path("id", id);
@@ -912,7 +919,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/{id}");
 
 			httpInvoker.path("id", id);
@@ -984,7 +991,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/product-groups/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductOptionResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductOptionResource.java
@@ -144,6 +144,12 @@ public interface ProductOptionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -167,6 +173,7 @@ public interface ProductOptionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -233,7 +240,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/{id}");
 
 			httpInvoker.path("id", id);
@@ -311,7 +318,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/batch");
 
 			httpInvoker.path("id", id);
@@ -389,7 +396,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/{id}");
 
 			httpInvoker.path("id", id);
@@ -461,7 +468,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/{id}");
 
 			httpInvoker.path("id", id);
@@ -563,7 +570,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/productOptions");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -660,7 +667,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/productOptions");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -761,7 +768,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/productOptions");
 
 			httpInvoker.path("id", id);
@@ -854,7 +861,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/productOptions");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductOptionValueResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductOptionValueResource.java
@@ -107,6 +107,12 @@ public interface ProductOptionValueResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -130,6 +136,7 @@ public interface ProductOptionValueResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -231,7 +238,7 @@ public interface ProductOptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/{id}/productOptionValues");
 
 			httpInvoker.path("id", id);
@@ -317,7 +324,7 @@ public interface ProductOptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/{id}/productOptionValues");
 
 			httpInvoker.path("id", id);
@@ -397,7 +404,7 @@ public interface ProductOptionValueResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/productOptions/productOptionValues/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductResource.java
@@ -167,6 +167,12 @@ public interface ProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -190,6 +196,7 @@ public interface ProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -291,7 +298,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products");
 
 			httpInvoker.userNameAndPassword(
@@ -369,7 +376,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products");
 
 			httpInvoker.userNameAndPassword(
@@ -444,7 +451,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -515,7 +522,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -599,7 +606,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -674,7 +681,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -769,7 +776,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/clone");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -836,7 +843,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}");
 
 			httpInvoker.path("id", id);
@@ -914,7 +921,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/batch");
 
 			httpInvoker.path("id", id);
@@ -991,7 +998,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}");
 
 			httpInvoker.path("id", id);
@@ -1061,7 +1068,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}");
 
 			httpInvoker.path("id", id);
@@ -1148,7 +1155,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/clone");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductShippingConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductShippingConfigurationResource.java
@@ -115,6 +115,12 @@ public interface ProductShippingConfigurationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -138,6 +144,7 @@ public interface ProductShippingConfigurationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -224,7 +231,7 @@ public interface ProductShippingConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/shippingConfiguration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -302,7 +309,7 @@ public interface ProductShippingConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/shippingConfiguration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -386,7 +393,7 @@ public interface ProductShippingConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/shippingConfiguration");
 
 			httpInvoker.path("id", id);
@@ -464,7 +471,7 @@ public interface ProductShippingConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/shippingConfiguration");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductSpecificationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductSpecificationResource.java
@@ -106,6 +106,12 @@ public interface ProductSpecificationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -129,6 +135,7 @@ public interface ProductSpecificationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -219,7 +226,7 @@ public interface ProductSpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/productSpecifications");
 
 			httpInvoker.path("id", id);
@@ -306,7 +313,7 @@ public interface ProductSpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/productSpecifications");
 
 			httpInvoker.path("id", id);
@@ -386,7 +393,7 @@ public interface ProductSpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/productSpecifications/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductSubscriptionConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductSubscriptionConfigurationResource.java
@@ -118,6 +118,12 @@ public interface ProductSubscriptionConfigurationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -141,6 +147,7 @@ public interface ProductSubscriptionConfigurationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -227,7 +234,7 @@ public interface ProductSubscriptionConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/subscriptionConfiguration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -309,7 +316,7 @@ public interface ProductSubscriptionConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/subscriptionConfiguration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -393,7 +400,7 @@ public interface ProductSubscriptionConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/subscriptionConfiguration");
 
 			httpInvoker.path("id", id);
@@ -474,7 +481,7 @@ public interface ProductSubscriptionConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/subscriptionConfiguration");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductTaxConfigurationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/ProductTaxConfigurationResource.java
@@ -112,6 +112,12 @@ public interface ProductTaxConfigurationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -135,6 +141,7 @@ public interface ProductTaxConfigurationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -220,7 +227,7 @@ public interface ProductTaxConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/taxConfiguration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -298,7 +305,7 @@ public interface ProductTaxConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/taxConfiguration");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -380,7 +387,7 @@ public interface ProductTaxConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/taxConfiguration");
 
 			httpInvoker.path("id", id);
@@ -456,7 +463,7 @@ public interface ProductTaxConfigurationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/taxConfiguration");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/RelatedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/RelatedProductResource.java
@@ -143,6 +143,12 @@ public interface RelatedProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -166,6 +172,7 @@ public interface RelatedProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -263,7 +270,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/relatedProducts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -349,7 +356,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/relatedProducts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -444,7 +451,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/relatedProducts");
 
 			httpInvoker.path("id", id);
@@ -528,7 +535,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/relatedProducts");
 
 			httpInvoker.path("id", id);
@@ -608,7 +615,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/relatedProducts/batch");
 
 			httpInvoker.path("id", id);
@@ -676,7 +683,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/relatedProducts/{id}");
 
 			httpInvoker.path("id", id);
@@ -754,7 +761,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/relatedProducts/batch");
 
 			httpInvoker.path("id", id);
@@ -832,7 +839,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/relatedProducts/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/SkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/SkuResource.java
@@ -173,6 +173,12 @@ public interface SkuResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -196,6 +202,7 @@ public interface SkuResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -285,7 +292,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/skus");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -371,7 +378,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/{externalReferenceCode}/skus");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -459,7 +466,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/skus");
 
 			httpInvoker.path("id", id);
@@ -540,7 +547,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/{id}/skus");
 
 			httpInvoker.path("id", id);
@@ -618,7 +625,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/products/skus/batch");
 
 			httpInvoker.path("id", id);
@@ -721,7 +728,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus");
 
 			httpInvoker.userNameAndPassword(
@@ -792,7 +799,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -875,7 +882,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -950,7 +957,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1016,7 +1023,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/{id}");
 
 			httpInvoker.path("id", id);
@@ -1093,7 +1100,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/batch");
 
 			httpInvoker.path("id", id);
@@ -1170,7 +1177,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/{id}");
 
 			httpInvoker.path("id", id);
@@ -1239,7 +1246,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/skus/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/SpecificationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/resource/v1_0/SpecificationResource.java
@@ -128,6 +128,12 @@ public interface SpecificationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -151,6 +157,7 @@ public interface SpecificationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -254,7 +261,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications");
 
 			httpInvoker.userNameAndPassword(
@@ -335,7 +342,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications");
 
 			httpInvoker.userNameAndPassword(
@@ -410,7 +417,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -475,7 +482,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications/{id}");
 
 			httpInvoker.path("id", id);
@@ -553,7 +560,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications/batch");
 
 			httpInvoker.path("id", id);
@@ -631,7 +638,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications/{id}");
 
 			httpInvoker.path("id", id);
@@ -703,7 +710,7 @@ public interface SpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-catalog/v1.0/specifications/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ChannelResource.java
@@ -174,6 +174,12 @@ public interface ChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -197,6 +203,7 @@ public interface ChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -298,7 +305,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels");
 
 			httpInvoker.userNameAndPassword(
@@ -376,7 +383,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels");
 
 			httpInvoker.userNameAndPassword(
@@ -451,7 +458,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -533,7 +540,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -617,7 +624,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -703,7 +710,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -789,7 +796,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -868,7 +875,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/{channelId}");
 
 			httpInvoker.path("channelId", channelId);
@@ -945,7 +952,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1021,7 +1028,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/{channelId}");
 
 			httpInvoker.path("channelId", channelId);
@@ -1104,7 +1111,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/{channelId}");
 
 			httpInvoker.path("channelId", channelId);
@@ -1187,7 +1194,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/{channelId}");
 
 			httpInvoker.path("channelId", channelId);
@@ -1264,7 +1271,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/OrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/OrderTypeResource.java
@@ -94,6 +94,12 @@ public interface OrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -117,6 +123,7 @@ public interface OrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -200,7 +207,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rel-order-types/{paymentMethodGroupRelOrderTypeId}/order-type");
 
 			httpInvoker.path(
@@ -287,7 +294,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-option-order-types/{shippingFixedOptionOrderTypeId}/order-type");
 
 			httpInvoker.path(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/PaymentMethodGroupRelOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/PaymentMethodGroupRelOrderTypeResource.java
@@ -121,6 +121,12 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -144,6 +150,7 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -227,7 +234,7 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rel-order-types/{paymentMethodGroupRelOrderTypeId}");
 
 			httpInvoker.path(
@@ -309,7 +316,7 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rel-order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -414,7 +421,7 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rels/{id}/payment-method-group-rel-order-types");
 
 			httpInvoker.path("id", id);
@@ -506,7 +513,7 @@ public interface PaymentMethodGroupRelOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rels/{id}/payment-method-group-rel-order-types");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/PaymentMethodGroupRelTermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/PaymentMethodGroupRelTermResource.java
@@ -118,6 +118,12 @@ public interface PaymentMethodGroupRelTermResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -141,6 +147,7 @@ public interface PaymentMethodGroupRelTermResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -224,7 +231,7 @@ public interface PaymentMethodGroupRelTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rel-terms/{paymentMethodGroupRelTermId}");
 
 			httpInvoker.path(
@@ -305,7 +312,7 @@ public interface PaymentMethodGroupRelTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rel-terms/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -409,7 +416,7 @@ public interface PaymentMethodGroupRelTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rels/{id}/payment-method-group-rel-terms");
 
 			httpInvoker.path("id", id);
@@ -499,7 +506,7 @@ public interface PaymentMethodGroupRelTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rels/{id}/payment-method-group-rel-terms");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ShippingFixedOptionOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ShippingFixedOptionOrderTypeResource.java
@@ -121,6 +121,12 @@ public interface ShippingFixedOptionOrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -144,6 +150,7 @@ public interface ShippingFixedOptionOrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -227,7 +234,7 @@ public interface ShippingFixedOptionOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-option-order-types/{shippingFixedOptionOrderTypeId}");
 
 			httpInvoker.path(
@@ -309,7 +316,7 @@ public interface ShippingFixedOptionOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-option-order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -414,7 +421,7 @@ public interface ShippingFixedOptionOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-options/{id}/shipping-fixed-option-order-types");
 
 			httpInvoker.path("id", id);
@@ -504,7 +511,7 @@ public interface ShippingFixedOptionOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-options/{id}/shipping-fixed-option-order-types");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ShippingFixedOptionTermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ShippingFixedOptionTermResource.java
@@ -117,6 +117,12 @@ public interface ShippingFixedOptionTermResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -140,6 +146,7 @@ public interface ShippingFixedOptionTermResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -223,7 +230,7 @@ public interface ShippingFixedOptionTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-option-terms/{shippingFixedOptionTermId}");
 
 			httpInvoker.path(
@@ -304,7 +311,7 @@ public interface ShippingFixedOptionTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-option-terms/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -408,7 +415,7 @@ public interface ShippingFixedOptionTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-options/{id}/shipping-fixed-option-terms");
 
 			httpInvoker.path("id", id);
@@ -496,7 +503,7 @@ public interface ShippingFixedOptionTermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-options/{id}/shipping-fixed-option-terms");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ShippingMethodResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/ShippingMethodResource.java
@@ -87,6 +87,12 @@ public interface ShippingMethodResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface ShippingMethodResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -200,7 +207,7 @@ public interface ShippingMethodResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/channels/{channelId}/shipping-methods");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/TaxCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/TaxCategoryResource.java
@@ -92,6 +92,12 @@ public interface TaxCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -115,6 +121,7 @@ public interface TaxCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -206,7 +213,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/tax-categories");
 
 			httpInvoker.userNameAndPassword(
@@ -282,7 +289,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/tax-categories/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/TermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/resource/v1_0/TermResource.java
@@ -92,6 +92,12 @@ public interface TermResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -115,6 +121,7 @@ public interface TermResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -198,7 +205,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/payment-method-group-rel-terms/{paymentMethodGroupRelTermId}/term");
 
 			httpInvoker.path(
@@ -284,7 +291,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-channel/v1.0/shipping-fixed-option-terms/{shippingFixedOptionTermId}/term");
 
 			httpInvoker.path(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/resource/v1_0/WarehouseItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/resource/v1_0/WarehouseItemResource.java
@@ -186,6 +186,12 @@ public interface WarehouseItemResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -209,6 +215,7 @@ public interface WarehouseItemResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -281,7 +288,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -365,7 +372,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -440,7 +447,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -526,7 +533,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -593,7 +600,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -671,7 +678,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/batch");
 
 			httpInvoker.path("id", id);
@@ -749,7 +756,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -821,7 +828,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -913,7 +920,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/by-externalReferenceCode/{externalReferenceCode}/warehouseItems");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -999,7 +1006,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/by-externalReferenceCode/{externalReferenceCode}/warehouseItems");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1089,7 +1096,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/{id}/warehouseItems");
 
 			httpInvoker.path("id", id);
@@ -1173,7 +1180,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/{id}/warehouseItems");
 
 			httpInvoker.path("id", id);
@@ -1278,7 +1285,7 @@ public interface WarehouseItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouseItems/updated");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/resource/v1_0/WarehouseResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/resource/v1_0/WarehouseResource.java
@@ -136,6 +136,12 @@ public interface WarehouseResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -159,6 +165,7 @@ public interface WarehouseResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -230,7 +237,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -314,7 +321,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -389,7 +396,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -456,7 +463,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/{id}");
 
 			httpInvoker.path("id", id);
@@ -534,7 +541,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/{id}");
 
 			httpInvoker.path("id", id);
@@ -606,7 +613,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses/{id}");
 
 			httpInvoker.path("id", id);
@@ -704,7 +711,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses");
 
 			httpInvoker.userNameAndPassword(
@@ -783,7 +790,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-inventory/v1.0/warehouses");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/AccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/AccountGroupResource.java
@@ -85,6 +85,12 @@ public interface AccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface AccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -192,7 +199,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-account-groups/{orderRuleAccountGroupId}/account-group");
 
 			httpInvoker.path(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/AccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/AccountResource.java
@@ -97,6 +97,12 @@ public interface AccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -120,6 +126,7 @@ public interface AccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -200,7 +207,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-accounts/{orderRuleAccountId}/account");
 
 			httpInvoker.path("orderRuleAccountId", orderRuleAccountId);
@@ -285,7 +292,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/account");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -364,7 +371,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/account");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/BillingAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/BillingAddressResource.java
@@ -108,6 +108,12 @@ public interface BillingAddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -131,6 +137,7 @@ public interface BillingAddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -215,7 +222,7 @@ public interface BillingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/billingAddress");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -290,7 +297,7 @@ public interface BillingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/billingAddress");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -372,7 +379,7 @@ public interface BillingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/billingAddress");
 
 			httpInvoker.path("id", id);
@@ -445,7 +452,7 @@ public interface BillingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/billingAddress");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/ChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/ChannelResource.java
@@ -104,6 +104,12 @@ public interface ChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -127,6 +133,7 @@ public interface ChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -207,7 +214,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-channels/{orderRuleChannelId}/channel");
 
 			httpInvoker.path("orderRuleChannelId", orderRuleChannelId);
@@ -289,7 +296,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-type-channels/{orderTypeChannelId}/channel");
 
 			httpInvoker.path("orderTypeChannelId", orderTypeChannelId);
@@ -374,7 +381,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/channel");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -453,7 +460,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/channel");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderItemResource.java
@@ -203,6 +203,12 @@ public interface OrderItemResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -226,6 +232,7 @@ public interface OrderItemResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -328,7 +335,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems");
 
 			httpInvoker.userNameAndPassword(
@@ -399,7 +406,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -483,7 +490,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -558,7 +565,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -644,7 +651,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -711,7 +718,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -789,7 +796,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/batch");
 
 			httpInvoker.path("id", id);
@@ -867,7 +874,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -939,7 +946,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -1022,7 +1029,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/{id}");
 
 			httpInvoker.path("id", id);
@@ -1100,7 +1107,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/batch");
 
 			httpInvoker.path("id", id);
@@ -1191,7 +1198,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/orderItems");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1277,7 +1284,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/orderItems");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1366,7 +1373,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/orderItems");
 
 			httpInvoker.path("id", id);
@@ -1449,7 +1456,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/orderItems");
 
 			httpInvoker.path("id", id);
@@ -1527,7 +1534,7 @@ public interface OrderItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/orderItems/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderNoteResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderNoteResource.java
@@ -170,6 +170,12 @@ public interface OrderNoteResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -193,6 +199,7 @@ public interface OrderNoteResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -264,7 +271,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -348,7 +355,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -423,7 +430,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -490,7 +497,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/{id}");
 
 			httpInvoker.path("id", id);
@@ -568,7 +575,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/batch");
 
 			httpInvoker.path("id", id);
@@ -646,7 +653,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/{id}");
 
 			httpInvoker.path("id", id);
@@ -718,7 +725,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderNotes/{id}");
 
 			httpInvoker.path("id", id);
@@ -809,7 +816,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/orderNotes");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -895,7 +902,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/orderNotes");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -984,7 +991,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/orderNotes");
 
 			httpInvoker.path("id", id);
@@ -1067,7 +1074,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/orderNotes");
 
 			httpInvoker.path("id", id);
@@ -1145,7 +1152,7 @@ public interface OrderNoteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/orderNotes/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderResource.java
@@ -147,6 +147,12 @@ public interface OrderResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -170,6 +176,7 @@ public interface OrderResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -271,7 +278,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders");
 
 			httpInvoker.userNameAndPassword(
@@ -349,7 +356,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders");
 
 			httpInvoker.userNameAndPassword(
@@ -424,7 +431,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -495,7 +502,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -579,7 +586,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -654,7 +661,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -720,7 +727,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}");
 
 			httpInvoker.path("id", id);
@@ -797,7 +804,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/batch");
 
 			httpInvoker.path("id", id);
@@ -874,7 +881,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}");
 
 			httpInvoker.path("id", id);
@@ -944,7 +951,7 @@ public interface OrderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleAccountGroupResource.java
@@ -146,6 +146,12 @@ public interface OrderRuleAccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -169,6 +175,7 @@ public interface OrderRuleAccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -250,7 +257,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-account-groups/{orderRuleAccountGroupId}");
 
 			httpInvoker.path(
@@ -331,7 +338,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-account-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -421,7 +428,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -511,7 +518,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -617,7 +624,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-account-groups");
 
 			httpInvoker.path("id", id);
@@ -704,7 +711,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-account-groups");
 
 			httpInvoker.path("id", id);
@@ -784,7 +791,7 @@ public interface OrderRuleAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/order-rule-account-groups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleAccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleAccountResource.java
@@ -141,6 +141,12 @@ public interface OrderRuleAccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -164,6 +170,7 @@ public interface OrderRuleAccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -244,7 +251,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-accounts/{orderRuleAccountId}");
 
 			httpInvoker.path("orderRuleAccountId", orderRuleAccountId);
@@ -322,7 +329,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -412,7 +419,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -501,7 +508,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -606,7 +613,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-accounts");
 
 			httpInvoker.path("id", id);
@@ -692,7 +699,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-accounts");
 
 			httpInvoker.path("id", id);
@@ -772,7 +779,7 @@ public interface OrderRuleAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/order-rule-accounts/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleChannelResource.java
@@ -141,6 +141,12 @@ public interface OrderRuleChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -164,6 +170,7 @@ public interface OrderRuleChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -244,7 +251,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-channels/{orderRuleChannelId}");
 
 			httpInvoker.path("orderRuleChannelId", orderRuleChannelId);
@@ -322,7 +329,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-channels/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -412,7 +419,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -501,7 +508,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -606,7 +613,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-channels");
 
 			httpInvoker.path("id", id);
@@ -692,7 +699,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-channels");
 
 			httpInvoker.path("id", id);
@@ -772,7 +779,7 @@ public interface OrderRuleChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/order-rule-channels/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleOrderTypeResource.java
@@ -142,6 +142,12 @@ public interface OrderRuleOrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -165,6 +171,7 @@ public interface OrderRuleOrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -245,7 +252,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-order-types/{orderRuleOrderTypeId}");
 
 			httpInvoker.path("orderRuleOrderTypeId", orderRuleOrderTypeId);
@@ -324,7 +331,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -414,7 +421,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -503,7 +510,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}/order-rule-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -598,7 +605,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-order-types");
 
 			httpInvoker.path("id", id);
@@ -684,7 +691,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}/order-rule-order-types");
 
 			httpInvoker.path("id", id);
@@ -764,7 +771,7 @@ public interface OrderRuleOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/order-rule-order-types/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderRuleResource.java
@@ -153,6 +153,12 @@ public interface OrderRuleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -176,6 +182,7 @@ public interface OrderRuleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -278,7 +285,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules");
 
 			httpInvoker.userNameAndPassword(
@@ -357,7 +364,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules");
 
 			httpInvoker.userNameAndPassword(
@@ -432,7 +439,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -514,7 +521,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -598,7 +605,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -684,7 +691,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -762,7 +769,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}");
 
 			httpInvoker.path("id", id);
@@ -840,7 +847,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/batch");
 
 			httpInvoker.path("id", id);
@@ -918,7 +925,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}");
 
 			httpInvoker.path("id", id);
@@ -1001,7 +1008,7 @@ public interface OrderRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rules/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderTypeChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderTypeChannelResource.java
@@ -140,6 +140,12 @@ public interface OrderTypeChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -163,6 +169,7 @@ public interface OrderTypeChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -243,7 +250,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-type-channels/{orderTypeChannelId}");
 
 			httpInvoker.path("orderTypeChannelId", orderTypeChannelId);
@@ -321,7 +328,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-type-channels/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -411,7 +418,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/by-externalReferenceCode/{externalReferenceCode}/order-type-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -500,7 +507,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/by-externalReferenceCode/{externalReferenceCode}/order-type-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -601,7 +608,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/{id}/order-type-channels");
 
 			httpInvoker.path("id", id);
@@ -687,7 +694,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/{id}/order-type-channels");
 
 			httpInvoker.path("id", id);
@@ -767,7 +774,7 @@ public interface OrderTypeChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/order-type-channels/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/OrderTypeResource.java
@@ -167,6 +167,12 @@ public interface OrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -190,6 +196,7 @@ public interface OrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -272,7 +279,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-rule-order-types/{orderRuleOrderTypeId}/order-type");
 
 			httpInvoker.path("orderRuleOrderTypeId", orderRuleOrderTypeId);
@@ -376,7 +383,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types");
 
 			httpInvoker.userNameAndPassword(
@@ -455,7 +462,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types");
 
 			httpInvoker.userNameAndPassword(
@@ -530,7 +537,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -612,7 +619,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -696,7 +703,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -782,7 +789,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -860,7 +867,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/{id}");
 
 			httpInvoker.path("id", id);
@@ -938,7 +945,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/batch");
 
 			httpInvoker.path("id", id);
@@ -1016,7 +1023,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/{id}");
 
 			httpInvoker.path("id", id);
@@ -1099,7 +1106,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/order-types/{id}");
 
 			httpInvoker.path("id", id);
@@ -1180,7 +1187,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/term-order-types/{termOrderTypeId}/order-type");
 
 			httpInvoker.path("termOrderTypeId", termOrderTypeId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/ShippingAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/ShippingAddressResource.java
@@ -115,6 +115,12 @@ public interface ShippingAddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -138,6 +144,7 @@ public interface ShippingAddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -219,7 +226,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orderItems/{id}/shippingAddress");
 
 			httpInvoker.path("id", id);
@@ -304,7 +311,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/shippingAddress");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -380,7 +387,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/by-externalReferenceCode/{externalReferenceCode}/shippingAddress");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -462,7 +469,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/shippingAddress");
 
 			httpInvoker.path("id", id);
@@ -535,7 +542,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/orders/{id}/shippingAddress");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/TermOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/TermOrderTypeResource.java
@@ -134,6 +134,12 @@ public interface TermOrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -157,6 +163,7 @@ public interface TermOrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -235,7 +242,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/term-order-types/{termOrderTypeId}");
 
 			httpInvoker.path("termOrderTypeId", termOrderTypeId);
@@ -312,7 +319,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/term-order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -402,7 +409,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/by-externalReferenceCode/{externalReferenceCode}/term-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -488,7 +495,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/by-externalReferenceCode/{externalReferenceCode}/term-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -581,7 +588,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/{id}/term-order-types");
 
 			httpInvoker.path("id", id);
@@ -665,7 +672,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/{id}/term-order-types");
 
 			httpInvoker.path("id", id);
@@ -745,7 +752,7 @@ public interface TermOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/term-order-types/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/TermResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/resource/v1_0/TermResource.java
@@ -147,6 +147,12 @@ public interface TermResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -170,6 +176,7 @@ public interface TermResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -271,7 +278,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms");
 
 			httpInvoker.userNameAndPassword(
@@ -348,7 +355,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms");
 
 			httpInvoker.userNameAndPassword(
@@ -423,7 +430,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -505,7 +512,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -588,7 +595,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -674,7 +681,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -751,7 +758,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/{id}");
 
 			httpInvoker.path("id", id);
@@ -828,7 +835,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/batch");
 
 			httpInvoker.path("id", id);
@@ -905,7 +912,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/{id}");
 
 			httpInvoker.path("id", id);
@@ -986,7 +993,7 @@ public interface TermResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-order/v1.0/terms/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountAccountGroupResource.java
@@ -142,6 +142,12 @@ public interface DiscountAccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -165,6 +171,7 @@ public interface DiscountAccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -232,7 +239,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountAccountGroups/{id}");
 
 			httpInvoker.path("id", id);
@@ -312,7 +319,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountAccountGroups/batch");
 
 			httpInvoker.path("id", id);
@@ -404,7 +411,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discountAccountGroups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -494,7 +501,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discountAccountGroups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -586,7 +593,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountAccountGroups");
 
 			httpInvoker.path("id", id);
@@ -673,7 +680,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountAccountGroups");
 
 			httpInvoker.path("id", id);
@@ -753,7 +760,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/discountAccountGroups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountCategoryResource.java
@@ -137,6 +137,12 @@ public interface DiscountCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -160,6 +166,7 @@ public interface DiscountCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -227,7 +234,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountCategories/{id}");
 
 			httpInvoker.path("id", id);
@@ -306,7 +313,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountCategories/batch");
 
 			httpInvoker.path("id", id);
@@ -398,7 +405,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discountCategories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -487,7 +494,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discountCategories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -577,7 +584,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountCategories");
 
 			httpInvoker.path("id", id);
@@ -663,7 +670,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountCategories");
 
 			httpInvoker.path("id", id);
@@ -743,7 +750,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/discountCategories/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountProductResource.java
@@ -137,6 +137,12 @@ public interface DiscountProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -160,6 +166,7 @@ public interface DiscountProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -227,7 +234,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountProducts/{id}");
 
 			httpInvoker.path("id", id);
@@ -305,7 +312,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountProducts/batch");
 
 			httpInvoker.path("id", id);
@@ -397,7 +404,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discountProducts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -486,7 +493,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discountProducts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -576,7 +583,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountProducts");
 
 			httpInvoker.path("id", id);
@@ -661,7 +668,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountProducts");
 
 			httpInvoker.path("id", id);
@@ -741,7 +748,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/discountProducts/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountResource.java
@@ -148,6 +148,12 @@ public interface DiscountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -171,6 +177,7 @@ public interface DiscountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -257,7 +264,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts");
 
 			httpInvoker.userNameAndPassword(
@@ -336,7 +343,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts");
 
 			httpInvoker.userNameAndPassword(
@@ -411,7 +418,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -482,7 +489,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -566,7 +573,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -641,7 +648,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -708,7 +715,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -786,7 +793,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/batch");
 
 			httpInvoker.path("id", id);
@@ -863,7 +870,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -933,7 +940,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountRuleResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/DiscountRuleResource.java
@@ -147,6 +147,12 @@ public interface DiscountRuleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -170,6 +176,7 @@ public interface DiscountRuleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -261,7 +268,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discount/by-externalReferenceCode/{externalReferenceCode}/discountRules");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -347,7 +354,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discount/by-externalReferenceCode/{externalReferenceCode}/discountRules");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -414,7 +421,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountRules/{id}");
 
 			httpInvoker.path("id", id);
@@ -492,7 +499,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountRules/batch");
 
 			httpInvoker.path("id", id);
@@ -570,7 +577,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountRules/{id}");
 
 			httpInvoker.path("id", id);
@@ -642,7 +649,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discountRules/{id}");
 
 			httpInvoker.path("id", id);
@@ -732,7 +739,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountRules");
 
 			httpInvoker.path("id", id);
@@ -816,7 +823,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/{id}/discountRules");
 
 			httpInvoker.path("id", id);
@@ -896,7 +903,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/discounts/discountRules/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/PriceEntryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/PriceEntryResource.java
@@ -172,6 +172,12 @@ public interface PriceEntryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -195,6 +201,7 @@ public interface PriceEntryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -266,7 +273,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -350,7 +357,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -425,7 +432,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -492,7 +499,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/{id}");
 
 			httpInvoker.path("id", id);
@@ -570,7 +577,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/batch");
 
 			httpInvoker.path("id", id);
@@ -648,7 +655,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/{id}");
 
 			httpInvoker.path("id", id);
@@ -720,7 +727,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/{id}");
 
 			httpInvoker.path("id", id);
@@ -812,7 +819,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}/priceEntries");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -898,7 +905,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}/priceEntries");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -988,7 +995,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}/priceEntries");
 
 			httpInvoker.path("id", id);
@@ -1072,7 +1079,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}/priceEntries");
 
 			httpInvoker.path("id", id);
@@ -1152,7 +1159,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/priceEntries/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/PriceListAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/PriceListAccountGroupResource.java
@@ -143,6 +143,12 @@ public interface PriceListAccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -166,6 +172,7 @@ public interface PriceListAccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -233,7 +240,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceListAccountGroups/{id}");
 
 			httpInvoker.path("id", id);
@@ -313,7 +320,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceListAccountGroups/batch");
 
 			httpInvoker.path("id", id);
@@ -405,7 +412,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}/priceListAccountGroup");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -495,7 +502,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}/priceListAccountGroup");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -587,7 +594,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}/priceListAccountGroups");
 
 			httpInvoker.path("id", id);
@@ -674,7 +681,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}/priceListAccountGroups");
 
 			httpInvoker.path("id", id);
@@ -754,7 +761,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/priceListAccountGroups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/PriceListResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/PriceListResource.java
@@ -150,6 +150,12 @@ public interface PriceListResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -173,6 +179,7 @@ public interface PriceListResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -269,7 +276,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists");
 
 			httpInvoker.userNameAndPassword(
@@ -348,7 +355,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists");
 
 			httpInvoker.userNameAndPassword(
@@ -423,7 +430,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -494,7 +501,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -578,7 +585,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -653,7 +660,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -720,7 +727,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}");
 
 			httpInvoker.path("id", id);
@@ -798,7 +805,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/batch");
 
 			httpInvoker.path("id", id);
@@ -876,7 +883,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}");
 
 			httpInvoker.path("id", id);
@@ -948,7 +955,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceLists/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/TierPriceResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v1_0/TierPriceResource.java
@@ -170,6 +170,12 @@ public interface TierPriceResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -193,6 +199,7 @@ public interface TierPriceResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -283,7 +290,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/by-externalReferenceCode/{externalReferenceCode}/tierPrices");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -369,7 +376,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/by-externalReferenceCode/{externalReferenceCode}/tierPrices");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -459,7 +466,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/{id}/tierPrices");
 
 			httpInvoker.path("id", id);
@@ -542,7 +549,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/{id}/tierPrices");
 
 			httpInvoker.path("id", id);
@@ -622,7 +629,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/priceEntries/tierPrices/batch");
 
 			httpInvoker.path("id", id);
@@ -695,7 +702,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -779,7 +786,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -854,7 +861,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -921,7 +928,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/{id}");
 
 			httpInvoker.path("id", id);
@@ -999,7 +1006,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/batch");
 
 			httpInvoker.path("id", id);
@@ -1077,7 +1084,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/{id}");
 
 			httpInvoker.path("id", id);
@@ -1149,7 +1156,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v1.0/tierPrices/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/AccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/AccountGroupResource.java
@@ -94,6 +94,12 @@ public interface AccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -117,6 +123,7 @@ public interface AccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -201,7 +208,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-account-groups/{discountAccountGroupId}/account-group");
 
 			httpInvoker.path("discountAccountGroupId", discountAccountGroupId);
@@ -286,7 +293,7 @@ public interface AccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-account-groups/{priceListAccountGroupId}/account-group");
 
 			httpInvoker.path(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/AccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/AccountResource.java
@@ -90,6 +90,12 @@ public interface AccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -113,6 +119,7 @@ public interface AccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -193,7 +200,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-accounts/{discountAccountId}/account");
 
 			httpInvoker.path("discountAccountId", discountAccountId);
@@ -275,7 +282,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-accounts/{priceListAccountId}/account");
 
 			httpInvoker.path("priceListAccountId", priceListAccountId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/CategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/CategoryResource.java
@@ -92,6 +92,12 @@ public interface CategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -115,6 +121,7 @@ public interface CategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -195,7 +202,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-categories/{discountCategoryId}/category");
 
 			httpInvoker.path("discountCategoryId", discountCategoryId);
@@ -280,7 +287,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-categories/{priceModifierCategoryId}/category");
 
 			httpInvoker.path(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/ChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/ChannelResource.java
@@ -90,6 +90,12 @@ public interface ChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -113,6 +119,7 @@ public interface ChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -193,7 +200,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-channels/{discountChannelId}/channel");
 
 			httpInvoker.path("discountChannelId", discountChannelId);
@@ -275,7 +282,7 @@ public interface ChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-channels/{priceListChannelId}/channel");
 
 			httpInvoker.path("priceListChannelId", priceListChannelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountAccountGroupResource.java
@@ -145,6 +145,12 @@ public interface DiscountAccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -168,6 +174,7 @@ public interface DiscountAccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -248,7 +255,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-account-groups/{discountAccountGroupId}");
 
 			httpInvoker.path("discountAccountGroupId", discountAccountGroupId);
@@ -328,7 +335,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-account-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -418,7 +425,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -508,7 +515,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -614,7 +621,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-account-groups");
 
 			httpInvoker.path("id", id);
@@ -701,7 +708,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-account-groups");
 
 			httpInvoker.path("id", id);
@@ -781,7 +788,7 @@ public interface DiscountAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-account-groups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountAccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountAccountResource.java
@@ -139,6 +139,12 @@ public interface DiscountAccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -162,6 +168,7 @@ public interface DiscountAccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -242,7 +249,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-accounts/{discountAccountId}");
 
 			httpInvoker.path("discountAccountId", discountAccountId);
@@ -320,7 +327,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -410,7 +417,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -499,7 +506,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -604,7 +611,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-accounts");
 
 			httpInvoker.path("id", id);
@@ -689,7 +696,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-accounts");
 
 			httpInvoker.path("id", id);
@@ -769,7 +776,7 @@ public interface DiscountAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-accounts/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountCategoryResource.java
@@ -140,6 +140,12 @@ public interface DiscountCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -163,6 +169,7 @@ public interface DiscountCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -243,7 +250,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-categories/{discountCategoryId}");
 
 			httpInvoker.path("discountCategoryId", discountCategoryId);
@@ -321,7 +328,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-categories/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -411,7 +418,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-categories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -500,7 +507,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-categories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -605,7 +612,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-categories");
 
 			httpInvoker.path("id", id);
@@ -691,7 +698,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-categories");
 
 			httpInvoker.path("id", id);
@@ -771,7 +778,7 @@ public interface DiscountCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-categories/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountChannelResource.java
@@ -139,6 +139,12 @@ public interface DiscountChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -162,6 +168,7 @@ public interface DiscountChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -242,7 +249,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-channels/{discountChannelId}");
 
 			httpInvoker.path("discountChannelId", discountChannelId);
@@ -320,7 +327,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-channels/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -410,7 +417,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -499,7 +506,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -604,7 +611,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-channels");
 
 			httpInvoker.path("id", id);
@@ -689,7 +696,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-channels");
 
 			httpInvoker.path("id", id);
@@ -769,7 +776,7 @@ public interface DiscountChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-channels/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountOrderTypeResource.java
@@ -143,6 +143,12 @@ public interface DiscountOrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -166,6 +172,7 @@ public interface DiscountOrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -246,7 +253,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-order-types/{discountOrderTypeId}");
 
 			httpInvoker.path("discountOrderTypeId", discountOrderTypeId);
@@ -325,7 +332,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -415,7 +422,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -504,7 +511,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -609,7 +616,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-order-types");
 
 			httpInvoker.path("id", id);
@@ -695,7 +702,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-order-types");
 
 			httpInvoker.path("id", id);
@@ -775,7 +782,7 @@ public interface DiscountOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-order-types/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountProductGroupResource.java
@@ -145,6 +145,12 @@ public interface DiscountProductGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -168,6 +174,7 @@ public interface DiscountProductGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -248,7 +255,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-product-groups/{discountProductGroupId}");
 
 			httpInvoker.path("discountProductGroupId", discountProductGroupId);
@@ -328,7 +335,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-product-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -418,7 +425,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-product-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -508,7 +515,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-product-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -614,7 +621,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-product-groups");
 
 			httpInvoker.path("id", id);
@@ -701,7 +708,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-product-groups");
 
 			httpInvoker.path("id", id);
@@ -781,7 +788,7 @@ public interface DiscountProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-product-groups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountProductResource.java
@@ -139,6 +139,12 @@ public interface DiscountProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -162,6 +168,7 @@ public interface DiscountProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -242,7 +249,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-products/{discountProductId}");
 
 			httpInvoker.path("discountProductId", discountProductId);
@@ -320,7 +327,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-products/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -410,7 +417,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -499,7 +506,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -604,7 +611,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-products");
 
 			httpInvoker.path("id", id);
@@ -689,7 +696,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-products");
 
 			httpInvoker.path("id", id);
@@ -769,7 +776,7 @@ public interface DiscountProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-products/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountResource.java
@@ -151,6 +151,12 @@ public interface DiscountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -174,6 +180,7 @@ public interface DiscountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -276,7 +283,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts");
 
 			httpInvoker.userNameAndPassword(
@@ -355,7 +362,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts");
 
 			httpInvoker.userNameAndPassword(
@@ -430,7 +437,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -512,7 +519,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -596,7 +603,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -682,7 +689,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -760,7 +767,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -838,7 +845,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/batch");
 
 			httpInvoker.path("id", id);
@@ -915,7 +922,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}");
 
 			httpInvoker.path("id", id);
@@ -998,7 +1005,7 @@ public interface DiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountRuleResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountRuleResource.java
@@ -149,6 +149,12 @@ public interface DiscountRuleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -172,6 +178,7 @@ public interface DiscountRuleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -249,7 +256,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-rules/{id}");
 
 			httpInvoker.path("id", id);
@@ -327,7 +334,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-rules/batch");
 
 			httpInvoker.path("id", id);
@@ -405,7 +412,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-rules/{id}");
 
 			httpInvoker.path("id", id);
@@ -489,7 +496,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-rules/{id}");
 
 			httpInvoker.path("id", id);
@@ -581,7 +588,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-rules");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -667,7 +674,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-rules");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -772,7 +779,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-rules");
 
 			httpInvoker.path("id", id);
@@ -856,7 +863,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-rules");
 
 			httpInvoker.path("id", id);
@@ -936,7 +943,7 @@ public interface DiscountRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-rules/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountSkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/DiscountSkuResource.java
@@ -136,6 +136,12 @@ public interface DiscountSkuResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -159,6 +165,7 @@ public interface DiscountSkuResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -236,7 +243,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-skus/{discountSkuId}");
 
 			httpInvoker.path("discountSkuId", discountSkuId);
@@ -313,7 +320,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-skus/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -403,7 +410,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-skus");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -489,7 +496,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/by-externalReferenceCode/{externalReferenceCode}/discount-skus");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -594,7 +601,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-skus");
 
 			httpInvoker.path("id", id);
@@ -678,7 +685,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/{id}/discount-skus");
 
 			httpInvoker.path("id", id);
@@ -758,7 +765,7 @@ public interface DiscountSkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discounts/discount-skus/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/OrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/OrderTypeResource.java
@@ -90,6 +90,12 @@ public interface OrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -113,6 +119,7 @@ public interface OrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -194,7 +201,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-order-types/{discountOrderTypeId}/order-type");
 
 			httpInvoker.path("discountOrderTypeId", discountOrderTypeId);
@@ -279,7 +286,7 @@ public interface OrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-order-types/{priceListOrderTypeId}/order-type");
 
 			httpInvoker.path("priceListOrderTypeId", priceListOrderTypeId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceEntryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceEntryResource.java
@@ -174,6 +174,12 @@ public interface PriceEntryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -197,6 +203,7 @@ public interface PriceEntryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -279,7 +286,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -363,7 +370,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -449,7 +456,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -528,7 +535,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -605,7 +612,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -682,7 +689,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -766,7 +773,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -858,7 +865,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-entries");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -944,7 +951,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-entries");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1049,7 +1056,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-entries");
 
 			httpInvoker.path("id", id);
@@ -1133,7 +1140,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-entries");
 
 			httpInvoker.path("id", id);
@@ -1213,7 +1220,7 @@ public interface PriceEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-entries/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListAccountGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListAccountGroupResource.java
@@ -146,6 +146,12 @@ public interface PriceListAccountGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -169,6 +175,7 @@ public interface PriceListAccountGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -250,7 +257,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-account-groups/{priceListAccountGroupId}");
 
 			httpInvoker.path(
@@ -331,7 +338,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-account-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -421,7 +428,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -511,7 +518,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-account-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -617,7 +624,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-account-groups");
 
 			httpInvoker.path("id", id);
@@ -704,7 +711,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-account-groups");
 
 			httpInvoker.path("id", id);
@@ -784,7 +791,7 @@ public interface PriceListAccountGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-list-account-groups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListAccountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListAccountResource.java
@@ -141,6 +141,12 @@ public interface PriceListAccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -164,6 +170,7 @@ public interface PriceListAccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -244,7 +251,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-accounts/{priceListAccountId}");
 
 			httpInvoker.path("priceListAccountId", priceListAccountId);
@@ -322,7 +329,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -412,7 +419,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -501,7 +508,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -606,7 +613,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-accounts");
 
 			httpInvoker.path("id", id);
@@ -692,7 +699,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-accounts");
 
 			httpInvoker.path("id", id);
@@ -772,7 +779,7 @@ public interface PriceListAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-list-accounts/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListChannelResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListChannelResource.java
@@ -141,6 +141,12 @@ public interface PriceListChannelResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -164,6 +170,7 @@ public interface PriceListChannelResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -244,7 +251,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-channels/{priceListChannelId}");
 
 			httpInvoker.path("priceListChannelId", priceListChannelId);
@@ -322,7 +329,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-channels/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -412,7 +419,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -501,7 +508,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-channels");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -606,7 +613,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-channels");
 
 			httpInvoker.path("id", id);
@@ -692,7 +699,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-channels");
 
 			httpInvoker.path("id", id);
@@ -772,7 +779,7 @@ public interface PriceListChannelResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-list-channels/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListDiscountResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListDiscountResource.java
@@ -142,6 +142,12 @@ public interface PriceListDiscountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -165,6 +171,7 @@ public interface PriceListDiscountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -245,7 +252,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-discounts/{priceListDiscountId}");
 
 			httpInvoker.path("priceListDiscountId", priceListDiscountId);
@@ -324,7 +331,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-discounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -414,7 +421,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-discounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -503,7 +510,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-discounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -594,7 +601,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-discounts");
 
 			httpInvoker.path("id", id);
@@ -680,7 +687,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-discounts");
 
 			httpInvoker.path("id", id);
@@ -760,7 +767,7 @@ public interface PriceListDiscountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-list-discounts/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListOrderTypeResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListOrderTypeResource.java
@@ -142,6 +142,12 @@ public interface PriceListOrderTypeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -165,6 +171,7 @@ public interface PriceListOrderTypeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -245,7 +252,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-order-types/{priceListOrderTypeId}");
 
 			httpInvoker.path("priceListOrderTypeId", priceListOrderTypeId);
@@ -324,7 +331,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-list-order-types/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -414,7 +421,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -503,7 +510,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-list-order-types");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -598,7 +605,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-order-types");
 
 			httpInvoker.path("id", id);
@@ -684,7 +691,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-list-order-types");
 
 			httpInvoker.path("id", id);
@@ -764,7 +771,7 @@ public interface PriceListOrderTypeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-list-order-types/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceListResource.java
@@ -153,6 +153,12 @@ public interface PriceListResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -176,6 +182,7 @@ public interface PriceListResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -278,7 +285,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists");
 
 			httpInvoker.userNameAndPassword(
@@ -357,7 +364,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists");
 
 			httpInvoker.userNameAndPassword(
@@ -432,7 +439,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -514,7 +521,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -598,7 +605,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -684,7 +691,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -762,7 +769,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}");
 
 			httpInvoker.path("id", id);
@@ -840,7 +847,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/batch");
 
 			httpInvoker.path("id", id);
@@ -918,7 +925,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}");
 
 			httpInvoker.path("id", id);
@@ -1001,7 +1008,7 @@ public interface PriceListResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierCategoryResource.java
@@ -147,6 +147,12 @@ public interface PriceModifierCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -170,6 +176,7 @@ public interface PriceModifierCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -251,7 +258,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-categories/{priceModifierCategoryId}");
 
 			httpInvoker.path(
@@ -332,7 +339,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-categories/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -422,7 +429,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}/price-modifier-categories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -512,7 +519,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}/price-modifier-categories");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -618,7 +625,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}/price-modifier-categories");
 
 			httpInvoker.path("id", id);
@@ -705,7 +712,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}/price-modifier-categories");
 
 			httpInvoker.path("id", id);
@@ -785,7 +792,7 @@ public interface PriceModifierCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/price-modifier-categories/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierProductGroupResource.java
@@ -149,6 +149,12 @@ public interface PriceModifierProductGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -172,6 +178,7 @@ public interface PriceModifierProductGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -255,7 +262,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-product-groups/{priceModifierProductGroupId}");
 
 			httpInvoker.path(
@@ -336,7 +343,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-product-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -426,7 +433,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}/price-modifier-product-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -516,7 +523,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}/price-modifier-product-groups");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -622,7 +629,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}/price-modifier-product-groups");
 
 			httpInvoker.path("id", id);
@@ -712,7 +719,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}/price-modifier-product-groups");
 
 			httpInvoker.path("id", id);
@@ -792,7 +799,7 @@ public interface PriceModifierProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/price-modifier-product-groups/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierProductResource.java
@@ -146,6 +146,12 @@ public interface PriceModifierProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -169,6 +175,7 @@ public interface PriceModifierProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -249,7 +256,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-products/{priceModifierProductId}");
 
 			httpInvoker.path("priceModifierProductId", priceModifierProductId);
@@ -329,7 +336,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-products/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -419,7 +426,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}/price-modifier-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -509,7 +516,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}/price-modifier-products");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -615,7 +622,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}/price-modifier-products");
 
 			httpInvoker.path("id", id);
@@ -702,7 +709,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}/price-modifier-products");
 
 			httpInvoker.path("id", id);
@@ -782,7 +789,7 @@ public interface PriceModifierProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/price-modifier-products/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/PriceModifierResource.java
@@ -178,6 +178,12 @@ public interface PriceModifierResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -201,6 +207,7 @@ public interface PriceModifierResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -292,7 +299,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-modifiers");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -378,7 +385,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/by-externalReferenceCode/{externalReferenceCode}/price-modifiers");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -483,7 +490,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-modifiers");
 
 			httpInvoker.path("id", id);
@@ -568,7 +575,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/{id}/price-modifiers");
 
 			httpInvoker.path("id", id);
@@ -648,7 +655,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-lists/price-modifiers/batch");
 
 			httpInvoker.path("id", id);
@@ -732,7 +739,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -816,7 +823,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -891,7 +898,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -969,7 +976,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}");
 
 			httpInvoker.path("id", id);
@@ -1047,7 +1054,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/batch");
 
 			httpInvoker.path("id", id);
@@ -1125,7 +1132,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}");
 
 			httpInvoker.path("id", id);
@@ -1197,7 +1204,7 @@ public interface PriceModifierResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifiers/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/ProductGroupResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/ProductGroupResource.java
@@ -94,6 +94,12 @@ public interface ProductGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -117,6 +123,7 @@ public interface ProductGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -201,7 +208,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-product-groups/{discountProductGroupId}/product-group");
 
 			httpInvoker.path("discountProductGroupId", discountProductGroupId);
@@ -286,7 +293,7 @@ public interface ProductGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-product-groups/{priceModifierProductGroupId}/product-group");
 
 			httpInvoker.path(

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/ProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/ProductResource.java
@@ -96,6 +96,12 @@ public interface ProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -119,6 +125,7 @@ public interface ProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -199,7 +206,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-products/{discountProductId}/product");
 
 			httpInvoker.path("discountProductId", discountProductId);
@@ -281,7 +288,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}/product");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -366,7 +373,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-modifier-products/{priceModifierProductId}/product");
 
 			httpInvoker.path("priceModifierProductId", priceModifierProductId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/SkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/SkuResource.java
@@ -88,6 +88,12 @@ public interface SkuResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -111,6 +117,7 @@ public interface SkuResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -189,7 +196,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/discount-skus/{discountSkuId}/sku");
 
 			httpInvoker.path("discountSkuId", discountSkuId);
@@ -269,7 +276,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}/sku");
 
 			httpInvoker.path("priceEntryId", priceEntryId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/TierPriceResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/resource/v2_0/TierPriceResource.java
@@ -171,6 +171,12 @@ public interface TierPriceResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -194,6 +200,7 @@ public interface TierPriceResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -284,7 +291,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/by-externalReferenceCode/{externalReferenceCode}/tier-prices");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -370,7 +377,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/by-externalReferenceCode/{externalReferenceCode}/tier-prices");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -461,7 +468,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}/tier-prices");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -545,7 +552,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}/tier-prices");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -625,7 +632,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/price-entries/{priceEntryId}/tier-prices/batch");
 
 			httpInvoker.path("priceEntryId", priceEntryId);
@@ -709,7 +716,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -793,7 +800,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -868,7 +875,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -946,7 +953,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/{id}");
 
 			httpInvoker.path("id", id);
@@ -1024,7 +1031,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/batch");
 
 			httpInvoker.path("id", id);
@@ -1102,7 +1109,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/{id}");
 
 			httpInvoker.path("id", id);
@@ -1174,7 +1181,7 @@ public interface TierPriceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-pricing/v2.0/tier-prices/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/resource/v1_0/ShipmentItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/resource/v1_0/ShipmentItemResource.java
@@ -167,6 +167,12 @@ public interface ShipmentItemResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -190,6 +196,7 @@ public interface ShipmentItemResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -273,7 +280,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -357,7 +364,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -443,7 +450,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -522,7 +529,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/{shipmentItemId}");
 
 			httpInvoker.path("shipmentItemId", shipmentItemId);
@@ -599,7 +606,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -678,7 +685,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/{shipmentItemId}");
 
 			httpInvoker.path("shipmentItemId", shipmentItemId);
@@ -762,7 +769,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipment-items/{shipmentItemId}");
 
 			httpInvoker.path("shipmentItemId", shipmentItemId);
@@ -853,7 +860,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/items");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -939,7 +946,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/items");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1028,7 +1035,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/items");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -1112,7 +1119,7 @@ public interface ShipmentItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/items");
 
 			httpInvoker.path("shipmentId", shipmentId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/resource/v1_0/ShipmentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/resource/v1_0/ShipmentResource.java
@@ -208,6 +208,12 @@ public interface ShipmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -231,6 +237,7 @@ public interface ShipmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -333,7 +340,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments");
 
 			httpInvoker.userNameAndPassword(
@@ -412,7 +419,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments");
 
 			httpInvoker.userNameAndPassword(
@@ -487,7 +494,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -569,7 +576,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -653,7 +660,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -739,7 +746,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -825,7 +832,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -909,7 +916,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/status-delivered");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -994,7 +1001,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/status-finish-processing");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1078,7 +1085,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/status-shipped");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1157,7 +1164,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -1234,7 +1241,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1310,7 +1317,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -1393,7 +1400,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -1474,7 +1481,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/status-delivered");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -1555,7 +1562,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/status-finish-processing");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -1636,7 +1643,7 @@ public interface ShipmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/status-shipped");
 
 			httpInvoker.path("shipmentId", shipmentId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/resource/v1_0/ShippingAddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/resource/v1_0/ShippingAddressResource.java
@@ -109,6 +109,12 @@ public interface ShippingAddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -132,6 +138,7 @@ public interface ShippingAddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -217,7 +224,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/shipping-address");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -307,7 +314,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/by-externalReferenceCode/{externalReferenceCode}/shipping-address");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -389,7 +396,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/shipping-address");
 
 			httpInvoker.path("shipmentId", shipmentId);
@@ -476,7 +483,7 @@ public interface ShippingAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-shipment/v1.0/shipments/{shipmentId}/shipping-address");
 
 			httpInvoker.path("shipmentId", shipmentId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/AvailabilityEstimateResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/AvailabilityEstimateResource.java
@@ -135,6 +135,12 @@ public interface AvailabilityEstimateResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -158,6 +164,7 @@ public interface AvailabilityEstimateResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -225,7 +232,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/availabilityEstimate/{id}");
 
 			httpInvoker.path("id", id);
@@ -305,7 +312,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/availabilityEstimate/batch");
 
 			httpInvoker.path("id", id);
@@ -386,7 +393,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/availabilityEstimate/{id}");
 
 			httpInvoker.path("id", id);
@@ -460,7 +467,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/availabilityEstimate/{id}");
 
 			httpInvoker.path("id", id);
@@ -540,7 +547,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/availabilityEstimate/batch");
 
 			httpInvoker.path("id", id);
@@ -632,7 +639,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/commerceAdminSiteSetting/{groupId}/availabilityEstimate");
 
 			httpInvoker.path("groupId", groupId);
@@ -720,7 +727,7 @@ public interface AvailabilityEstimateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/commerceAdminSiteSetting/{groupId}/availabilityEstimate");
 
 			httpInvoker.path("groupId", groupId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/MeasurementUnitResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/MeasurementUnitResource.java
@@ -183,6 +183,12 @@ public interface MeasurementUnitResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -206,6 +212,7 @@ public interface MeasurementUnitResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -303,7 +310,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units");
 
 			httpInvoker.userNameAndPassword(
@@ -385,7 +392,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units");
 
 			httpInvoker.userNameAndPassword(
@@ -460,7 +467,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -542,7 +549,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -626,7 +633,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -702,7 +709,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-externalReferenceCode/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -781,7 +788,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-key/{key}");
 
 			httpInvoker.path("key", key);
@@ -862,7 +869,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-key/{key}");
 
 			httpInvoker.path("key", key);
@@ -935,7 +942,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-key/{key}");
 
 			httpInvoker.path("key", key);
@@ -1031,7 +1038,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/by-type/{measurementUnitType}");
 
 			httpInvoker.path("measurementUnitType", measurementUnitType);
@@ -1110,7 +1117,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/{id}");
 
 			httpInvoker.path("id", id);
@@ -1188,7 +1195,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/batch");
 
 			httpInvoker.path("id", id);
@@ -1266,7 +1273,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/{id}");
 
 			httpInvoker.path("id", id);
@@ -1339,7 +1346,7 @@ public interface MeasurementUnitResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/measurement-units/{id}");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/TaxCategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/TaxCategoryResource.java
@@ -129,6 +129,12 @@ public interface TaxCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -152,6 +158,7 @@ public interface TaxCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -242,7 +249,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/commerceAdminSiteSetting/{groupId}/taxCategory");
 
 			httpInvoker.path("groupId", groupId);
@@ -328,7 +335,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/commerceAdminSiteSetting/{groupId}/taxCategory");
 
 			httpInvoker.path("groupId", groupId);
@@ -395,7 +402,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/taxCategory/{id}");
 
 			httpInvoker.path("id", id);
@@ -473,7 +480,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/taxCategory/batch");
 
 			httpInvoker.path("id", id);
@@ -551,7 +558,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/taxCategory/{id}");
 
 			httpInvoker.path("id", id);
@@ -623,7 +630,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/taxCategory/{id}");
 
 			httpInvoker.path("id", id);
@@ -701,7 +708,7 @@ public interface TaxCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/taxCategory/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/WarehouseResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/resource/v1_0/WarehouseResource.java
@@ -127,6 +127,12 @@ public interface WarehouseResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -150,6 +156,7 @@ public interface WarehouseResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -243,7 +250,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/commerceAdminSiteSetting/{groupId}/warehouse");
 
 			httpInvoker.path("groupId", groupId);
@@ -329,7 +336,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/commerceAdminSiteSetting/{groupId}/warehouse");
 
 			httpInvoker.path("groupId", groupId);
@@ -396,7 +403,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/warehouse/{id}");
 
 			httpInvoker.path("id", id);
@@ -474,7 +481,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/warehouse/batch");
 
 			httpInvoker.path("id", id);
@@ -552,7 +559,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/warehouse/{id}");
 
 			httpInvoker.path("id", id);
@@ -624,7 +631,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/warehouse/{id}");
 
 			httpInvoker.path("id", id);
@@ -702,7 +709,7 @@ public interface WarehouseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-admin-site-setting/v1.0/warehouse/batch");
 
 			httpInvoker.path("id", id);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/AddressResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/AddressResource.java
@@ -88,6 +88,12 @@ public interface AddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -111,6 +117,7 @@ public interface AddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -189,7 +196,7 @@ public interface AddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/billing-address");
 
 			httpInvoker.path("cartId", cartId);
@@ -269,7 +276,7 @@ public interface AddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/shipping-address");
 
 			httpInvoker.path("cartId", cartId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/CartCommentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/CartCommentResource.java
@@ -136,6 +136,12 @@ public interface CartCommentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -159,6 +165,7 @@ public interface CartCommentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -225,7 +232,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-comments/{cartCommentId}");
 
 			httpInvoker.path("cartCommentId", cartCommentId);
@@ -302,7 +309,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-comments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -379,7 +386,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-comments/{cartCommentId}");
 
 			httpInvoker.path("cartCommentId", cartCommentId);
@@ -463,7 +470,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-comments/{cartCommentId}");
 
 			httpInvoker.path("cartCommentId", cartCommentId);
@@ -547,7 +554,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-comments/{cartCommentId}");
 
 			httpInvoker.path("cartCommentId", cartCommentId);
@@ -624,7 +631,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-comments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -711,7 +718,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/comments");
 
 			httpInvoker.path("cartId", cartId);
@@ -794,7 +801,7 @@ public interface CartCommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/comments");
 
 			httpInvoker.path("cartId", cartId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/CartItemResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/CartItemResource.java
@@ -132,6 +132,12 @@ public interface CartItemResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -155,6 +161,7 @@ public interface CartItemResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -221,7 +228,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-items/{cartItemId}");
 
 			httpInvoker.path("cartItemId", cartItemId);
@@ -298,7 +305,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-items/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -374,7 +381,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-items/{cartItemId}");
 
 			httpInvoker.path("cartItemId", cartItemId);
@@ -457,7 +464,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-items/{cartItemId}");
 
 			httpInvoker.path("cartItemId", cartItemId);
@@ -540,7 +547,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-items/{cartItemId}");
 
 			httpInvoker.path("cartItemId", cartItemId);
@@ -617,7 +624,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/cart-items/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -708,7 +715,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/items");
 
 			httpInvoker.path("cartId", cartId);
@@ -791,7 +798,7 @@ public interface CartItemResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/items");
 
 			httpInvoker.path("cartId", cartId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/CartResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/CartResource.java
@@ -148,6 +148,12 @@ public interface CartResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -171,6 +177,7 @@ public interface CartResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -236,7 +243,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}");
 
 			httpInvoker.path("cartId", cartId);
@@ -313,7 +320,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -388,7 +395,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}");
 
 			httpInvoker.path("cartId", cartId);
@@ -469,7 +476,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}");
 
 			httpInvoker.path("cartId", cartId);
@@ -550,7 +557,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}");
 
 			httpInvoker.path("cartId", cartId);
@@ -627,7 +634,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -704,7 +711,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/checkout");
 
 			httpInvoker.path("cartId", cartId);
@@ -787,7 +794,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/coupon-code");
 
 			httpInvoker.path("cartId", cartId);
@@ -873,7 +880,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/payment-url");
 
 			httpInvoker.path("cartId", cartId);
@@ -963,7 +970,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/channels/{channelId}/account/{accountId}/carts");
 
 			httpInvoker.path("accountId", accountId);
@@ -1047,7 +1054,7 @@ public interface CartResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/channels/{channelId}/carts");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/PaymentMethodResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/PaymentMethodResource.java
@@ -85,6 +85,12 @@ public interface PaymentMethodResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface PaymentMethodResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -188,7 +195,7 @@ public interface PaymentMethodResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/payment-methods");
 
 			httpInvoker.path("cartId", cartId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/ShippingMethodResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/resource/v1_0/ShippingMethodResource.java
@@ -85,6 +85,12 @@ public interface ShippingMethodResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface ShippingMethodResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -188,7 +195,7 @@ public interface ShippingMethodResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-cart/v1.0/carts/{cartId}/shipping-methods");
 
 			httpInvoker.path("cartId", cartId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/AttachmentResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/AttachmentResource.java
@@ -100,6 +100,12 @@ public interface AttachmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -123,6 +129,7 @@ public interface AttachmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -218,7 +225,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/attachments");
 
 			httpInvoker.path("channelId", channelId);
@@ -315,7 +322,7 @@ public interface AttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/images");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/CategoryResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/CategoryResource.java
@@ -87,6 +87,12 @@ public interface CategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface CategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -199,7 +206,7 @@ public interface CategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/categories");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/MappedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/MappedProductResource.java
@@ -90,6 +90,12 @@ public interface MappedProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -113,6 +119,7 @@ public interface MappedProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -218,7 +225,7 @@ public interface MappedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/mapped-products");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/PinResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/PinResource.java
@@ -89,6 +89,12 @@ public interface PinResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -112,6 +118,7 @@ public interface PinResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -215,7 +222,7 @@ public interface PinResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/pins");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/ProductOptionResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/ProductOptionResource.java
@@ -87,6 +87,12 @@ public interface ProductOptionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface ProductOptionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -200,7 +207,7 @@ public interface ProductOptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/product-options");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/ProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/ProductResource.java
@@ -97,6 +97,12 @@ public interface ProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -120,6 +126,7 @@ public interface ProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -222,7 +229,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products");
 
 			httpInvoker.path("channelId", channelId);
@@ -308,7 +315,7 @@ public interface ProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/ProductSpecificationResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/ProductSpecificationResource.java
@@ -89,6 +89,12 @@ public interface ProductSpecificationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -112,6 +118,7 @@ public interface ProductSpecificationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -203,7 +210,7 @@ public interface ProductSpecificationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/product-specifications");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/RelatedProductResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/RelatedProductResource.java
@@ -89,6 +89,12 @@ public interface RelatedProductResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -112,6 +118,7 @@ public interface RelatedProductResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -208,7 +215,7 @@ public interface RelatedProductResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/related-products");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/SkuResource.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/resource/v1_0/SkuResource.java
@@ -89,6 +89,12 @@ public interface SkuResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -112,6 +118,7 @@ public interface SkuResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -206,7 +213,7 @@ public interface SkuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-delivery-catalog/v1.0/channels/{channelId}/products/{productId}/skus");
 
 			httpInvoker.path("channelId", channelId);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionFieldLinkResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionFieldLinkResource.java
@@ -88,6 +88,12 @@ public interface DataDefinitionFieldLinkResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -111,6 +117,7 @@ public interface DataDefinitionFieldLinkResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -199,7 +206,7 @@ public interface DataDefinitionFieldLinkResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-definition-field-links");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataDefinitionResource.java
@@ -199,6 +199,12 @@ public interface DataDefinitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -222,6 +228,7 @@ public interface DataDefinitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -323,7 +330,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/by-content-type/{contentType}");
 
 			httpInvoker.path("contentType", contentType);
@@ -409,7 +416,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/by-content-type/{contentType}");
 
 			httpInvoker.path("contentType", contentType);
@@ -490,7 +497,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/data-definition-fields/field-types");
 
 			httpInvoker.userNameAndPassword(
@@ -569,7 +576,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -646,7 +653,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -725,7 +732,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -810,7 +817,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -894,7 +901,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -971,7 +978,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1057,7 +1064,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/permissions");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -1151,7 +1158,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/permissions");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -1253,7 +1260,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/sites/{siteId}/data-definitions/by-content-type/{contentType}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1341,7 +1348,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/sites/{siteId}/data-definitions/by-content-type/{contentType}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1427,7 +1434,7 @@ public interface DataDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/sites/{siteId}/data-definitions/by-content-type/{contentType}/by-data-definition-key/{dataDefinitionKey}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataLayoutResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataLayoutResource.java
@@ -166,6 +166,12 @@ public interface DataLayoutResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -189,6 +195,7 @@ public interface DataLayoutResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -269,7 +276,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-layouts");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -370,7 +377,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-layouts");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -456,7 +463,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-layouts");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -536,7 +543,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-layouts/batch");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -615,7 +622,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-layouts/{dataLayoutId}");
 
 			httpInvoker.path("dataLayoutId", dataLayoutId);
@@ -692,7 +699,8 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/data-engine/v2.0/data-layouts/batch");
+					_builder._port + _builder._pathContext +
+						"/o/data-engine/v2.0/data-layouts/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -768,7 +776,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-layouts/{dataLayoutId}");
 
 			httpInvoker.path("dataLayoutId", dataLayoutId);
@@ -852,7 +860,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-layouts/{dataLayoutId}");
 
 			httpInvoker.path("dataLayoutId", dataLayoutId);
@@ -929,7 +937,8 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/data-engine/v2.0/data-layouts/batch");
+					_builder._port + _builder._pathContext +
+						"/o/data-engine/v2.0/data-layouts/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -1003,7 +1012,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-layouts/{dataLayoutId}/context");
 
 			httpInvoker.path("dataLayoutId", dataLayoutId);
@@ -1087,7 +1096,7 @@ public interface DataLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/sites/{siteId}/data-layouts/by-content-type/{contentType}/by-data-layout-key/{dataLayoutKey}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataListViewResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataListViewResource.java
@@ -148,6 +148,12 @@ public interface DataListViewResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -171,6 +177,7 @@ public interface DataListViewResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -252,7 +259,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-list-views");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -353,7 +360,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-list-views");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -439,7 +446,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-list-views");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -519,7 +526,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-list-views/batch");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -598,7 +605,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-list-views/{dataListViewId}");
 
 			httpInvoker.path("dataListViewId", dataListViewId);
@@ -675,7 +682,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-list-views/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -754,7 +761,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-list-views/{dataListViewId}");
 
 			httpInvoker.path("dataListViewId", dataListViewId);
@@ -838,7 +845,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-list-views/{dataListViewId}");
 
 			httpInvoker.path("dataListViewId", dataListViewId);
@@ -915,7 +922,7 @@ public interface DataListViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-list-views/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordCollectionResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordCollectionResource.java
@@ -197,6 +197,12 @@ public interface DataRecordCollectionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -220,6 +226,7 @@ public interface DataRecordCollectionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -303,7 +310,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-record-collection");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -401,7 +408,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-record-collections");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -490,7 +497,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-record-collections");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -570,7 +577,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-record-collections/batch");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -651,7 +658,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -731,7 +738,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -811,7 +818,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -899,7 +906,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -978,7 +985,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1064,7 +1071,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/permissions");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -1158,7 +1165,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/permissions");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -1242,7 +1249,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/permissions/by-current-user");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -1327,7 +1334,7 @@ public interface DataRecordCollectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/sites/{siteId}/data-record-collections/by-data-record-collection-key/{dataRecordCollectionKey}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordResource.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/resource/v2_0/DataRecordResource.java
@@ -184,6 +184,12 @@ public interface DataRecordResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -207,6 +213,7 @@ public interface DataRecordResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -312,7 +319,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-records");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -398,7 +405,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-records");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -478,7 +485,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-definitions/{dataDefinitionId}/data-records/batch");
 
 			httpInvoker.path("dataDefinitionId", dataDefinitionId);
@@ -585,7 +592,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/data-records");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -671,7 +678,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/data-records");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -752,7 +759,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/data-records/batch");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -843,7 +850,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-record-collections/{dataRecordCollectionId}/data-records/export");
 
 			httpInvoker.path("dataRecordCollectionId", dataRecordCollectionId);
@@ -922,7 +929,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-records/{dataRecordId}");
 
 			httpInvoker.path("dataRecordId", dataRecordId);
@@ -999,7 +1006,8 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/data-engine/v2.0/data-records/batch");
+					_builder._port + _builder._pathContext +
+						"/o/data-engine/v2.0/data-records/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -1075,7 +1083,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-records/{dataRecordId}");
 
 			httpInvoker.path("dataRecordId", dataRecordId);
@@ -1159,7 +1167,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-records/{dataRecordId}");
 
 			httpInvoker.path("dataRecordId", dataRecordId);
@@ -1243,7 +1251,7 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/data-engine/v2.0/data-records/{dataRecordId}");
 
 			httpInvoker.path("dataRecordId", dataRecordId);
@@ -1320,7 +1328,8 @@ public interface DataRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/data-engine/v2.0/data-records/batch");
+					_builder._port + _builder._pathContext +
+						"/o/data-engine/v2.0/data-records/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/resource/v1_0/DSEnvelopeResource.java
+++ b/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/resource/v1_0/DSEnvelopeResource.java
@@ -111,6 +111,12 @@ public interface DSEnvelopeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -134,6 +140,7 @@ public interface DSEnvelopeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -221,7 +228,7 @@ public interface DSEnvelopeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/digital-signature-rest/v1.0/sites/{siteId}/ds-envelopes");
 
 			httpInvoker.path("siteId", siteId);
@@ -304,7 +311,7 @@ public interface DSEnvelopeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/digital-signature-rest/v1.0/sites/{siteId}/ds-envelopes");
 
 			httpInvoker.path("siteId", siteId);
@@ -385,7 +392,7 @@ public interface DSEnvelopeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/digital-signature-rest/v1.0/sites/{siteId}/ds-envelopes/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -466,7 +473,7 @@ public interface DSEnvelopeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/digital-signature-rest/v1.0/sites/{siteId}/ds-envelopes/{dsEnvelopeId}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/resource/v1_0/ActiveViewResource.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/resource/v1_0/ActiveViewResource.java
@@ -93,6 +93,12 @@ public interface ActiveViewResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -116,6 +122,7 @@ public interface ActiveViewResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -198,7 +205,7 @@ public interface ActiveViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/frontend-view-state/v1.0/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}");
 
 			httpInvoker.path("activeViewId", activeViewId);
@@ -277,7 +284,7 @@ public interface ActiveViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/frontend-view-state/v1.0/active-view/{activeViewId}/page-layout/{pageLayoutId}/portlet/{portletId}");
 
 			httpInvoker.path("activeViewId", activeViewId);

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/resource/v1_0/CountryResource.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/resource/v1_0/CountryResource.java
@@ -159,6 +159,12 @@ public interface CountryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -182,6 +188,7 @@ public interface CountryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -284,7 +291,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries");
 
 			httpInvoker.userNameAndPassword(
@@ -362,7 +369,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries");
 
 			httpInvoker.userNameAndPassword(
@@ -437,7 +444,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -513,7 +520,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/by-a2/{a2}");
 
 			httpInvoker.path("a2", a2);
@@ -591,7 +598,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/by-a3/{a3}");
 
 			httpInvoker.path("a3", a3);
@@ -670,7 +677,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/by-name/{name}");
 
 			httpInvoker.path("name", name);
@@ -749,7 +756,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/by-number/{number}");
 
 			httpInvoker.path("number", number);
@@ -828,7 +835,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}");
 
 			httpInvoker.path("countryId", countryId);
@@ -905,7 +912,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -981,7 +988,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}");
 
 			httpInvoker.path("countryId", countryId);
@@ -1064,7 +1071,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}");
 
 			httpInvoker.path("countryId", countryId);
@@ -1147,7 +1154,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}");
 
 			httpInvoker.path("countryId", countryId);
@@ -1224,7 +1231,7 @@ public interface CountryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/resource/v1_0/RegionResource.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/resource/v1_0/RegionResource.java
@@ -158,6 +158,12 @@ public interface RegionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -181,6 +187,7 @@ public interface RegionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -283,7 +290,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}/regions");
 
 			httpInvoker.path("countryId", countryId);
@@ -366,7 +373,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}/regions");
 
 			httpInvoker.path("countryId", countryId);
@@ -445,7 +452,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}/regions/batch");
 
 			httpInvoker.path("countryId", countryId);
@@ -528,7 +535,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/countries/{countryId}/regions/by-region-code/{regionCode}");
 
 			httpInvoker.path("countryId", countryId);
@@ -632,7 +639,8 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-admin-address/v1.0/regions");
+					_builder._port + _builder._pathContext +
+						"/o/headless-admin-address/v1.0/regions");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -707,7 +715,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/regions/{regionId}");
 
 			httpInvoker.path("regionId", regionId);
@@ -784,7 +792,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/regions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -860,7 +868,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/regions/{regionId}");
 
 			httpInvoker.path("regionId", regionId);
@@ -943,7 +951,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/regions/{regionId}");
 
 			httpInvoker.path("regionId", regionId);
@@ -1024,7 +1032,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/regions/{regionId}");
 
 			httpInvoker.path("regionId", regionId);
@@ -1101,7 +1109,7 @@ public interface RegionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-address/v1.0/regions/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/DisplayPageTemplateResource.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/DisplayPageTemplateResource.java
@@ -95,6 +95,12 @@ public interface DisplayPageTemplateResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -118,6 +124,7 @@ public interface DisplayPageTemplateResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -212,7 +219,7 @@ public interface DisplayPageTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/sites/{siteId}/display-page-templates");
 
 			httpInvoker.path("siteId", siteId);
@@ -295,7 +302,7 @@ public interface DisplayPageTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/sites/{siteId}/display-page-templates/{displayPageTemplateKey}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/PageDefinitionResource.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/PageDefinitionResource.java
@@ -84,6 +84,12 @@ public interface PageDefinitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -107,6 +113,7 @@ public interface PageDefinitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -181,7 +188,7 @@ public interface PageDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/sites/{siteId}/page-definitions/preview");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/resource/v1_0/StructuredContentResource.java
@@ -126,6 +126,12 @@ public interface StructuredContentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -149,6 +155,7 @@ public interface StructuredContentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -260,7 +267,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/sites/{siteId}/structured-contents");
 
 			httpInvoker.path("siteId", siteId);
@@ -346,7 +353,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/sites/{siteId}/structured-contents/draft");
 
 			httpInvoker.path("siteId", siteId);
@@ -430,7 +437,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}/by-version/{version}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -515,7 +522,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}/by-version/{version}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -600,7 +607,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-content/v1.0/structured-contents/{structuredContentId}/versions");
 
 			httpInvoker.path("structuredContentId", structuredContentId);

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/resource/v1_0/ListTypeDefinitionResource.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/resource/v1_0/ListTypeDefinitionResource.java
@@ -149,6 +149,12 @@ public interface ListTypeDefinitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -172,6 +178,7 @@ public interface ListTypeDefinitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -275,7 +282,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions");
 
 			httpInvoker.userNameAndPassword(
@@ -357,7 +364,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions");
 
 			httpInvoker.userNameAndPassword(
@@ -433,7 +440,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -512,7 +519,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -591,7 +598,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -671,7 +678,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -758,7 +765,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -845,7 +852,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -923,7 +930,7 @@ public interface ListTypeDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/resource/v1_0/ListTypeEntryResource.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/resource/v1_0/ListTypeEntryResource.java
@@ -145,6 +145,12 @@ public interface ListTypeEntryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -168,6 +174,7 @@ public interface ListTypeEntryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -275,7 +282,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}/list-type-entries");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -361,7 +368,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}/list-type-entries");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -442,7 +449,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-definitions/{listTypeDefinitionId}/list-type-entries/batch");
 
 			httpInvoker.path("listTypeDefinitionId", listTypeDefinitionId);
@@ -521,7 +528,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-entries/{listTypeEntryId}");
 
 			httpInvoker.path("listTypeEntryId", listTypeEntryId);
@@ -598,7 +605,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-entries/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -677,7 +684,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-entries/{listTypeEntryId}");
 
 			httpInvoker.path("listTypeEntryId", listTypeEntryId);
@@ -761,7 +768,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-entries/{listTypeEntryId}");
 
 			httpInvoker.path("listTypeEntryId", listTypeEntryId);
@@ -838,7 +845,7 @@ public interface ListTypeEntryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-list-type/v1.0/list-type-entries/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/KeywordResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/KeywordResource.java
@@ -216,6 +216,12 @@ public interface KeywordResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -239,6 +245,7 @@ public interface KeywordResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -342,7 +349,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -426,7 +433,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -506,7 +513,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -594,7 +601,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -688,7 +695,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/keywords/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -785,7 +792,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/ranked");
 
 			httpInvoker.userNameAndPassword(
@@ -862,7 +869,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/{keywordId}");
 
 			httpInvoker.path("keywordId", keywordId);
@@ -939,7 +946,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1015,7 +1022,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/{keywordId}");
 
 			httpInvoker.path("keywordId", keywordId);
@@ -1098,7 +1105,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/{keywordId}");
 
 			httpInvoker.path("keywordId", keywordId);
@@ -1175,7 +1182,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1252,7 +1259,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/{keywordId}/subscribe");
 
 			httpInvoker.path("keywordId", keywordId);
@@ -1331,7 +1338,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/keywords/{keywordId}/unsubscribe");
 
 			httpInvoker.path("keywordId", keywordId);
@@ -1435,7 +1442,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords");
 
 			httpInvoker.path("siteId", siteId);
@@ -1518,7 +1525,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords");
 
 			httpInvoker.path("siteId", siteId);
@@ -1596,7 +1603,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1683,7 +1690,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1776,7 +1783,7 @@ public interface KeywordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/keywords/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyCategoryResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyCategoryResource.java
@@ -233,6 +233,12 @@ public interface TaxonomyCategoryResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -256,6 +262,7 @@ public interface TaxonomyCategoryResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -349,7 +356,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked");
 
 			httpInvoker.userNameAndPassword(
@@ -454,7 +461,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
 
 			httpInvoker.path(
@@ -543,7 +550,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{parentTaxonomyCategoryId}/taxonomy-categories");
 
 			httpInvoker.path(
@@ -625,7 +632,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}");
 
 			httpInvoker.path("taxonomyCategoryId", taxonomyCategoryId);
@@ -703,7 +710,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -782,7 +789,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}");
 
 			httpInvoker.path("taxonomyCategoryId", taxonomyCategoryId);
@@ -867,7 +874,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}");
 
 			httpInvoker.path("taxonomyCategoryId", taxonomyCategoryId);
@@ -952,7 +959,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}");
 
 			httpInvoker.path("taxonomyCategoryId", taxonomyCategoryId);
@@ -1029,7 +1036,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1115,7 +1122,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}/permissions");
 
 			httpInvoker.path("taxonomyCategoryId", taxonomyCategoryId);
@@ -1209,7 +1216,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-categories/{taxonomyCategoryId}/permissions");
 
 			httpInvoker.path("taxonomyCategoryId", taxonomyCategoryId);
@@ -1318,7 +1325,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1405,7 +1412,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1486,7 +1493,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/batch");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1571,7 +1578,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1657,7 +1664,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1748,7 +1755,7 @@ public interface TaxonomyCategoryResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyVocabularyResource.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/resource/v1_0/TaxonomyVocabularyResource.java
@@ -264,6 +264,12 @@ public interface TaxonomyVocabularyResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -287,6 +293,7 @@ public interface TaxonomyVocabularyResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -392,7 +399,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -478,7 +485,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -558,7 +565,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -647,7 +654,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -742,7 +749,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/asset-libraries/{assetLibraryId}/taxonomy-vocabularies/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -847,7 +854,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies");
 
 			httpInvoker.path("siteId", siteId);
@@ -932,7 +939,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies");
 
 			httpInvoker.path("siteId", siteId);
@@ -1012,7 +1019,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1096,7 +1103,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1182,7 +1189,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1272,7 +1279,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1361,7 +1368,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1455,7 +1462,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/sites/{siteId}/taxonomy-vocabularies/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1536,7 +1543,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1615,7 +1622,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1695,7 +1702,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1782,7 +1789,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1869,7 +1876,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -1947,7 +1954,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -2033,7 +2040,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/permissions");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);
@@ -2127,7 +2134,7 @@ public interface TaxonomyVocabularyResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/{taxonomyVocabularyId}/permissions");
 
 			httpInvoker.path("taxonomyVocabularyId", taxonomyVocabularyId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountResource.java
@@ -237,6 +237,12 @@ public interface AccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -260,6 +266,7 @@ public interface AccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -361,7 +368,8 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-admin-user/v1.0/accounts");
+					_builder._port + _builder._pathContext +
+						"/o/headless-admin-user/v1.0/accounts");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -438,7 +446,8 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-admin-user/v1.0/accounts");
+					_builder._port + _builder._pathContext +
+						"/o/headless-admin-user/v1.0/accounts");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -512,7 +521,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -594,7 +603,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -678,7 +687,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -764,7 +773,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -850,7 +859,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -929,7 +938,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1006,7 +1015,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1082,7 +1091,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1165,7 +1174,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1248,7 +1257,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1325,7 +1334,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1419,7 +1428,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/move-accounts/{sourceOrganizationId}/{targetOrganizationId}");
 
 			httpInvoker.path("sourceOrganizationId", sourceOrganizationId);
@@ -1516,7 +1525,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/move-accounts/{sourceOrganizationId}/{targetOrganizationId}/by-external-reference-code");
 
 			httpInvoker.path("sourceOrganizationId", sourceOrganizationId);
@@ -1609,7 +1618,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/accounts");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1714,7 +1723,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/accounts");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1805,7 +1814,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/accounts");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1899,7 +1908,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/accounts/by-external-reference-code");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1993,7 +2002,7 @@ public interface AccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/accounts/by-external-reference-code");
 
 			httpInvoker.path("organizationId", organizationId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/AccountRoleResource.java
@@ -213,6 +213,12 @@ public interface AccountRoleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -236,6 +242,7 @@ public interface AccountRoleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -322,7 +329,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
 
 			httpInvoker.path(
@@ -415,7 +422,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
 
 			httpInvoker.path(
@@ -508,7 +515,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}/account-roles");
 
 			httpInvoker.path(
@@ -621,7 +628,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-roles");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -707,7 +714,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-roles");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -794,7 +801,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -883,7 +890,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/account-roles/{accountRoleId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -970,7 +977,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}/account-roles");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1075,7 +1082,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles");
 
 			httpInvoker.path("accountId", accountId);
@@ -1159,7 +1166,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles");
 
 			httpInvoker.path("accountId", accountId);
@@ -1238,7 +1245,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/batch");
 
 			httpInvoker.path("accountId", accountId);
@@ -1322,7 +1329,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1408,7 +1415,7 @@ public interface AccountRoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/account-roles/{accountRoleId}/user-accounts/{userAccountId}");
 
 			httpInvoker.path("accountId", accountId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/EmailAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/EmailAddressResource.java
@@ -100,6 +100,12 @@ public interface EmailAddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -123,6 +129,7 @@ public interface EmailAddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -203,7 +210,7 @@ public interface EmailAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/email-addresses/{emailAddressId}");
 
 			httpInvoker.path("emailAddressId", emailAddressId);
@@ -286,7 +293,7 @@ public interface EmailAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/email-addresses");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -368,7 +375,7 @@ public interface EmailAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/email-addresses");
 
 			httpInvoker.path("userAccountId", userAccountId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/OrganizationResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/OrganizationResource.java
@@ -294,6 +294,12 @@ public interface OrganizationResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -317,6 +323,7 @@ public interface OrganizationResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -425,7 +432,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/organizations");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -509,7 +516,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/organizations/{organizationId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -594,7 +601,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/organizations/{organizationId}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -699,7 +706,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/organizations");
 
 			httpInvoker.path("accountId", accountId);
@@ -782,7 +789,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/organizations/{organizationId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -865,7 +872,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/organizations/{organizationId}");
 
 			httpInvoker.path("accountId", accountId);
@@ -974,7 +981,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations");
 
 			httpInvoker.userNameAndPassword(
@@ -1055,7 +1062,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations");
 
 			httpInvoker.userNameAndPassword(
@@ -1130,7 +1137,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1212,7 +1219,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1296,7 +1303,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1382,7 +1389,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1468,7 +1475,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1547,7 +1554,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1624,7 +1631,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1703,7 +1710,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1787,7 +1794,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1871,7 +1878,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -1948,7 +1955,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -2057,7 +2064,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/child-organizations");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -2151,7 +2158,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/user-accounts/by-email-address");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -2252,7 +2259,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/user-accounts/by-email-address");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -2336,7 +2343,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -2421,7 +2428,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -2533,7 +2540,7 @@ public interface OrganizationResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{parentOrganizationId}/organizations");
 
 			httpInvoker.path("parentOrganizationId", parentOrganizationId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/PhoneResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/PhoneResource.java
@@ -97,6 +97,12 @@ public interface PhoneResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -120,6 +126,7 @@ public interface PhoneResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -199,7 +206,7 @@ public interface PhoneResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/phones");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -277,7 +284,7 @@ public interface PhoneResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/phones/{phoneId}");
 
 			httpInvoker.path("phoneId", phoneId);
@@ -358,7 +365,7 @@ public interface PhoneResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/phones");
 
 			httpInvoker.path("userAccountId", userAccountId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/PostalAddressResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/PostalAddressResource.java
@@ -102,6 +102,12 @@ public interface PostalAddressResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -125,6 +131,7 @@ public interface PostalAddressResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -207,7 +214,7 @@ public interface PostalAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/postal-addresses");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -288,7 +295,7 @@ public interface PostalAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/postal-addresses/{postalAddressId}");
 
 			httpInvoker.path("postalAddressId", postalAddressId);
@@ -371,7 +378,7 @@ public interface PostalAddressResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/postal-addresses");
 
 			httpInvoker.path("userAccountId", userAccountId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/RoleResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/RoleResource.java
@@ -143,6 +143,12 @@ public interface RoleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -166,6 +172,7 @@ public interface RoleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -258,7 +265,8 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-admin-user/v1.0/roles");
+					_builder._port + _builder._pathContext +
+						"/o/headless-admin-user/v1.0/roles");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -332,7 +340,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}");
 
 			httpInvoker.path("roleId", roleId);
@@ -416,7 +424,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}/association/user-account/{userAccountId}");
 
 			httpInvoker.path("roleId", roleId);
@@ -501,7 +509,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}/association/user-account/{userAccountId}");
 
 			httpInvoker.path("roleId", roleId);
@@ -586,7 +594,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}/association/user-account/{userAccountId}/organization/{organizationId}");
 
 			httpInvoker.path("roleId", roleId);
@@ -672,7 +680,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}/association/user-account/{userAccountId}/organization/{organizationId}");
 
 			httpInvoker.path("roleId", roleId);
@@ -758,7 +766,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}/association/user-account/{userAccountId}/site/{siteId}");
 
 			httpInvoker.path("roleId", roleId);
@@ -844,7 +852,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/roles/{roleId}/association/user-account/{userAccountId}/site/{siteId}");
 
 			httpInvoker.path("roleId", roleId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SegmentResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SegmentResource.java
@@ -94,6 +94,12 @@ public interface SegmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -117,6 +123,7 @@ public interface SegmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -204,7 +211,7 @@ public interface SegmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/sites/{siteId}/segments");
 
 			httpInvoker.path("siteId", siteId);
@@ -288,7 +295,7 @@ public interface SegmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts/{userAccountId}/segments");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SegmentUserResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SegmentUserResource.java
@@ -87,6 +87,12 @@ public interface SegmentUserResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface SegmentUserResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -197,7 +204,7 @@ public interface SegmentUserResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/segments/{segmentId}/user-accounts");
 
 			httpInvoker.path("segmentId", segmentId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SiteResource.java
@@ -98,6 +98,12 @@ public interface SiteResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -121,6 +127,7 @@ public interface SiteResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -207,7 +214,7 @@ public interface SiteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/my-user-account/sites");
 
 			httpInvoker.userNameAndPassword(
@@ -286,7 +293,7 @@ public interface SiteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/sites/by-friendly-url-path/{friendlyUrlPath}");
 
 			httpInvoker.path("friendlyUrlPath", friendlyUrlPath);
@@ -363,7 +370,7 @@ public interface SiteResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/sites/{siteId}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SubscriptionResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/SubscriptionResource.java
@@ -102,6 +102,12 @@ public interface SubscriptionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -125,6 +131,7 @@ public interface SubscriptionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -220,7 +227,7 @@ public interface SubscriptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/my-user-account/subscriptions");
 
 			httpInvoker.userNameAndPassword(
@@ -299,7 +306,7 @@ public interface SubscriptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/my-user-account/subscriptions/{subscriptionId}");
 
 			httpInvoker.path("subscriptionId", subscriptionId);
@@ -380,7 +387,7 @@ public interface SubscriptionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/my-user-account/subscriptions/{subscriptionId}");
 
 			httpInvoker.path("subscriptionId", subscriptionId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
@@ -341,6 +341,12 @@ public interface UserAccountResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -364,6 +370,7 @@ public interface UserAccountResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -450,7 +457,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
 
 			httpInvoker.path(
@@ -542,7 +549,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{accountExternalReferenceCode}/user-accounts/by-external-reference-code/{userAccountExternalReferenceCode}");
 
 			httpInvoker.path(
@@ -655,7 +662,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -741,7 +748,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -836,7 +843,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -931,7 +938,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1016,7 +1023,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1101,7 +1108,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/by-external-reference-code/{externalReferenceCode}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -1206,7 +1213,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts");
 
 			httpInvoker.path("accountId", accountId);
@@ -1290,7 +1297,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts");
 
 			httpInvoker.path("accountId", accountId);
@@ -1369,7 +1376,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/batch");
 
 			httpInvoker.path("accountId", accountId);
@@ -1463,7 +1470,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address");
 
 			httpInvoker.path("accountId", accountId);
@@ -1562,7 +1569,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address");
 
 			httpInvoker.path("accountId", accountId);
@@ -1646,7 +1653,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1731,7 +1738,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/accounts/{accountId}/user-accounts/by-email-address/{emailAddress}");
 
 			httpInvoker.path("accountId", accountId);
@@ -1810,7 +1817,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/my-user-account");
 
 			httpInvoker.userNameAndPassword(
@@ -1914,7 +1921,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/user-accounts");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -2018,7 +2025,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts");
 
 			httpInvoker.path("siteId", siteId);
@@ -2122,7 +2129,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts");
 
 			httpInvoker.userNameAndPassword(
@@ -2203,7 +2210,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts");
 
 			httpInvoker.userNameAndPassword(
@@ -2278,7 +2285,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -2360,7 +2367,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -2444,7 +2451,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -2530,7 +2537,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -2609,7 +2616,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}");
 
 			httpInvoker.path("userAccountId", userAccountId);
@@ -2686,7 +2693,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -2763,7 +2770,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}");
 
 			httpInvoker.path("userAccountId", userAccountId);
@@ -2847,7 +2854,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}");
 
 			httpInvoker.path("userAccountId", userAccountId);
@@ -2931,7 +2938,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}");
 
 			httpInvoker.path("userAccountId", userAccountId);
@@ -3008,7 +3015,7 @@ public interface UserAccountResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserGroupResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserGroupResource.java
@@ -193,6 +193,12 @@ public interface UserGroupResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -216,6 +222,7 @@ public interface UserGroupResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -318,7 +325,8 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-admin-user/v1.0/user-groups");
+					_builder._port + _builder._pathContext +
+						"/o/headless-admin-user/v1.0/user-groups");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -396,7 +404,8 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-admin-user/v1.0/user-groups");
+					_builder._port + _builder._pathContext +
+						"/o/headless-admin-user/v1.0/user-groups");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -470,7 +479,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -552,7 +561,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -636,7 +645,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -722,7 +731,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -808,7 +817,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -887,7 +896,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/{userGroupId}");
 
 			httpInvoker.path("userGroupId", userGroupId);
@@ -964,7 +973,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1041,7 +1050,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/{userGroupId}");
 
 			httpInvoker.path("userGroupId", userGroupId);
@@ -1124,7 +1133,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/{userGroupId}");
 
 			httpInvoker.path("userGroupId", userGroupId);
@@ -1207,7 +1216,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/{userGroupId}");
 
 			httpInvoker.path("userGroupId", userGroupId);
@@ -1284,7 +1293,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1373,7 +1382,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/{userGroupId}/user-group-users");
 
 			httpInvoker.path("userGroupId", userGroupId);
@@ -1464,7 +1473,7 @@ public interface UserGroupResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-groups/{userGroupId}/user-group-users");
 
 			httpInvoker.path("userGroupId", userGroupId);

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/WebUrlResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/WebUrlResource.java
@@ -97,6 +97,12 @@ public interface WebUrlResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -120,6 +126,7 @@ public interface WebUrlResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -199,7 +206,7 @@ public interface WebUrlResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/web-urls");
 
 			httpInvoker.path("organizationId", organizationId);
@@ -280,7 +287,7 @@ public interface WebUrlResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/web-urls");
 
 			httpInvoker.path("userAccountId", userAccountId);
@@ -358,7 +365,7 @@ public interface WebUrlResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-user/v1.0/web-urls/{webUrlId}");
 
 			httpInvoker.path("webUrlId", webUrlId);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/AssigneeResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/AssigneeResource.java
@@ -88,6 +88,12 @@ public interface AssigneeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -111,6 +117,7 @@ public interface AssigneeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -200,7 +207,7 @@ public interface AssigneeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/assignable-users");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/TransitionResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/TransitionResource.java
@@ -97,6 +97,12 @@ public interface TransitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -120,6 +126,7 @@ public interface TransitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -209,7 +216,7 @@ public interface TransitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}/next-transitions");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -300,7 +307,7 @@ public interface TransitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/next-transitions");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowDefinitionResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowDefinitionResource.java
@@ -128,6 +128,12 @@ public interface WorkflowDefinitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -151,6 +157,7 @@ public interface WorkflowDefinitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -248,7 +255,7 @@ public interface WorkflowDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-definitions");
 
 			httpInvoker.userNameAndPassword(
@@ -332,7 +339,7 @@ public interface WorkflowDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-definitions/by-name/{name}");
 
 			httpInvoker.path("name", name);
@@ -417,7 +424,7 @@ public interface WorkflowDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-definitions/deploy");
 
 			httpInvoker.userNameAndPassword(
@@ -499,7 +506,7 @@ public interface WorkflowDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-definitions/save");
 
 			httpInvoker.userNameAndPassword(
@@ -590,7 +597,7 @@ public interface WorkflowDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-definitions/undeploy");
 
 			httpInvoker.userNameAndPassword(
@@ -686,7 +693,7 @@ public interface WorkflowDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-definitions/update-active");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowInstanceResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowInstanceResource.java
@@ -122,6 +122,12 @@ public interface WorkflowInstanceResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -145,6 +151,7 @@ public interface WorkflowInstanceResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -250,7 +257,7 @@ public interface WorkflowInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances");
 
 			httpInvoker.userNameAndPassword(
@@ -333,7 +340,7 @@ public interface WorkflowInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/submit");
 
 			httpInvoker.userNameAndPassword(
@@ -412,7 +419,7 @@ public interface WorkflowInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -493,7 +500,7 @@ public interface WorkflowInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -579,7 +586,7 @@ public interface WorkflowInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}/change-transition");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowLogResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowLogResource.java
@@ -102,6 +102,12 @@ public interface WorkflowLogResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -125,6 +131,7 @@ public interface WorkflowLogResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -221,7 +228,7 @@ public interface WorkflowLogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}/workflow-logs");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -300,7 +307,7 @@ public interface WorkflowLogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-logs/{workflowLogId}");
 
 			httpInvoker.path("workflowLogId", workflowLogId);
@@ -397,7 +404,7 @@ public interface WorkflowLogResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/workflow-logs");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowTaskAssignableUsersResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowTaskAssignableUsersResource.java
@@ -86,6 +86,12 @@ public interface WorkflowTaskAssignableUsersResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -109,6 +115,7 @@ public interface WorkflowTaskAssignableUsersResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -193,7 +200,7 @@ public interface WorkflowTaskAssignableUsersResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assignable-users");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowTaskResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowTaskResource.java
@@ -264,6 +264,12 @@ public interface WorkflowTaskResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -287,6 +293,7 @@ public interface WorkflowTaskResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -383,7 +390,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}/workflow-tasks");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -481,7 +488,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}/workflow-tasks/assigned-to-me");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -583,7 +590,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-instances/{workflowInstanceId}/workflow-tasks/assigned-to-user");
 
 			httpInvoker.path("workflowInstanceId", workflowInstanceId);
@@ -682,7 +689,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks");
 
 			httpInvoker.userNameAndPassword(
@@ -774,7 +781,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assign-to-user");
 
 			httpInvoker.userNameAndPassword(
@@ -862,7 +869,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assigned-to-me");
 
 			httpInvoker.userNameAndPassword(
@@ -950,7 +957,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assigned-to-my-roles");
 
 			httpInvoker.userNameAndPassword(
@@ -1043,7 +1050,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assigned-to-role");
 
 			httpInvoker.userNameAndPassword(
@@ -1136,7 +1143,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assigned-to-user");
 
 			httpInvoker.userNameAndPassword(
@@ -1229,7 +1236,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/assigned-to-user-roles");
 
 			httpInvoker.userNameAndPassword(
@@ -1321,7 +1328,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/change-transition");
 
 			httpInvoker.userNameAndPassword(
@@ -1414,7 +1421,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/submitting-user");
 
 			httpInvoker.userNameAndPassword(
@@ -1506,7 +1513,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/update-due-date");
 
 			httpInvoker.userNameAndPassword(
@@ -1585,7 +1592,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);
@@ -1673,7 +1680,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/assign-to-me");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);
@@ -1762,7 +1769,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/assign-to-role");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);
@@ -1851,7 +1858,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/assign-to-user");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);
@@ -1937,7 +1944,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/change-transition");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);
@@ -2019,7 +2026,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/has-assignable-users");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);
@@ -2108,7 +2115,7 @@ public interface WorkflowTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/{workflowTaskId}/update-due-date");
 
 			httpInvoker.path("workflowTaskId", workflowTaskId);

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowTaskTransitionsResource.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/resource/v1_0/WorkflowTaskTransitionsResource.java
@@ -86,6 +86,12 @@ public interface WorkflowTaskTransitionsResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -109,6 +115,7 @@ public interface WorkflowTaskTransitionsResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -192,7 +199,7 @@ public interface WorkflowTaskTransitionsResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-admin-workflow/v1.0/workflow-tasks/next-transitions");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ExportTaskResource.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ExportTaskResource.java
@@ -118,6 +118,12 @@ public interface ExportTaskResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -141,6 +147,7 @@ public interface ExportTaskResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -223,7 +230,7 @@ public interface ExportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/export-task/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -296,7 +303,7 @@ public interface ExportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/export-task/by-external-reference-code/{externalReferenceCode}/content");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -407,7 +414,7 @@ public interface ExportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/export-task/{className}/{contentType}");
 
 			httpInvoker.path("className", className);
@@ -487,7 +494,7 @@ public interface ExportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/export-task/{exportTaskId}");
 
 			httpInvoker.path("exportTaskId", exportTaskId);
@@ -555,7 +562,7 @@ public interface ExportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/export-task/{exportTaskId}/content");
 
 			httpInvoker.path("exportTaskId", exportTaskId);

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ImportTaskResource.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/resource/v1_0/ImportTaskResource.java
@@ -198,6 +198,12 @@ public interface ImportTaskResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -221,6 +227,7 @@ public interface ImportTaskResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -303,7 +310,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -376,7 +383,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/{externalReferenceCode}/content");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -449,7 +456,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/by-external-reference-code/{externalReferenceCode}/failed-items/report");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
@@ -561,7 +568,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{className}");
 
 			httpInvoker.path("className", className);
@@ -682,7 +689,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{className}");
 
 			httpInvoker.path("className", className);
@@ -805,7 +812,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{className}");
 
 			httpInvoker.path("className", className);
@@ -936,7 +943,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{className}");
 
 			httpInvoker.path("className", className);
@@ -1054,7 +1061,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{className}");
 
 			httpInvoker.path("className", className);
@@ -1180,7 +1187,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{className}");
 
 			httpInvoker.path("className", className);
@@ -1259,7 +1266,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{importTaskId}");
 
 			httpInvoker.path("importTaskId", importTaskId);
@@ -1327,7 +1334,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{importTaskId}/content");
 
 			httpInvoker.path("importTaskId", importTaskId);
@@ -1397,7 +1404,7 @@ public interface ImportTaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-batch-engine/v1.0/import-task/{importTaskId}/failed-items/report");
 
 			httpInvoker.path("importTaskId", importTaskId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingImageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingImageResource.java
@@ -133,6 +133,12 @@ public interface BlogPostingImageResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -156,6 +162,7 @@ public interface BlogPostingImageResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -236,7 +243,7 @@ public interface BlogPostingImageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-posting-images/{blogPostingImageId}");
 
 			httpInvoker.path("blogPostingImageId", blogPostingImageId);
@@ -314,7 +321,7 @@ public interface BlogPostingImageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-posting-images/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -393,7 +400,7 @@ public interface BlogPostingImageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-posting-images/{blogPostingImageId}");
 
 			httpInvoker.path("blogPostingImageId", blogPostingImageId);
@@ -500,7 +507,7 @@ public interface BlogPostingImageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images");
 
 			httpInvoker.path("siteId", siteId);
@@ -595,7 +602,7 @@ public interface BlogPostingImageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images");
 
 			httpInvoker.path("siteId", siteId);
@@ -680,7 +687,7 @@ public interface BlogPostingImageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-posting-images/batch");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/BlogPostingResource.java
@@ -261,6 +261,12 @@ public interface BlogPostingResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -284,6 +290,7 @@ public interface BlogPostingResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -361,7 +368,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -438,7 +445,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -515,7 +522,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -599,7 +606,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -683,7 +690,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -760,7 +767,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -839,7 +846,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/my-rating");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -920,7 +927,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/my-rating");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -1003,7 +1010,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/my-rating");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -1086,7 +1093,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/my-rating");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -1174,7 +1181,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/permissions");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -1268,7 +1275,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/permissions");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -1352,7 +1359,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/rendered-content-by-display-page/{displayPageKey}");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -1458,7 +1465,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings");
 
 			httpInvoker.path("siteId", siteId);
@@ -1542,7 +1549,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings");
 
 			httpInvoker.path("siteId", siteId);
@@ -1621,7 +1628,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1705,7 +1712,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1790,7 +1797,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1879,7 +1886,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1968,7 +1975,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2062,7 +2069,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2141,7 +2148,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/subscribe");
 
 			httpInvoker.path("siteId", siteId);
@@ -2222,7 +2229,7 @@ public interface BlogPostingResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/unsubscribe");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/CommentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/CommentResource.java
@@ -350,6 +350,12 @@ public interface CommentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -373,6 +379,7 @@ public interface CommentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -476,7 +483,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/comments");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -560,7 +567,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/comments");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -639,7 +646,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/comments/batch");
 
 			httpInvoker.path("blogPostingId", blogPostingId);
@@ -718,7 +725,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/{commentId}");
 
 			httpInvoker.path("commentId", commentId);
@@ -795,7 +802,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -871,7 +878,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/{commentId}");
 
 			httpInvoker.path("commentId", commentId);
@@ -954,7 +961,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/{commentId}");
 
 			httpInvoker.path("commentId", commentId);
@@ -1031,7 +1038,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1134,7 +1141,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/{parentCommentId}/comments");
 
 			httpInvoker.path("parentCommentId", parentCommentId);
@@ -1217,7 +1224,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/comments/{parentCommentId}/comments");
 
 			httpInvoker.path("parentCommentId", parentCommentId);
@@ -1322,7 +1329,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/comments");
 
 			httpInvoker.path("documentId", documentId);
@@ -1405,7 +1412,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/comments");
 
 			httpInvoker.path("documentId", documentId);
@@ -1484,7 +1491,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/comments/batch");
 
 			httpInvoker.path("documentId", documentId);
@@ -1572,7 +1579,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{blogPostingExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1664,7 +1671,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{blogPostingExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1758,7 +1765,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/blog-postings/by-external-reference-code/{blogPostingExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1850,7 +1857,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/comments/by-external-reference-code/{parentCommentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1942,7 +1949,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/comments/by-external-reference-code/{parentCommentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2036,7 +2043,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/comments/by-external-reference-code/{parentCommentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2128,7 +2135,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/by-external-reference-code/{documentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2219,7 +2226,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/by-external-reference-code/{documentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2312,7 +2319,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/by-external-reference-code/{documentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2403,7 +2410,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-external-reference-code/{structuredContentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2495,7 +2502,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-external-reference-code/{structuredContentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2589,7 +2596,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-external-reference-code/{structuredContentExternalReferenceCode}/comments/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2701,7 +2708,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/comments");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -2787,7 +2794,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/comments");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -2867,7 +2874,7 @@ public interface CommentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/comments/batch");
 
 			httpInvoker.path("structuredContentId", structuredContentId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentElementResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentElementResource.java
@@ -101,6 +101,12 @@ public interface ContentElementResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -124,6 +130,7 @@ public interface ContentElementResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -230,7 +237,7 @@ public interface ContentElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-elements");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -335,7 +342,7 @@ public interface ContentElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-elements");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentSetElementResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentSetElementResource.java
@@ -127,6 +127,12 @@ public interface ContentSetElementResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -150,6 +156,7 @@ public interface ContentSetElementResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -241,7 +248,7 @@ public interface ContentSetElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-sets/by-key/{key}/content-set-elements");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -334,7 +341,7 @@ public interface ContentSetElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-sets/by-uuid/{uuid}/content-set-elements");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -426,7 +433,7 @@ public interface ContentSetElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/content-sets/{contentSetId}/content-set-elements");
 
 			httpInvoker.path("contentSetId", contentSetId);
@@ -518,7 +525,7 @@ public interface ContentSetElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-sets/by-key/{key}/content-set-elements");
 
 			httpInvoker.path("siteId", siteId);
@@ -611,7 +618,7 @@ public interface ContentSetElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-sets/by-uuid/{uuid}/content-set-elements");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentStructureResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentStructureResource.java
@@ -165,6 +165,12 @@ public interface ContentStructureResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -188,6 +194,7 @@ public interface ContentStructureResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -294,7 +301,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-structures");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -382,7 +389,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-structures/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -476,7 +483,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-structures/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -557,7 +564,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/content-structures/{contentStructureId}");
 
 			httpInvoker.path("contentStructureId", contentStructureId);
@@ -645,7 +652,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/content-structures/{contentStructureId}/permissions");
 
 			httpInvoker.path("contentStructureId", contentStructureId);
@@ -739,7 +746,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/content-structures/{contentStructureId}/permissions");
 
 			httpInvoker.path("contentStructureId", contentStructureId);
@@ -846,7 +853,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-structures");
 
 			httpInvoker.path("siteId", siteId);
@@ -934,7 +941,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-structures/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1028,7 +1035,7 @@ public interface ContentStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-structures/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentTemplateResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/ContentTemplateResource.java
@@ -109,6 +109,12 @@ public interface ContentTemplateResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -132,6 +138,7 @@ public interface ContentTemplateResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -238,7 +245,7 @@ public interface ContentTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/content-templates");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -343,7 +350,7 @@ public interface ContentTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-templates");
 
 			httpInvoker.path("siteId", siteId);
@@ -425,7 +432,7 @@ public interface ContentTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/content-templates/{contentTemplateId}");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentFolderResource.java
@@ -274,6 +274,12 @@ public interface DocumentFolderResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -297,6 +303,7 @@ public interface DocumentFolderResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -408,7 +415,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -494,7 +501,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -574,7 +581,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -662,7 +669,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -756,7 +763,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/document-folders/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -837,7 +844,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -914,7 +921,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -993,7 +1000,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1078,7 +1085,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1162,7 +1169,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1239,7 +1246,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1325,7 +1332,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/permissions");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1419,7 +1426,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/permissions");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1500,7 +1507,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/subscribe");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1581,7 +1588,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/unsubscribe");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1693,7 +1700,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{parentDocumentFolderId}/document-folders");
 
 			httpInvoker.path("parentDocumentFolderId", parentDocumentFolderId);
@@ -1779,7 +1786,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{parentDocumentFolderId}/document-folders");
 
 			httpInvoker.path("parentDocumentFolderId", parentDocumentFolderId);
@@ -1890,7 +1897,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-folders");
 
 			httpInvoker.path("siteId", siteId);
@@ -1974,7 +1981,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-folders");
 
 			httpInvoker.path("siteId", siteId);
@@ -2053,7 +2060,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-folders/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -2141,7 +2148,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2235,7 +2242,7 @@ public interface DocumentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/document-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/DocumentResource.java
@@ -342,6 +342,12 @@ public interface DocumentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -365,6 +371,7 @@ public interface DocumentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -475,7 +482,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -568,7 +575,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -653,7 +660,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -741,7 +748,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -835,7 +842,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/documents/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -947,7 +954,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/documents");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1040,7 +1047,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/documents");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1125,7 +1132,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/document-folders/{documentFolderId}/documents/batch");
 
 			httpInvoker.path("documentFolderId", documentFolderId);
@@ -1204,7 +1211,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}");
 
 			httpInvoker.path("documentId", documentId);
@@ -1281,7 +1288,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1357,7 +1364,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}");
 
 			httpInvoker.path("documentId", documentId);
@@ -1449,7 +1456,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}");
 
 			httpInvoker.path("documentId", documentId);
@@ -1541,7 +1548,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}");
 
 			httpInvoker.path("documentId", documentId);
@@ -1622,7 +1629,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1699,7 +1706,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/my-rating");
 
 			httpInvoker.path("documentId", documentId);
@@ -1778,7 +1785,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/my-rating");
 
 			httpInvoker.path("documentId", documentId);
@@ -1861,7 +1868,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/my-rating");
 
 			httpInvoker.path("documentId", documentId);
@@ -1944,7 +1951,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/my-rating");
 
 			httpInvoker.path("documentId", documentId);
@@ -2030,7 +2037,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/permissions");
 
 			httpInvoker.path("documentId", documentId);
@@ -2122,7 +2129,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/permissions");
 
 			httpInvoker.path("documentId", documentId);
@@ -2206,7 +2213,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/documents/{documentId}/rendered-content-by-display-page/{displayPageKey}");
 
 			httpInvoker.path("documentId", documentId);
@@ -2318,7 +2325,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents");
 
 			httpInvoker.path("siteId", siteId);
@@ -2410,7 +2417,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents");
 
 			httpInvoker.path("siteId", siteId);
@@ -2493,7 +2500,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -2577,7 +2584,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2662,7 +2669,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2757,7 +2764,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2845,7 +2852,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2938,7 +2945,7 @@ public interface DocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/documents/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseArticleResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseArticleResource.java
@@ -353,6 +353,12 @@ public interface KnowledgeBaseArticleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -376,6 +382,7 @@ public interface KnowledgeBaseArticleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -456,7 +463,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -536,7 +543,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -616,7 +623,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -704,7 +711,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -792,7 +799,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -871,7 +878,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -953,7 +960,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/my-rating");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1037,7 +1044,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/my-rating");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1123,7 +1130,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/my-rating");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1209,7 +1216,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/my-rating");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1297,7 +1304,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/permissions");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1391,7 +1398,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/permissions");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1475,7 +1482,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/subscribe");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1559,7 +1566,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/unsubscribe");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -1674,7 +1681,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles");
 
 			httpInvoker.path(
@@ -1765,7 +1772,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{parentKnowledgeBaseArticleId}/knowledge-base-articles");
 
 			httpInvoker.path(
@@ -1879,7 +1886,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -1968,7 +1975,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -2049,7 +2056,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/knowledge-base-articles/batch");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -2161,7 +2168,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles");
 
 			httpInvoker.path("siteId", siteId);
@@ -2248,7 +2255,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles");
 
 			httpInvoker.path("siteId", siteId);
@@ -2328,7 +2335,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -2412,7 +2419,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2498,7 +2505,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2589,7 +2596,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2678,7 +2685,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2772,7 +2779,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2853,7 +2860,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/subscribe");
 
 			httpInvoker.path("siteId", siteId);
@@ -2934,7 +2941,7 @@ public interface KnowledgeBaseArticleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-articles/unsubscribe");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseAttachmentResource.java
@@ -142,6 +142,12 @@ public interface KnowledgeBaseAttachmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -165,6 +171,7 @@ public interface KnowledgeBaseAttachmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -249,7 +256,7 @@ public interface KnowledgeBaseAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -349,7 +356,7 @@ public interface KnowledgeBaseAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -436,7 +443,7 @@ public interface KnowledgeBaseAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-articles/{knowledgeBaseArticleId}/knowledge-base-attachments/batch");
 
 			httpInvoker.path("knowledgeBaseArticleId", knowledgeBaseArticleId);
@@ -520,7 +527,7 @@ public interface KnowledgeBaseAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-attachments/{knowledgeBaseAttachmentId}");
 
 			httpInvoker.path(
@@ -601,7 +608,7 @@ public interface KnowledgeBaseAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-attachments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -682,7 +689,7 @@ public interface KnowledgeBaseAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-attachments/{knowledgeBaseAttachmentId}");
 
 			httpInvoker.path(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/KnowledgeBaseFolderResource.java
@@ -241,6 +241,12 @@ public interface KnowledgeBaseFolderResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -264,6 +270,7 @@ public interface KnowledgeBaseFolderResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -344,7 +351,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -423,7 +430,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -503,7 +510,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -591,7 +598,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -679,7 +686,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -757,7 +764,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -843,7 +850,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/permissions");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -937,7 +944,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{knowledgeBaseFolderId}/permissions");
 
 			httpInvoker.path("knowledgeBaseFolderId", knowledgeBaseFolderId);
@@ -1029,7 +1036,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders");
 
 			httpInvoker.path(
@@ -1119,7 +1126,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/knowledge-base-folders/{parentKnowledgeBaseFolderId}/knowledge-base-folders");
 
 			httpInvoker.path(
@@ -1210,7 +1217,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders");
 
 			httpInvoker.path("siteId", siteId);
@@ -1296,7 +1303,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders");
 
 			httpInvoker.path("siteId", siteId);
@@ -1376,7 +1383,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1460,7 +1467,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1546,7 +1553,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1637,7 +1644,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1726,7 +1733,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1820,7 +1827,7 @@ public interface KnowledgeBaseFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/knowledge-base-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/LanguageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/LanguageResource.java
@@ -91,6 +91,12 @@ public interface LanguageResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -114,6 +120,7 @@ public interface LanguageResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -193,7 +200,7 @@ public interface LanguageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/languages");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -274,7 +281,7 @@ public interface LanguageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/languages");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardAttachmentResource.java
@@ -178,6 +178,12 @@ public interface MessageBoardAttachmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -201,6 +207,7 @@ public interface MessageBoardAttachmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -283,7 +290,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-attachments/{messageBoardAttachmentId}");
 
 			httpInvoker.path(
@@ -364,7 +371,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-attachments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -444,7 +451,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-attachments/{messageBoardAttachmentId}");
 
 			httpInvoker.path(
@@ -530,7 +537,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/message-board-attachments");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -630,7 +637,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/message-board-attachments");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -717,7 +724,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/message-board-attachments/batch");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -802,7 +809,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-attachments");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -902,7 +909,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-attachments");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -989,7 +996,7 @@ public interface MessageBoardAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-attachments/batch");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardMessageResource.java
@@ -323,6 +323,12 @@ public interface MessageBoardMessageResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -346,6 +352,7 @@ public interface MessageBoardMessageResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -426,7 +433,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -505,7 +512,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -585,7 +592,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -673,7 +680,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -761,7 +768,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -839,7 +846,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -921,7 +928,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/my-rating");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1004,7 +1011,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/my-rating");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1090,7 +1097,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/my-rating");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1176,7 +1183,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/my-rating");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1264,7 +1271,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/permissions");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1358,7 +1365,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/permissions");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1441,7 +1448,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/subscribe");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1525,7 +1532,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{messageBoardMessageId}/unsubscribe");
 
 			httpInvoker.path("messageBoardMessageId", messageBoardMessageId);
@@ -1640,7 +1647,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{parentMessageBoardMessageId}/message-board-messages");
 
 			httpInvoker.path(
@@ -1730,7 +1737,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-messages/{parentMessageBoardMessageId}/message-board-messages");
 
 			httpInvoker.path(
@@ -1840,7 +1847,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-messages");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1929,7 +1936,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-messages");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -2010,7 +2017,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/message-board-messages/batch");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -2122,7 +2129,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages");
 
 			httpInvoker.path("siteId", siteId);
@@ -2206,7 +2213,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2292,7 +2299,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2383,7 +2390,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2468,7 +2475,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/by-friendly-url-path/{friendlyUrlPath}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2557,7 +2564,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2651,7 +2658,7 @@ public interface MessageBoardMessageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-messages/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardSectionResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardSectionResource.java
@@ -234,6 +234,12 @@ public interface MessageBoardSectionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -257,6 +263,7 @@ public interface MessageBoardSectionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -337,7 +344,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -416,7 +423,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -496,7 +503,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -584,7 +591,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -672,7 +679,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -750,7 +757,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -836,7 +843,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/permissions");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -930,7 +937,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/permissions");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -1013,7 +1020,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/subscribe");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -1097,7 +1104,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/unsubscribe");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -1206,7 +1213,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{parentMessageBoardSectionId}/message-board-sections");
 
 			httpInvoker.path(
@@ -1296,7 +1303,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{parentMessageBoardSectionId}/message-board-sections");
 
 			httpInvoker.path(
@@ -1409,7 +1416,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-sections");
 
 			httpInvoker.path("siteId", siteId);
@@ -1495,7 +1502,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-sections");
 
 			httpInvoker.path("siteId", siteId);
@@ -1575,7 +1582,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-sections/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1663,7 +1670,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-sections/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1757,7 +1764,7 @@ public interface MessageBoardSectionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-sections/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/MessageBoardThreadResource.java
@@ -297,6 +297,12 @@ public interface MessageBoardThreadResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -320,6 +326,7 @@ public interface MessageBoardThreadResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -428,7 +435,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/message-board-threads");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -516,7 +523,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/message-board-threads");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -597,7 +604,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-sections/{messageBoardSectionId}/message-board-threads/batch");
 
 			httpInvoker.path("messageBoardSectionId", messageBoardSectionId);
@@ -717,7 +724,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/ranked");
 
 			httpInvoker.userNameAndPassword(
@@ -796,7 +803,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -875,7 +882,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -955,7 +962,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1042,7 +1049,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1129,7 +1136,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1207,7 +1214,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1288,7 +1295,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/my-rating");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1370,7 +1377,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/my-rating");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1456,7 +1463,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/my-rating");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1542,7 +1549,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/my-rating");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1630,7 +1637,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/permissions");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1724,7 +1731,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/permissions");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1807,7 +1814,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/subscribe");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -1890,7 +1897,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/message-board-threads/{messageBoardThreadId}/unsubscribe");
 
 			httpInvoker.path("messageBoardThreadId", messageBoardThreadId);
@@ -2002,7 +2009,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-threads");
 
 			httpInvoker.path("siteId", siteId);
@@ -2087,7 +2094,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-threads");
 
 			httpInvoker.path("siteId", siteId);
@@ -2167,7 +2174,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-threads/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -2251,7 +2258,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-threads/by-friendly-url-path/{friendlyUrlPath}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2340,7 +2347,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-threads/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2434,7 +2441,7 @@ public interface MessageBoardThreadResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/message-board-threads/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/NavigationMenuResource.java
@@ -177,6 +177,12 @@ public interface NavigationMenuResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -200,6 +206,7 @@ public interface NavigationMenuResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -280,7 +287,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/{navigationMenuId}");
 
 			httpInvoker.path("navigationMenuId", navigationMenuId);
@@ -357,7 +364,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -436,7 +443,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/{navigationMenuId}");
 
 			httpInvoker.path("navigationMenuId", navigationMenuId);
@@ -520,7 +527,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/{navigationMenuId}");
 
 			httpInvoker.path("navigationMenuId", navigationMenuId);
@@ -597,7 +604,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -683,7 +690,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/{navigationMenuId}/permissions");
 
 			httpInvoker.path("navigationMenuId", navigationMenuId);
@@ -777,7 +784,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/navigation-menus/{navigationMenuId}/permissions");
 
 			httpInvoker.path("navigationMenuId", navigationMenuId);
@@ -866,7 +873,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/navigation-menus");
 
 			httpInvoker.path("siteId", siteId);
@@ -950,7 +957,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/navigation-menus");
 
 			httpInvoker.path("siteId", siteId);
@@ -1029,7 +1036,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/navigation-menus/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1117,7 +1124,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/navigation-menus/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1211,7 +1218,7 @@ public interface NavigationMenuResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/navigation-menus/permissions");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/SitePageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/SitePageResource.java
@@ -131,6 +131,12 @@ public interface SitePageResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -154,6 +160,7 @@ public interface SitePageResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -257,7 +264,7 @@ public interface SitePageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/site-pages");
 
 			httpInvoker.path("siteId", siteId);
@@ -338,7 +345,7 @@ public interface SitePageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}");
 
 			httpInvoker.path("siteId", siteId);
@@ -423,7 +430,7 @@ public interface SitePageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences");
 
 			httpInvoker.path("siteId", siteId);
@@ -508,7 +515,7 @@ public interface SitePageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}");
 
 			httpInvoker.path("siteId", siteId);
@@ -594,7 +601,7 @@ public interface SitePageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/experiences/{experienceKey}/rendered-page");
 
 			httpInvoker.path("siteId", siteId);
@@ -679,7 +686,7 @@ public interface SitePageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/site-pages/{friendlyUrlPath}/rendered-page");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentFolderResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentFolderResource.java
@@ -299,6 +299,12 @@ public interface StructuredContentFolderResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -322,6 +328,7 @@ public interface StructuredContentFolderResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -434,7 +441,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -523,7 +530,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -603,7 +610,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -692,7 +699,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -787,7 +794,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-content-folders/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -900,7 +907,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-content-folders");
 
 			httpInvoker.path("siteId", siteId);
@@ -988,7 +995,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-content-folders");
 
 			httpInvoker.path("siteId", siteId);
@@ -1068,7 +1075,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-content-folders/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1156,7 +1163,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-content-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1250,7 +1257,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-content-folders/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1338,7 +1345,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folder/{structuredContentFolderId}/permissions");
 
 			httpInvoker.path(
@@ -1433,7 +1440,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folder/{structuredContentFolderId}/permissions");
 
 			httpInvoker.path(
@@ -1543,7 +1550,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders");
 
 			httpInvoker.path(
@@ -1635,7 +1642,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{parentStructuredContentFolderId}/structured-content-folders");
 
 			httpInvoker.path(
@@ -1721,7 +1728,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}");
 
 			httpInvoker.path(
@@ -1802,7 +1809,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1883,7 +1890,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}");
 
 			httpInvoker.path(
@@ -1973,7 +1980,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}");
 
 			httpInvoker.path(
@@ -2062,7 +2069,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}");
 
 			httpInvoker.path(
@@ -2143,7 +2150,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -2225,7 +2232,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/subscribe");
 
 			httpInvoker.path(
@@ -2310,7 +2317,7 @@ public interface StructuredContentFolderResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/unsubscribe");
 
 			httpInvoker.path(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/StructuredContentResource.java
@@ -427,6 +427,12 @@ public interface StructuredContentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -450,6 +456,7 @@ public interface StructuredContentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -561,7 +568,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -647,7 +654,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -727,7 +734,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents/batch");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -811,7 +818,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -897,7 +904,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -987,7 +994,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -1076,7 +1083,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -1170,7 +1177,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/asset-libraries/{assetLibraryId}/structured-contents/permissions");
 
 			httpInvoker.path("assetLibraryId", assetLibraryId);
@@ -1279,7 +1286,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/content-structures/{contentStructureId}/structured-contents");
 
 			httpInvoker.path("contentStructureId", contentStructureId);
@@ -1391,7 +1398,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents");
 
 			httpInvoker.path("siteId", siteId);
@@ -1476,7 +1483,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents");
 
 			httpInvoker.path("siteId", siteId);
@@ -1556,7 +1563,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -1640,7 +1647,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1726,7 +1733,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1816,7 +1823,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1900,7 +1907,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-key/{key}");
 
 			httpInvoker.path("siteId", siteId);
@@ -1984,7 +1991,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/by-uuid/{uuid}");
 
 			httpInvoker.path("siteId", siteId);
@@ -2073,7 +2080,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2167,7 +2174,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/structured-contents/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -2282,7 +2289,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/structured-contents");
 
 			httpInvoker.path(
@@ -2371,7 +2378,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/structured-contents");
 
 			httpInvoker.path(
@@ -2454,7 +2461,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-content-folders/{structuredContentFolderId}/structured-contents/batch");
 
 			httpInvoker.path(
@@ -2536,7 +2543,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -2615,7 +2622,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -2694,7 +2701,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -2779,7 +2786,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -2864,7 +2871,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -2941,7 +2948,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -3022,7 +3029,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/my-rating");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3104,7 +3111,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/my-rating");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3190,7 +3197,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/my-rating");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3276,7 +3283,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/my-rating");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3364,7 +3371,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/permissions");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3458,7 +3465,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/permissions");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3543,7 +3550,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/rendered-content-by-display-page/{displayPageKey}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3628,7 +3635,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/rendered-content/{contentTemplateId}");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3711,7 +3718,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/subscribe");
 
 			httpInvoker.path("structuredContentId", structuredContentId);
@@ -3794,7 +3801,7 @@ public interface StructuredContentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/structured-contents/{structuredContentId}/unsubscribe");
 
 			httpInvoker.path("structuredContentId", structuredContentId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiNodeResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiNodeResource.java
@@ -210,6 +210,12 @@ public interface WikiNodeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -233,6 +239,7 @@ public interface WikiNodeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -336,7 +343,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes");
 
 			httpInvoker.path("siteId", siteId);
@@ -419,7 +426,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes");
 
 			httpInvoker.path("siteId", siteId);
@@ -497,7 +504,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes/batch");
 
 			httpInvoker.path("siteId", siteId);
@@ -581,7 +588,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -666,7 +673,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -754,7 +761,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -842,7 +849,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -935,7 +942,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-nodes/permissions");
 
 			httpInvoker.path("siteId", siteId);
@@ -1014,7 +1021,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -1091,7 +1098,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1167,7 +1174,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -1250,7 +1257,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -1327,7 +1334,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1411,7 +1418,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/permissions");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -1503,7 +1510,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/permissions");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -1582,7 +1589,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/subscribe");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -1661,7 +1668,7 @@ public interface WikiNodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/unsubscribe");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageAttachmentResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageAttachmentResource.java
@@ -131,6 +131,12 @@ public interface WikiPageAttachmentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -154,6 +160,7 @@ public interface WikiPageAttachmentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -234,7 +241,7 @@ public interface WikiPageAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-page-attachments/{wikiPageAttachmentId}");
 
 			httpInvoker.path("wikiPageAttachmentId", wikiPageAttachmentId);
@@ -313,7 +320,7 @@ public interface WikiPageAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-page-attachments/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -393,7 +400,7 @@ public interface WikiPageAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-page-attachments/{wikiPageAttachmentId}");
 
 			httpInvoker.path("wikiPageAttachmentId", wikiPageAttachmentId);
@@ -475,7 +482,7 @@ public interface WikiPageAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/wiki-page-attachments");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -571,7 +578,7 @@ public interface WikiPageAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/wiki-page-attachments");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -656,7 +663,7 @@ public interface WikiPageAttachmentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/wiki-page-attachments/batch");
 
 			httpInvoker.path("wikiPageId", wikiPageId);

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageResource.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/resource/v1_0/WikiPageResource.java
@@ -209,6 +209,12 @@ public interface WikiPageResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -232,6 +238,7 @@ public interface WikiPageResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -314,7 +321,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -399,7 +406,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -487,7 +494,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/sites/{siteId}/wiki-pages/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("siteId", siteId);
@@ -593,7 +600,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -676,7 +683,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -755,7 +762,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-nodes/{wikiNodeId}/wiki-pages/batch");
 
 			httpInvoker.path("wikiNodeId", wikiNodeId);
@@ -836,7 +843,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages");
 
 			httpInvoker.path("parentWikiPageId", parentWikiPageId);
@@ -920,7 +927,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{parentWikiPageId}/wiki-pages");
 
 			httpInvoker.path("parentWikiPageId", parentWikiPageId);
@@ -999,7 +1006,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -1076,7 +1083,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1152,7 +1159,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -1235,7 +1242,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -1312,7 +1319,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -1396,7 +1403,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/permissions");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -1488,7 +1495,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/permissions");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -1567,7 +1574,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/subscribe");
 
 			httpInvoker.path("wikiPageId", wikiPageId);
@@ -1646,7 +1653,7 @@ public interface WikiPageResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-delivery/v1.0/wiki-pages/{wikiPageId}/unsubscribe");
 
 			httpInvoker.path("wikiPageId", wikiPageId);

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormDocumentResource.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormDocumentResource.java
@@ -96,6 +96,12 @@ public interface FormDocumentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -119,6 +125,7 @@ public interface FormDocumentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -197,7 +204,7 @@ public interface FormDocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-documents/{formDocumentId}");
 
 			httpInvoker.path("formDocumentId", formDocumentId);
@@ -274,7 +281,7 @@ public interface FormDocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-documents/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -353,7 +360,7 @@ public interface FormDocumentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-documents/{formDocumentId}");
 
 			httpInvoker.path("formDocumentId", formDocumentId);

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormRecordResource.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormRecordResource.java
@@ -128,6 +128,12 @@ public interface FormRecordResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -151,6 +157,7 @@ public interface FormRecordResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -228,7 +235,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-records/{formRecordId}");
 
 			httpInvoker.path("formRecordId", formRecordId);
@@ -312,7 +319,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-records/{formRecordId}");
 
 			httpInvoker.path("formRecordId", formRecordId);
@@ -389,7 +396,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-records/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -476,7 +483,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/forms/{formId}/form-records");
 
 			httpInvoker.path("formId", formId);
@@ -559,7 +566,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/forms/{formId}/form-records");
 
 			httpInvoker.path("formId", formId);
@@ -638,7 +645,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/forms/{formId}/form-records/batch");
 
 			httpInvoker.path("formId", formId);
@@ -719,7 +726,7 @@ public interface FormRecordResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/forms/{formId}/form-records/by-latest-draft");
 
 			httpInvoker.path("formId", formId);

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormResource.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormResource.java
@@ -113,6 +113,12 @@ public interface FormResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -136,6 +142,7 @@ public interface FormResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -211,7 +218,8 @@ public interface FormResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/headless-form/v1.0/forms/{formId}");
+					_builder._port + _builder._pathContext +
+						"/o/headless-form/v1.0/forms/{formId}");
 
 			httpInvoker.path("formId", formId);
 
@@ -294,7 +302,7 @@ public interface FormResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/forms/{formId}/evaluate-context");
 
 			httpInvoker.path("formId", formId);
@@ -384,7 +392,7 @@ public interface FormResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/forms/{formId}/form-document");
 
 			httpInvoker.path("formId", formId);
@@ -472,7 +480,7 @@ public interface FormResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/sites/{siteId}/forms");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormStructureResource.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/resource/v1_0/FormStructureResource.java
@@ -94,6 +94,12 @@ public interface FormStructureResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -117,6 +123,7 @@ public interface FormStructureResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -197,7 +204,7 @@ public interface FormStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/form-structures/{formStructureId}");
 
 			httpInvoker.path("formStructureId", formStructureId);
@@ -286,7 +293,7 @@ public interface FormStructureResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-form/v1.0/sites/{siteId}/form-structures");
 
 			httpInvoker.path("siteId", siteId);

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
@@ -127,6 +127,12 @@ public interface PortalInstanceResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -150,6 +156,7 @@ public interface PortalInstanceResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -235,7 +242,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances");
 
 			httpInvoker.userNameAndPassword(
@@ -316,7 +323,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances");
 
 			httpInvoker.userNameAndPassword(
@@ -395,7 +402,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}");
 
 			httpInvoker.path("portalInstanceId", portalInstanceId);
@@ -476,7 +483,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}");
 
 			httpInvoker.path("portalInstanceId", portalInstanceId);
@@ -561,7 +568,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}");
 
 			httpInvoker.path("portalInstanceId", portalInstanceId);
@@ -642,7 +649,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/activate");
 
 			httpInvoker.path("portalInstanceId", portalInstanceId);
@@ -723,7 +730,7 @@ public interface PortalInstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/deactivate");
 
 			httpInvoker.path("portalInstanceId", portalInstanceId);

--- a/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/resource/v1_0/NotificationTemplateResource.java
+++ b/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/resource/v1_0/NotificationTemplateResource.java
@@ -155,6 +155,12 @@ public interface NotificationTemplateResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -178,6 +184,7 @@ public interface NotificationTemplateResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -258,7 +265,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-template/{notificationTemplateId}");
 
 			httpInvoker.path("notificationTemplateId", notificationTemplateId);
@@ -338,7 +345,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-template/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -418,7 +425,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-template/{notificationTemplateId}");
 
 			httpInvoker.path("notificationTemplateId", notificationTemplateId);
@@ -506,7 +513,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-template/{notificationTemplateId}");
 
 			httpInvoker.path("notificationTemplateId", notificationTemplateId);
@@ -594,7 +601,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-template/{notificationTemplateId}");
 
 			httpInvoker.path("notificationTemplateId", notificationTemplateId);
@@ -673,7 +680,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-template/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -777,7 +784,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-templates");
 
 			httpInvoker.userNameAndPassword(
@@ -860,7 +867,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-templates");
 
 			httpInvoker.userNameAndPassword(
@@ -937,7 +944,7 @@ public interface NotificationTemplateResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/notification/v1.0/notification-templates/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectActionResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectActionResource.java
@@ -148,6 +148,12 @@ public interface ObjectActionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -171,6 +177,7 @@ public interface ObjectActionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -249,7 +256,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-actions/{objectActionId}");
 
 			httpInvoker.path("objectActionId", objectActionId);
@@ -326,7 +333,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-actions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -405,7 +412,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-actions/{objectActionId}");
 
 			httpInvoker.path("objectActionId", objectActionId);
@@ -489,7 +496,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-actions/{objectActionId}");
 
 			httpInvoker.path("objectActionId", objectActionId);
@@ -573,7 +580,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-actions/{objectActionId}");
 
 			httpInvoker.path("objectActionId", objectActionId);
@@ -650,7 +657,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-actions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -744,7 +751,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-actions");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -830,7 +837,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-actions");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -910,7 +917,7 @@ public interface ObjectActionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-actions/batch");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectDefinitionResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectDefinitionResource.java
@@ -156,6 +156,12 @@ public interface ObjectDefinitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -179,6 +185,7 @@ public interface ObjectDefinitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -282,7 +289,8 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/object-admin/v1.0/object-definitions");
+					_builder._port + _builder._pathContext +
+						"/o/object-admin/v1.0/object-definitions");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -363,7 +371,8 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/object-admin/v1.0/object-definitions");
+					_builder._port + _builder._pathContext +
+						"/o/object-admin/v1.0/object-definitions");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -437,7 +446,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -516,7 +525,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -594,7 +603,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -673,7 +682,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -758,7 +767,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -843,7 +852,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -920,7 +929,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -999,7 +1008,7 @@ public interface ObjectDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/publish");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectFieldResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectFieldResource.java
@@ -147,6 +147,12 @@ public interface ObjectFieldResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -170,6 +176,7 @@ public interface ObjectFieldResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -264,7 +271,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-fields");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -350,7 +357,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-fields");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -430,7 +437,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-fields/batch");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -509,7 +516,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-fields/{objectFieldId}");
 
 			httpInvoker.path("objectFieldId", objectFieldId);
@@ -586,7 +593,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-fields/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -663,7 +670,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-fields/{objectFieldId}");
 
 			httpInvoker.path("objectFieldId", objectFieldId);
@@ -747,7 +754,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-fields/{objectFieldId}");
 
 			httpInvoker.path("objectFieldId", objectFieldId);
@@ -831,7 +838,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-fields/{objectFieldId}");
 
 			httpInvoker.path("objectFieldId", objectFieldId);
@@ -908,7 +915,7 @@ public interface ObjectFieldResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-fields/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectLayoutResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectLayoutResource.java
@@ -140,6 +140,12 @@ public interface ObjectLayoutResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -163,6 +169,7 @@ public interface ObjectLayoutResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -258,7 +265,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-layouts");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -344,7 +351,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-layouts");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -424,7 +431,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-layouts/batch");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -503,7 +510,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-layouts/{objectLayoutId}");
 
 			httpInvoker.path("objectLayoutId", objectLayoutId);
@@ -580,7 +587,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-layouts/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -659,7 +666,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-layouts/{objectLayoutId}");
 
 			httpInvoker.path("objectLayoutId", objectLayoutId);
@@ -743,7 +750,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-layouts/{objectLayoutId}");
 
 			httpInvoker.path("objectLayoutId", objectLayoutId);
@@ -820,7 +827,7 @@ public interface ObjectLayoutResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-layouts/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectRelationshipResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectRelationshipResource.java
@@ -144,6 +144,12 @@ public interface ObjectRelationshipResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -167,6 +173,7 @@ public interface ObjectRelationshipResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -268,7 +275,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -355,7 +362,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -435,7 +442,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-relationships/batch");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -516,7 +523,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-relationships/{objectRelationshipId}");
 
 			httpInvoker.path("objectRelationshipId", objectRelationshipId);
@@ -595,7 +602,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-relationships/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -675,7 +682,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-relationships/{objectRelationshipId}");
 
 			httpInvoker.path("objectRelationshipId", objectRelationshipId);
@@ -762,7 +769,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-relationships/{objectRelationshipId}");
 
 			httpInvoker.path("objectRelationshipId", objectRelationshipId);
@@ -840,7 +847,7 @@ public interface ObjectRelationshipResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-relationships/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectValidationRuleResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectValidationRuleResource.java
@@ -158,6 +158,12 @@ public interface ObjectValidationRuleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -181,6 +187,7 @@ public interface ObjectValidationRuleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -278,7 +285,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-validation-rules");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -367,7 +374,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-validation-rules");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -447,7 +454,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-validation-rules/batch");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -528,7 +535,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-validation-rules/{objectValidationRuleId}");
 
 			httpInvoker.path("objectValidationRuleId", objectValidationRuleId);
@@ -608,7 +615,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-validation-rules/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -688,7 +695,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-validation-rules/{objectValidationRuleId}");
 
 			httpInvoker.path("objectValidationRuleId", objectValidationRuleId);
@@ -776,7 +783,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-validation-rules/{objectValidationRuleId}");
 
 			httpInvoker.path("objectValidationRuleId", objectValidationRuleId);
@@ -864,7 +871,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-validation-rules/{objectValidationRuleId}");
 
 			httpInvoker.path("objectValidationRuleId", objectValidationRuleId);
@@ -943,7 +950,7 @@ public interface ObjectValidationRuleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-validation-rules/batch");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectViewResource.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/resource/v1_0/ObjectViewResource.java
@@ -143,6 +143,12 @@ public interface ObjectViewResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -166,6 +172,7 @@ public interface ObjectViewResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -260,7 +267,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-views");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -346,7 +353,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-views");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -426,7 +433,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-definitions/{objectDefinitionId}/object-views/batch");
 
 			httpInvoker.path("objectDefinitionId", objectDefinitionId);
@@ -505,7 +512,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-views/{objectViewId}");
 
 			httpInvoker.path("objectViewId", objectViewId);
@@ -582,7 +589,8 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/object-admin/v1.0/object-views/batch");
+					_builder._port + _builder._pathContext +
+						"/o/object-admin/v1.0/object-views/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -658,7 +666,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-views/{objectViewId}");
 
 			httpInvoker.path("objectViewId", objectViewId);
@@ -742,7 +750,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-views/{objectViewId}");
 
 			httpInvoker.path("objectViewId", objectViewId);
@@ -819,7 +827,8 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/object-admin/v1.0/object-views/batch");
+					_builder._port + _builder._pathContext +
+						"/o/object-admin/v1.0/object-views/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -897,7 +906,7 @@ public interface ObjectViewResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/object-admin/v1.0/object-views/{objectViewId}/copy");
 
 			httpInvoker.path("objectViewId", objectViewId);

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -459,7 +459,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.26'."
+        'com.liferay.object.admin.rest.client', and version '1.0.28'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.26'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.28'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/resource/v1_0/SuggestionResource.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/resource/v1_0/SuggestionResource.java
@@ -95,6 +95,12 @@ public interface SuggestionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -118,6 +124,7 @@ public interface SuggestionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -243,7 +250,8 @@ public interface SuggestionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/portal-search-rest/v1.0/suggestions");
+					_builder._port + _builder._pathContext +
+						"/o/portal-search-rest/v1.0/suggestions");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountCategoryForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountCategoryForecastResource.java
@@ -96,6 +96,12 @@ public interface AccountCategoryForecastResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -119,6 +125,7 @@ public interface AccountCategoryForecastResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -248,7 +255,7 @@ public interface AccountCategoryForecastResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-machine-learning/v1.0/accountCategoryForecasts/by-monthlyRevenue");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/AccountForecastResource.java
@@ -95,6 +95,12 @@ public interface AccountForecastResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -118,6 +124,7 @@ public interface AccountForecastResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -239,7 +246,7 @@ public interface AccountForecastResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-machine-learning/v1.0/accountForecasts/by-monthlyRevenue");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/SkuForecastResource.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/resource/v1_0/SkuForecastResource.java
@@ -93,6 +93,12 @@ public interface SkuForecastResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -116,6 +122,7 @@ public interface SkuForecastResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -233,7 +240,7 @@ public interface SkuForecastResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/headless-commerce-machine-learning/v1.0/skuForecasts/by-monthlyDemand");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/AssigneeMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/AssigneeMetricResource.java
@@ -90,6 +90,12 @@ public interface AssigneeMetricResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -113,6 +119,7 @@ public interface AssigneeMetricResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -213,7 +220,7 @@ public interface AssigneeMetricResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/assignees/metrics");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/AssigneeResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/AssigneeResource.java
@@ -87,6 +87,12 @@ public interface AssigneeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface AssigneeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -194,7 +201,7 @@ public interface AssigneeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/assignees");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/CalendarResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/CalendarResource.java
@@ -83,6 +83,12 @@ public interface CalendarResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -106,6 +112,7 @@ public interface CalendarResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -182,7 +189,7 @@ public interface CalendarResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/calendars");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/HistogramMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/HistogramMetricResource.java
@@ -89,6 +89,12 @@ public interface HistogramMetricResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -112,6 +118,7 @@ public interface HistogramMetricResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -214,7 +221,7 @@ public interface HistogramMetricResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/histograms/metrics");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/IndexResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/IndexResource.java
@@ -93,6 +93,12 @@ public interface IndexResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -116,6 +122,7 @@ public interface IndexResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -192,7 +199,8 @@ public interface IndexResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/portal-workflow-metrics/v1.0/indexes");
+					_builder._port + _builder._pathContext +
+						"/o/portal-workflow-metrics/v1.0/indexes");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -270,7 +278,7 @@ public interface IndexResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/indexes/refresh");
 
 			httpInvoker.userNameAndPassword(
@@ -349,7 +357,7 @@ public interface IndexResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/indexes/reindex");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/InstanceResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/InstanceResource.java
@@ -141,6 +141,12 @@ public interface InstanceResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -164,6 +170,7 @@ public interface InstanceResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -311,7 +318,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances");
 
 			httpInvoker.path("processId", processId);
@@ -394,7 +401,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances");
 
 			httpInvoker.path("processId", processId);
@@ -473,7 +480,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances/batch");
 
 			httpInvoker.path("processId", processId);
@@ -554,7 +561,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances/{instanceId}");
 
 			httpInvoker.path("processId", processId);
@@ -636,7 +643,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances/{instanceId}");
 
 			httpInvoker.path("processId", processId);
@@ -722,7 +729,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances/{instanceId}");
 
 			httpInvoker.path("processId", processId);
@@ -809,7 +816,7 @@ public interface InstanceResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/instances/{instanceId}/complete");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/NodeMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/NodeMetricResource.java
@@ -94,6 +94,12 @@ public interface NodeMetricResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -117,6 +123,7 @@ public interface NodeMetricResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -240,7 +247,7 @@ public interface NodeMetricResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/nodes/metrics");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/NodeResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/NodeResource.java
@@ -104,6 +104,12 @@ public interface NodeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -127,6 +133,7 @@ public interface NodeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -204,7 +211,7 @@ public interface NodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/nodes");
 
 			httpInvoker.path("processId", processId);
@@ -287,7 +294,7 @@ public interface NodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/nodes");
 
 			httpInvoker.path("processId", processId);
@@ -366,7 +373,7 @@ public interface NodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/nodes/batch");
 
 			httpInvoker.path("processId", processId);
@@ -447,7 +454,7 @@ public interface NodeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/nodes/{nodeId}");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessMetricResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessMetricResource.java
@@ -100,6 +100,12 @@ public interface ProcessMetricResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -123,6 +129,7 @@ public interface ProcessMetricResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -220,7 +227,7 @@ public interface ProcessMetricResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/metrics");
 
 			httpInvoker.userNameAndPassword(
@@ -320,7 +327,7 @@ public interface ProcessMetricResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/metrics");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessResource.java
@@ -123,6 +123,12 @@ public interface ProcessResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -146,6 +152,7 @@ public interface ProcessResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -225,7 +232,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes");
 
 			httpInvoker.userNameAndPassword(
@@ -300,7 +307,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -377,7 +384,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}");
 
 			httpInvoker.path("processId", processId);
@@ -454,7 +461,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -531,7 +538,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}");
 
 			httpInvoker.path("processId", processId);
@@ -614,7 +621,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}");
 
 			httpInvoker.path("processId", processId);
@@ -691,7 +698,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -768,7 +775,7 @@ public interface ProcessResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/title");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessVersionResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ProcessVersionResource.java
@@ -85,6 +85,12 @@ public interface ProcessVersionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface ProcessVersionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -189,7 +196,7 @@ public interface ProcessVersionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/process-versions");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ReindexStatusResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/ReindexStatusResource.java
@@ -83,6 +83,12 @@ public interface ReindexStatusResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -106,6 +112,7 @@ public interface ReindexStatusResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -183,7 +190,7 @@ public interface ReindexStatusResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/reindex/statuses");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/RoleResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/RoleResource.java
@@ -85,6 +85,12 @@ public interface RoleResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface RoleResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -191,7 +198,7 @@ public interface RoleResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/roles");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/SLAResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/SLAResource.java
@@ -131,6 +131,12 @@ public interface SLAResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -154,6 +160,7 @@ public interface SLAResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -245,7 +252,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/slas");
 
 			httpInvoker.path("processId", processId);
@@ -326,7 +333,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/slas");
 
 			httpInvoker.path("processId", processId);
@@ -405,7 +412,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/slas/batch");
 
 			httpInvoker.path("processId", processId);
@@ -483,7 +490,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/slas/{slaId}");
 
 			httpInvoker.path("slaId", slaId);
@@ -561,7 +568,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/slas/{slaId}/batch");
 
 			httpInvoker.path("slaId", slaId);
@@ -638,7 +645,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/slas/{slaId}");
 
 			httpInvoker.path("slaId", slaId);
@@ -718,7 +725,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/slas/{slaId}");
 
 			httpInvoker.path("slaId", slaId);
@@ -796,7 +803,7 @@ public interface SLAResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/slas/{slaId}/batch");
 
 			httpInvoker.path("slaId", slaId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/SLAResultResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/SLAResultResource.java
@@ -82,6 +82,12 @@ public interface SLAResultResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -105,6 +111,7 @@ public interface SLAResultResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -185,7 +192,7 @@ public interface SLAResultResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/last-sla-result");
 
 			httpInvoker.path("processId", processId);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/TaskResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/TaskResource.java
@@ -134,6 +134,12 @@ public interface TaskResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -157,6 +163,7 @@ public interface TaskResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -234,7 +241,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks");
 
 			httpInvoker.path("processId", processId);
@@ -317,7 +324,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks");
 
 			httpInvoker.path("processId", processId);
@@ -396,7 +403,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks/batch");
 
 			httpInvoker.path("processId", processId);
@@ -477,7 +484,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks/{taskId}");
 
 			httpInvoker.path("processId", processId);
@@ -559,7 +566,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks/{taskId}");
 
 			httpInvoker.path("processId", processId);
@@ -643,7 +650,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks/{taskId}");
 
 			httpInvoker.path("processId", processId);
@@ -728,7 +735,7 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/processes/{processId}/tasks/{taskId}/complete");
 
 			httpInvoker.path("processId", processId);
@@ -820,7 +827,8 @@ public interface TaskResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/portal-workflow-metrics/v1.0/tasks");
+					_builder._port + _builder._pathContext +
+						"/o/portal-workflow-metrics/v1.0/tasks");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/TimeRangeResource.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/resource/v1_0/TimeRangeResource.java
@@ -83,6 +83,12 @@ public interface TimeRangeResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -106,6 +112,7 @@ public interface TimeRangeResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -182,7 +189,7 @@ public interface TimeRangeResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/portal-workflow-metrics/v1.0/time-ranges");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/FieldMappingInfoResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/FieldMappingInfoResource.java
@@ -85,6 +85,12 @@ public interface FieldMappingInfoResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface FieldMappingInfoResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -192,7 +199,7 @@ public interface FieldMappingInfoResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/field-mapping-infos");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/KeywordQueryContributorResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/KeywordQueryContributorResource.java
@@ -85,6 +85,12 @@ public interface KeywordQueryContributorResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface KeywordQueryContributorResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -188,7 +195,7 @@ public interface KeywordQueryContributorResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/keyword-query-contributors");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/ModelPrefilterContributorResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/ModelPrefilterContributorResource.java
@@ -85,6 +85,12 @@ public interface ModelPrefilterContributorResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface ModelPrefilterContributorResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -189,7 +196,7 @@ public interface ModelPrefilterContributorResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/model-prefilter-contributors");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/QueryPrefilterContributorResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/QueryPrefilterContributorResource.java
@@ -85,6 +85,12 @@ public interface QueryPrefilterContributorResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface QueryPrefilterContributorResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -189,7 +196,7 @@ public interface QueryPrefilterContributorResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/query-prefilter-contributors");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPBlueprintResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPBlueprintResource.java
@@ -152,6 +152,12 @@ public interface SXPBlueprintResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -175,6 +181,7 @@ public interface SXPBlueprintResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -278,7 +285,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints");
 
 			httpInvoker.userNameAndPassword(
@@ -359,7 +366,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints");
 
 			httpInvoker.userNameAndPassword(
@@ -436,7 +443,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -517,7 +524,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/validate");
 
 			httpInvoker.userNameAndPassword(
@@ -594,7 +601,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}");
 
 			httpInvoker.path("sxpBlueprintId", sxpBlueprintId);
@@ -673,7 +680,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}/batch");
 
 			httpInvoker.path("sxpBlueprintId", sxpBlueprintId);
@@ -754,7 +761,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}");
 
 			httpInvoker.path("sxpBlueprintId", sxpBlueprintId);
@@ -838,7 +845,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}");
 
 			httpInvoker.path("sxpBlueprintId", sxpBlueprintId);
@@ -919,7 +926,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}/copy");
 
 			httpInvoker.path("sxpBlueprintId", sxpBlueprintId);
@@ -989,7 +996,7 @@ public interface SXPBlueprintResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-blueprints/{sxpBlueprintId}/export");
 
 			httpInvoker.path("sxpBlueprintId", sxpBlueprintId);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPElementResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPElementResource.java
@@ -147,6 +147,12 @@ public interface SXPElementResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -170,6 +176,7 @@ public interface SXPElementResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -272,7 +279,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements");
 
 			httpInvoker.userNameAndPassword(
@@ -353,7 +360,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements");
 
 			httpInvoker.userNameAndPassword(
@@ -430,7 +437,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/batch");
 
 			httpInvoker.userNameAndPassword(
@@ -511,7 +518,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/validate");
 
 			httpInvoker.userNameAndPassword(
@@ -588,7 +595,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/{sxpElementId}");
 
 			httpInvoker.path("sxpElementId", sxpElementId);
@@ -667,7 +674,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/{sxpElementId}/batch");
 
 			httpInvoker.path("sxpElementId", sxpElementId);
@@ -746,7 +753,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/{sxpElementId}");
 
 			httpInvoker.path("sxpElementId", sxpElementId);
@@ -830,7 +837,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/{sxpElementId}");
 
 			httpInvoker.path("sxpElementId", sxpElementId);
@@ -911,7 +918,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/{sxpElementId}/copy");
 
 			httpInvoker.path("sxpElementId", sxpElementId);
@@ -979,7 +986,7 @@ public interface SXPElementResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-elements/{sxpElementId}/export");
 
 			httpInvoker.path("sxpElementId", sxpElementId);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPParameterContributorDefinitionResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SXPParameterContributorDefinitionResource.java
@@ -86,6 +86,12 @@ public interface SXPParameterContributorDefinitionResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -109,6 +115,7 @@ public interface SXPParameterContributorDefinitionResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -191,7 +198,7 @@ public interface SXPParameterContributorDefinitionResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/sxp-parameter-contributor-definitions");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SearchResponseResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SearchResponseResource.java
@@ -87,6 +87,12 @@ public interface SearchResponseResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -110,6 +116,7 @@ public interface SearchResponseResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -204,7 +211,8 @@ public interface SearchResponseResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/search-experiences-rest/v1.0/search");
+					_builder._port + _builder._pathContext +
+						"/o/search-experiences-rest/v1.0/search");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SearchableAssetNameDisplayResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SearchableAssetNameDisplayResource.java
@@ -86,6 +86,12 @@ public interface SearchableAssetNameDisplayResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -109,6 +115,7 @@ public interface SearchableAssetNameDisplayResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -192,7 +199,7 @@ public interface SearchableAssetNameDisplayResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/searchable-asset-names/{languageId}");
 
 			httpInvoker.path("languageId", languageId);

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SearchableAssetNameResource.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/resource/v1_0/SearchableAssetNameResource.java
@@ -84,6 +84,12 @@ public interface SearchableAssetNameResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -107,6 +113,7 @@ public interface SearchableAssetNameResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -187,7 +194,7 @@ public interface SearchableAssetNameResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/search-experiences-rest/v1.0/searchable-asset-names");
 
 			httpInvoker.userNameAndPassword(

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/ExperimentResource.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/ExperimentResource.java
@@ -96,6 +96,12 @@ public interface ExperimentResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -119,6 +125,7 @@ public interface ExperimentResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -196,7 +203,7 @@ public interface ExperimentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/segments-asah/v1.0/experiments/{experimentId}");
 
 			httpInvoker.path("experimentId", experimentId);
@@ -273,7 +280,8 @@ public interface ExperimentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + "/o/segments-asah/v1.0/experiments/batch");
+					_builder._port + _builder._pathContext +
+						"/o/segments-asah/v1.0/experiments/batch");
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -349,7 +357,7 @@ public interface ExperimentResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/segments-asah/v1.0/experiments/{experimentId}");
 
 			httpInvoker.path("experimentId", experimentId);

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/ExperimentRunResource.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/ExperimentRunResource.java
@@ -85,6 +85,12 @@ public interface ExperimentRunResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -108,6 +114,7 @@ public interface ExperimentRunResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -191,7 +198,7 @@ public interface ExperimentRunResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/segments-asah/v1.0/experiments/{experimentId}/run");
 
 			httpInvoker.path("experimentId", experimentId);

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/StatusResource.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/resource/v1_0/StatusResource.java
@@ -93,6 +93,12 @@ public interface StatusResource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -116,6 +122,7 @@ public interface StatusResource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -197,7 +204,7 @@ public interface StatusResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/segments-asah/v1.0/experiments/{experimentId}/status");
 
 			httpInvoker.path("experimentId", experimentId);
@@ -276,7 +283,7 @@ public interface StatusResource {
 
 			httpInvoker.path(
 				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port +
+					_builder._port + _builder._pathContext +
 						"/o/segments-asah/v1.0/experiments/{experimentId}/status/batch");
 
 			httpInvoker.path("experimentId", experimentId);

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/client_resource.ftl
@@ -105,6 +105,12 @@ public interface ${schemaName}Resource {
 			return this;
 		}
 
+		public Builder pathContext(String pathContext) {
+			_pathContext = pathContext;
+
+			return this;
+		}
+
 		public Builder parameters(String... parameters) {
 			if ((parameters.length % 2) != 0) {
 				throw new IllegalArgumentException(
@@ -128,6 +134,7 @@ public interface ${schemaName}Resource {
 		private String _host = "localhost";
 		private Locale _locale;
 		private String _login = "";
+		private String _pathContext = "";
 		private String _password = "";
 		private Map<String, String> _parameters = new LinkedHashMap<>();
 		private int _port = 8080;
@@ -305,7 +312,7 @@ public interface ${schemaName}Resource {
 					</#if>
 				</#list>
 
-				httpInvoker.path(_builder._scheme + "://" + _builder._host + ":" + _builder._port + "/o${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}");
+				httpInvoker.path(_builder._scheme + "://" + _builder._host + ":" + _builder._port + _builder._pathContext + "/o${configYAML.application.baseURI}/${openAPIYAML.info.version}${javaMethodSignature.path}");
 
 				<#list javaMethodSignature.pathJavaMethodParameters as javaMethodParameter>
 					httpInvoker.path("${javaMethodParameter.parameterName}", ${javaMethodParameter.parameterName});


### PR DESCRIPTION
This PR contains the REST Builder code to autogenerate, for each Java client, a new parameter in the `Resource Builder` to set optionally the path context of the URL.

**Before the PR:**

It was not possible to set the path context between the `host:port` and the `/o/....`

```
StructuredContentResource.Builder builder = StructuredContentResource.builder();

structuredContentResource = builder.authentication(
	"test@liferay.com", "test"
).locale(
	LocaleUtil.getDefault()
).build();
```
Then, the path context will not be included when building the URL:
```
httpInvoker.path(
	_builder._scheme + "://" + _builder._host + ":" +
	_builder._port + 
	"/o/headless-delivery" ......
```

**After the PR:**

```
StructuredContentResource.Builder builder = StructuredContentResource.builder();

structuredContentResource = builder.authentication(
	"test@liferay.com", "test"
).locale(
	LocaleUtil.getDefault()
).pathContext(
	"path-context"
).build();
```
Then, the path context will be included when building the URL:
```
httpInvoker.path(
	_builder._scheme + "://" + _builder._host + ":" +
	_builder._port +
	_builder._port + _builder._pathContext +
	"/o/headless-delivery" ......
```