### PR TITLE
LPS-156142 Replace pause with waitfors from FI tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -223,7 +223,7 @@ definition {
 
 		FileInstall.deployFileOnServer(jarFile = "${appName}.war");
 
-		Pause(locator1 = "30000");
+		WaitForConsoleTextPresent(value1 = "STARTED ${appName}");
 
 		Navigator.openSitePage(
 			pageName = "Theme Test Page",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -72,7 +72,7 @@ definition {
 
 		takeScreenshot();
 
-		Pause(locator1 = "5000");
+		WaitForElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 
 		takeScreenshot();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -64,7 +64,7 @@ definition {
 
 			Navigator.gotoNavTab(navTab = "Widgets");
 
-			Pause(locator1 = "3000");
+			WaitForElementPresent(locator1 = "NavBar#APPLICATION_SEARCH_FIELD");
 
 			Type(
 				locator1 = "NavBar#APPLICATION_SEARCH_FIELD",
@@ -395,7 +395,7 @@ definition {
 
 			Navigator.gotoNavTab(navTab = "Widgets");
 
-			Pause(locator1 = "3000");
+			WaitForElementPresent(locator1 = "NavBar#APPLICATION_SEARCH_FIELD");
 
 			Type(
 				locator1 = "NavBar#APPLICATION_SEARCH_FIELD",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase.testcase
@@ -52,7 +52,7 @@ definition {
 			navTab = "Blog Images",
 			uploadFileName = "Document_1.jpg");
 
-		Pause(locator1 = "1000");
+		WaitForElementPresent(locator1 = "Button#SAVE_AS_DRAFT");
 
 		BlogsEntry.saveAsDraft();
 
@@ -244,8 +244,6 @@ definition {
 			KeyPress(
 				locator1 = "//body",
 				value1 = "a");
-
-			Pause(locator1 = "1000");
 
 			KeyPress(
 				locator1 = "//body",

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -246,10 +246,6 @@
 		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoPreview\.testcase" />
 		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoPreviewLocalStaging\.testcase" />
 		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/externalvideoshortcut/DMVideoShortcut\.testcase" />
-		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme\.testcase" />
-		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert\.testcase" />
-		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps\.testcase" />
-		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/usecase/WYSIWYGUsecase\.testcase" />
 		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/pageaudit/PageAudit\.testcase" />
 		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/PublicationsCalendar\.testcase" />
 		<suppress checks="PoshiPauseUsageCheck" files="portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/StagingUsecaseWithRoles\.testcase" />


### PR DESCRIPTION
Affected FI tests in source-formatter-suppressions.xml:
	Theme.testcase
	ClayAlert.testcase
	RemoteApps.testcase
	WYSIWYGUsecase.testcase

Steps:
	Go to one of the files that you own in the suppressions and remove the suppression
	Fix all the pauses within that file
	Find a solution with waitfors and not pauses.

JIRA Ticket:
	[https://issues.liferay.com/browse/LPS-156142](https://issues.liferay.com/browse/LPS-156142)