### PR TITLE
LRQA-75709, LRQA-75710 Test fixes for JS Components Sample

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/WalkthroughPopover.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/WalkthroughPopover.macro
@@ -79,10 +79,10 @@ definition {
 	macro viewCoordinatePositionMatchesElementStep {
 		var step_x = WalkthroughPopover.getElementRectanglePositionX(elementId = "${stepElementId}");
 		var step_y = WalkthroughPopover.getElementRectanglePositionY(elementId = "${stepElementId}");
-		var hotspotChildIndex = "0";
+		var hotspotChildIndex = "1";
 
 		if (contains("${stepElementId}", "teststep")) {
-			var hotspotChildIndex = "1";
+			var hotspotChildIndex = "0";
 		}
 
 		var hotspot_x = WalkthroughPopover.getElementCirclePositionX(

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/TranslationManager.testcase
@@ -24,6 +24,8 @@ definition {
 				widgetName = "JS Components Sample");
 
 			Navigator.gotoPage(pageName = "JS Components Sample Page");
+
+			Navigator.gotoNavTab(navTab = "Translation Manager");
 		}
 	}
 


### PR DESCRIPTION
**Background**
JS Components Sample portlet tabs were resorted. 
- Test Walkable tab comes before Walkable tab > Update indexes
- Translation Manager is no longer the first tab > Navigate to Translation Manager tab 

**JIRA Ticket:**
https://issues.liferay.com/browse/LRQA-75709
https://issues.liferay.com/browse/LRQA-75710