### PR TITLE
LPS-157281 - Node env should default to production

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -519,7 +519,7 @@
     # Set the environment variable NODE_ENV when invoking the Node.js package
     # manager via Gradle.
     #
-    nodejs.node.env=
+    nodejs.node.env=production
     #nodejs.node.env=production
     #nodejs.node.env=development
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-157281

Many npm modules will check for NODE_ENV=production to opt in for performance gains. It is best we make this a default rather than leaving it empty.