### PR TITLE
LPS 156393

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -431,6 +431,7 @@ public class BaseContainerTag extends AttributesTagSupport {
 		if (!dynamicAttributesString.isEmpty()) {
 			JspWriter jspWriter = pageContext.getOut();
 
+			jspWriter.write(StringPool.SPACE);
 			jspWriter.write(dynamicAttributesString);
 		}
 	}


### PR DESCRIPTION
To reproduce the issue follow the LPS steps

As explained the resulting markup is:

`<a class="btn btn-outline-borderless btn-monospaced btn-sm btn-outline-secondary lfr-portal-tooltip"href="http://www.facebook.com/sharer.php?u=xxx" title="Facebook" ><svg class="lexicon-icon lexicon-icon-social-facebook"role="presentation" viewBox="0 0 512 512" ><use xlink:href="xxx" /></svg></a>`

it produces some accessibility problems:

The expected behavior is:

`<a class="btn btn-outline-borderless btn-monospaced btn-sm btn-outline-secondary lfr-portal-tooltip" href="http://www.facebook.com/sharer.php?u=xxx" title="Facebook" ><svg class="lexicon-icon lexicon-icon-social-facebook"role="presentation" viewBox="0 0 512 512" ><use xlink:href="xxx" /></svg></a>`

cc: @antonio-ortega 