### PR TITLE
LPS-154645 Add tests CanDisplayPreviousButtonOnIntermediateStep, FirstStepDoesNotHavePreviousStepButton

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -1,0 +1,17 @@
+definition {
+
+	macro enablePopoverMode {
+		if (IsElementNotPresent(locator1 = "Walkthrough#POPOVER")) {
+			Click(locator1 = "Walkthrough#HOTSPOT");
+		}
+	}
+
+	macro goToNextStep {
+		Click(locator1 = "Button#OK");
+
+		VerifyElementPresent(
+			key_title = "Step ${key_step}",
+			locator1 = "Walkthrough#POPOVER_TITLE");
+	}
+
+}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -77,6 +77,38 @@ definition {
 		}
 	}
 
+	@description = "LPS-154645. Assert popover contains a button to transition to previous step."
+	@priority = "5"
+	test CanDisplayPreviousButtonOnIntermediateStep {
+		task ("And Given popover mode") {
+			Walkthrough.enablePopoverMode();
+		}
+
+		task ("When navigate to 2nd step popover") {
+			Walkthrough.goToNextStep(key_step = "2");
+		}
+
+		task ("Then previous step button is present") {
+			AssertElementPresent(locator1 = "Button#PREVIOUS");
+		}
+
+		task ("And When click on previous step button") {
+			Click(locator1 = "Button#PREVIOUS");
+		}
+
+		task ("Then 1st step popover is present") {
+			AssertElementPresent(
+				key_title = "Step 1 of 5: Title 1",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+
+		task ("And Then 2nd step popover is not present") {
+			AssertElementNotPresent(
+				key_title = "Step 2 of 5: Title 2",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
 	@description = "LPS-154642. Assert popover mode contains a title."
 	@priority = "5"
 	test CanDisplayTitle {
@@ -105,6 +137,44 @@ definition {
 				attribute1 = "fill",
 				locator1 = "Walkthrough#POPOVER_OVERLAY",
 				value1 = "#393a4a");
+		}
+	}
+
+	@description = "LPS-154646. Assert 1st step popover does not contain a button to transition to previous step."
+	@priority = "5"
+	test FirstStepDoesNotHavePreviousStepButton {
+		task ("And Given popover mode") {
+			Walkthrough.enablePopoverMode();
+		}
+
+		task ("When on 1st step popover") {
+			VerifyElementPresent(
+				key_title = "Step 1 of 5: Title 1",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+
+		task ("Then previous step button is not present") {
+			AssertElementNotPresent(locator1 = "Button#PREVIOUS");
+		}
+
+		task ("And Then the primary button next step is present") {
+			AssertElementPresent(locator1 = "Button#OK");
+		}
+
+		task ("And When click on next step button") {
+			Click(locator1 = "Button#OK");
+		}
+
+		task ("Then 2nd step popover is present") {
+			AssertElementPresent(
+				key_title = "Step 2 of 5: Title 2",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+
+		task ("And Then 1st step popover is not present") {
+			AssertElementNotPresent(
+				key_title = "Step 1 of 5: Title 1",
+				locator1 = "Walkthrough#POPOVER_TITLE");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automated tests for Walkthrough Component.


**Test Plan**
**WalkthroughPopover#CanDisplayPreviousButtonOnIntermediateStep**
Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
And Given: popover mode
When: navigate to 2nd step popover
Then: Then previous step button is present
And When: click on previous step button
And Then: 1st step popover is present
And Then: 2nd step popover is not present

**WalkthroughPopover#FirstStepDoesNotHavePreviousStepButton**
Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
And Given: popover mode When: on 1st step popover
Then: previous step button is not present
And Then: the primary button next step is present
And When: click on next step button Then: 2nd step popover is present And Then: 1st step popover is not present

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-154645
https://issues.liferay.com/browse/LPS-154646