### PR TITLE
LPS-154647 Add test WalkthroughPopover#IntermediateStepHasPreviousAndNextStepPresent

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -14,4 +14,10 @@ definition {
 			locator1 = "Walkthrough#POPOVER_TITLE");
 	}
 
+	macro goToSpecificStep {
+		while (IsElementNotPresent(key_title = "Step ${key_step}", locator1 = "Walkthrough#POPOVER_TITLE")) {
+			Click(locator1 = "Button#OK");
+		}
+	}
+
 }

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -178,30 +178,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-154639. Assert component will switch to hotspot mode in the 2nd step when closing 2nd popover."
-	@priority = "5"
-	test WhenClosedCanTransitionToHotSpotModeOnCurrentStepElement {
-		task ("Given click hotspot element") {
-			Click(locator1 = "Walkthrough#HOTSPOT");
-		}
-
-		task ("Click on next step") {
-			Click(locator1 = "Button#OK");
-		}
-
-		task ("When Click close icon") {
-			Click(locator1 = "Walkthrough#CLOSE_POPOVER");
-		}
-
-		task ("Then hotspot element is present on the 2nd element") {
-			AssertElementPresent(locator1 = "Walkthrough#HOTSPOT");
-
-			WalkthroughPopover.viewCoordinatePositionMatchesElementStep(
-				hotspotElementClass = "lfr-walkthrough-hotspot-inner",
-				stepElementId = "step2");
-		}
-	}
-
 	@description = "LPS-154647. Assert intermediate step displays previous and next step button."
 	@priority = "5"
 	test IntermediateStepHasPreviousAndNextStepPresent {
@@ -231,6 +207,30 @@ definition {
 
 		task ("And Then secondary button previous step is present") {
 			AssertElementPresent(locator1 = "Button#PREVIOUS");
+		}
+	}
+
+	@description = "LPS-154639. Assert component will switch to hotspot mode in the 2nd step when closing 2nd popover."
+	@priority = "5"
+	test WhenClosedCanTransitionToHotSpotModeOnCurrentStepElement {
+		task ("Given click hotspot element") {
+			Click(locator1 = "Walkthrough#HOTSPOT");
+		}
+
+		task ("Click on next step") {
+			Click(locator1 = "Button#OK");
+		}
+
+		task ("When Click close icon") {
+			Click(locator1 = "Walkthrough#CLOSE_POPOVER");
+		}
+
+		task ("Then hotspot element is present on the 2nd element") {
+			AssertElementPresent(locator1 = "Walkthrough#HOTSPOT");
+
+			WalkthroughPopover.viewCoordinatePositionMatchesElementStep(
+				hotspotElementClass = "lfr-walkthrough-hotspot-inner",
+				stepElementId = "step2");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -202,4 +202,36 @@ definition {
 		}
 	}
 
+	@description = "LPS-154647. Assert intermediate step displays previous and next step button."
+	@priority = "5"
+	test IntermediateStepHasPreviousAndNextStepPresent {
+		task ("And Given popover mode") {
+			Walkthrough.enablePopoverMode();
+		}
+
+		task ("When on 1st step popover") {
+			VerifyElementPresent(
+				key_title = "Step 1 of 5: Title 1",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+
+		task ("And When click on next steps until second to last step") {
+			Walkthrough.goToSpecificStep(key_step = "4");
+		}
+
+		task ("Then able to reach second to final step") {
+			AssertElementPresent(
+				key_title = "Step 4",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+
+		task ("And Then primary button is present") {
+			AssertElementPresent(locator1 = "Button#OK");
+		}
+
+		task ("And Then secondary button previous step is present") {
+			AssertElementPresent(locator1 = "Button#PREVIOUS");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Create automated tests for Walkthrough component. 


**Test Plan**
Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
And Given: popover mode
When: on 1st step popover
And When: Click on next steps until ~final step~ second to last step (final step contains Close instead of OK button)
Then: Able to reach ~final step 5~ second to final step
And Then: primary button is present
And Then: secondary button previous step is present

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-154647