### PR TITLE
LPS-157268 | Can delete object entry with disassociate deletionType relationship created_2

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -106,6 +106,81 @@ definition {
 		}
 	}
 
+	@priority = "4"
+	test CanDeleteObjectEntryWithDisassociateDeletionTypeRelationshipCreated_2 {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects with deletionType Disassociate created") {
+			var objectDefinitionId1 = JSONObject.getObjectId(objectName = "University");
+			var objectDefinitionId2 = JSONObject.getObjectId(objectName = "Subject");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "disassociate",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${objectDefinitionId1}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given three university entries created") {
+			var universityId1 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay First University");
+			var universityId2 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay Second University");
+			var universityId3 = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay Third University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("When I relate subject entry with all three universities through universities PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId1}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId2}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId3}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("When deleting one of the universities") {
+			var response = ObjectDefinitionAPI.deleteObjectEntry(
+				en_US_plural_label = "universities",
+				objectEntryId = "${universityId1}");
+		}
+
+		task ("Then receiving correct information about the related objects in subjects GET endpoint with nestedFields=universitiesSubjects") {
+			var responseToParse = ObjectDefinitionAPI.getObjectsWithNestedField(
+				nestedField = "universitiesSubjects",
+				objects = "subjects");
+
+			ObjectDefinitionAPI.assertNestedFieldDetail(
+				expectedValue = "Liferay Second University,Liferay Third University",
+				getObjectsWithNestedFieldReponse = "${responseToParse}",
+				nestedField = "universitiesSubjects",
+				objectEntryId = "${subjectId}",
+				objectField = "name");
+		}
+	}
+
 	@priority = "5"
 	test CanGetManyToManyRelationshipDetailsAsNestedFields_1 {
 		property portal.acceptance = "true";


### PR DESCRIPTION
**Background**
Add a test to assert can delete object entry with disassociate deletionType relationship created_2

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects with deletionType Disassociate created
And Given three university entries created
And Given subject entry created
And Given subject related to all three universities
When one of the universities is deleted
Then I receive correct information about the related objects o/\c/\subjects?nestedFields=universitiesSubjects

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157268