### PR TITLE
LPS-154639 Add test WalkthroughPopover#WhenClosedCanTransitionToHotSpotModeOnCurrentStepElement

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/WalkthroughPopover.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/WalkthroughPopover.macro
@@ -1,0 +1,98 @@
+definition {
+
+	macro getElementCirclePositionX {
+		WaitForSPARefresh();
+
+		var javascript = '''
+		let elem = document.querySelector('*.${elementClass}');
+
+		let elementCoordinates = elem.getBoundingClientRect();
+
+		let leftPositionX = Math.round(elementCoordinates.x);
+
+		let centerPositionX = (leftPositionX + (elementCoordinates.width)/2).toString();
+
+		return centerPositionX;
+		''';
+
+		var position_x = selenium.getEval("${javascript}");
+
+		return "${position_x}";
+	}
+
+	macro getElementCirclePositionY {
+		WaitForSPARefresh();
+
+		var javascript = '''
+		let elem = document.querySelector('*.${elementClass}');
+
+		let elementCoordinates = elem.getBoundingClientRect();
+
+		let topPositionY = Math.round(elementCoordinates.y);
+
+		let centerPositionY = (topPositionY + (elementCoordinates.width)/2).toString();
+
+		return centerPositionY;
+		''';
+
+		var position_y = selenium.getEval("${javascript}");
+
+		return "${position_y}";
+	}
+
+	macro getElementRectanglePositionX {
+		WaitForSPARefresh();
+
+		var javascript = '''
+		let elem = document.querySelector('#${elementId}');
+
+		let elementCoordinates = elem.getBoundingClientRect();
+
+		let positionX = Math.round(elementCoordinates.x).toString();
+
+		return positionX;
+		''';
+
+		var position_x = selenium.getEval("${javascript}");
+
+		return "${position_x}";
+	}
+
+	macro getElementRectanglePositionY {
+		WaitForSPARefresh();
+
+		var javascript = '''
+		let elem = document.querySelector('#${elementId}');
+
+		let elementCoordinates = elem.getBoundingClientRect();
+
+		let positionY = Math.round(elementCoordinates.y).toString();
+
+		return positionY;
+		''';
+
+		var position_y = selenium.getEval("${javascript}");
+
+		return "${position_y}";
+	}
+
+	macro viewCoordinatePositionMatchesElementStep {
+		var step_x = WalkthroughPopover.getElementRectanglePositionX(elementId = "${stepElementId}");
+		var step_y = WalkthroughPopover.getElementRectanglePositionY(elementId = "${stepElementId}");
+		var hotspot_x = WalkthroughPopover.getElementCirclePositionX(elementClass = "${hotspotElementClass}");
+		var hotspot_y = WalkthroughPopover.getElementCirclePositionY(elementClass = "${hotspotElementClass}");
+
+		echo("position step (x,y): ${step_x},${step_y}");
+
+		echo("position hotspot (x,y): ${hotspot_x},${hotspot_y}");
+
+		if ("${step_x}" != "${hotspot_x}") {
+			fail("FAIL. X coordinate positions do not match.");
+		}
+
+		if ("${step_y}" != "${hotspot_y}") {
+			fail("FAIL. Y coordinate positions do not match.");
+		}
+	}
+
+}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -194,14 +194,11 @@ definition {
 		}
 
 		task ("Then hotspot element is present on the 2nd element") {
-			SetWindowSize(value1 = "800,800");
-
 			AssertElementPresent(locator1 = "Walkthrough#HOTSPOT");
 
-			AssertAttributeValue(
-				attribute1 = "style",
-				locator1 = "Walkthrough#HOTSPOT",
-				value1 = "left: 286.5px; top: 117px;");
+			WalkthroughPopover.viewCoordinatePositionMatchesElementStep(
+				hotspotElementClass = "lfr-walkthrough-hotspot-inner",
+				stepElementId = "step2");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -178,4 +178,31 @@ definition {
 		}
 	}
 
+	@description = "LPS-154639. Assert component will switch to hotspot mode in the 2nd step when closing 2nd popover."
+	@priority = "5"
+	test WhenClosedCanTransitionToHotSpotModeOnCurrentStepElement {
+		task ("Given click hotspot element") {
+			Click(locator1 = "Walkthrough#HOTSPOT");
+		}
+
+		task ("Click on next step") {
+			Click(locator1 = "Button#OK");
+		}
+
+		task ("When Click close icon") {
+			Click(locator1 = "Walkthrough#CLOSE_POPOVER");
+		}
+
+		task ("Then hotspot element is present on the 2nd element") {
+			SetWindowSize(value1 = "800,800");
+
+			AssertElementPresent(locator1 = "Walkthrough#HOTSPOT");
+
+			AssertAttributeValue(
+				attribute1 = "style",
+				locator1 = "Walkthrough#HOTSPOT",
+				value1 = "left: 286.5px; top: 117px;");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Create automated tests for Walkthrough component.

**Test Plan**
Given: frontend-js-components-sample-web deployed to test page
And Given: Navigate to Walkable tab on sample portlet
And Given: Click hotspot element
When: Click on next step
When: Click close icon
Then: hotspot element is present on the 2nd element

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-154639