### PR TITLE
LPS-149283 Return relatedObject when create a relationship between objects

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/manager/v1_0/DefaultObjectEntryManagerImpl.java
@@ -149,7 +149,10 @@ public class DefaultObjectEntryManagerImpl implements ObjectEntryManager {
 			primaryKey2, new ServiceContext());
 
 		return getObjectEntry(
-			dtoConverterContext, objectDefinition, primaryKey1);
+			dtoConverterContext,
+			_objectDefinitionLocalService.getObjectDefinition(
+				objectRelationship.getObjectDefinitionId2()),
+			primaryKey2);
 	}
 
 	@Override


### PR DESCRIPTION
Related ticket -> [LPS-149283](https://issues.liferay.com/browse/LPS-149283)
____
This is a follow-up PR. 
Right now, it is possible to create relations between objects but the response is not very useful. For example, let's see we have 2 objects: University and Students. Each student belongs to a university and a university can have a lot of students, so there is a one-to-many relationship between them. 
Right now, if we use the university endpoint to create relationship with a student, it respond with the university:

<img width="1178" alt="imagen" src="https://user-images.githubusercontent.com/17163902/173183843-35862e32-1744-4bf3-81e2-a7f4b8468eb9.png">

The purpose of this PR is to change this response in the way that we receive the information of the student instead of the university because we are creating a relationship with that student., which is more useful information.

<img width="1149" alt="imagen" src="https://user-images.githubusercontent.com/17163902/173183931-ccdf95f8-7a73-4fea-aa28-9c7f585ef789.png">


