### PR TITLE
LPS-155463 Add test CanDisplayUpToThreeIcons

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -113,6 +113,32 @@ definition {
 		}
 	}
 
+	@description = "LPS-155463. Assert that Quick actions icons list should be limited to three actions."
+	@priority = "4"
+	test CanDisplayUpToThreeIcons {
+		task ("Then quick action menu only has 3 actions icons available") {
+			AssertElementPresent(
+				key_index = "1",
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#QUICK_ACTION_ITEM_INDEX");
+
+			AssertElementPresent(
+				key_index = "2",
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#QUICK_ACTION_ITEM_INDEX");
+
+			AssertElementPresent(
+				key_index = "3",
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#QUICK_ACTION_ITEM_INDEX");
+
+			AssertElementNotPresent(
+				key_index = "4",
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#QUICK_ACTION_ITEM_INDEX");
+		}
+	}
+
 	@description = "LPS-155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -21,6 +21,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>QUICK_ACTION_ITEM_INDEX</td>
+	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[contains(@class,'quick-action-item')][${key_index}]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>EDIT_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-pencil')]]</td>
 	<td></td>


### PR DESCRIPTION
**Background**
Create automated tests for the Frontend Dataset component.

**Test Plan**
Given: frontend-data-set-sample-web (FDS Sample Portlet) deployed
And Given FDS Sample Portlet added to page
When: Hover over 1st row item (Sample 1)
Then: quick action menu only has only 3 actions icons available

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-155463