### PR TITLE
LPS-156609 | Deleted object does not appear in ManyToMany relationship details nested fields_1

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -175,6 +175,23 @@ definition {
 		return "${response}";
 	}
 
+	macro _deleteObjectEntry {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectEntryId}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase("${en_US_plural_label}");
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectEntryId} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var response = JSONCurlUtil.delete("${curl}");
+
+		return "${response}";
+	}
+
 	macro _getEmployeeFirstnameById {
 		Variables.assertDefined(parameterList = "${employeeId}");
 
@@ -400,6 +417,14 @@ definition {
 			expected = "${managerId2}");
 	}
 
+	macro assertResponseNotIncludeDetailsOfDeletedObject {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..universitiesSubjects[?(@.id==${subjectId})].name");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "");
+	}
+
 	macro assertResponseNotIncludesDetailsOfDeletedEmployee {
 		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..items[?(@.id==${employeeId1} && @.r_supervisor_c_managerId==${managerId1})].r_supervisor_c_managerId");
 
@@ -500,6 +525,12 @@ definition {
 
 	macro deleteEmployee {
 		ObjectDefinitionAPI._deleteEmployee(employeeId = "${employeeId}");
+	}
+
+	macro deleteObjectEntry {
+		ObjectDefinitionAPI._deleteObjectEntry(
+			en_US_plural_label = "${en_US_plural_label}",
+			objectEntryId = "${objectEntryId}");
 	}
 
 	macro getObjectsWithAggregationTerms {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -418,11 +418,11 @@ definition {
 	}
 
 	macro assertResponseNotIncludeDetailsOfDeletedObject {
-		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..universitiesSubjects[?(@.id==${subjectId})].name");
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..universitiesSubjects");
 
 		TestUtils.assertEquals(
 			actual = "${actual}",
-			expected = "");
+			expected = "${expectedValue}");
 	}
 
 	macro assertResponseNotIncludesDetailsOfDeletedEmployee {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -266,4 +266,76 @@ definition {
 		}
 	}
 
+	@priority = "4"
+	test DeletedObjectDoesNotAppearInManyToManyRelationshipDetailsNestedFields_1 {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var objectDefinitionId1 = JSONObject.getObjectId(objectName = "University");
+			var objectDefinitionId2 = JSONObject.getObjectId(objectName = "Subject");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId1 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay First University");
+			var universityId2 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay Second University");
+			var universityId3 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay Third University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("When I relate subject entry with all three universities through universities PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId1}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId2}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId3}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("When deleting subject entry") {
+			ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "subjects",
+				objectEntryId = "${subjectId}");
+		}
+
+		task ("Then the subject is not appear in any of the universities in universities GET endpoint with nestedFields=universitiesSubjects") {
+			var responseToParse = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedField = "universitiesSubjects",
+				objects = "universities");
+
+			ObjectDefinitionAPI.assertResponseNotIncludeDetailsOfDeletedObject(
+				responseToParse = "${responseToParse}",
+				subjectId = "${subjectId}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -327,14 +327,14 @@ definition {
 				objectEntryId = "${subjectId}");
 		}
 
-		task ("Then the subject is not appear in any of the universities in universities GET endpoint with nestedFields=universitiesSubjects") {
+		task ("Then the subject does not appear in any of the universities in universities GET endpoint with nestedFields=universitiesSubjects") {
 			var responseToParse = ObjectDefinitionAPI.getObjectsWithNestedField(
 				nestedField = "universitiesSubjects",
 				objects = "universities");
 
 			ObjectDefinitionAPI.assertResponseNotIncludeDetailsOfDeletedObject(
-				responseToParse = "${responseToParse}",
-				subjectId = "${subjectId}");
+				expectedValue = "[],[],[]",
+				responseToParse = "${responseToParse}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Add a test to assert deleted object does not appear in ManyToMany relationship details nested fields_1

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects with deletionType cascade created
And Given three university entries created
And Given subject entry created
And Given subject related to all three universities
When subject is deleted
Then it does not appear in any of the universities in o/c/universities?nestedFields=universitiesSubjects

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-156609