### PR TITLE
LPS-157292 Fix FeatureFlags global object

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -156,7 +156,7 @@
 
 		Liferay.FeatureFlags = Object.keys(featureFlags).reduce(
 			(acc, key) => ({
-				...acc, [key]: Boolean(featureFlags[key])
+				...acc, [key]: featureFlags[key] === 'true'
 			}), {}
 		);
 


### PR DESCRIPTION
The global feature flags object wasn't created correctly since it enabled all the FF that were put in the portal-ext.properties.

This didn't seem to be much of a problem because you could remove it from the file and the FF was disabled. Now that we have all the FF in the portal.properties by default: https://github.com/brianchandotcom/liferay-portal/commit/7bb31c4fb4b6da9b80e7a992857f68af7d2691e7 this may be a bigger problem. Since all the frontend FF are enabled by default