### PR TITLE
LPS-156966 Use context contributor for FDS quick actions flag

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 8.1.1
+Bundle-Version: 9.0.0
 Export-Package:\
 	com.liferay.frontend.data.set.constants,\
 	com.liferay.frontend.data.set.filter,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/FDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/FDSView.java
@@ -17,7 +17,6 @@ package com.liferay.frontend.data.set.view;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author Marco Leo
@@ -38,10 +37,6 @@ public interface FDSView {
 	public String getLabel();
 
 	public String getName();
-
-	public default Map<String, Object> getOptions() {
-		return null;
-	}
 
 	public String getThumbnail();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/BaseTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/BaseTableFDSView.java
@@ -51,4 +51,8 @@ public abstract class BaseTableFDSView implements FDSView {
 		return FDSConstants.TABLE;
 	}
 
+	public boolean isQuickActionsEnabled() {
+		return false;
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/cards/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/cards/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/list/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/list/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
@@ -1,1 +1,1 @@
-version 6.1.0
+version 7.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/selectable/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/selectable/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/timeline/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/timeline/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
@@ -60,8 +60,6 @@ public class FDSViewSerializerImpl implements FDSViewSerializer {
 			).put(
 				"name", fdsView.getName()
 			).put(
-				"options", fdsView.getOptions()
-			).put(
 				"thumbnail", fdsView.getThumbnail()
 			);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/table/TableFDSViewContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/table/TableFDSViewContextContributor.java
@@ -88,6 +88,8 @@ public class TableFDSViewContextContributor
 		}
 
 		return HashMapBuilder.<String, Object>put(
+			"quickActionsEnabled", baseTableFDSView.isQuickActionsEnabled()
+		).put(
 			"schema", JSONUtil.put("fields", fieldsJSONArray)
 		).build();
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -20,10 +20,8 @@ import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
-import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.Locale;
-import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -65,10 +63,9 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 		).build();
 	}
 
-	public Map<String, Object> getOptions() {
-		return HashMapBuilder.<String, Object>put(
-			"quickActionsEnabled", true
-		).build();
+	@Override
+	public boolean isQuickActionsEnabled() {
+		return true;
 	}
 
 	@Reference

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -155,11 +155,9 @@ function Actions({actions, itemData, itemId}) {
 
 	const [
 		{
-			activeView: {options},
+			activeView: {quickActionsEnabled},
 		},
 	] = useContext(ViewsContext);
-
-	const {quickActionsEnabled} = options || {};
 
 	const inlineEditingAvailable =
 		inlineEditingSettings && itemData.actions?.update;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
@@ -87,12 +87,10 @@ function Table({dataLoading, items, itemsActions, schema, style}) {
 	} = useContext(FrontendDataSetContext);
 	const [
 		{
-			activeView: {options},
+			activeView: {quickActionsEnabled},
 			visibleFieldNames,
 		},
 	] = useContext(ViewsContext);
-
-	const {quickActionsEnabled} = options || {};
 
 	const visibleFields = getVisibleFields(schema.fields, visibleFieldNames);
 


### PR DESCRIPTION
### References

- [LPS-156966 Use context contributor for FDS quick actions flag](https://issues.liferay.com/browse/LPS-156966)
- Related to https://github.com/liferay-frontend/liferay-portal/pull/2222

### What is the goal of this PR?

In this PR, we are reverting the `options` property added in #2222, replacing it with customization though a context contributor. The main purpose of this change is to standardize FDS API.

The purpose of the `options` property was to have a mechanism that would enable us to customize only one view (table), without making serializer too complicated. What I did not realize until recently is that we have the context contributor mechanism just for that purpose. It enables us to extend `Base*FDSView` classes with relevant properties, and have them serialized in specific `*FDSViewContextContributor`s. We are using this pattern a lot in FDS, not just for views, but for [filters](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/DateRangeFDSFilterContextContributor.java#L70-L76) as well.

### What does it look like?

No changes in UI.

### Steps to reproduce

Place `frontend-data-set-sample-web` as a widget on any page, confirm quick actions on the `Customized` tab work.
