### PR TITLE
LPS-155465, LPS-155467 | master

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -111,4 +111,24 @@ definition {
 		}
 	}
 
+	@description = "LPS-155467. Assert the quick action is not visible when the row checkbox is checked."
+	@priority = "3"
+	test IsNotVisibleOnCheckedRow {
+		task ("When mark a row checkbox as checked") {
+			Check.checkToggleSwitch(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_CHECKBOX");
+		}
+
+		task ("And when hover mouse over checked row") {
+			MouseOver(
+				key_itemName = "Sample1",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+		}
+
+		task ("Then the quick action icons are not visible") {
+			FDSQuickActions.viewQuickActionMenuNotPresent(title = "Sample1");
+		}
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -53,6 +53,36 @@ definition {
 		}
 	}
 
+	@description = "LPS-155465. Assert that clicking quick action is equivalent to clicking the ellipsis dropdown menu."
+	@priority = "5"
+	test BehaviorIsEqualToEllipsisDropdownEquivalentAction {
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("When click on Pencil Icon") {
+			ClickNoError(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#EDIT_ACTION_BUTTON");
+		}
+
+		task ("And when copy the browser URL (#test-pencil is appended)") {
+			AssertLocation(value1 = "${portalURL}/frontend-data-set-test-page#test-pencil");
+		}
+
+		task ("And when click on ellipsis of 1st row item in FDS table") {
+			Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+		task ("And when click on Pencil Icon") {
+			Click(locator1 = "FrontendDataSet#DROPDOWN_MENU_SHOW_ITEM_EDIT_ICON");
+		}
+
+		task ("Then browser URL matches copied URL (#test-pencil)") {
+			AssertLocation(value1 = "${portalURL}/frontend-data-set-test-page#test-pencil");
+		}
+	}
+
 	@description = "LPS-155457. Assert that hover over mouse off of the table body quick action menu is not visible."
 	@priority = "5"
 	test CanDisappearWhenNotHovered {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -26,6 +26,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ENTRY_CHECKBOX</td>
+	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']/preceding-sibling::div//input[contains(@type,'checkbox')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>ENTRY_VERTICAL_ELLIPSIS</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']/..//*[name()='svg'][contains(@class,'icon-ellipsis')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -16,8 +16,18 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DROPDOWN_MENU_SHOW_ITEM_EDIT_ICON</td>
+	<td>//div[contains(@class,'dropdown-menu show')]//*[*[name()='svg'][contains(@class,'lexicon-icon-pencil')]]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>EDIT_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-pencil')]]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ENTRY_VERTICAL_ELLIPSIS</td>
+	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']/..//*[name()='svg'][contains(@class,'icon-ellipsis')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Background**
Create automated tests for the Frontend Dataset component.

**Test Plan**
**FDSQuickActions#BehaviorIsEqualToEllipsisDropdownEquivalentAction**
Given: frontend-data-set-sample-web (FDS Sample Portlet) deployed
And Given FDS Sample Portlet added to page
When: Hover over 1st row item (Sample 1)
And When: click on Pencil Icon
And When: copy the browser URL (#test-pencil is appended)
And When: Click on ellipsis of 1st row item in FDS table
And When: click on Pencil Icon
Then: browser URL matches copied URL (#test-pencil)

**FDSQuickActions#IsNotVisibleOnCheckedRow**
Given: frontend-data-set-sample-web (FDS Sample Portlet) deployed
And Given: FDS Sample Portlet added to page
When: Mark a row checkbox as checked
And When: Hover mouse over checked row
Then: the quick action icons are not visible

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155465
https://issues.liferay.com/browse/LPS-155467