### PR TITLE
LPS-148047 Include list of available languages in the exception thrown when there is none matching

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -118,6 +118,7 @@ import java.io.Serializable;
 
 import java.time.LocalDateTime;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -458,8 +459,9 @@ public class StructuredContentResourceImpl
 					LocaleUtil.toW3cLanguageId(
 						contextAcceptLanguage.getPreferredLanguageId()),
 					" because it is only available in the following languages ",
-					LocaleUtil.toW3cLanguageIds(
-						journalArticle.getAvailableLanguageIds())));
+					Arrays.toString(
+						LocaleUtil.toW3cLanguageIds(
+							journalArticle.getAvailableLanguageIds()))));
 		}
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();


### PR DESCRIPTION
This PR contains the code to return the list of available languages when a patch operation is done over a Structured Content with an accept language that does not match with any of the available languages of the Structured Content.

**How to reproduce it:**

1. Create an StructuredContent (Web Content) from the UI with only en-US language included.
2. Get the information of the StructuredContent by using the endpoint `/v1.0​/structured-contents​/\{structuredContentId}` and GET method.
3. Call the endpoint `/v1.0​/structured-contents​/\{structuredContentId}` with PATCH method including the header Accept-Language with a different value from en-US.

For example:
```
'Accept-Language: es-ES'
```

**Before the PR:**

Error code 400 Bad request response and the following trace:
```
Unable to patch structured content with language es-ES because it is only available in the following languages [Ljava.lang.String;@77e6d3a6"
```

**After the PR:**

Error code 400 Bad request response and the following trace:
```
Unable to patch structured content with language es-ES because it is only available in the following languages [en-US]
```
