### PR TITLE
LPS-155507 - Use new icons path

### DIFF
--- a/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
+++ b/modules/apps/headless/headless-discovery/headless-discovery-web/src/js/Icon.js
@@ -25,7 +25,7 @@ export const spritemap =
 	'//' +
 	window.location.host +
 	contextPath +
-	'/o/classic-theme/images/clay/icons.svg';
+	'/o/icons/pack/clay.svg';
 
 const Icon = (props) => {
 	const {symbol, ...otherProps} = props;


### PR DESCRIPTION
@LuismiBarcos here is an update to that PR from earlier. This change is to just make sure we are using the same icon references from the new icon packs feature. Let me know if you see any issue with this.