### PR TITLE
LPS-147618 - Escape url provided to remote app iframe

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/ClientExtensionEntryPortlet.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/ClientExtensionEntryPortlet.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
 import com.liferay.portal.kernel.servlet.taglib.util.OutputData;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -194,7 +195,7 @@ public class ClientExtensionEntryPortlet extends MVCPortlet {
 				iFrameURL, (String)entry.getKey(), (String)entry.getValue());
 		}
 
-		printWriter.print(iFrameURL);
+		printWriter.print(HtmlUtil.escapeHREF(iFrameURL));
 
 		printWriter.print("\"></iframe>");
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147618

I believe this escape util should do the trick at preventing xss in our iframe src.

Using:
`http://example.com" onmouseover="alert(1)`

### Before:
![Screen Shot 2022-06-09 at 4 23 23 PM](https://user-images.githubusercontent.com/6843530/172846022-ac5f27cf-075c-4dae-b307-a3a118e5dbc6.png)

### After:
![Screen Shot 2022-06-09 at 4 17 02 PM](https://user-images.githubusercontent.com/6843530/172845983-889fe4aa-18b6-4658-b5e0-f8442f1f0909.png)