### PR TITLE
LPS-154642, LPS-154643 Add tests WalkthroughPopover#CanDisplayTitle and WalkthroughPopover#CanDisplayContent

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/Walkthrough.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/Walkthrough.path
@@ -16,8 +16,23 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CLOSE_POPOVER</td>
+	<td>//*[contains(@class,'popover')]//button[*[name()='svg'][contains(@class,'icon-times')]]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>POPOVER</td>
 	<td>//*[contains(@class,'popover') and contains(@class,'show')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>POPOVER_SAMPLE_CONTENT</td>
+	<td>//*[contains(@class,'popover-body')][//span[text()='Content ${key_index}'] and //br and //code[text()='Hello${key_index}']]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>POPOVER_TITLE</td>
+	<td>//*[contains(@class,'popover-header')]//span[contains(.,'${key_title}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -1,0 +1,78 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-js-components-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Walkthrough";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given walkthrough component sample portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "JS Components Sample Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "JS Components Sample Page",
+				widgetName = "JS Components Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "JS Components Sample Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "JS Components Sample Page");
+
+			Navigator.gotoNavTab(navTab = "Walkable");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "JS Components Sample Page");
+		}
+	}
+
+	@description = "LPS-154643. Assert popover mode contains content."
+	@priority = "5"
+	test CanDisplayContent {
+		task ("When click hotspot element") {
+			Click(locator1 = "Walkthrough#HOTSPOT");
+		}
+
+		task ("Then content text is present on popover") {
+			AssertElementPresent(
+				key_index = "1",
+				locator1 = "Walkthrough#POPOVER_SAMPLE_CONTENT");
+		}
+	}
+
+	@description = "LPS-154642. Assert popover mode contains a title."
+	@priority = "5"
+	test CanDisplayTitle {
+		task ("When click hotspot element") {
+			Click(locator1 = "Walkthrough#HOTSPOT");
+		}
+
+		task ("Then title text is present on popover") {
+			AssertElementPresent(
+				key_title = "Step 1 of 5: Title 1",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Create automated tests for Walkthrough component. 


**Test Plan**
**WalkthroughPopover#CanDisplayTitle**
Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
When: Click hotspot element
Then: title text is present on popover

**WalkthroughPopover#CanDisplayContent**
Given: ** frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
When: Click hotspot element
Then: title content is present on popover


**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-154642
https://issues.liferay.com/browse/LPS-154643