### PR TITLE
COMMERCE-9467 Cannot edit Billing/Shipping Address of an open order if the address is already set

### DIFF
--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_order/billing_address.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_order/billing_address.jsp
@@ -44,7 +44,7 @@ CommerceOrder commerceOrder = commerceOrderEditDisplayContext.getCommerceOrder()
 			formName="fm"
 			id="<%= CommerceOrderFDSNames.BILLING_ADDRESSES %>"
 			itemsPerPage="<%= 10 %>"
-			selectedItems="<%= Collections.singletonList(String.valueOf(commerceOrder.getBillingAddressId())) %>"
+			selectedItems="<%= Collections.singletonList(Math.toIntExact(commerceOrder.getBillingAddressId())) %>"
 			selectedItemsKey="addressId"
 			selectionType="single"
 		/>

--- a/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_order/shipping_address.jsp
+++ b/modules/apps/commerce/commerce-order-web/src/main/resources/META-INF/resources/commerce_order/shipping_address.jsp
@@ -44,7 +44,7 @@ CommerceOrder commerceOrder = commerceOrderEditDisplayContext.getCommerceOrder()
 			formName="fm"
 			id="<%= CommerceOrderFDSNames.SHIPPING_ADDRESSES %>"
 			itemsPerPage="<%= 10 %>"
-			selectedItems="<%= Collections.singletonList(String.valueOf(commerceOrder.getShippingAddressId())) %>"
+			selectedItems="<%= Collections.singletonList(Math.toIntExact(commerceOrder.getShippingAddressId())) %>"
 			selectedItemsKey="addressId"
 			selectionType="single"
 		/>

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.data.set.taglib.internal.util.ServicesProvider;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNameUtil;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.frontend.js.module.launcher.JSModuleResolver;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.template.react.renderer.ComponentDescriptor;
@@ -27,6 +28,7 @@ import com.liferay.taglib.util.AttributesTagSupport;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
 import javax.portlet.PortletResponse;
@@ -89,6 +91,10 @@ public class BaseDisplayTag extends AttributesTagSupport {
 		return _randomNamespace;
 	}
 
+	public List<Object> getSelectedItems() {
+		return _selectedItems;
+	}
+
 	public void setAdditionalProps(Map<String, Object> additionalProps) {
 		_additionalProps = additionalProps;
 	}
@@ -123,6 +129,10 @@ public class BaseDisplayTag extends AttributesTagSupport {
 		_randomNamespace = randomNamespace;
 	}
 
+	public void setSelectedItems(List<Object> selectedItems) {
+		_selectedItems = selectedItems;
+	}
+
 	protected void cleanUp() {
 		_additionalProps = null;
 		_id = null;
@@ -131,6 +141,7 @@ public class BaseDisplayTag extends AttributesTagSupport {
 		_propsTransformer = null;
 		_propsTransformerServletContext = null;
 		_randomNamespace = null;
+		_selectedItems = null;
 	}
 
 	protected void doClearTag() {
@@ -150,13 +161,22 @@ public class BaseDisplayTag extends AttributesTagSupport {
 	}
 
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
-		if (_additionalProps != null) {
-			props.put("additionalProps", _additionalProps);
-		}
+		return HashMapBuilder.<String, Object>putAll(
+			props
+		).put(
+			"additionalProps",
+			() -> {
+				if (_additionalProps != null) {
+					return _additionalProps;
+				}
 
-		props.put("namespace", getNamespace());
-
-		return props;
+				return null;
+			}
+		).put(
+			"namespace", getNamespace()
+		).put(
+			"selectedItems", _selectedItems
+		).build();
 	}
 
 	protected int processEndTag() throws Exception {
@@ -219,5 +239,6 @@ public class BaseDisplayTag extends AttributesTagSupport {
 	private String _propsTransformer;
 	private ServletContext _propsTransformerServletContext;
 	private String _randomNamespace;
+	private List<Object> _selectedItems;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -168,10 +168,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		return _pageNumber;
 	}
 
-	public List<String> getSelectedItems() {
-		return _selectedItems;
-	}
-
 	public String getSelectedItemsKey() {
 		return _selectedItemsKey;
 	}
@@ -259,10 +255,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_pageNumber = pageNumber;
 	}
 
-	public void setSelectedItems(List<String> selectedItems) {
-		_selectedItems = selectedItems;
-	}
-
 	public void setSelectedItemsKey(String selectedItemsKey) {
 		_selectedItemsKey = selectedItemsKey;
 	}
@@ -311,7 +303,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_nestedItemsReferenceKey = null;
 		_pageNumber = 0;
 		_paginationSelectedEntry = 0;
-		_selectedItems = null;
 		_selectedItemsKey = null;
 		_selectionType = null;
 		_showManagementBar = true;
@@ -364,8 +355,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 				).build()
 			).put(
 				"portletId", PortalUtil.getPortletId(getRequest())
-			).put(
-				"selectedItems", _selectedItems
 			).put(
 				"selectedItemsKey", _toNullOrObject(_selectedItemsKey)
 			).put(
@@ -464,7 +453,6 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 	private String _nestedItemsReferenceKey;
 	private int _pageNumber;
 	private int _paginationSelectedEntry;
-	private List<String> _selectedItems;
 	private String _selectedItemsKey;
 	private String _selectionType;
 	private boolean _showManagementBar = true;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -131,10 +131,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		return _pageNumber;
 	}
 
