### PR TITLE
LPS-154637 Add WalkthroughHotspot#WillDisplayPopoverWhenClicked

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughHotspot.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughHotspot.testcase
@@ -47,6 +47,22 @@ definition {
 		}
 	}
 
+	@description = "LPS-154637. Assert a hotspot element will switch to popover mode after clicking."
+	@priority = "5"
+	test WillDisplayPopoverWhenClicked {
+		task ("When click hospot element") {
+			Click(locator1 = "Walkthrough#HOTSPOT");
+		}
+
+		task ("Then popover is present") {
+			AssertElementPresent(locator1 = "Walkthrough#POPOVER");
+		}
+
+		task ("And then hotspot element is not present") {
+			AssertElementNotPresent(locator1 = "Walkthrough#HOTSPOT");
+		}
+	}
+
 	@description = "LPS-154636. Assert walkthrough component renders a hotspot element as initial state."
 	@priority = "5"
 	test WillRenderAsInitialState {


### PR DESCRIPTION
**Background**
Create automated tests for Walkthrough component.

**Test Plan**
Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
When: Click hospot element
Then: popover is present
And Then: hotspot element is not present

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-154637