### PR TITLE
LRQA-75607 Use doubleclick for indeterminate boxes

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -99,7 +99,7 @@ definition {
 		}
 
 		task ("When all children checkboxes states are checked") {
-			Click.clickAtNotVisible(
+			DoubleClick.doubleClickNotVisible(
 				key_label = "Content & Data",
 				locator1 = "ClaySamplePortlet#CHECKBOX_NESTED");
 


### PR DESCRIPTION
**Background**
ClayCheckbox#ParentMustBeCheckedIfAllChildrenAreChecked is failing. Looks like Content & Data needs to be double clicked to select all children from indeterminate state.

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-75607