### PR TITLE
LPS-154538 Export `PortletURL` utils and import them throughout the codebase

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/DefaultAddresses.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/js/DefaultAddresses.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {createPortletURL, delegate} from 'frontend-js-web';
 
 export default function ({
 	baseSelectDefaultAddressURL,
@@ -49,7 +49,7 @@ export default function ({
 					return;
 				}
 
-				const updateAccountEntryDefaultAddressesURL = Liferay.Util.PortletURL.createPortletURL(
+				const updateAccountEntryDefaultAddressesURL = createPortletURL(
 					baseUpdateAccountEntryDefaultAddressesURL,
 					{addressId: selectedItem.entityid, type}
 				);
@@ -61,10 +61,7 @@ export default function ({
 			},
 			selectEventName: '<portlet:namespace />selectDefaultAddress',
 			title,
-			url: Liferay.Util.PortletURL.createPortletURL(
-				baseSelectDefaultAddressURL,
-				{type}
-			),
+			url: createPortletURL(baseSelectDefaultAddressURL, {type}),
 		});
 	};
 

--- a/modules/apps/commerce/commerce-payment-web/src/main/resources/META-INF/resources/js/DefaultCommercePaymentMethod.js
+++ b/modules/apps/commerce/commerce-payment-web/src/main/resources/META-INF/resources/js/DefaultCommercePaymentMethod.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {createPortletURL, delegate} from 'frontend-js-web';
 
 export default function ({
 	baseSelectDefaultCommercePaymentMethodURL,
@@ -37,7 +37,7 @@ export default function ({
 					return;
 				}
 
-				const updateAccountEntryDefaultCommercePaymentMethodURL = Liferay.Util.PortletURL.createPortletURL(
+				const updateAccountEntryDefaultCommercePaymentMethodURL = createPortletURL(
 					baseUpdateAccountEntryDefaultCommercePaymentMethodURL,
 					{commercePaymentMethodKey: selectedItem.entityid}
 				);
@@ -50,9 +50,7 @@ export default function ({
 			selectEventName:
 				'<portlet:namespace />selectDefaultCommercePaymentMethod',
 			title,
-			url: Liferay.Util.PortletURL.createPortletURL(
-				baseSelectDefaultCommercePaymentMethodURL
-			),
+			url: createPortletURL(baseSelectDefaultCommercePaymentMethodURL),
 		});
 	};
 

--- a/modules/apps/commerce/commerce-term-web/src/main/resources/META-INF/resources/js/DefaultCommerceTermEntries.js
+++ b/modules/apps/commerce/commerce-term-web/src/main/resources/META-INF/resources/js/DefaultCommerceTermEntries.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {delegate} from 'frontend-js-web';
+import {createPortletURL, delegate} from 'frontend-js-web';
 
 export default function ({
 	baseSelectDefaultCommerceTermEntryURL,
@@ -49,7 +49,7 @@ export default function ({
 					return;
 				}
 
-				const updateAccountEntryDefaultCommerceTermEntryURL = Liferay.Util.PortletURL.createPortletURL(
+				const updateAccountEntryDefaultCommerceTermEntryURL = createPortletURL(
 					baseUpdateAccountEntryDefaultCommerceTermEntryURL,
 					{commerceTermEntryId: selectedItem.entityid, type}
 				);
@@ -62,10 +62,9 @@ export default function ({
 			selectEventName:
 				'<portlet:namespace />selectDefaultCommerceTermEntry',
 			title,
-			url: Liferay.Util.PortletURL.createPortletURL(
-				baseSelectDefaultCommerceTermEntryURL,
-				{type}
-			),
+			url: createPortletURL(baseSelectDefaultCommerceTermEntryURL, {
+				type,
+			}),
 		});
 	};
 

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/digital-signature-form/FileSelector.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/digital-signature-form/FileSelector.js
@@ -13,6 +13,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import {createPortletURL} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 import {AppContext} from '../../AppContext';
@@ -33,7 +34,7 @@ const getDocumentLibrarySelectorURL = (portletNamespace) => {
 		'refererGroupId': Liferay.ThemeDisplay.getSiteGroupId(),
 	};
 
-	const documentLibrarySelectorURL = Liferay.Util.PortletURL.createPortletURL(
+	const documentLibrarySelectorURL = createPortletURL(
 		themeDisplay.getLayoutRelativeControlPanelURL(),
 		documentLibrarySelectorParameters
 	);

--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeView.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/pages/envelope/EnvelopeView.js
@@ -16,7 +16,12 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {createActionURL, fetch, openToast} from 'frontend-js-web';
+import {
+	createActionURL,
+	createResourceURL,
+	fetch,
+	openToast,
+} from 'frontend-js-web';
 import React, {useContext, useEffect, useState} from 'react';
 
 import {AppContext} from '../../AppContext';
@@ -94,14 +99,11 @@ const EnvelopeHeader = ({docusignStatus, emailSubject, envelopeId}) => {
 			<ClayButton
 				onClick={() =>
 					window.open(
-						Liferay.Util.PortletURL.createResourceURL(
-							baseResourceURL,
-							{
-								dsEnvelopeId: envelopeId,
-								p_p_resource_id:
-									'/digital_signature/get_ds_documents_as_bytes',
-							}
-						),
+						createResourceURL(baseResourceURL, {
+							dsEnvelopeId: envelopeId,
+							p_p_resource_id:
+								'/digital_signature/get_ds_documents_as_bytes',
+						}),
 						'_blank'
 					)
 				}
@@ -134,7 +136,7 @@ function EnvelopeView({
 	const getEnvelope = async () => {
 		try {
 			const response = await fetch(
-				Liferay.Util.PortletURL.createResourceURL(baseResourceURL, {
+				createResourceURL(baseResourceURL, {
 					dsEnvelopeId: envelopeId,
 					p_p_resource_id: '/digital_signature/get_ds_envelope',
 				})

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -700,6 +700,21 @@ export function toggleSelectBox(
 	toggleBoxId: string
 ): void;
 
+export function createActionURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createPortletURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
+export function createRenderURL(
+	basePortletURL: string,
+	parameters?: Object
+): URL;
+
 export function createResourceURL(
 	basePortletURL: string,
 	parameters?: Object

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -64,11 +64,8 @@ export {default as openSimpleInputModal} from './liferay/modal/commands/OpenSimp
 // PortletURL API
 
 export {default as createActionURL} from './liferay/util/portlet_url/create_action_url.es';
-
 export {default as createPortletURL} from './liferay/util/portlet_url/create_portlet_url.es';
-
 export {default as createRenderURL} from './liferay/util/portlet_url/create_render_url.es';
-
 export {default as createResourceURL} from './liferay/util/portlet_url/create_resource_url.es';
 
 // Align API

--- a/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/editRedirectEntry.js
+++ b/modules/apps/redirect/redirect-web/src/main/resources/META-INF/resources/js/editRedirectEntry.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openToast} from 'frontend-js-web';
+import {createResourceURL, openToast} from 'frontend-js-web';
 
 export default function ({
 	getRedirectEntryChainCauseURL,
@@ -59,13 +59,10 @@ export default function ({
 		}
 		else {
 			Liferay.Util.fetch(
-				Liferay.Util.PortletURL.createResourceURL(
-					getRedirectEntryChainCauseURL,
-					{
-						destinationURL: destinationURL.value,
-						sourceURL: sourceURL.value,
-					}
-				)
+				createResourceURL(getRedirectEntryChainCauseURL, {
+					destinationURL: destinationURL.value,
+					sourceURL: sourceURL.value,
+				})
 			)
 				.then((response) => {
 					return response.json();


### PR DESCRIPTION
Pretty self-explanatory. This PR exports the remaining utils living under the `Liferay.Util.PortletURL` namespace, and replaced their usages to importing instead of using the global namespace.