### PR TITLE
LPS-156371 Add a test to can get ManyToMany relationship details as nested fields_3

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -150,4 +150,62 @@ definition {
 		}
 	}
 
+	@priority = "5"
+	test CanGetManyToManyRelationshipDetailsAsNestedFields_3 {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var objectDefinitionId1 = JSONObject.getObjectId(objectName = "University");
+			var objectDefinitionId2 = JSONObject.getObjectId(objectName = "Subject");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("When I relate subject entry with university entry through subjects PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "subjects",
+				objectEntry1 = "${subjectId}",
+				objectEntry2 = "${universityId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("Then the subject is related to the university in subjects GET endpoint with nestedFields=universitiesSubjects") {
+			var getObjectsWithNestedFieldReponse = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedField = "universitiesSubjects",
+				objects = "subjects");
+
+			ObjectDefinitionAPI.assertNestedFieldDetail(
+				expectedValue = "${universityId}",
+				getObjectsWithNestedFieldReponse = "${getObjectsWithNestedFieldReponse}",
+				nestedField = "universitiesSubjects",
+				objectEntryId = "${subjectId}",
+				objectField = "id");
+
+			ObjectDefinitionAPI.assertNestedFieldDetail(
+				expectedValue = "Liferay",
+				getObjectsWithNestedFieldReponse = "${getObjectsWithNestedFieldReponse}",
+				nestedField = "universitiesSubjects",
+				objectEntryId = "${subjectId}",
+				objectField = "name");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Add a test to can get ManyToMany relationship details as nested fields_3

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects created
And Given university entry created
And Given subject entry created
When in c/subjects I use PUT /{subjectId}/universitiesSubjects/{universityId}
Then the subject is related to the university in /o/c/subjects?nestedFields=universitiesSubjects

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-156371