### PR TITLE
LPS-XXXXXX Add state persistence and page navigation support

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/SampleWalkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/SampleWalkthrough.js
@@ -18,17 +18,20 @@ import React from 'react';
 const WALKTHROUGH_CONFIG = {
 	closeOnClickOutside: false,
 	closeable: true,
+	pages: {'/': ['step-1', 'step-2', 'step-3', 'step-4', 'step-5']},
 	skippable: true,
 	steps: [
 		{
 			content: '<span>Content 1</span><br/><code>Hello1</code>',
 			darkbg: true,
+			id: 'step-1',
 			nodeToHighlight: '#step1',
 			title: 'Title 1',
 		},
 		{
 			content: '<span>Content 2</span><br/><code>Hello2</code>',
 			darkbg: true,
+			id: 'step-2',
 			nodeToHighlight: '#step2',
 			positioning: 'top',
 			title: 'Title 2',
@@ -36,16 +39,19 @@ const WALKTHROUGH_CONFIG = {
 		{
 			content: '<span>Content 3</span><br/><code>Hello3</code>',
 			darkbg: true,
+			id: 'step-3',
 			nodeToHighlight: '#step3',
 			title: 'Title 3',
 		},
 		{
 			content: '<span>Content 4</span><br/><code>Hello4</code>',
+			id: 'step-4',
 			nodeToHighlight: '#step4',
 			title: 'Title 4',
 		},
 		{
 			content: '<span>Content 5</span><br/><code>Hello5</code>',
+			id: 'step-5',
 			nodeToHighlight: '#step5',
 			positioning: 'bottom',
 			title: 'Title 5',

--- a/modules/apps/frontend-js/frontend-js-components-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-components-web/build.gradle
@@ -5,6 +5,8 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/java/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/java/java/com/liferay/frontend/js/components/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.components.web.internal.servlet.taglib;
+
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Matuzalem Teles
+ * @author Diego Nascimento
+ */
+@Component(service = DynamicInclude.class)
+public class WalkthroughBottomJSPDynamicInclude implements DynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String key)
+		throws IOException {
+
+		ScriptData scriptData = new ScriptData();
+
+		String resolvedModuleName = _npmResolver.resolveModuleName(
+			"frontend-js-components-web/walkthrough/WalkthroughRender");
+
+		System.out.println(resolvedModuleName);
+
+		JSONObject propsJSONObject = JSONUtil.put("sampleProp", Boolean.TRUE);
+
+		scriptData.append(
+			null,
+			"WalkthroughRender.default(" + propsJSONObject.toString() + ")",
+			resolvedModuleName + " as WalkthroughRender",
+			ScriptData.ModulesType.ES6);
+
+		scriptData.writeTo(httpServletResponse.getWriter());
+	}
+
+	@Override
+	public void register(
+		DynamicInclude.DynamicIncludeRegistry dynamicIncludeRegistry) {
+
+		dynamicIncludeRegistry.register("/html/common/themes/bottom.jsp#post");
+	}
+
+	@Reference
+	private NPMResolver _npmResolver;
+
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/SampleWalkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/SampleWalkthrough.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+
+import Walkthrough from './Walkthrough';
+
+const WALKTHROUGH_CONFIG = {
+	closeOnClickOutside: false,
+	closeable: true,
+	pages: {
+		'/group/guest/~/control_panel/manage?p_p_id=com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_mvcRenderCommandName=%2Fadmin%2Fedit_form_instance&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_redirect=http%3A%2F%2Flocalhost%3A8080%2Fgroup%2Fguest%2F%7E%2Fcontrol_panel%2Fmanage%3Fp_p_id%3Dcom_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet%26p_p_lifecycle%3D0%26p_p_state%3Dmaximized%26p_p_mode%3Dview&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_displayStyle=list&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_formInstanceId=41581#/rules': [
+			'button-2',
+		],
+		'/page-2': ['button-1'],
+		'/page-3': ['fragment-1', 'fragment-2', 'fragment-3'],
+	},
+	skippable: true,
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'button-1',
+			next: '/page-3',
+			nodeToHighlight: '#fragment-zgbz-link',
+			title: 'Button 1',
+		},
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'fragment-1',
+			nodeToHighlight: '#fragment-0-tkrl',
+			previous: '/page-2',
+			title: 'Fragment 1',
+		},
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'fragment-2',
+			nodeToHighlight: '#fragment-0-kluh',
+			title: 'Fragment 2',
+		},
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'fragment-3',
+			next:
+				'/group/guest/~/control_panel/manage?p_p_id=com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_mvcRenderCommandName=%2Fadmin%2Fedit_form_instance&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_redirect=http%3A%2F%2Flocalhost%3A8080%2Fgroup%2Fguest%2F%7E%2Fcontrol_panel%2Fmanage%3Fp_p_id%3Dcom_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet%26p_p_lifecycle%3D0%26p_p_state%3Dmaximized%26p_p_mode%3Dview&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_displayStyle=list&_com_liferay_dynamic_data_mapping_form_web_portlet_DDMFormAdminPortlet_formInstanceId=41581#/rules',
+			nodeToHighlight: '#fragment-0-eitz',
+			title: 'Fragment 3',
+		},
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'button-2',
+			nodeToHighlight: '#addFieldButton',
+			previous: '/page-3',
+			title: 'Add new rule',
+		},
+	],
+};
+
+export default function SampleWalkthrough(...props) {
+	return <Walkthrough {...WALKTHROUGH_CONFIG} {...props} />;
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/Walkthrough.js
@@ -205,6 +205,10 @@ const Walkthrough = ({closeOnClickOutside, closeable, skippable, steps}) => {
 				setCurrentStepIndex(index);
 			}
 			else {
+				console.error(
+					`Walkthrough Exception: ${steps[index].nodeToHighlight} element for highlight does not exist in DOM`
+				);
+
 				setCurrentStepIndex(
 					index === steps.length - 1
 						? index - 1

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/Walkthrough.scss
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/Walkthrough.scss
@@ -4,8 +4,8 @@
 	&-hotspot {
 		align-items: center;
 		background-color: rgb(255, 255, 255);
-		border: 2px solid $primary-d1;
 		border-radius: 100%;
+		border: 2px solid $primary-d1;
 		cursor: pointer;
 		display: flex;
 		height: 32px;
@@ -14,6 +14,7 @@
 		margin-top: -10px;
 		position: absolute;
 		width: 32px;
+		z-index: 1020;
 
 		&-inner {
 			background-color: $primary-d2;

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/WalkthroughRender.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/WalkthroughRender.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {render} from '@liferay/frontend-js-react-web';
+
+import SampleWalkthrough from './SampleWalkthrough';
+
+const DEFAULT_CONTAINER_ID = 'walkthroughContainer';
+
+const getDefaultContainer = () => {
+	let container = document.getElementById(DEFAULT_CONTAINER_ID);
+
+	if (!container) {
+		container = document.createElement('div');
+		container.id = DEFAULT_CONTAINER_ID;
+		document.body.appendChild(container);
+	}
+
+	return container;
+};
+
+export default function main(props) {
+	render(SampleWalkthrough, props, getDefaultContainer());
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/useLocalStorage.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/walkthrough/useLocalStorage.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {useCallback, useState} from 'react';
+
+export function useLocalStorage(key, initialValue) {
+	const [storedValue, setStoredValue] = useState(() => {
+		if (typeof window === 'undefined') {
+			return initialValue;
+		}
+		try {
+			const item = window.localStorage.getItem(key);
+
+			return item ? JSON.parse(item) : initialValue;
+		}
+		catch (error) {
+			console.error(error);
+
+			return initialValue;
+		}
+	});
+
+	const setValue = useCallback(
+		(value) => {
+			try {
+				const valueToStore =
+					value instanceof Function ? value(storedValue) : value;
+
+				setStoredValue(valueToStore);
+
+				if (typeof window !== 'undefined') {
+					window.localStorage.setItem(
+						key,
+						JSON.stringify(valueToStore)
+					);
+				}
+			}
+			catch (error) {
+				console.error(error);
+			}
+		},
+		[storedValue, key]
+	);
+
+	return [storedValue, setValue];
+}


### PR DESCRIPTION
I'm submitting this PR as a demonstration of how the navigation system in the Walkthrough component will work, in order for this to go forward, we need to deal with the backend-related tickets first. This PR includes the DynamicInclude implementation so that we could test the navigation but it will not be in the final PR, I believe we will have to have a specific module for this component since the backend needs to deal with more business rules considering the LPS-150904 ticket.

To make the mechanism work correctly we need to add a new property to the JSON called `pages` that can help us to tell which pages have steps and which are those steps so it helps us to know if we have steps on another page.

```js
{
  pages: {
    '/page-2': ['button-1'],
    '/page-3': ['fragment-1', 'fragment-2', 'fragment-3']
  }
}
```

We also had to add two new properties to step to symbolize the action of `next` and `previous` if necessary, so we can know if clicking `Ok` should navigate to the next page and on which page, the same happens with ` previous`.

```js
{
  steps: [
    {
      id: 'button-1',
      next: '/page-3',
    },
    {
      id: 'fragment-1',
      previous: '/page-2',
    }
  ]
}
```

The implementation uses local storage to at least store the state of the current step and if the popover is visible, then we get a better UX and we can make the sequential steps flow, but we don't reset this value after finishing, I believe we can do that after we click `Close` or when the user checks the box to not show this again but we also need a way for the backend to also know that on the user's next visits the onboarding should not be shown again.

A tradeoff of this implementation is that the URL is very sensitive, we use `location.pathname + location.search + location.hash` to set the `path` and know if the step exists on that page and we also avoid rendering the component on the page that the step is no longer available. We also use `hash` for this to work with React Router the last step of the demo goes to the forms which is a page managed by react-router. There is also a race condition issue as React renders in DXP do not have SSR, it can happen that the popover gets lost and cannot position itself because the application has not been rendered yet.

Please do not consider code from `SampleWalkthrough.js` and `WalkthroughRender.js` just for testing purposes and working with DynamicInclude.

There is a positioning bug but this will be fixed in another PR, this is due to the same offset being used for all positions.

## Demo

https://user-images.githubusercontent.com/13750819/173873342-73ceea9d-f6c2-4dea-bb78-eff5d6f01319.mov

cc @dsanz 