### PR TITLE
LPS-155313 Add test FDSFilters#ExcludeCanBeEnabled

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -16,7 +16,7 @@ definition {
 					key_status = "Draft",
 					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
 			}
-			else if ("${status}" == "Pending"){
+			else if ("${status}" == "Pending") {
 				Check.checkNotVisibleNoErrors(
 					key_status = "Pending",
 					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -1,0 +1,33 @@
+definition {
+
+	macro enableStatusFilters {
+		Click(
+			key_filter = "Status",
+			locator1 = "FrontendDataSet#FILTER_OPTION");
+
+		for (var status : list "${key_status}") {
+			if ("${status}" == "Approved") {
+				Check.checkNotVisibleNoErrors(
+					key_status = "Approved",
+					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
+			}
+			else if ("${status}" == "Draft") {
+				Check.checkNotVisibleNoErrors(
+					key_status = "Draft",
+					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
+			}
+			else if ("${status}" == "Pending"){
+				Check.checkNotVisibleNoErrors(
+					key_status = "Pending",
+					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
+			}
+		}
+	}
+
+	macro openFilters {
+		if (IsElementNotPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
+			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
+		}
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -1,0 +1,76 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "false";
+	property portal.release = "false";
+	property portal.upstream = "quarantine";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Frontend Dataset sample portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+	}
+
+	@description = "LPS-155313. Assert results can be correctly filtered when exclude is enabled."
+	@priority = "5"
+	test ExcludeCanBeEnabled {
+		task ("When click on the filter button") {
+			FDSFilters.openFilters();
+		}
+
+		task ("And When adding an option from the status list filter") {
+			FDSFilters.enableStatusFilters(key_status = "Approved, Draft");
+		}
+
+		task ("And When the exclude option is active") {
+			Check.checkToggleSwitch(locator1 = "FrontendDataSet#EXCLUDE_TOGGLE");
+
+			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+		}
+
+		task ("Then the filter will be added to the Filters Summary") {
+			AssertElementPresent(
+				key_filter = "Status: (Exclude) Approved, Draft",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+
+		task ("And Then the results will be displayed according to the filter") {
+			AssertElementPresent(locator1 = "FrontendDataSet#EMPTY_FDS_TABLE_MESSAGE");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -40,6 +40,49 @@
 	<td>//*[normalize-space(text())='${key_itemName}']/parent::*[contains(@class,'dnd-tr')]</td>
 	<td></td>
 </tr>
+
+<!--FILTERS-->
+
+<tr>
+	<td>EDIT_FILTER_BUTTON</td>
+	<td>//div[@class='dropdown-menu show']//*[@type="button" and contains(.,'Edit Filter')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>EMPTY_FDS_TABLE_MESSAGE</td>
+	<td>//div[contains(@class,'empty-state-text') and contains(.,'Sorry, no results were found.')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>EXCLUDE_TOGGLE</td>
+	<td>//div[@class='dropdown-menu show']//*[@type="checkbox" and @id='autocomplete-exclude-status']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_BUTTON</td>
+	<td>//*[contains(@class,'fds')]//*[contains(@class,'filters-dropdown-button')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_DROPDOWN</td>
+	<td>//*[@class='dropdown-menu show' and contains(.,'Filters')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_OPTION</td>
+	<td>//div[@class='dropdown-menu show']//*[@class='dropdown-item' and contains(.,'${key_filter}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FILTER_SUMMARY_LABEL</td>
+	<td>//*[@class='tbar-section']//*[@class='label-section' and contains(.,'${key_filter}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>STATUS_FILTER_CHECKBOX</td>
+	<td>//div[@class='dropdown-menu show']//*[@type="checkbox" and @aria-label='${key_status}']</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>


### PR DESCRIPTION
**Background**
Create automated tests for FDS Filters.


**Test Plan**
Given Sample FDS portlet deployed
And entering on a page which uses FDS
When clicking on the filter button
And adding an option from the status list filter
And the exclude option is active
Then the filter will be added the Filters Summary
And the results will be displayed updated accordingly to it

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155313