### PR TITLE
LPS-156119 - Add warning for an icon pack without a name

### DIFF
--- a/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/pages/instance_settings/AddIconPackModal.tsx
+++ b/modules/apps/frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/pages/instance_settings/AddIconPackModal.tsx
@@ -72,7 +72,10 @@ export default function AddIconPackModal({
 
 	const containsWhiteSpace = !!iconPackName.match(/\s/);
 
-	const hasError = nameTaken || containsWhiteSpace;
+	const hasError =
+		nameTaken ||
+		containsWhiteSpace ||
+		(!!Object.keys(selectedIcons).length && !iconPackName);
 
 	const handleUploadSpritemapSubmit = () => {
 		if (hasError) {
@@ -210,6 +213,10 @@ export default function AddIconPackModal({
 											: containsWhiteSpace
 											? Liferay.Language.get(
 													'name-of-icon-pack-cannot-contain-whitespace'
+											  )
+											: !iconPackName
+											? Liferay.Language.get(
+													'name-of-icon-pack-is-required'
 											  )
 											: ''
 									}`}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
+name-of-icon-pack-is-required=Name of icon pack is required.
 +-add-address-line=+ Add Address Line
 0-analytics-cloud-connection=Analytics Cloud Connection
 1-account-was-added-to-x=1 account was added to {0}.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-156119

There was no need for a toast pop up since the button to submit is disabled. Instead I went with adding an error if the user selects icons but doesn't provide a name for the pack

## Before:
![Screen Shot 2022-06-17 at 9 41 17 AM](https://user-images.githubusercontent.com/6843530/174232742-885cd1e3-d814-40d1-a29d-d75b76e181ca.png)


## After:
![Screen Shot 2022-06-17 at 9 39 39 AM](https://user-images.githubusercontent.com/6843530/174232554-71f7d1a2-7792-4ea4-8de9-e6cc469d930b.png)
.