### PR TITLE
LPS-155310 Add test FilterCanBeSearched

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -133,6 +133,36 @@ definition {
 		}
 	}
 
+	@description = "LPS-155310. Assert results can be correctly filtered when searching for a filter."
+	@priority = "5"
+	test FilterCanBeSearched {
+		task ("When click on the filter button") {
+			FDSFilters.openFilters();
+		}
+
+		task ("And When typing a key word in the category search box") {
+			FDSFilters.searchFilter(searchTerm = "status");
+		}
+
+		task ("And When there is a matching filter ") {
+			VerifyElementPresent(
+				key_filter = "Status",
+				locator1 = "FrontendDataSet#FILTER_OPTION");
+		}
+
+		task ("Then the results will be displayed updated accordingly to it") {
+			FDSFilters.enableStatusFilters(key_status = "Pending");
+
+			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+		}
+
+		task ("And Then the Filters Summary boxes will be updated accordingly to it") {
+			AssertElementPresent(
+				key_filter = "Status: Approved, Draft, Pending",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+	}
+
 	@description = "LPS-155311. Assert the filter cannot be filtered by searching."
 	@priority = "3"
 	test FilterNotFound {


### PR DESCRIPTION
**Background**
Create automated tests for FDS filters.


**Test Plan**
Given Sample FDS portlet deployed
And entering on a page which uses FDS
When clicking on the filter button
And typing a key word in the category search box
And there is a matching filter 
Then the results will be displayed updated accordingly to it
And the Filters Summary boxes will be updated accordingly to it

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155310