### PR TITLE
LPS-155699: Fix restrictField syntax in Headless Delivery API Explorer

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5118,7 +5118,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5175,7 +5175,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5220,7 +5220,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5266,7 +5266,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5318,7 +5318,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5367,7 +5367,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5429,7 +5429,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5508,7 +5508,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5561,7 +5561,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5735,7 +5735,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5781,7 +5781,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -5823,7 +5823,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -5989,7 +5989,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6042,7 +6042,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6213,7 +6213,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6402,7 +6402,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6580,7 +6580,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6724,7 +6724,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6813,7 +6813,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6875,7 +6875,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -6927,7 +6927,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -7093,7 +7093,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -7179,7 +7179,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -7266,7 +7266,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -7462,7 +7462,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -7641,7 +7641,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -7808,7 +7808,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -7972,7 +7972,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -8060,7 +8060,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -8292,7 +8292,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -8373,7 +8373,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -8418,7 +8418,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -8626,7 +8626,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -8790,7 +8790,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -8878,7 +8878,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9065,7 +9065,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9146,7 +9146,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9230,7 +9230,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9320,7 +9320,7 @@ paths:
                       format: int64
                       type: integer
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9464,7 +9464,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -9538,7 +9538,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9717,7 +9717,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9861,7 +9861,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -9912,7 +9912,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10005,7 +10005,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10274,7 +10274,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10457,7 +10457,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10516,7 +10516,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10563,7 +10563,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10611,7 +10611,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10663,7 +10663,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10712,7 +10712,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10802,7 +10802,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10883,7 +10883,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -10939,7 +10939,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11218,7 +11218,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11274,7 +11274,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11442,7 +11442,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11519,7 +11519,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11675,7 +11675,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11721,7 +11721,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -11766,7 +11766,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11934,7 +11934,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -11990,7 +11990,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12071,7 +12071,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12127,7 +12127,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12237,7 +12237,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12280,7 +12280,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12350,7 +12350,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12402,7 +12402,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12462,7 +12462,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: header
@@ -12502,7 +12502,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: header
@@ -12551,7 +12551,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: header
@@ -12595,7 +12595,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -12627,7 +12627,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:
@@ -12665,7 +12665,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12823,7 +12823,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -12879,7 +12879,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -13220,7 +13220,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -13272,7 +13272,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -13437,7 +13437,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -13566,7 +13566,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -13618,7 +13618,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -13809,7 +13809,7 @@ paths:
                   schema:
                       type: boolean
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -14048,7 +14048,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -14227,7 +14227,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -14421,7 +14421,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -14505,7 +14505,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -14627,7 +14627,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: strin
             responses:
@@ -14756,7 +14756,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
                 - in: query
@@ -14834,7 +14834,7 @@ paths:
                   schema:
                       type: string
                 - in: query
-                  name: restrictedFields
+                  name: restrictFields
                   schema:
                       type: string
             responses:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingImageResourceImpl.java
