### PR TITLE
LPS-155458 | master

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSQuickActions.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSQuickActions.macro
@@ -1,5 +1,19 @@
 definition {
 
+	macro viewQuickActionMenuIsPresent {
+		AssertElementPresent(
+			key_title = "${title}",
+			locator1 = "FrontendDataSet#VIEW_ACTION_BUTTON");
+
+		AssertElementPresent(
+			key_title = "${title}",
+			locator1 = "FrontendDataSet#EDIT_ACTION_BUTTON");
+
+		AssertElementPresent(
+			key_title = "${title}",
+			locator1 = "FrontendDataSet#DELETE_ACTION_BUTTON");
+	}
+
 	macro viewQuickActionMenuNotPresent {
 		AssertNotVisible(
 			key_title = "${title}",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -95,6 +95,24 @@ definition {
 		}
 	}
 
+	@description = "LPS-155458. Assert can be displayed on one an active row."
+	@priority = "5"
+	test CanDisplayOnOneActiveRow {
+		task ("When hover over 2nd row item") {
+			MouseOver(
+				key_itemName = "Sample2",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+		}
+
+		task ("Then quick action menu is displayed on the 2nd row") {
+			FDSQuickActions.viewQuickActionMenuIsPresent(title = "Sample2");
+		}
+
+		task ("Then quick action menu is not displayed on 1st row") {
+			FDSQuickActions.viewQuickActionMenuNotPresent(title = "Sample1");
+		}
+	}
+
 	@description = "LPS-155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {


### PR DESCRIPTION
**Background**
Create automated tests for the Frontend Dataset component.

**Test Plan**
FDSQuickActions#CanDisplayOnOneActiveRow
Given: frontend-data-set-sample-web deployed
And Given: FDS Sample Portlet added to page
When: Hover over 1st row item (Sample 1)
And When: hover over 2nd row item (Sample 2)
Then: uick action menu is displayed on 2nd row
And Then: quick action menu is not displayed on 1st row

**JIRA Ticket**:
https://issues.liferay.com/browse/LPS-155458