### PR TITLE
LPS-156268 Apply Clay classes when it has animation so the content is centered and well spaced

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
@@ -37,46 +37,43 @@
 	</c:if>
 
 	<c:if test="<%= Validator.isNotNull(actionDropdownItems) %>">
-		<div class="c-mt-3">
-			<c:choose>
-				<c:when test="<%= actionDropdownItems.size() > 1 %>">
-					<clay:dropdown-menu
-						additionalProps="<%= additionalProps %>"
-						displayType="<%= buttonCssClass %>"
-						dropdownItems="<%= actionDropdownItems %>"
-						label="new"
-						propsTransformer="<%= propsTransformer %>"
-						propsTransformerServletContext="<%= propsTransformerServletContext %>"
-						small="<%= true %>"
-					/>
-				</c:when>
-				<c:otherwise>
+		<c:choose>
+			<c:when test="<%= actionDropdownItems.size() > 1 %>">
+				<clay:dropdown-menu
+					additionalProps="<%= additionalProps %>"
+					displayType="<%= buttonCssClass %>"
+					dropdownItems="<%= actionDropdownItems %>"
+					label="new"
+					propsTransformer="<%= propsTransformer %>"
+					propsTransformerServletContext="<%= propsTransformerServletContext %>"
+				/>
+			</c:when>
+			<c:otherwise>
 
-					<%
-					DropdownItem actionDropdownItem = actionDropdownItems.get(0);
-					%>
+				<%
+				DropdownItem actionDropdownItem = actionDropdownItems.get(0);
+				%>
 
-					<c:choose>
-						<c:when test='<%= Validator.isNotNull(actionDropdownItem.get("href")) %>'>
-							<clay:link
-								displayType="<%= buttonCssClass %>"
-								href='<%= String.valueOf(actionDropdownItem.get("href")) %>'
-								label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
-								type="button"
-							/>
-						</c:when>
-						<c:otherwise>
-							<clay:button
-								additionalProps='<%= (HashMap)actionDropdownItem.get("data") %>'
-								displayType="<%= buttonCssClass %>"
-								label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
-								propsTransformer="<%= buttonPropsTransformer %>"
-								propsTransformerServletContext="<%= propsTransformerServletContext %>"
-							/>
-						</c:otherwise>
-					</c:choose>
-				</c:otherwise>
-			</c:choose>
-		</div>
+				<c:choose>
+					<c:when test='<%= Validator.isNotNull(actionDropdownItem.get("href")) %>'>
+						<clay:link
+							displayType="<%= buttonCssClass %>"
+							href='<%= String.valueOf(actionDropdownItem.get("href")) %>'
+							label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
+							type="button"
+						/>
+					</c:when>
+					<c:otherwise>
+						<clay:button
+							additionalProps='<%= (HashMap)actionDropdownItem.get("data") %>'
+							displayType="<%= buttonCssClass %>"
+							label='<%= String.valueOf(actionDropdownItem.get("label")) %>'
+							propsTransformer="<%= buttonPropsTransformer %>"
+							propsTransformerServletContext="<%= propsTransformerServletContext %>"
+						/>
+					</c:otherwise>
+				</c:choose>
+			</c:otherwise>
+		</c:choose>
 	</c:if>
 </div>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/empty_result_message/page.jsp
@@ -16,8 +16,8 @@
 
 <%@ include file="/empty_result_message/init.jsp" %>
 
-<div class="taglib-empty-result-message">
-	<div class="<%= animationTypeCssClass %>"></div>
+<div class="taglib-empty-result-message <%= Validator.isNotNull(animationTypeCssClass) ? "c-empty-state-animation" : StringPool.BLANK %>">
+	<div class="<%= "c-empty-state-image " + animationTypeCssClass %>"></div>
 
 	<h1 class="taglib-empty-result-message-title">
 		<c:choose>


### PR DESCRIPTION
/cc @john-co 

Hi guys! This is a follow-up of https://github.com/liferay-frontend/liferay-portal/pull/2359, and contains a fix for a regression I caused with the first PR 😅

I have added some CSS classes that are used here: https://clayui.com/docs/components/empty-state/markup.html. I'm adding `c-empty-state-animation` when it has an animation so the correct margin is applied and the content is centered. Adding it only when it has animation also makes this case work as expected:

![image](https://user-images.githubusercontent.com/2444936/174620657-3364787d-9427-4268-86cd-45b4b809955f.png)

This one won't be affected by `c-empty-state-animation` so it will remain left aligned.

Please let me know what you think.

Thanks! 🥰