### PR TITLE
LPS-152018

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/checkbox/aui/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/checkbox/aui/page.jsp
@@ -22,4 +22,4 @@
 	<%@ include file="/checkbox/extended_label.jspf" %>
 </liferay-util:buffer>
 
-<aui:input checked="<%= checked %>" data-qa-id="<%= name %>" disabled="<%= disabled %>" id="<%= id %>" ignoreRequestValue="<%= true %>" label="<%= extendedLabel %>" name="<%= name %>" type="checkbox" />
+<aui:input checked="<%= checked %>" cssClass="label-item" data-qa-id="<%= name %>" disabled="<%= disabled %>" id="<%= id %>" ignoreRequestValue="<%= true %>" label="<%= extendedLabel %>" name="<%= name %>" type="checkbox" />


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152018

## Steps to reproduce

1. Enable local staging on default site.
1. Navigate to staging admin
1. Add a Custom Publish Process

Note that the checkboxes do not match.

## Root cause analysis

The issue arises due to `display: flex` without a `flex-shrink: 0` set on the checkbox, so it winds up shrinking. We can get a `flex-shrink: 0` by adding the `label-item` class, so this is the solution we went with here:

https://github.com/liferay/clay/blob/v2.24.1/packages/clay-css/src/scss/components/_labels.scss#L113

Please let me know if you have any questions, or if you feel we should try a different solution.