### PR TITLE
Master lps 157040 | Can load headless delivery api explorer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Select.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Select.path
@@ -255,6 +255,11 @@
 	<td>//select[contains(@id,'workflowDefinition-1')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>HEADLESS_SERVERS</td>
+	<td>//div[contains(@class,'servers')]//select</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDiscovery/HeadlessDiscovery.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDiscovery/HeadlessDiscovery.testcase
@@ -1,0 +1,40 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "Load headless delivery openAPI explorer"
+	@priority = "5"
+	test CanLoadHeadlessDeliveryOpenAPI {
+		property portal.acceptance = "true";
+
+		task ("Given navigate to headless delivery endpoint") {
+			var portalURL = PropsUtil.get("portal.url");
+
+			Navigator.openSpecificURL(url = "${portalURL}/o/api?endpoint=${portalURL}/o/headless-delivery/v1.0/openapi.json");
+		}
+
+		task ("Then headless delivery api loaded with no errors") {
+			AssertTextEquals(
+				locator1 = "Select#HEADLESS_SERVERS",
+				value1 = "${portalURL}/o/headless-delivery/");
+
+			AssertConsoleTextNotPresent(value1 = "Failed to load API definition");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a test to assert headless delivery api can open successfully

**Test Plan**
Given Navigate to [headless-delivery](http://localhost:8080/o/api?endpoint=http://localhost:8080/o/headless-delivery/v1.0/openapi.json) endpoint
Then Assert no errors in console
         Assert Headless Delivery present

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157040