### PR TITLE
LPS-155312 Add test StatusFilterCanBeAdded

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -165,4 +165,30 @@ definition {
 		}
 	}
 
+	@description = "LPS-155312. Assert results can be correctly filtered when using the status filter."
+	@priority = "5"
+	test StatusFilterCanBeAdded {
+		task ("When click on the filter button") {
+			FDSFilters.openFilters();
+		}
+
+		task ("And When adding an option from the status list filter") {
+			FDSFilters.enableStatusFilters(key_status = "Pending");
+
+			FDSFilters.disableStatusFilters(key_status = "Approved");
+
+			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+		}
+
+		task ("Then the filter will be added to the Filters Summary") {
+			AssertElementPresent(
+				key_filter = "Status: Draft, Pending",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+
+		task ("And Then the results will be displayed according to the filter") {
+			AssertElementPresent(locator1 = "FrontendDataSet#EMPTY_FDS_TABLE_MESSAGE");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Create automated tests for FDS filters.


**Test Plan**
Given Sample FDS portlet deployed
And entering on a page which uses FDS
When clicking on the filter button
And adding an option from the status list filter
Then the filter will be added the Filters Summary
And the results will be displayed updated accordingly to it

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155312