### PR TITLE
LPS-155306 | master

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -6,21 +6,9 @@ definition {
 			locator1 = "FrontendDataSet#FILTER_OPTION");
 
 		for (var status : list "${key_status}") {
-			if ("${status}" == "Approved") {
-				Check.checkNotVisibleNoErrors(
-					key_status = "Approved",
-					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
-			}
-			else if ("${status}" == "Draft") {
-				Check.checkNotVisibleNoErrors(
-					key_status = "Draft",
-					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
-			}
-			else if ("${status}" == "Pending") {
-				Check.checkNotVisibleNoErrors(
-					key_status = "Pending",
-					locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
-			}
+			Check.checkNotVisibleNoErrors(
+				key_status = "${status}",
+				locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -1,5 +1,19 @@
 definition {
 
+	macro disableStatusFilters {
+		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
+			Click(
+				key_filter = "Status",
+				locator1 = "FrontendDataSet#FILTER_OPTION");
+		}
+
+		for (var status : list "${key_status}") {
+			Uncheck.uncheckNotVisible(
+				key_status = "${status}",
+				locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
+		}
+	}
+
 	macro enableStatusFilters {
 		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -1,9 +1,11 @@
 definition {
 
 	macro enableStatusFilters {
-		Click(
-			key_filter = "Status",
-			locator1 = "FrontendDataSet#FILTER_OPTION");
+		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
+			Click(
+				key_filter = "Status",
+				locator1 = "FrontendDataSet#FILTER_OPTION");
+		}
 
 		for (var status : list "${key_status}") {
 			Check.checkNotVisibleNoErrors(

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -73,4 +73,38 @@ definition {
 		}
 	}
 
+	@description = "LPS-155306. Assert results can be correctly filtered by editing the filter summary boxes."
+	@priority = "5"
+	test FilterCanBeEdited {
+		task ("When there is a filter already established") {
+			AssertElementPresent(
+				key_filter = "Status: Approved, Draft",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+
+		task ("And clicking on the Filters Summary") {
+			ClickNoError(
+				key_filter = "Status: Approved, Draft",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+
+		task ("And the filter is edited") {
+			FDSFilters.disableStatusFilters(key_status = "Approved,Draft");
+
+			FDSFilters.enableStatusFilters(key_status = "Pending");
+
+			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+		}
+
+		task ("Then the results will be displayed updated accordingly to it") {
+			AssertElementPresent(locator1 = "FrontendDataSet#EMPTY_FDS_TABLE_MESSAGE");
+		}
+
+		task ("And the Filters Summary boxes will be updated accordingly to it") {
+			AssertElementPresent(
+				key_filter = "Status: Pending",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -53,7 +53,7 @@ definition {
 		}
 
 		task ("And When adding an option from the status list filter") {
-			FDSFilters.enableStatusFilters(key_status = "Approved, Draft");
+			FDSFilters.enableStatusFilters(key_status = "Approved,Draft");
 		}
 
 		task ("And When the exclude option is active") {


### PR DESCRIPTION
**Background**
Create automated tests for FDS Filters.

**Test Plan**
**FDSFilters#FilterCanBeEdited**
Given Sample FDS portlet deployed
And entering on a page which uses FDS
When there is a filter already established
And clicking on the Filters Summary
And the filter is edited
Then the results will be displayed updated accordingly to it
And the Filters Summary boxes will be updated accordingly to it

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155306