-	public List<String> getSelectedItems() {
-		return _selectedItems;
-	}
-
 	public String getSelectedItemsKey() {
 		return _selectedItemsKey;
 	}
@@ -232,10 +228,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_pageNumber = pageNumber;
 	}
 
-	public void setSelectedItems(List<String> selectedItems) {
-		_selectedItems = selectedItems;
-	}
-
 	public void setSelectedItemsKey(String selectedItemsKey) {
 		_selectedItemsKey = selectedItemsKey;
 	}
@@ -286,7 +278,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_nestedItemsReferenceKey = null;
 		_pageNumber = 0;
 		_paginationSelectedEntry = 0;
-		_selectedItems = null;
 		_selectedItemsKey = null;
 		_selectionType = null;
 		_showManagementBar = true;
@@ -343,8 +334,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 				).build()
 			).put(
 				"portletId", PortalUtil.getPortletId(getRequest())
-			).put(
-				"selectedItems", _selectedItems
 			).put(
 				"selectedItemsKey", _validateDataAttribute(_selectedItemsKey)
 			).put(
@@ -451,7 +440,6 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private String _nestedItemsReferenceKey;
 	private int _pageNumber;
 	private int _paginationSelectedEntry;
-	private List<String> _selectedItems;
 	private String _selectedItemsKey;
 	private String _selectionType;
 	private boolean _showManagementBar = true;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -322,7 +322,9 @@ const FrontendDataSet = ({
 
 	useEffect(() => {
 		setSelectedItems((selectedItems) => {
-			return selectedItemsValue.map((value) => {
+			const newSelectedItems = [];
+
+			selectedItemsValue.forEach((value) => {
 				let selectedItem = items.find(
 					(item) => item[selectedItemsKey] === value
 				);
@@ -333,8 +335,12 @@ const FrontendDataSet = ({
 					);
 				}
 
-				return selectedItem;
+				if (selectedItem) {
+					newSelectedItems.push(selectedItem);
+				}
 			});
+
+			return newSelectedItems;
 		});
 	}, [selectedItemsValue, items, selectedItemsKey]);
 


### PR DESCRIPTION
### References

- [COMMERCE-9467 Cannot edit Billing/Shipping Address of an open order if the address is already set](https://issues.liferay.com/browse/COMMERCE-9467)

### What is the goal of this PR?

The root cause of the issue is that the `addressId` is a `number` in data response JSON, while it is a `String` when passes in as `selectedItems` tag attribute. The comparison [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js#L327) is falsy.

Since the tags always required `String`, I'm guessing this bug is a regression from changing data type in response data. But, the value _is_ really a number, and FDS should support setting of list of numbers as selected values. That is what we are doing in this PR, allowing any type to be passed in to FDS tags.

Additional complication is that we are [serializing](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/json/JSONSerializerImpl.java#L147-L148) `long` to a `String`. To get a number, we are converting `long` to `int` before passing it in. This is in a separate commit in this PR.



### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/173065573-18afcbed-80bf-45fb-a3ef-337721bc6e18.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/173065538-324e5c47-60de-4f48-98e7-c28154bf9b48.gif)

### Steps to reproduce

See steps to reproduce in JIRA ticket.