### PR TITLE
LPS-152829 | Aggregation Terms in oneToMany relationship

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -217,6 +217,21 @@ definition {
 		return "${objectFirstname}";
 	}
 
+	macro _getObjectsWithAggregationTerms {
+		Variables.assertDefined(parameterList = "${aggregationTermsValue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/${objects}?aggregationTerms=${aggregationTermsValue} \
+			-u test@liferay.com:test
+		''';
+
+		var json = JSONCurlUtil.get("${curl}");
+
+		return "${json}";
+	}
+
 	macro _getObjectsWithNestedField {
 		Variables.assertDefined(parameterList = "${nestedField}");
 
@@ -304,6 +319,14 @@ definition {
 			objectId = "${objectId}",
 			relationshipName = "${relationshipName}",
 			responseToParse = "${responseToParse}");
+	}
+
+	macro assertInFacetsWithCorrectValue {
+		var actualValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..facetValues[?(@.term=='${managerId}' && @.numberOfOccurrences==${expectedValue})].numberOfOccurrences");
+
+		TestUtils.assertEquals(
+			actual = "${actualValue}",
+			expected = "${expectedValue}");
 	}
 
 	macro assertResponseIncludesDetailsOfNotDeletedEmployee {
@@ -398,6 +421,14 @@ definition {
 
 	macro deleteEmployee {
 		ObjectDefinitionAPI._deleteEmployee(employeeId = "${employeeId}");
+	}
+
+	macro getObjectsWithAggregationTerms {
+		var getObjectsWithAggregationTermsJSON = ObjectDefinitionAPI._getObjectsWithAggregationTerms(
+			aggregationTermsValue = "${aggregationTermsValue}",
+			objects = "${objects}");
+
+		return "${getObjectsWithAggregationTermsJSON}";
 	}
 
 	macro getObjectsWithNestedField {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -1,4 +1,5 @@
 @component-name = "portal-headless-frontend-infrastructure"
+@disable-webdriver = "true"
 definition {
 
 	property portal.release = "true";
@@ -40,6 +41,47 @@ definition {
 			ObjectAdmin.deleteObjectViaAPI(objectName = "Manager");
 
 			ObjectAdmin.deleteObjectViaAPI(objectName = "Employee");
+		}
+	}
+
+	@description = "Aggregation Terms in oneToMany relationship"
+	@priority = "5"
+	test CanReturnAggregationTermsDetailsInOneToManyRelationship {
+		property portal.acceptance = "true";
+
+		task ("Given two manager accounts created") {
+			var managerId1 = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
+			var managerId2 = ObjectDefinitionAPI.createManager(managerFirstname = "Aaron");
+		}
+
+		task ("Given three employee accounts created") {
+			var employeeId1 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Bruce",
+				managerId = "${managerId1}");
+			var employeeId2 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Riley",
+				managerId = "${managerId2}");
+			var employeeId3 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Justin",
+				managerId = "${managerId2}");
+		}
+
+		task ("When calling for 'employees' with a 'managerId' as aggregationTerms parameter") {
+			var getFacetsWithManagerId = ObjectDefinitionAPI.getObjectsWithAggregationTerms(
+				aggregationTermsValue = "managerId",
+				objects = "employees");
+		}
+
+		task ("Then receiving the managerId in facets with a correct number of ocurrences") {
+			ObjectDefinitionAPI.assertInFacetsWithCorrectValue(
+				expectedValue = "1",
+				managerId = "${managerId1}",
+				responseToParse = "${getFacetsWithManagerId}");
+
+			ObjectDefinitionAPI.assertInFacetsWithCorrectValue(
+				expectedValue = "2",
+				managerId = "${managerId2}",
+				responseToParse = "${getFacetsWithManagerId}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Aggregation Terms in oneToMany relationship

**Test Plan**
Given active object definitions created
And Given a relationship between two object definitions created
And Given two manager accounts created
And Given three employee accounts created with two of them related to the same manager
When calling for employees with "managerId" as aggregationTerms parameter
Then I receive the managerId in facets with a correct number of occurrences

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-152829