### PR TITLE
LPS-156900: Update resource checking permission in service part of Headless Delivery

### DIFF
--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -90,6 +90,11 @@ public interface BlogsEntryService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<BlogsEntry> getCompanyEntries(
 			long companyId, Date displayDate, int status, int max)
 		throws PortalException;

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -100,6 +100,14 @@ public class BlogsEntryServiceUtil {
 			groupId, externalReferenceCode);
 	}
 
+	public static BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getBlogsEntryByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
 	public static List<BlogsEntry> getCompanyEntries(
 			long companyId, java.util.Date displayDate, int status, int max)
 		throws PortalException {

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -104,6 +104,15 @@ public class BlogsEntryServiceWrapper
 	}
 
 	@Override
+	public BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryService.getBlogsEntryByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
+	@Override
 	public java.util.List<BlogsEntry> getCompanyEntries(
 			long companyId, java.util.Date displayDate, int status, int max)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -276,6 +276,49 @@ public class BlogsEntryServiceHttp {
 		}
 	}
 
+	public static com.liferay.blogs.model.BlogsEntry
+			getBlogsEntryByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long siteId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class,
+				"getBlogsEntryByExternalReferenceCode",
+				_getBlogsEntryByExternalReferenceCodeParameterTypes5);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, siteId, externalReferenceCode);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List<com.liferay.blogs.model.BlogsEntry>
 			getCompanyEntries(
 				HttpPrincipal httpPrincipal, long companyId,
@@ -285,7 +328,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getCompanyEntries",
-				_getCompanyEntriesParameterTypes5);
+				_getCompanyEntriesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, displayDate, status, max);
@@ -330,7 +373,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getCompanyEntriesRSS",
-				_getCompanyEntriesRSSParameterTypes6);
+				_getCompanyEntriesRSSParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, displayDate, status, max, type, version,
@@ -371,7 +414,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntriesPrevAndNext",
-				_getEntriesPrevAndNextParameterTypes7);
+				_getEntriesPrevAndNextParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -410,7 +453,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntry",
-				_getEntryParameterTypes8);
+				_getEntryParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -449,7 +492,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntry",
-				_getEntryParameterTypes9);
+				_getEntryParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -490,7 +533,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes10);
+				_getGroupEntriesParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, max);
@@ -525,7 +568,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes11);
+				_getGroupEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, start, end);
@@ -559,7 +602,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes12);
+				_getGroupEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, max);
@@ -594,7 +637,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes13);
+				_getGroupEntriesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end);
@@ -631,7 +674,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes14);
+				_getGroupEntriesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -665,7 +708,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesCount",
-				_getGroupEntriesCountParameterTypes15);
+				_getGroupEntriesCountParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status);
@@ -697,7 +740,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesCount",
-				_getGroupEntriesCountParameterTypes16);
+				_getGroupEntriesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -734,7 +777,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesRSS",
-				_getGroupEntriesRSSParameterTypes17);
+				_getGroupEntriesRSSParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, max, type, version,
@@ -777,7 +820,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupsEntries",
-				_getGroupsEntriesParameterTypes18);
+				_getGroupsEntriesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, displayDate, status, max);
@@ -821,7 +864,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntries",
-				_getGroupUserEntriesParameterTypes19);
+				_getGroupUserEntriesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, status, start, end,
@@ -859,7 +902,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntries",
-				_getGroupUserEntriesParameterTypes20);
+				_getGroupUserEntriesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, statuses, start, end,
@@ -893,7 +936,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntriesCount",
-				_getGroupUserEntriesCountParameterTypes21);
+				_getGroupUserEntriesCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, status);
@@ -926,7 +969,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntriesCount",
-				_getGroupUserEntriesCountParameterTypes22);
+				_getGroupUserEntriesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, statuses);
@@ -961,7 +1004,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getOrganizationEntries",
-				_getOrganizationEntriesParameterTypes23);
+				_getOrganizationEntriesParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizationId, displayDate, status, max);
@@ -1006,7 +1049,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getOrganizationEntriesRSS",
-				_getOrganizationEntriesRSSParameterTypes24);
+				_getOrganizationEntriesRSSParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizationId, displayDate, status, max, type,
@@ -1047,7 +1090,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "moveEntryToTrash",
-				_moveEntryToTrashParameterTypes25);
+				_moveEntryToTrashParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -1086,7 +1129,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "restoreEntryFromTrash",
-				_restoreEntryFromTrashParameterTypes26);
+				_restoreEntryFromTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -1120,7 +1163,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "subscribe",
-				_subscribeParameterTypes27);
+				_subscribeParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1154,7 +1197,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes28);
+				_unsubscribeParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1199,7 +1242,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "updateEntry",
-				_updateEntryParameterTypes29);
+				_updateEntryParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, entryId, title, subtitle, description, content,
@@ -1254,7 +1297,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "updateEntry",
-				_updateEntryParameterTypes30);
+				_updateEntryParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, entryId, title, subtitle, urlTitle, description,
@@ -1320,84 +1363,88 @@ public class BlogsEntryServiceHttp {
 		_fetchBlogsEntryByExternalReferenceCodeParameterTypes4 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getCompanyEntriesParameterTypes5 =
+	private static final Class<?>[]
+		_getBlogsEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _getCompanyEntriesParameterTypes6 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes6 =
+	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes7 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes7 =
+	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes8 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getEntryParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getEntryParameterTypes10 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getGroupEntriesParameterTypes10 =
-		new Class[] {long.class, java.util.Date.class, int.class, int.class};
 	private static final Class<?>[] _getGroupEntriesParameterTypes11 =
+		new Class[] {long.class, java.util.Date.class, int.class, int.class};
+	private static final Class<?>[] _getGroupEntriesParameterTypes12 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes12 =
-		new Class[] {long.class, int.class, int.class};
 	private static final Class<?>[] _getGroupEntriesParameterTypes13 =
-		new Class[] {long.class, int.class, int.class, int.class};
+		new Class[] {long.class, int.class, int.class};
 	private static final Class<?>[] _getGroupEntriesParameterTypes14 =
+		new Class[] {long.class, int.class, int.class, int.class};
+	private static final Class<?>[] _getGroupEntriesParameterTypes15 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes15 =
-		new Class[] {long.class, java.util.Date.class, int.class};
 	private static final Class<?>[] _getGroupEntriesCountParameterTypes16 =
+		new Class[] {long.class, java.util.Date.class, int.class};
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes17 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getGroupEntriesRSSParameterTypes17 =
+	private static final Class<?>[] _getGroupEntriesRSSParameterTypes18 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupsEntriesParameterTypes18 =
+	private static final Class<?>[] _getGroupsEntriesParameterTypes19 =
 		new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes19 =
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 =
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes21 =
 		new Class[] {
 			long.class, long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes21 =
-		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes22 =
+		new Class[] {long.class, long.class, int.class};
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes23 =
 		new Class[] {long.class, long.class, int[].class};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes23 =
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes24 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes24 =
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes25 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _moveEntryToTrashParameterTypes25 =
+	private static final Class<?>[] _moveEntryToTrashParameterTypes26 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreEntryFromTrashParameterTypes26 =
+	private static final Class<?>[] _restoreEntryFromTrashParameterTypes27 =
 		new Class[] {long.class};
-	private static final Class<?>[] _subscribeParameterTypes27 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes28 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _unsubscribeParameterTypes28 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes29 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _updateEntryParameterTypes29 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
 		long.class, String.class, String.class, String.class, String.class,
 		int.class, int.class, int.class, int.class, int.class, boolean.class,
 		boolean.class, String[].class, String.class,
@@ -1405,7 +1452,7 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
 		long.class, String.class, String.class, String.class, String.class,
 		String.class, int.class, int.class, int.class, int.class, int.class,
 		boolean.class, boolean.class, String[].class, String.class,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -159,6 +159,21 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	}
 
 	@Override
+	public BlogsEntry getBlogsEntryByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException {
+
+		BlogsEntry entry =
+			blogsEntryLocalService.getBlogsEntryByExternalReferenceCode(
+				siteId, externalReferenceCode);
+
+		_blogsEntryModelResourcePermission.check(
+			getPermissionChecker(), entry, ActionKeys.VIEW);
+
+		return entry;
+	}
+
+	@Override
 	public List<BlogsEntry> getCompanyEntries(
 			long companyId, Date displayDate, int status, int max)
 		throws PortalException {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -58,7 +58,6 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
@@ -151,20 +150,9 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 			Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		BlogsEntry blogsEntry =
-			_blogsEntryLocalService.getBlogsEntryByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		String resourceName = getPermissionCheckerResourceName(
-			blogsEntry.getEntryId());
-		Long resourceId = getPermissionCheckerResourceId(
-			blogsEntry.getEntryId());
-
-		PermissionUtil.checkPermission(
-			ActionKeys.VIEW, groupLocalService, resourceName, resourceId,
-			getPermissionCheckerGroupId(blogsEntry.getEntryId()));
-
-		return _toBlogPosting(blogsEntry);
+		return _toBlogPosting(
+			_blogsEntryService.getBlogsEntryByExternalReferenceCode(
+				siteId, externalReferenceCode));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseFolderResourceImpl.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.permission.PermissionUtil;
 
 import java.io.Serializable;
 
@@ -121,20 +120,9 @@ public class KnowledgeBaseFolderResourceImpl
 				Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		KBFolder kbFolder =
-			_kbFolderLocalService.getKBFolderByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		String resourceName = getPermissionCheckerResourceName(
-			kbFolder.getKbFolderId());
-		Long resourceId = getPermissionCheckerResourceId(
-			kbFolder.getKbFolderId());
-
-		PermissionUtil.checkPermission(
-			ActionKeys.VIEW, groupLocalService, resourceName, resourceId,
-			getPermissionCheckerGroupId(kbFolder.getKbFolderId()));
-
-		return _toKnowledgeBaseFolder(kbFolder);
+		return _toKnowledgeBaseFolder(
+			_kbFolderService.getKBFolderByExternalReferenceCode(
+				siteId, externalReferenceCode));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiNodeResourceImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.permission.PermissionUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.wiki.constants.WikiConstants;
 import com.liferay.wiki.service.WikiNodeLocalService;
@@ -82,19 +81,9 @@ public class WikiNodeResourceImpl extends BaseWikiNodeResourceImpl {
 			Long siteId, String externalReferenceCode)
 		throws Exception {
 
-		com.liferay.wiki.model.WikiNode wikiNode =
-			_wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
-				siteId, externalReferenceCode);
-
-		String resourceName = getPermissionCheckerResourceName(
-			wikiNode.getNodeId());
-		Long resourceId = getPermissionCheckerResourceId(wikiNode.getNodeId());
-
-		PermissionUtil.checkPermission(
-			ActionKeys.VIEW, groupLocalService, resourceName, resourceId,
-			getPermissionCheckerGroupId(wikiNode.getNodeId()));
-
-		return _toWikiNode(wikiNode);
+		return _toWikiNode(
+			_wikiNodeService.getWikiNodeByExternalReferenceCode(
+				siteId, externalReferenceCode));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageAttachmentResourceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.wiki.constants.WikiConstants;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiPageLocalService;
+import com.liferay.wiki.service.WikiPageService;
 
 import java.util.Optional;
 
@@ -69,11 +70,7 @@ public class WikiPageAttachmentResourceImpl
 			Long wikiPageId)
 		throws Exception {
 
-		WikiPage wikiPage = _wikiPageLocalService.getPageByPageId(wikiPageId);
-
-		_wikiPageModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), wikiPage,
-			ActionKeys.VIEW);
+		WikiPage wikiPage = _wikiPageService.getPageByPageId(wikiPageId);
 
 		return Page.of(
 			transform(
@@ -86,7 +83,7 @@ public class WikiPageAttachmentResourceImpl
 			Long wikiPageId, MultipartBody multipartBody)
 		throws Exception {
 
-		WikiPage wikiPage = _wikiPageLocalService.getPageByPageId(wikiPageId);
+		WikiPage wikiPage = _wikiPageService.getPageByPageId(wikiPageId);
 
 		_wikiPageModelResourcePermission.check(
 			PermissionThreadLocal.getPermissionChecker(), wikiPage,
@@ -140,5 +137,8 @@ public class WikiPageAttachmentResourceImpl
 
 	@Reference(target = "(model.class.name=com.liferay.wiki.model.WikiPage)")
 	private ModelResourcePermission<WikiPage> _wikiPageModelResourcePermission;
+
+	@Reference
+	private WikiPageService _wikiPageService;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/WikiPageResourceImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.Constants;
@@ -172,26 +171,15 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 
 	@Override
 	public WikiPage getWikiPage(Long wikiPageId) throws Exception {
-		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPage(wikiPageId);
-
-		_wikiPageModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), wikiPage,
-			ActionKeys.VIEW);
-
-		return _toWikiPage(wikiPage);
+		return _toWikiPage(_wikiPageService.getPage(wikiPageId));
 	}
 
 	@Override
 	public Page<WikiPage> getWikiPageWikiPagesPage(Long parentWikiPageId)
 		throws Exception {
 
-		com.liferay.wiki.model.WikiPage wikiPage =
-			_wikiPageLocalService.getPage(parentWikiPageId);
-
-		_wikiPageModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(), wikiPage,
-			ActionKeys.VIEW);
+		com.liferay.wiki.model.WikiPage wikiPage = _wikiPageService.getPage(
+			parentWikiPageId);
 
 		return Page.of(
 			HashMapBuilder.put(
@@ -238,17 +226,13 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage parentWikiPage =
-			_wikiPageLocalService.getPage(parentWikiPageId);
-
-		_wikiNodeModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(),
-			parentWikiPage.getNodeId(), ActionKeys.ADD_PAGE);
+			_wikiPageService.getPage(parentWikiPageId);
 
 		ServiceContext serviceContext = _createServiceContext(
 			Constants.ADD, parentWikiPage.getGroupId(), wikiPage);
 
 		return _toWikiPage(
-			_wikiPageLocalService.addPage(
+			_wikiPageService.addPage(
 				wikiPage.getExternalReferenceCode(), contextUser.getUserId(),
 				parentWikiPage.getNodeId(), wikiPage.getHeadline(),
 				WikiPageConstants.VERSION_DEFAULT, wikiPage.getContent(),
@@ -288,11 +272,7 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 		throws Exception {
 
 		com.liferay.wiki.model.WikiPage serviceBuilderWikiPage =
-			_wikiPageLocalService.getPage(wikiPageId);
-
-		_wikiPageModelResourcePermission.check(
-			PermissionThreadLocal.getPermissionChecker(),
-			serviceBuilderWikiPage, ActionKeys.UPDATE);
+			_wikiPageService.getPage(wikiPageId);
 
 		return _updateWikiPage(serviceBuilderWikiPage, wikiPage);
 	}
@@ -485,10 +465,6 @@ public class WikiPageResourceImpl extends BaseWikiPageResourceImpl {
 
 	@Reference
 	private WikiPageLocalService _wikiPageLocalService;
-
-	@Reference(target = "(model.class.name=com.liferay.wiki.model.WikiPage)")
-	private ModelResourcePermission<com.liferay.wiki.model.WikiPage>
-		_wikiPageModelResourcePermission;
 
 	@Reference
 	private WikiPageService _wikiPageService;

--- a/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
+++ b/modules/apps/knowledge-base/knowledge-base-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Knowledge Base API
 Bundle-SymbolicName: com.liferay.knowledge.base.api
-Bundle-Version: 12.0.3
+Bundle-Version: 12.1.0
 Export-Package:\
 	com.liferay.knowledge.base.configuration,\
 	com.liferay.knowledge.base.constants,\

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderService.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderService.java
@@ -83,6 +83,11 @@ public interface KBFolderService extends BaseService {
 	public KBFolder getKBFolder(long kbFolderId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public KBFolder getKBFolderByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public KBFolder getKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
 		throws PortalException;

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceUtil.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceUtil.java
@@ -91,6 +91,14 @@ public class KBFolderServiceUtil {
 		return getService().getKBFolder(kbFolderId);
 	}
 
+	public static KBFolder getKBFolderByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getKBFolderByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
 	public static KBFolder getKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
 		throws PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceWrapper.java
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/java/com/liferay/knowledge/base/service/KBFolderServiceWrapper.java
@@ -100,6 +100,16 @@ public class KBFolderServiceWrapper
 	}
 
 	@Override
+	public com.liferay.knowledge.base.model.KBFolder
+			getKBFolderByExternalReferenceCode(
+				long siteId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _kbFolderService.getKBFolderByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
+	@Override
 	public com.liferay.knowledge.base.model.KBFolder getKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
+++ b/modules/apps/knowledge-base/knowledge-base-api/src/main/resources/com/liferay/knowledge/base/service/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceHttp.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/http/KBFolderServiceHttp.java
@@ -343,6 +343,48 @@ public class KBFolderServiceHttp {
 	}
 
 	public static com.liferay.knowledge.base.model.KBFolder
+			getKBFolderByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long siteId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				KBFolderServiceUtil.class, "getKBFolderByExternalReferenceCode",
+				_getKBFolderByExternalReferenceCodeParameterTypes7);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, siteId, externalReferenceCode);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.knowledge.base.model.KBFolder)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.knowledge.base.model.KBFolder
 			getKBFolderByUrlTitle(
 				HttpPrincipal httpPrincipal, long groupId,
 				long parentKbFolderId, String urlTitle)
@@ -351,7 +393,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFolderByUrlTitle",
-				_getKBFolderByUrlTitleParameterTypes7);
+				_getKBFolderByUrlTitleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKbFolderId, urlTitle);
@@ -393,7 +435,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFolders",
-				_getKBFoldersParameterTypes8);
+				_getKBFoldersParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKBFolderId, start, end);
@@ -435,7 +477,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFoldersAndKBArticles",
-				_getKBFoldersAndKBArticlesParameterTypes9);
+				_getKBFoldersAndKBArticlesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status, start, end,
@@ -469,7 +511,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFoldersAndKBArticlesCount",
-				_getKBFoldersAndKBArticlesCountParameterTypes10);
+				_getKBFoldersAndKBArticlesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentResourcePrimKey, status);
@@ -502,7 +544,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "getKBFoldersCount",
-				_getKBFoldersCountParameterTypes11);
+				_getKBFoldersCountParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentKBFolderId);
@@ -542,7 +584,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "moveKBFolder",
-				_moveKBFolderParameterTypes12);
+				_moveKBFolderParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, kbFolderId, parentKBFolderId);
@@ -581,7 +623,7 @@ public class KBFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				KBFolderServiceUtil.class, "updateKBFolder",
-				_updateKBFolderParameterTypes13);
+				_updateKBFolderParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, parentResourceClassNameId, parentResourcePrimKey,
@@ -637,25 +679,29 @@ public class KBFolderServiceHttp {
 	private static final Class<?>[] _getKBFolderParameterTypes6 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getKBFolderByUrlTitleParameterTypes7 =
+	private static final Class<?>[]
+		_getKBFolderByExternalReferenceCodeParameterTypes7 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _getKBFolderByUrlTitleParameterTypes8 =
 		new Class[] {long.class, long.class, String.class};
-	private static final Class<?>[] _getKBFoldersParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getKBFoldersParameterTypes9 = new Class[] {
 		long.class, long.class, int.class, int.class
 	};
-	private static final Class<?>[] _getKBFoldersAndKBArticlesParameterTypes9 =
+	private static final Class<?>[] _getKBFoldersAndKBArticlesParameterTypes10 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getKBFoldersAndKBArticlesCountParameterTypes10 = new Class[] {
+		_getKBFoldersAndKBArticlesCountParameterTypes11 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getKBFoldersCountParameterTypes11 =
+	private static final Class<?>[] _getKBFoldersCountParameterTypes12 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _moveKBFolderParameterTypes12 =
+	private static final Class<?>[] _moveKBFolderParameterTypes13 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _updateKBFolderParameterTypes13 =
+	private static final Class<?>[] _updateKBFolderParameterTypes14 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/service/impl/KBFolderServiceImpl.java
@@ -129,6 +129,21 @@ public class KBFolderServiceImpl extends KBFolderServiceBaseImpl {
 	}
 
 	@Override
+	public KBFolder getKBFolderByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException {
+
+		KBFolder kbFolder =
+			kbFolderLocalService.getKBFolderByExternalReferenceCode(
+				siteId, externalReferenceCode);
+
+		_kbFolderModelResourcePermission.check(
+			getPermissionChecker(), kbFolder, KBActionKeys.VIEW);
+
+		return kbFolder;
+	}
+
+	@Override
 	public KBFolder getKBFolderByUrlTitle(
 			long groupId, long parentKbFolderId, String urlTitle)
 		throws PortalException {

--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 9.0.1
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeService.java
@@ -111,6 +111,11 @@ public interface WikiNodeService extends BaseService {
 	 */
 	public String getOSGiServiceIdentifier();
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiNode getWikiNodeByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException;
+
 	public void importPages(
 			long nodeId, String importer, InputStream[] inputStreams,
 			Map<String, String[]> options)

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceUtil.java
@@ -124,6 +124,14 @@ public class WikiNodeServiceUtil {
 		return getService().getOSGiServiceIdentifier();
 	}
 
+	public static WikiNode getWikiNodeByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException {
+
+		return getService().getWikiNodeByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
 	public static void importPages(
 			long nodeId, String importer, InputStream[] inputStreams,
 			Map<String, String[]> options)

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiNodeServiceWrapper.java
@@ -140,6 +140,15 @@ public class WikiNodeServiceWrapper
 	}
 
 	@Override
+	public com.liferay.wiki.model.WikiNode getWikiNodeByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _wikiNodeService.getWikiNodeByExternalReferenceCode(
+			siteId, externalReferenceCode);
+	}
+
+	@Override
 	public void importPages(
 			long nodeId, String importer, java.io.InputStream[] inputStreams,
 			java.util.Map<String, String[]> options)

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageService.java
@@ -78,6 +78,13 @@ public interface WikiPageService extends BaseService {
 		throws PortalException;
 
 	public WikiPage addPage(
+			String externalReferenceCode, long userId, long nodeId,
+			String title, double version, String content, String summary,
+			boolean minorEdit, String format, boolean head, String parentTitle,
+			String redirectTitle, ServiceContext serviceContext)
+		throws PortalException;
+
+	public WikiPage addPage(
 			String externalReferenceCode, long nodeId, String title,
 			String content, String summary, boolean minorEdit, String format,
 			String parentTitle, String redirectTitle,
@@ -211,6 +218,9 @@ public interface WikiPageService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public WikiPage getPage(long nodeId, String title, double version)
 		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public WikiPage getPageByPageId(long pageId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<WikiPage> getPages(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceUtil.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceUtil.java
@@ -70,6 +70,20 @@ public class WikiPageServiceUtil {
 	}
 
 	public static WikiPage addPage(
+			String externalReferenceCode, long userId, long nodeId,
+			String title, double version, String content, String summary,
+			boolean minorEdit, String format, boolean head, String parentTitle,
+			String redirectTitle,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addPage(
+			externalReferenceCode, userId, nodeId, title, version, content,
+			summary, minorEdit, format, head, parentTitle, redirectTitle,
+			serviceContext);
+	}
+
+	public static WikiPage addPage(
 			String externalReferenceCode, long nodeId, String title,
 			String content, String summary, boolean minorEdit, String format,
 			String parentTitle, String redirectTitle,
@@ -290,6 +304,10 @@ public class WikiPageServiceUtil {
 		throws PortalException {
 
 		return getService().getPage(nodeId, title, version);
+	}
+
+	public static WikiPage getPageByPageId(long pageId) throws PortalException {
+		return getService().getPageByPageId(pageId);
 	}
 
 	public static List<WikiPage> getPages(

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/service/WikiPageServiceWrapper.java
@@ -66,6 +66,21 @@ public class WikiPageServiceWrapper
 
 	@Override
 	public com.liferay.wiki.model.WikiPage addPage(
+			String externalReferenceCode, long userId, long nodeId,
+			String title, double version, String content, String summary,
+			boolean minorEdit, String format, boolean head, String parentTitle,
+			String redirectTitle,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _wikiPageService.addPage(
+			externalReferenceCode, userId, nodeId, title, version, content,
+			summary, minorEdit, format, head, parentTitle, redirectTitle,
+			serviceContext);
+	}
+
+	@Override
+	public com.liferay.wiki.model.WikiPage addPage(
 			String externalReferenceCode, long nodeId, String title,
 			String content, String summary, boolean minorEdit, String format,
 			String parentTitle, String redirectTitle,
@@ -321,6 +336,13 @@ public class WikiPageServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _wikiPageService.getPage(nodeId, title, version);
+	}
+
+	@Override
+	public com.liferay.wiki.model.WikiPage getPageByPageId(long pageId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _wikiPageService.getPageByPageId(pageId);
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiNodeServiceHttp.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiNodeServiceHttp.java
@@ -483,6 +483,48 @@ public class WikiNodeServiceHttp {
 		}
 	}
 
+	public static com.liferay.wiki.model.WikiNode
+			getWikiNodeByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long siteId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				WikiNodeServiceUtil.class, "getWikiNodeByExternalReferenceCode",
+				_getWikiNodeByExternalReferenceCodeParameterTypes12);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, siteId, externalReferenceCode);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.wiki.model.WikiNode)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static void importPages(
 			HttpPrincipal httpPrincipal, long nodeId, String importer,
 			java.io.InputStream[] inputStreams,
@@ -492,7 +534,7 @@ public class WikiNodeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiNodeServiceUtil.class, "importPages",
-				_importPagesParameterTypes12);
+				_importPagesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, importer, inputStreams, options);
@@ -528,7 +570,7 @@ public class WikiNodeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiNodeServiceUtil.class, "moveNodeToTrash",
-				_moveNodeToTrashParameterTypes13);
+				_moveNodeToTrashParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, nodeId);
 
@@ -567,7 +609,7 @@ public class WikiNodeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiNodeServiceUtil.class, "restoreNodeFromTrash",
-				_restoreNodeFromTrashParameterTypes14);
+				_restoreNodeFromTrashParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, nodeId);
 
@@ -601,7 +643,7 @@ public class WikiNodeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiNodeServiceUtil.class, "subscribeNode",
-				_subscribeNodeParameterTypes15);
+				_subscribeNodeParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, nodeId);
 
