### PR TITLE
LPS-155938 Added ariaLabel

### DIFF
--- a/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/display/template/dependencies/portlet_display_template_icon.ftl
+++ b/modules/apps/site-navigation/site-navigation-language-web/src/main/resources/com/liferay/site/navigation/language/web/portlet/display/template/dependencies/portlet_display_template_icon.ftl
@@ -6,6 +6,7 @@
 
 		<#if !entry.isDisabled()>
 			<@liferay_aui["icon"]
+				ariaLabel=entry.getLongDisplayName()
 				cssClass=cssClass
 				image=entry.getW3cLanguageId()?lower_case
 				markupView="lexicon"


### PR DESCRIPTION
Hi Team,

Language Selector Widget accessibility issue: 
The issue is that Wave accessibility tool detected empty links on Language Selector Widget.
I have added **ariaLabel** attribute to the liferay_aui["icon"] element.

Thanks, Roland

https://issues.liferay.com/browse/LPS-155938