### PR TITLE
LPS-156091 Not possible to retrieve the pages of a site through headless APIs

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.theme.ThemeUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -59,6 +60,7 @@ import com.liferay.portal.vulcan.util.JaxRsLinkUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.segments.SegmentsEntryRetriever;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.context.RequestContextMapper;
 import com.liferay.segments.model.SegmentsExperience;
@@ -329,6 +331,13 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 					contextHttpServletRequest, null, layout.getGroupId(),
 					_portal.getClassNameId(Layout.class.getName()),
 					layout.getPlid(), segmentsEntryIds);
+
+		if (ArrayUtil.isEmpty(segmentsExperienceIds)) {
+			return _segmentsExperienceLocalService.fetchSegmentsExperience(
+				layout.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+				_portal.getClassNameId(Layout.class.getName()),
+				layout.getPlid());
+		}
 
 		return _segmentsExperienceLocalService.getSegmentsExperience(
 			segmentsExperienceIds[0]);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -368,9 +368,11 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		SegmentsExperience segmentsExperience = _getSegmentsExperience(
 			layout, segmentsExperienceKey);
 
-		contextHttpServletRequest.setAttribute(
-			SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS,
-			new long[] {segmentsExperience.getSegmentsExperienceId()});
+		if (segmentsExperience != null) {
+			contextHttpServletRequest.setAttribute(
+				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS,
+				new long[] {segmentsExperience.getSegmentsExperienceId()});
+		}
 
 		contextHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, _getThemeDisplay(layout));


### PR DESCRIPTION
- LPS-156091 If we don't get any segmentsExperienceIds, fetch the default one for the layout
- LPS-156091 Avoid NPE
