### PR TITLE
LPS-152830 | Aggregation Terms in oneToMany updated relationship

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/AdvancedObjectAPI.testcase
@@ -130,6 +130,49 @@ definition {
 		}
 	}
 
+	@description = "Aggregation Terms in oneToMany updated relationship"
+	@priority = "5"
+	test CanReturnAggregationTermsDetailsInOneToManyUpdatedRelationship {
+		property portal.acceptance = "true";
+
+		task ("Given two manager accounts created") {
+			var managerId1 = ObjectDefinitionAPI.createManager(managerFirstname = "Courtney");
+			var managerId2 = ObjectDefinitionAPI.createManager(managerFirstname = "Aaron");
+		}
+
+		task ("Given three employee accounts created") {
+			var employeeId1 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Bruce",
+				managerId = "${managerId1}");
+			var employeeId2 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Riley",
+				managerId = "${managerId2}");
+			var employeeId3 = ObjectDefinitionAPI.createEmployee(
+				employeeFirstname = "Justin",
+				managerId = "${managerId2}");
+		}
+
+		task ("Given the third employee updated by relating with the same manager") {
+			ObjectDefinitionAPI.updateEmployee(
+				employeeFirstname = "Bruce",
+				employeeId = "${employeeId1}",
+				managerId = "${managerId2}");
+		}
+
+		task ("When calling for 'employees' with a 'managerId' as aggregationTerms parameter") {
+			var getFacetsWithManagerId = ObjectDefinitionAPI.getObjectsWithAggregationTerms(
+				aggregationTermsValue = "managerId",
+				objects = "employees");
+		}
+
+		task ("Then receiving the managerId in facets with a correct number of ocurrences") {
+			ObjectDefinitionAPI.assertInFacetsWithCorrectValue(
+				expectedValue = "3",
+				managerId = "${managerId2}",
+				responseToParse = "${getFacetsWithManagerId}");
+		}
+	}
+
 	@description = "Nested fields in oneToMany relationship"
 	@priority = "5"
 	test CanReturnNestedFieldsDetailsInOneToManyRelationship {


### PR DESCRIPTION
**Background**
Aggregation Terms in oneToMany updated relationship

**Test Plan**
Given active object definitions created
And Given a relationship between two object definitions created
And Given two manager accounts created
And Given three employee accounts created with two of them related to the same manager
And Given the third employee updated by relating with the same manager
When calling for employees with "managerId" as aggregationTerms parameter
Then I receive the managerId in facets with a value 3 as the number of ocurrences

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-152830