### PR TITLE
LPS-157466 When the session cannot be extended because it was already expired, the browser should stop trying to extend it and it should display a warning to the final user

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -103,7 +103,13 @@ AUI.add(
 					instance.set('timestamp');
 
 					if (event.src === SRC) {
-						Liferay.Util.fetch(URL_BASE + 'extend_session');
+						Liferay.Util.fetch(URL_BASE + 'extend_session').then(
+							(response) => {
+								if (response.status === 500) {
+									instance.expire();
+								}
+							}
+						);
 					}
 				},
 

--- a/portal-web/docroot/html/portal/extend_session.jsp
+++ b/portal-web/docroot/html/portal/extend_session.jsp
@@ -17,15 +17,17 @@
 <%@ include file="/html/portal/init.jsp" %>
 
 <%
-if (_log.isWarnEnabled()) {
-	String requestedSessionId = request.getRequestedSessionId();
+String requestedSessionId = request.getRequestedSessionId();
 
-	if (Validator.isNotNull(requestedSessionId) && !StringUtil.equals(requestedSessionId, session.getId())) {
-		_log.warn("Unable to extend the HTTP session. Review the portal property \"session.timeout\" if this warning is displayed frequently.");
+if (Validator.isNotNull(requestedSessionId) && !StringUtil.equals(requestedSessionId, session.getId())) {
+	response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
-		if (_log.isDebugEnabled()) {
-			_log.debug("The requested session " + requestedSessionId + " is not the same as session " + session.getId());
-		}
+	if (_log.isWarnEnabled()) {
+		_log.warn("Unable to extend the HTTP session.");
+	}
+
+	if (_log.isDebugEnabled()) {
+		_log.debug("The requested session " + requestedSessionId + " is not the same as session " + session.getId());
 	}
 }
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-157466

When the session cannot be extended because it was already expired, the browser should stop trying to extend it and it should display a warning to the final user.

This is reproduced if you have a Liferay cluster with a front-end web server with a sticky session that distributes the requests between the Liferay cluster nodes and the current node stops working:

1. The user access to the Liferay web page through the load balancer
2. As the sticky session is configured, all the user requests are redirected to one of the nodes. In this node, the extend_session requests will be sent to extend the session.
3. We shut down the server where the user is connected and we wait until the subsequent extend_session request is sent
4. As the current server node is shut down, the request is routed to another cluster node but the session cannot be extended because it doesn't exist in that node
5. Even if the session wasn't extended, Liferay doesn't display any warning to the final user
6. If we wait some time, we will see the browser continues sending extended session requests to the server

To solve it, I have modified the `portal-web/docroot/html/portal/extend_session.jsp` to return a 500 error code when the session wasn't correctly extended and I have added a check in the `modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js` to verify that the extend_session request returns ok.
If it doesn't returns ok, we will expire the session to display a warning to the final user.


I have also changed the WARN trace to just "Unable to extend the HTTP session." https://github.com/liferay-frontend/liferay-portal/commit/da28aee35dad1686571c4a8b9eec9ef41642775d#diff-9f493b3000a84a1b1e6e9cc720ccd93a850a3c632010f1ff6c8b96720c187095R26 because this warning can be reproduced  even you session.timeout is correct if current server is shutdown or the sessions are invalidated in some way.
