### PR TITLE
LPS-156481

### DIFF
--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.ts
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.ts
@@ -116,7 +116,7 @@ class CollapseProvider {
 			});
 
 			panel.classList.add(CssClass.COLLAPSING);
-			panel.style[dimension] = 0;
+			panel.style.removeProperty(dimension);
 		}
 	};
 


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-156481

## Proposed solution

The current solution sets the height to blank. I wasn't sure whether `auto`, `unset`, or `initial` was more correct than a blank string, but if you happen to have a preference, please let me know.

## Steps to verify

1. Start Liferay
1. Make sure the navigation menu widget is displayed correctly
1. Reduce browser size to minimize navigation menu widget (note the navigation menu is hidden automatically)
1. Click on the hamburger menu icon to make the navigation menu re-appear (note the navigation menu is visible)
1. Click the hamburger menu icon again to hide it
1. Restore the browser window to the original size

https://issues.liferay.com/secure/attachment/457069/Steps%20to%20reproduce%20%281%29.mov