### PR TITLE
LPS-156713 | Deleted object does not appear in ManyToMany relationship details nested fields_2

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -409,6 +409,14 @@ definition {
 			expected = "${expectedValue}");
 	}
 
+	macro assertResponseIncludeCorrectDetailsOfNotDeletedObject {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..universitiesSubjects[?(@.id==${subjectId})].name");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedValue}");
+	}
+
 	macro assertResponseIncludesDetailsOfNotDeletedEmployee {
 		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..items[?(@.id==${employeeId2} && @.r_supervisor_c_managerId==${managerId2})].r_supervisor_c_managerId");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -338,4 +338,77 @@ definition {
 		}
 	}
 
+	@priority = "4"
+	test DeletedObjectDoesNotAppearInManyToManyRelationshipDetailsNestedFields_2 {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var objectDefinitionId1 = JSONObject.getObjectId(objectName = "University");
+			var objectDefinitionId2 = JSONObject.getObjectId(objectName = "Subject");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId1 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay First University");
+			var universityId2 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay Second University");
+			var universityId3 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay Third University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("When I relate subject entry with all three universities through universities PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId1}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId2}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId3}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("When deleting one of the universities") {
+			ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "universities",
+				objectEntryId = "${universityId1}");
+		}
+
+		task ("Then receiving correct information about the related objects in universities GET endpoint with nestedFields=universitiesSubjects") {
+			var responseToParse = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedField = "universitiesSubjects",
+				objects = "universities");
+
+			ObjectDefinitionAPI.assertResponseIncludeCorrectDetailsOfNotDeletedObject(
+				expectedValue = "Liferay Foundations,Liferay Foundations",
+				responseToParse = "${responseToParse}",
+				subjectId = "${subjectId}");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Add a test to assert deleted object does not appear in ManyToMany relationship details nested fields_2

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects with deletionType cascade created
And Given three university entries created
And Given subject entry created
And Given subject related to all three universities
When one of the universities is deleted
Then I receive correct information about the related objects in o/c/universities?nestedFields=universitiesSubjects

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-156713