### PR TITLE
LPS-153135 Test Autom. StructuredContentAssetPriority#StructuredContentDraftByVersionContainsSetPriority

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -91,7 +91,7 @@ definition {
 	macro _createStructuredContent {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
 			site = "true");
@@ -126,7 +126,7 @@ definition {
 	macro _createStructuredContentDraft {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${priority},${title}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
 			site = "true");
@@ -161,7 +161,7 @@ definition {
 	macro _editStructuredContent {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority},${structuredContentId}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
 			site = "true");
@@ -196,7 +196,7 @@ definition {
 	macro _filterStructuredContent {
 		Variables.assertDefined(parameterList = "${filtervalue}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
 			site = "true");
@@ -215,7 +215,7 @@ definition {
 	macro _sortStructureContent {
 		Variables.assertDefined(parameterList = "${sortvalue}");
 
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
 			site = "true");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -332,16 +332,16 @@ definition {
 		return "${response}";
 	}
 
-	macro versionStructureContent {
-		var response = HeadlessWebcontentAPI._versionStructureContent(
-			responseToParse = "${responseToParse}",
-			versionvalue = "${versionvalue}");
+	macro sortStructureContent {
+		var response = HeadlessWebcontentAPI._sortStructureContent(sortvalue = "${sortvalue}");
 
 		return "${response}";
 	}
 
-	macro sortStructureContent {
-		var response = HeadlessWebcontentAPI._sortStructureContent(sortvalue = "${sortvalue}");
+	macro versionStructureContent {
+		var response = HeadlessWebcontentAPI._versionStructureContent(
+			responseToParse = "${responseToParse}",
+			versionvalue = "${versionvalue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -212,6 +212,24 @@ definition {
 		return "${curl}";
 	}
 
+	macro _versionStructuredContent {
+		Variables.assertDefined(parameterList = "${versionvalue},${responseToParse}");
+
+		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
+
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/structured-contents/${structuredContentId}/by-version/${versionvalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _sortStructureContent {
 		Variables.assertDefined(parameterList = "${sortvalue}");
 
@@ -311,6 +329,14 @@ definition {
 
 	macro filterStructuredContent {
 		var response = HeadlessWebcontentAPI._filterStructuredContent(filtervalue = "${filtervalue}");
+
+		return "${response}";
+	}
+
+	macro filterStructuredVersion {
+		var response = HeadlessWebcontentAPI._versionStructuredContent(
+			responseToParse = "${responseToParse}",
+			versionvalue = "${versionvalue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -212,24 +212,6 @@ definition {
 		return "${curl}";
 	}
 
-	macro _versionStructuredContent {
-		Variables.assertDefined(parameterList = "${versionvalue},${responseToParse}");
-
-		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
-
-		var portalURL = JSONCompany.getDefaultPortalURL();
-
-		var curl = '''
-			${portalURL}/o/headless-admin-content/v1.0/structured-contents/${structuredContentId}/by-version/${versionvalue} \
-			-u test@liferay.com:test \
-			-H accept: application/json
-		''';
-
-		var curl = JSONCurlUtil.get("${curl}");
-
-		return "${curl}";
-	}
-
 	macro _sortStructureContent {
 		Variables.assertDefined(parameterList = "${sortvalue}");
 
@@ -240,6 +222,23 @@ definition {
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/structured-contents?sort=${sortvalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
+	macro _versionStructuredContent {
+		Variables.assertDefined(parameterList = "${versionvalue},${responseToParse}");
+
+		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
+		var portalURL = JSONCompany.getDefaultPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/structured-contents/${structuredContentId}/by-version/${versionvalue} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -231,11 +231,11 @@ definition {
 		return "${curl}";
 	}
 
-	macro _versionStructuredContent {
+	macro _versionStructureContent {
 		Variables.assertDefined(parameterList = "${versionvalue},${responseToParse}");
 
 		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
-		var portalURL = JSONCompany.getDefaultPortalURL();
+		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
 			${portalURL}/o/headless-admin-content/v1.0/structured-contents/${structuredContentId}/by-version/${versionvalue} \
@@ -332,8 +332,8 @@ definition {
 		return "${response}";
 	}
 
-	macro filterStructuredVersion {
-		var response = HeadlessWebcontentAPI._versionStructuredContent(
+	macro versionStructureContent {
+		var response = HeadlessWebcontentAPI._versionStructureContent(
 			responseToParse = "${responseToParse}",
 			versionvalue = "${versionvalue}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -116,4 +116,33 @@ definition {
 		}
 	}
 
+	@priority = "5"
+	test StructuredContentDraftByVersionContainsSetPriority {
+		property portal.acceptance = "true";
+
+		task ("When in Headless Admin Content I create a structuredContent draft with a priority field set") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1",
+				title = "Title");
+		}
+
+		task ("When web contents are filtered with 1.0 version") {
+			var response = HeadlessWebcontentAPI.filterStructuredVersion(
+				responseToParse = "${responseToParse}",
+				versionvalue = "1.0");
+		}
+		
+		task ("Then the response body includes the set priority") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "1.0",
+				responseToParse = "${response}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -37,7 +37,7 @@ definition {
 	test StructuredContentDraftByVersionContainsSetPriority {
 		property portal.acceptance = "true";
 
-		task ("When in Headless Admin Content I create a structuredContent draft with a priority field set") {
+		task ("Given in Headless Admin Content I create a structuredContent draft with a priority field set") {
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
 			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
@@ -49,8 +49,8 @@ definition {
 				title = "Title");
 		}
 
-		task ("When web contents are filtered with 1.0 version") {
-			var response = HeadlessWebcontentAPI.filterStructuredVersion(
+		task ("When returning only web content with version 1.0") {
+			var response = HeadlessWebcontentAPI.versionStructureContent(
 				responseToParse = "${responseToParse}",
 				versionvalue = "1.0");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/StructuredContentAssetPriority.testcase
@@ -34,6 +34,35 @@ definition {
 	}
 
 	@priority = "5"
+	test StructuredContentDraftByVersionContainsSetPriority {
+		property portal.acceptance = "true";
+
+		task ("When in Headless Admin Content I create a structuredContent draft with a priority field set") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1",
+				title = "Title");
+		}
+
+		task ("When web contents are filtered with 1.0 version") {
+			var response = HeadlessWebcontentAPI.filterStructuredVersion(
+				responseToParse = "${responseToParse}",
+				versionvalue = "1.0");
+		}
+
+		task ("Then the response body includes the set priority") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "1.0",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "5"
 	test StructuredContentDraftContainsModifiedPriorityValue {
 		property portal.acceptance = "true";
 
@@ -113,35 +142,6 @@ definition {
 			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
 				expectedPriorityValue = "1.0",
 				responseToParse = "${responseToParse}");
-		}
-	}
-
-	@priority = "5"
-	test StructuredContentDraftByVersionContainsSetPriority {
-		property portal.acceptance = "true";
-
-		task ("When in Headless Admin Content I create a structuredContent draft with a priority field set") {
-			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
-
-			var responseToParse = HeadlessWebcontentAPI.createStructuredContentDraft(
-				data = "Text",
-				ddmStructureId = "${ddmStructureId}",
-				label = "Text",
-				name = "Text",
-				priority = "1",
-				title = "Title");
-		}
-
-		task ("When web contents are filtered with 1.0 version") {
-			var response = HeadlessWebcontentAPI.filterStructuredVersion(
-				responseToParse = "${responseToParse}",
-				versionvalue = "1.0");
-		}
-		
-		task ("Then the response body includes the set priority") {
-			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
-				expectedPriorityValue = "1.0",
-				responseToParse = "${response}");
 		}
 	}
 


### PR DESCRIPTION
Background
Create automation test StructuredContentAssetPriority#StructuredContentDraftByVersionContainsSetPriority

Test Plan
Given a structuredContent draft with Headless Admin Content POST "/v1.0/sites/{siteId}/structured-contents/draft" with a priority field set (as in the json example attached) is created
When invoking /v1.0/structured-contents/{structuredContentId}/by-version/{version}
Then the response body includes the set priority field

JIRA Ticket:
https://issues.liferay.com/browse/LPS-153135