@@ -635,7 +677,7 @@ public class WikiNodeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiNodeServiceUtil.class, "unsubscribeNode",
-				_unsubscribeNodeParameterTypes16);
+				_unsubscribeNodeParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, nodeId);
 
@@ -672,7 +714,7 @@ public class WikiNodeServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiNodeServiceUtil.class, "updateNode",
-				_updateNodeParameterTypes17);
+				_updateNodeParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, name, description, serviceContext);
@@ -744,19 +786,23 @@ public class WikiNodeServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getNodesCountParameterTypes11 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _importPagesParameterTypes12 = new Class[] {
+	private static final Class<?>[]
+		_getWikiNodeByExternalReferenceCodeParameterTypes12 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _importPagesParameterTypes13 = new Class[] {
 		long.class, String.class, java.io.InputStream[].class,
 		java.util.Map.class
 	};
-	private static final Class<?>[] _moveNodeToTrashParameterTypes13 =
+	private static final Class<?>[] _moveNodeToTrashParameterTypes14 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreNodeFromTrashParameterTypes14 =
+	private static final Class<?>[] _restoreNodeFromTrashParameterTypes15 =
 		new Class[] {long.class};
-	private static final Class<?>[] _subscribeNodeParameterTypes15 =
+	private static final Class<?>[] _subscribeNodeParameterTypes16 =
 		new Class[] {long.class};
-	private static final Class<?>[] _unsubscribeNodeParameterTypes16 =
+	private static final Class<?>[] _unsubscribeNodeParameterTypes17 =
 		new Class[] {long.class};
-	private static final Class<?>[] _updateNodeParameterTypes17 = new Class[] {
+	private static final Class<?>[] _updateNodeParameterTypes18 = new Class[] {
 		long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiPageServiceHttp.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/http/WikiPageServiceHttp.java
@@ -137,6 +137,51 @@ public class WikiPageServiceHttp {
 
 	public static com.liferay.wiki.model.WikiPage addPage(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long userId, long nodeId, String title, double version,
+			String content, String summary, boolean minorEdit, String format,
+			boolean head, String parentTitle, String redirectTitle,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				WikiPageServiceUtil.class, "addPage", _addPageParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, userId, nodeId, title,
+				version, content, summary, minorEdit, format, head, parentTitle,
+				redirectTitle, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.wiki.model.WikiPage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.wiki.model.WikiPage addPage(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			long nodeId, String title, String content, String summary,
 			boolean minorEdit, String format, String parentTitle,
 			String redirectTitle,
@@ -145,7 +190,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "addPage", _addPageParameterTypes2);
+				WikiPageServiceUtil.class, "addPage", _addPageParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, nodeId, title, content,
@@ -189,7 +234,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "addPageAttachment",
-				_addPageAttachmentParameterTypes3);
+				_addPageAttachmentParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName, file, mimeType);
@@ -233,7 +278,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "addPageAttachment",
-				_addPageAttachmentParameterTypes4);
+				_addPageAttachmentParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName, inputStream, mimeType);
@@ -279,7 +324,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "addPageAttachments",
-				_addPageAttachmentsParameterTypes5);
+				_addPageAttachmentsParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, inputStreamOVPs);
@@ -324,7 +369,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "addTempFileEntry",
-				_addTempFileEntryParameterTypes6);
+				_addTempFileEntryParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, folderName, fileName, inputStream, mimeType);
@@ -367,7 +412,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "changeParent",
-				_changeParentParameterTypes7);
+				_changeParentParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, newParentTitle, serviceContext);
@@ -404,7 +449,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "copyPageAttachments",
-				_copyPageAttachmentsParameterTypes8);
+				_copyPageAttachmentsParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, templateNodeId, templateTitle, nodeId, title);
@@ -440,7 +485,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "deletePage",
-				_deletePageParameterTypes9);
+				_deletePageParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -477,7 +522,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "deletePageAttachment",
-				_deletePageAttachmentParameterTypes10);
+				_deletePageAttachmentParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName);
@@ -513,7 +558,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "deletePageAttachments",
-				_deletePageAttachmentsParameterTypes11);
+				_deletePageAttachmentsParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -550,7 +595,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "deleteTempFileEntry",
-				_deleteTempFileEntryParameterTypes12);
+				_deleteTempFileEntryParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, folderName, fileName);
@@ -586,7 +631,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "deleteTrashPageAttachments",
-				_deleteTrashPageAttachmentsParameterTypes13);
+				_deleteTrashPageAttachmentsParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -623,7 +668,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "discardDraft",
-				_discardDraftParameterTypes14);
+				_discardDraftParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
@@ -662,7 +707,7 @@ public class WikiPageServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class,
 				"fetchLatestPageByExternalReferenceCode",