@@ -211,7 +211,7 @@ public abstract class BaseBlogPostingImageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseBlogPostingResourceImpl.java
@@ -530,7 +530,7 @@ public abstract class BaseBlogPostingResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -705,7 +705,7 @@ public abstract class BaseBlogPostingResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -987,7 +987,7 @@ public abstract class BaseBlogPostingResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseCommentResourceImpl.java
@@ -96,7 +96,7 @@ public abstract class BaseCommentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -443,7 +443,7 @@ public abstract class BaseCommentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -551,7 +551,7 @@ public abstract class BaseCommentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1335,7 +1335,7 @@ public abstract class BaseCommentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentElementResourceImpl.java
@@ -92,7 +92,7 @@ public abstract class BaseContentElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -164,7 +164,7 @@ public abstract class BaseContentElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentSetElementResourceImpl.java
@@ -91,7 +91,7 @@ public abstract class BaseContentSetElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -151,7 +151,7 @@ public abstract class BaseContentSetElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -210,7 +210,7 @@ public abstract class BaseContentSetElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -266,7 +266,7 @@ public abstract class BaseContentSetElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -327,7 +327,7 @@ public abstract class BaseContentSetElementResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentStructureResourceImpl.java
@@ -100,7 +100,7 @@ public abstract class BaseContentStructureResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -168,7 +168,7 @@ public abstract class BaseContentStructureResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -337,7 +337,7 @@ public abstract class BaseContentStructureResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -479,7 +479,7 @@ public abstract class BaseContentStructureResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -547,7 +547,7 @@ public abstract class BaseContentStructureResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseContentTemplateResourceImpl.java
@@ -92,7 +92,7 @@ public abstract class BaseContentTemplateResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -164,7 +164,7 @@ public abstract class BaseContentTemplateResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentFolderResourceImpl.java
@@ -105,7 +105,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -266,7 +266,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -696,7 +696,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -898,7 +898,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1021,7 +1021,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1183,7 +1183,7 @@ public abstract class BaseDocumentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseDocumentResourceImpl.java
@@ -108,7 +108,7 @@ public abstract class BaseDocumentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -391,7 +391,7 @@ public abstract class BaseDocumentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -528,7 +528,7 @@ public abstract class BaseDocumentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1042,7 +1042,7 @@ public abstract class BaseDocumentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1221,7 +1221,7 @@ public abstract class BaseDocumentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1507,7 +1507,7 @@ public abstract class BaseDocumentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseArticleResourceImpl.java
@@ -598,7 +598,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -822,7 +822,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -951,7 +951,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1138,7 +1138,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1449,7 +1449,7 @@ public abstract class BaseKnowledgeBaseArticleResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseAttachmentResourceImpl.java
@@ -93,7 +93,7 @@ public abstract class BaseKnowledgeBaseAttachmentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseKnowledgeBaseFolderResourceImpl.java
@@ -403,7 +403,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -549,7 +549,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -647,7 +647,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -936,7 +936,7 @@ public abstract class BaseKnowledgeBaseFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseLanguageResourceImpl.java
@@ -91,7 +91,7 @@ public abstract class BaseLanguageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -132,7 +132,7 @@ public abstract class BaseLanguageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardAttachmentResourceImpl.java
@@ -213,7 +213,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -362,7 +362,7 @@ public abstract class BaseMessageBoardAttachmentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardMessageResourceImpl.java
@@ -608,7 +608,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -830,7 +830,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -955,7 +955,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1139,7 +1139,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1399,7 +1399,7 @@ public abstract class BaseMessageBoardMessageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardSectionResourceImpl.java
@@ -404,7 +404,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -622,7 +622,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -748,7 +748,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -916,7 +916,7 @@ public abstract class BaseMessageBoardSectionResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseMessageBoardThreadResourceImpl.java
@@ -105,7 +105,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -280,7 +280,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -830,7 +830,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1042,7 +1042,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1246,7 +1246,7 @@ public abstract class BaseMessageBoardThreadResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseNavigationMenuResourceImpl.java
@@ -291,7 +291,7 @@ public abstract class BaseNavigationMenuResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -422,7 +422,7 @@ public abstract class BaseNavigationMenuResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -562,7 +562,7 @@ public abstract class BaseNavigationMenuResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -96,7 +96,7 @@ public abstract class BaseSitePageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -169,7 +169,7 @@ public abstract class BaseSitePageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -218,7 +218,7 @@ public abstract class BaseSitePageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -273,7 +273,7 @@ public abstract class BaseSitePageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -332,7 +332,7 @@ public abstract class BaseSitePageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -387,7 +387,7 @@ public abstract class BaseSitePageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentFolderResourceImpl.java
@@ -105,7 +105,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -423,7 +423,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -572,7 +572,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -875,7 +875,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1009,7 +1009,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1161,7 +1161,7 @@ public abstract class BaseStructuredContentFolderResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseStructuredContentResourceImpl.java
@@ -107,7 +107,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -402,7 +402,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -543,7 +543,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -624,7 +624,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1005,7 +1005,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1146,7 +1146,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -1809,7 +1809,7 @@ public abstract class BaseStructuredContentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiNodeResourceImpl.java
@@ -104,7 +104,7 @@ public abstract class BaseWikiNodeResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -386,7 +386,7 @@ public abstract class BaseWikiNodeResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -695,7 +695,7 @@ public abstract class BaseWikiNodeResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageAttachmentResourceImpl.java
@@ -208,7 +208,7 @@ public abstract class BaseWikiPageAttachmentResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseWikiPageResourceImpl.java
@@ -233,7 +233,7 @@ public abstract class BaseWikiPageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
@@ -389,7 +389,7 @@ public abstract class BaseWikiPageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			)
 		}
 	)
@@ -649,7 +649,7 @@ public abstract class BaseWikiPageResourceImpl
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "restrictedFields"
+				name = "restrictFields"
 			),
 			@io.swagger.v3.oas.annotations.Parameter(
 				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -596,7 +596,7 @@ public class ResourceOpenAPIParser {
 				StringUtil.equals(parameterName, "aggregationTerms") ||
 				StringUtil.equals(parameterName, "fields") ||
 				StringUtil.equals(parameterName, "filter") ||
-				StringUtil.equals(parameterName, "restrictedFields") ||
+				StringUtil.equals(parameterName, "restrictFields") ||
 				StringUtil.equals(parameterName, "sort")) {
 
 				continue;


### PR DESCRIPTION
**What is new?**

- Update `restrictedFields` to `restrictFields` in Headless Delivery

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155699

