### PR TITLE
LPS-155200 Fix Remote App tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -3,11 +3,11 @@ definition {
 	macro _deleteRemoteAppAPI {
 		var currentURL = Navigator.getCurrentURL();
 
-		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "clientExtensionEntryId=");
+		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "externalReferenceCode=");
 
-		var clientExtensionEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
+		var externalReferenceCodeValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
 
-		JSONRemoteApp.deleteIFrameRemoteAppEntry(clientExtensionEntryId = "${clientExtensionEntryIdValue}");
+		JSONRemoteApp.deleteIFrameRemoteAppEntry(externalReferenceCode = "${externalReferenceCodeValue}");
 	}
 
 	macro addApp {
@@ -203,7 +203,7 @@ definition {
 		PortletEntry.publish();
 	}
 
-	macro getClientExtensionEntryIdValue {
+	macro getExternalReferenceCodeValue {
 		WaitForSPARefresh();
 
 		RemoteApps.goToRemoteAppsPortlet();
@@ -214,11 +214,13 @@ definition {
 
 		var currentURL = Navigator.getCurrentURL();
 
-		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "clientExtensionEntryId=");
+		var findWhereIdBegins = StringUtil.extractLast("${currentURL}", "externalReferenceCode=");
 
-		var clientExtensionEntryIdValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
+		var externalReferenceCodeValue = StringUtil.extractFirst("${findWhereIdBegins}", "&_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet_redirect");
 
-		return "${clientExtensionEntryIdValue}";
+		var externalReferenceCodeValue = StringUtil.replace("${externalReferenceCodeValue}", "-", "_");
+
+		return "${externalReferenceCodeValue}";
 	}
 
 	macro getRemoteAppEntryName {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
@@ -25,9 +25,9 @@ definition {
 	}
 
 	macro deleteIFrameRemoteAppEntry {
-		Variables.assertDefined(parameterList = "${clientExtensionEntryId}");
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
 
-		JSONRemoteAppAPI._deleteIFrameRemoteAppEntry(clientExtensionEntryId = "${clientExtensionEntryId}");
+		JSONRemoteAppAPI._deleteIFrameRemoteAppEntry(externalReferenceCode = "${externalReferenceCode}");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteApp.macro
@@ -3,25 +3,21 @@ definition {
 	macro addCustomElementRemoteAppEntry {
 		Variables.assertDefined(parameterList = "${customElementName},${customElementHtmlName},${customElementURL}");
 
-		var response = JSONRemoteAppAPI._addCustomElementRemoteAppEntry(
+		JSONRemoteAppAPI._addCustomElementRemoteAppEntry(
 			customElementCssurl = "${customElementCssurl}",
 			customElementHtmlName = "${customElementHtmlName}",
 			customElementName = "${customElementName}",
 			customElementProperties = "${customElementProperties}",
 			customElementURL = "${customElementURL}",
 			customElementUseESM = "${customElementUseESM}");
-
-		return "{response}";
 	}
 
 	macro addIFrameRemoteAppEntry {
 		Variables.assertDefined(parameterList = "${iFrameURL},${name}");
 
-		var response = JSONRemoteAppAPI._addIFrameRemoteAppEntry(
+		JSONRemoteAppAPI._addIFrameRemoteAppEntry(
 			iFrameURL = "${iFrameURL}",
 			name = "${name}");
-
-		return "${response}";
 	}
 
 	macro deleteIFrameRemoteAppEntry {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
@@ -31,25 +31,25 @@ definition {
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
-			${portalURL}/api/jsonws/remoteapp.clientextensionentry/add-custom-element-client-extension-entry \
+			${portalURL}/api/jsonws/remoteapp.clientextensionentry/add-client-extension-entry \
 				  -u test@liferay.com:test \
-				  -d customElementCSSURLs=${customElementCssurlModified} \
-				  -d customElementHTMLElementName=${htmlNameModified} \
-				  -d customElementURLs=${customElementURLModified} \
-				  -d customElementUseESM=${customElementUseESMValue} \
 				  -d description= \
 				  -d externalReferenceCode= \
-				  -d friendlyURLMapping= \
-				  -d instanceable=true \
 				  -d nameMap='{\"en_US\":\"${nameModified}\"}' \
-				  -d portletCategoryName=RemoteApps \
 				  -d properties=${customElementPropertiesModified} \
-				  -d sourceCodeURL=
+				  -d sourceCodeURL= \
+				  -d type='customElement' \
+				  -d typeSettings='cssURLs=${customElementCssurlModified}%0A \
+				     	htmlElementName=${htmlNameModified}%0A \
+				     	urls=${customElementURLModified}%0A \
+				     	useESM=${customElementUseESMValue}%0A \
+				     	instanceable=true%0A \
+				     	portletCategoryName=category.remote-apps'
 		''';
 
-		var clientExtensionEntryId = JSONCurlUtil.post("${curl}", "$.['clientExtensionEntryId']");
+		var externalReferenceCode = JSONCurlUtil.post("${curl}", "$.['externalReferenceCode']");
 
-		return "${clientExtensionEntryId}";
+		return "${externalReferenceCode}";
 	}
 
 	macro _addIFrameRemoteAppEntry {
@@ -60,32 +60,33 @@ definition {
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
-			${portalURL}/api/jsonws/remoteapp.clientextensionentry/add-i-frame-client-extension-entry \
-				  -u test@liferay.com:test \
-				  -d description= \
-				  -d friendlyURLMapping= \
-				  -d iFrameURL=${iFrameURLModified} \
-				  -d instanceable=true \
-				  -d nameMap='{\"en_US\":\"${nameModified}\"}' \
-				  -d portletCategoryName=RemoteApps \
-				  -d properties= \
-				  -d sourceCodeURL=
+			${portalURL}/api/jsonws/remoteapp.clientextensionentry/add-client-extension-entry \
+				-u test@liferay.com:test \
+				-d externalReferenceCode='' \
+				-d description='' \
+				-d nameMap='{\"en_US\":\"${nameModified}\"}' \
+				-d properties='' \
+				-d sourceCodeURL='' \
+				-d type='iframe' \
+				-d typeSettings='url=${iFrameURLModified}'
 		''';
 
-		var clientExtensionEntryId = JSONCurlUtil.post("${curl}", "$.['clientExtensionEntryId']");
+		var externalReferenceCode = JSONCurlUtil.post("${curl}", "$.['externalReferenceCode']");
 
-		return "${clientExtensionEntryId}";
+		return "${externalReferenceCode}";
 	}
 
 	macro _deleteIFrameRemoteAppEntry {
-		Variables.assertDefined(parameterList = "${clientExtensionEntryId}");
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
 
 		var portalURL = JSONCompany.getPortalURL();
+		var companyId = JSONCompany.getCompanyId();
 
 		var curl = '''
-			${portalURL}/api/jsonws/remoteapp.clientextensionentry/delete-client-extension-entry \
+			${portalURL}/api/jsonws/remoteapp.clientextensionentry/delete-client-extension-entry-by-external-reference-code \
 				  -u test@liferay.com:test \
-				  -d clientExtensionEntryId=${clientExtensionEntryId}
+				  -d companyId=${companyId} \
+				  -d externalReferenceCode=${externalReferenceCode}
 		''';
 
 		com.liferay.poshi.runner.util.JSONCurlUtil.post("${curl}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/remote_apps/JSONRemoteAppAPI.macro
@@ -39,17 +39,10 @@ definition {
 				  -d properties=${customElementPropertiesModified} \
 				  -d sourceCodeURL= \
 				  -d type='customElement' \
-				  -d typeSettings='cssURLs=${customElementCssurlModified}%0A \
-				     	htmlElementName=${htmlNameModified}%0A \
-				     	urls=${customElementURLModified}%0A \
-				     	useESM=${customElementUseESMValue}%0A \
-				     	instanceable=true%0A \
-				     	portletCategoryName=category.remote-apps'
+				  -d typeSettings=cssURLs=${customElementCssurlModified}%0AhtmlElementName=${htmlNameModified}%0Aurls=${customElementURLModified}%0AuseESM=${customElementUseESMValue}%0Ainstanceable=true%0AportletCategoryName=category.remote-apps
 		''';
 
-		var externalReferenceCode = JSONCurlUtil.post("${curl}", "$.['externalReferenceCode']");
-
-		return "${externalReferenceCode}";
+		JSONCurlUtil.post("${curl}");
 	}
 
 	macro _addIFrameRemoteAppEntry {
@@ -71,9 +64,7 @@ definition {
 				-d typeSettings='url=${iFrameURLModified}'
 		''';
 
-		var externalReferenceCode = JSONCurlUtil.post("${curl}", "$.['externalReferenceCode']");
-
-		return "${externalReferenceCode}";
+		JSONCurlUtil.post("${curl}");
 	}
 
 	macro _deleteIFrameRemoteAppEntry {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/RemoteApps.path
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 	<td>EMPTY_REMOTE_TABLE_MESSAGE</td>
-	<td>//div[contains(@class,'sheet-text') and contains(.,'No items were found.')]</td>
+	<td>//div[contains(@class,'empty-state-text') and contains(.,'Sorry, no results were found.')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -93,7 +93,7 @@ definition {
 
 		RemoteApps.deleteRemoteApp(tableEntry = "${remoteAppName}");
 
-		RemoteApps.assertTableEntryNameNotPresent(entryName = "${remoteAppName}");
+		RemoteApps.viewEmptyRemoteTable();
 	}
 
 	@description = "Verify that remote app of type Custom Element can be created"
@@ -362,12 +362,12 @@ definition {
 		}
 
 		task ("Obtain Vanilla Counter's remoteAppEntryId") {
-			var clientExtensionEntryIdValue = RemoteApps.getClientExtensionEntryIdValue();
+			var externalReferenceCodeValue = RemoteApps.getExternalReferenceCodeValue();
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Guest",
 				layoutName = "Test Page",
-				remoteAppEntryId = "${clientExtensionEntryIdValue}",
+				remoteAppEntryId = "${externalReferenceCodeValue}",
 				widgetName = "Vanilla Counter");
 		}
 
@@ -434,12 +434,12 @@ definition {
 		}
 
 		task ("Add Vanilla Counter to Test Page") {
-			var clientExtensionEntryIdValue = RemoteApps.getClientExtensionEntryIdValue();
+			var externalReferenceCodeValue = RemoteApps.getExternalReferenceCodeValue();
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Guest",
 				layoutName = "Test Page",
-				remoteAppEntryId = "${clientExtensionEntryIdValue}",
+				remoteAppEntryId = "${externalReferenceCodeValue}",
 				widgetName = "Vanilla Counter");
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnline.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/saas/tests/LiferayOnline.testcase
@@ -293,7 +293,7 @@ definition {
 		}
 
 		task ("Assert the Remote App is Not Present") {
-			RemoteApps.assertTableEntryNameNotPresent(entryName = "My New Remote App");
+			RemoteApps.viewEmptyRemoteTable();
 		}
 	}
 


### PR DESCRIPTION
**Background**
Recent changes from Client Extension hackathon caused remote app tests to fail. Fixes in this PR:
- some test fixes because there is no longer an empty table found, just a message saying there are no results
- `externalReferenceCode` is now being used instead of `clientExtensionEntryId`
- updated the JSON parameters to account for `type` and `typeSettings`
- removed returning the JSON response because the tests were failing at that point and the tests weren't doing anything with the response

**Affected Cases:**
[LocalFile.RemoteApps#CanBeDeleted](https://testray.liferay.com/home/-/testray/case_results/1866355400)
[LocalFile.LiferayOnline#RemoteAppsCanBeDeletedInLiferayOnline](https://testray.liferay.com/home/-/testray/case_results/1866353746)
[LocalFile.RemoteApps#CustomElementCanBeDeleted](https://testray.liferay.com/home/-/testray/case_results/1866355424)
[LocalFile.RemoteApps#CustomElementCanBeEdited](https://testray.liferay.com/home/-/testray/case_results/1866355458) should still fail due to [LPS-155473](https://issues.liferay.com/browse/LPS-155473)
[LocalFile.RemoteApps#CustomElementCanBeInstanceable](https://testray.liferay.com/home/-/testray/case_results/1866355479)
[LocalFile.RemoteApps#CustomElementCanConfigurePortletName](https://testray.liferay.com/home/-/testray/case_results/1866355317) should still fail due to [LPS-155473](https://issues.liferay.com/browse/LPS-155473)
[LocalFile.RemoteApps#CustomElementCanInjectHTMLProperties](https://testray.liferay.com/home/-/testray/case_results/1866355334)

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155200