-				_fetchLatestPageByExternalReferenceCodeParameterTypes15);
+				_fetchLatestPageByExternalReferenceCodeParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -703,7 +748,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "fetchPage",
-				_fetchPageParameterTypes16);
+				_fetchPageParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
@@ -744,7 +789,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getChildren",
-				_getChildrenParameterTypes17);
+				_getChildrenParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, parentTitle);
@@ -784,7 +829,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getDraftPage",
-				_getDraftPageParameterTypes18);
+				_getDraftPageParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -827,7 +872,7 @@ public class WikiPageServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class,
 				"getLatestPageByExternalReferenceCode",
-				_getLatestPageByExternalReferenceCodeParameterTypes19);
+				_getLatestPageByExternalReferenceCodeParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -867,7 +912,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getNodePages",
-				_getNodePagesParameterTypes20);
+				_getNodePagesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, max);
@@ -909,7 +954,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getNodePagesRSS",
-				_getNodePagesRSSParameterTypes21);
+				_getNodePagesRSSParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, max, type, version, displayStyle, feedURL,
@@ -950,7 +995,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getOrphans",
-				_getOrphansParameterTypes22);
+				_getOrphansParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, node);
 
@@ -988,7 +1033,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes23);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, pageId);
 
@@ -1027,7 +1072,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes24);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, title);
@@ -1066,7 +1111,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes25);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1106,7 +1151,7 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes26);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, head);
@@ -1146,10 +1191,49 @@ public class WikiPageServiceHttp {
 
 		try {
 			MethodKey methodKey = new MethodKey(
-				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes27);
+				WikiPageServiceUtil.class, "getPage", _getPageParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.wiki.model.WikiPage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.wiki.model.WikiPage getPageByPageId(
+			HttpPrincipal httpPrincipal, long pageId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				WikiPageServiceUtil.class, "getPageByPageId",
+				_getPageByPageIdParameterTypes29);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, pageId);
 
 			Object returnObj = null;
 
@@ -1189,7 +1273,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPages",
-				_getPagesParameterTypes28);
+				_getPagesParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, status, start, end,
@@ -1234,7 +1318,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPages",
-				_getPagesParameterTypes29);
+				_getPagesParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, userId, includeOwner, status,
@@ -1276,7 +1360,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPages",
-				_getPagesParameterTypes30);
+				_getPagesParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, nodeId, status, start, end);
@@ -1317,7 +1401,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesCount",
-				_getPagesCountParameterTypes31);
+				_getPagesCountParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head);
@@ -1358,7 +1442,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesCount",
-				_getPagesCountParameterTypes32);
+				_getPagesCountParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, head, userId, includeOwner, status);
@@ -1399,7 +1483,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesCount",
-				_getPagesCountParameterTypes33);
+				_getPagesCountParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, nodeId, status);
@@ -1442,7 +1526,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getPagesRSS",
-				_getPagesRSSParameterTypes34);
+				_getPagesRSSParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, max, type, version, displayStyle,
@@ -1485,7 +1569,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getRecentChanges",
-				_getRecentChangesParameterTypes35);
+				_getRecentChangesParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId, start, end);
@@ -1525,7 +1609,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getRecentChangesCount",
-				_getRecentChangesCountParameterTypes36);
+				_getRecentChangesCountParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, nodeId);
@@ -1565,7 +1649,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "getTempFileNames",
-				_getTempFileNamesParameterTypes37);
+				_getTempFileNamesParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, folderName);
@@ -1607,7 +1691,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "movePageAttachmentToTrash",
-				_movePageAttachmentToTrashParameterTypes38);
+				_movePageAttachmentToTrashParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName);
@@ -1648,7 +1732,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "movePageToTrash",
-				_movePageToTrashParameterTypes39);
+				_movePageToTrashParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1689,7 +1773,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "movePageToTrash",
-				_movePageToTrashParameterTypes40);
+				_movePageToTrashParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version);
@@ -1731,7 +1815,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "renamePage",
-				_renamePageParameterTypes41);
+				_renamePageParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, newTitle, serviceContext);
@@ -1768,7 +1852,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "restorePageAttachmentFromTrash",
-				_restorePageAttachmentFromTrashParameterTypes42);
+				_restorePageAttachmentFromTrashParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, fileName);
@@ -1804,7 +1888,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "restorePageFromTrash",
-				_restorePageFromTrashParameterTypes43);
+				_restorePageFromTrashParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1842,7 +1926,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "revertPage",
-				_revertPageParameterTypes44);
+				_revertPageParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version, serviceContext);
@@ -1882,7 +1966,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "subscribePage",
-				_subscribePageParameterTypes45);
+				_subscribePageParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1918,7 +2002,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "unsubscribePage",
-				_unsubscribePageParameterTypes46);
+				_unsubscribePageParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title);
@@ -1957,7 +2041,7 @@ public class WikiPageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				WikiPageServiceUtil.class, "updatePage",
-				_updatePageParameterTypes47);
+				_updatePageParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, nodeId, title, version, content, summary, minorEdit,
@@ -2003,146 +2087,154 @@ public class WikiPageServiceHttp {
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _addPageParameterTypes2 = new Class[] {
+		String.class, long.class, long.class, String.class, double.class,
+		String.class, String.class, boolean.class, String.class, boolean.class,
+		String.class, String.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _addPageParameterTypes3 = new Class[] {
 		String.class, long.class, String.class, String.class, String.class,
 		boolean.class, String.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addPageAttachmentParameterTypes3 =
+	private static final Class<?>[] _addPageAttachmentParameterTypes4 =
 		new Class[] {
 			long.class, String.class, String.class, java.io.File.class,
 			String.class
 		};
-	private static final Class<?>[] _addPageAttachmentParameterTypes4 =
+	private static final Class<?>[] _addPageAttachmentParameterTypes5 =
 		new Class[] {
 			long.class, String.class, String.class, java.io.InputStream.class,
 			String.class
 		};
-	private static final Class<?>[] _addPageAttachmentsParameterTypes5 =
+	private static final Class<?>[] _addPageAttachmentsParameterTypes6 =
 		new Class[] {long.class, String.class, java.util.List.class};
-	private static final Class<?>[] _addTempFileEntryParameterTypes6 =
+	private static final Class<?>[] _addTempFileEntryParameterTypes7 =
 		new Class[] {
 			long.class, String.class, String.class, java.io.InputStream.class,
 			String.class
 		};
-	private static final Class<?>[] _changeParentParameterTypes7 = new Class[] {
+	private static final Class<?>[] _changeParentParameterTypes8 = new Class[] {
 		long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _copyPageAttachmentsParameterTypes8 =
+	private static final Class<?>[] _copyPageAttachmentsParameterTypes9 =
 		new Class[] {long.class, String.class, long.class, String.class};
-	private static final Class<?>[] _deletePageParameterTypes9 = new Class[] {
+	private static final Class<?>[] _deletePageParameterTypes10 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _deletePageAttachmentParameterTypes10 =
+	private static final Class<?>[] _deletePageAttachmentParameterTypes11 =
 		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _deletePageAttachmentsParameterTypes11 =
+	private static final Class<?>[] _deletePageAttachmentsParameterTypes12 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _deleteTempFileEntryParameterTypes12 =
+	private static final Class<?>[] _deleteTempFileEntryParameterTypes13 =
 		new Class[] {long.class, String.class, String.class};
 	private static final Class<?>[]
-		_deleteTrashPageAttachmentsParameterTypes13 = new Class[] {
+		_deleteTrashPageAttachmentsParameterTypes14 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _discardDraftParameterTypes14 =
+	private static final Class<?>[] _discardDraftParameterTypes15 =
 		new Class[] {long.class, String.class, double.class};
 	private static final Class<?>[]
-		_fetchLatestPageByExternalReferenceCodeParameterTypes15 = new Class[] {
+		_fetchLatestPageByExternalReferenceCodeParameterTypes16 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _fetchPageParameterTypes16 = new Class[] {
+	private static final Class<?>[] _fetchPageParameterTypes17 = new Class[] {
 		long.class, String.class, double.class
 	};
-	private static final Class<?>[] _getChildrenParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getChildrenParameterTypes18 = new Class[] {
 		long.class, long.class, boolean.class, String.class
 	};
-	private static final Class<?>[] _getDraftPageParameterTypes18 =
+	private static final Class<?>[] _getDraftPageParameterTypes19 =
 		new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_getLatestPageByExternalReferenceCodeParameterTypes19 = new Class[] {
+		_getLatestPageByExternalReferenceCodeParameterTypes20 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getNodePagesParameterTypes20 =
+	private static final Class<?>[] _getNodePagesParameterTypes21 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getNodePagesRSSParameterTypes21 =
+	private static final Class<?>[] _getNodePagesRSSParameterTypes22 =
 		new Class[] {
 			long.class, int.class, String.class, double.class, String.class,
 			String.class, String.class, String.class
 		};
-	private static final Class<?>[] _getOrphansParameterTypes22 = new Class[] {
+	private static final Class<?>[] _getOrphansParameterTypes23 = new Class[] {
 		com.liferay.wiki.model.WikiNode.class
 	};
-	private static final Class<?>[] _getPageParameterTypes23 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes24 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getPageParameterTypes24 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes25 = new Class[] {
 		long.class, long.class, String.class
 	};
-	private static final Class<?>[] _getPageParameterTypes25 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes26 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getPageParameterTypes26 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes27 = new Class[] {
 		long.class, String.class, Boolean.class
 	};
-	private static final Class<?>[] _getPageParameterTypes27 = new Class[] {
+	private static final Class<?>[] _getPageParameterTypes28 = new Class[] {
 		long.class, String.class, double.class
 	};
-	private static final Class<?>[] _getPagesParameterTypes28 = new Class[] {
+	private static final Class<?>[] _getPageByPageIdParameterTypes29 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getPagesParameterTypes30 = new Class[] {
 		long.class, long.class, boolean.class, int.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getPagesParameterTypes29 = new Class[] {
+	private static final Class<?>[] _getPagesParameterTypes31 = new Class[] {
 		long.class, long.class, boolean.class, long.class, boolean.class,
 		int.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getPagesParameterTypes30 = new Class[] {
+	private static final Class<?>[] _getPagesParameterTypes32 = new Class[] {
 		long.class, long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _getPagesCountParameterTypes31 =
+	private static final Class<?>[] _getPagesCountParameterTypes33 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _getPagesCountParameterTypes32 =
+	private static final Class<?>[] _getPagesCountParameterTypes34 =
 		new Class[] {
 			long.class, long.class, boolean.class, long.class, boolean.class,
 			int.class
 		};
-	private static final Class<?>[] _getPagesCountParameterTypes33 =
+	private static final Class<?>[] _getPagesCountParameterTypes35 =
 		new Class[] {long.class, long.class, long.class, int.class};
-	private static final Class<?>[] _getPagesRSSParameterTypes34 = new Class[] {
+	private static final Class<?>[] _getPagesRSSParameterTypes36 = new Class[] {
 		long.class, String.class, int.class, String.class, double.class,
 		String.class, String.class, String.class, String.class,
 		java.util.Locale.class
 	};
-	private static final Class<?>[] _getRecentChangesParameterTypes35 =
+	private static final Class<?>[] _getRecentChangesParameterTypes37 =
 		new Class[] {long.class, long.class, int.class, int.class};
-	private static final Class<?>[] _getRecentChangesCountParameterTypes36 =
+	private static final Class<?>[] _getRecentChangesCountParameterTypes38 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getTempFileNamesParameterTypes37 =
+	private static final Class<?>[] _getTempFileNamesParameterTypes39 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _movePageAttachmentToTrashParameterTypes38 =
+	private static final Class<?>[] _movePageAttachmentToTrashParameterTypes40 =
 		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _movePageToTrashParameterTypes39 =
+	private static final Class<?>[] _movePageToTrashParameterTypes41 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _movePageToTrashParameterTypes40 =
+	private static final Class<?>[] _movePageToTrashParameterTypes42 =
 		new Class[] {long.class, String.class, double.class};
-	private static final Class<?>[] _renamePageParameterTypes41 = new Class[] {
+	private static final Class<?>[] _renamePageParameterTypes43 = new Class[] {
 		long.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[]
-		_restorePageAttachmentFromTrashParameterTypes42 = new Class[] {
+		_restorePageAttachmentFromTrashParameterTypes44 = new Class[] {
 			long.class, String.class, String.class
 		};
-	private static final Class<?>[] _restorePageFromTrashParameterTypes43 =
+	private static final Class<?>[] _restorePageFromTrashParameterTypes45 =
 		new Class[] {long.class};
-	private static final Class<?>[] _revertPageParameterTypes44 = new Class[] {
+	private static final Class<?>[] _revertPageParameterTypes46 = new Class[] {
 		long.class, String.class, double.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _subscribePageParameterTypes45 =
+	private static final Class<?>[] _subscribePageParameterTypes47 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _unsubscribePageParameterTypes46 =
+	private static final Class<?>[] _unsubscribePageParameterTypes48 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updatePageParameterTypes47 = new Class[] {
+	private static final Class<?>[] _updatePageParameterTypes49 = new Class[] {
 		long.class, String.class, double.class, String.class, String.class,
 		boolean.class, String.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiNodeServiceImpl.java
@@ -177,6 +177,20 @@ public class WikiNodeServiceImpl extends WikiNodeServiceBaseImpl {
 	}
 
 	@Override
+	public WikiNode getWikiNodeByExternalReferenceCode(
+			long siteId, String externalReferenceCode)
+		throws PortalException {
+
+		WikiNode node = wikiNodeLocalService.getWikiNodeByExternalReferenceCode(
+			siteId, externalReferenceCode);
+
+		_wikiNodeModelResourcePermission.check(
+			getPermissionChecker(), node, ActionKeys.VIEW);
+
+		return node;
+	}
+
+	@Override
 	public void importPages(
 			long nodeId, String importer, InputStream[] inputStreams,
 			Map<String, String[]> options)

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/service/impl/WikiPageServiceImpl.java
@@ -125,6 +125,23 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 
 	@Override
 	public WikiPage addPage(
+			String externalReferenceCode, long userId, long nodeId,
+			String title, double version, String content, String summary,
+			boolean minorEdit, String format, boolean head, String parentTitle,
+			String redirectTitle, ServiceContext serviceContext)
+		throws PortalException {
+
+		_wikiNodeModelResourcePermission.check(
+			getPermissionChecker(), nodeId, ActionKeys.ADD_PAGE);
+
+		return wikiPageLocalService.addPage(
+			externalReferenceCode, userId, nodeId, title, version, content,
+			summary, minorEdit, format, head, parentTitle, redirectTitle,
+			serviceContext);
+	}
+
+	@Override
+	public WikiPage addPage(
 			String externalReferenceCode, long nodeId, String title,
 			String content, String summary, boolean minorEdit, String format,
 			String parentTitle, String redirectTitle,
@@ -518,6 +535,16 @@ public class WikiPageServiceImpl extends WikiPageServiceBaseImpl {
 		throws PortalException {
 
 		WikiPage page = wikiPageLocalService.getPage(nodeId, title, version);
+
+		_wikiPageModelResourcePermission.check(
+			getPermissionChecker(), page, ActionKeys.VIEW);
+
+		return page;
+	}
+
+	@Override
+	public WikiPage getPageByPageId(long pageId) throws PortalException {
+		WikiPage page = wikiPageLocalService.getPageByPageId(pageId);
 
 		_wikiPageModelResourcePermission.check(
 			getPermissionChecker(), page, ActionKeys.VIEW);


### PR DESCRIPTION
**What is new?**

- `KnowledgeBaseFolderService` adding new resource permission in GET method by `siteId` and by `externalReferenceCode`.
- `BlogEntryService` adding new resource permission in GET method by `siteId` and by `externalReferenceCode`.
- `WikiPageAttachment` adding new resource permission in GET method by `wikiPageId`.
- `WikiNode` adding new resource permission in GET method by `siteId` and by `externalReferenceCode`.
- `WikiPage` adding new resource permission in GET method by `wikiPageId` and in POST method adding new `wikiPageId`.

## SERVICE.
Update checking resource permissions that used bad patterns in `headless-adming-taxonomy`.


**JIRA Ticket**
https://issues.liferay.com/browse/LPS-156900