### PR TITLE
Master LPS-157569 | Add test case to assert structured content created with erc by default

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -244,6 +244,25 @@ definition {
 		return "${curl}";
 	}
 
+	macro _getStructuredContentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-contents \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+	}
+	''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _sortStructureContent {
 		Variables.assertDefined(parameterList = "${sortvalue}");
 
@@ -285,7 +304,7 @@ definition {
 
 		TestUtils.assertEquals(
 			actual = "${actualExternalReferenceCodeValue}",
-			expected = "${expectedactualExternalReferenceCodeValueValue}");
+			expected = "${expectedExternalReferenceCodeValue}");
 	}
 
 	macro assertPriorityFieldWithCorrectValue {
@@ -392,6 +411,22 @@ definition {
 		var response = HeadlessWebcontentAPI._filterStructuredContent(filtervalue = "${filtervalue}");
 
 		return "${response}";
+	}
+
+	macro getKeyFromResponse {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		var keyValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.['key']");
+
+		return "${keyValue}";
+	}
+
+	macro getStructredContentTitleInAssetLibrary {
+		var response = HeadlessWebcontentAPI._getStructuredContentInAssetLibrary(assetLibraryId = "${assetLibraryId}");
+
+		var structuredContentTitle = JSONUtil.getWithJSONPath("${response}", "$..title");
+
+		return "${structuredContentTitle}";
 	}
 
 	macro sortStructureContent {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -59,9 +59,52 @@ definition {
 				title = "WC WebContent Title");
 		}
 
-		task ("Then structured Content is being createdAnd Then I can see the custom erc in the body response") {
+		task ("Then the structured content is created properly") {
+			var structuredContentTitle = HeadlessWebcontentAPI.getStructredContentTitleInAssetLibrary(assetLibraryId = "${depotId}");
+
+			TestUtils.assertEquals(
+				actual = "${structuredContentTitle}",
+				expected = "WC WebContent Title");
+		}
+
+		task ("And Then I can see the custom erc in the body response") {
 			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
-				expectedactualExternalReferenceCodeValueValue = "erc",
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+	}
+
+	@description = "StructuredContent is created in an asset library with default erc"
+	@priority = "5"
+	test StructuredContentIsCreatedInAssetLibraryWithErcByDefault {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a structured Content without erc in asset library") {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var response = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("Then the structured content is created properly") {
+			var structuredContentTitle = HeadlessWebcontentAPI.getStructredContentTitleInAssetLibrary(assetLibraryId = "${depotId}");
+
+			TestUtils.assertEquals(
+				actual = "${structuredContentTitle}",
+				expected = "WC WebContent Title");
+		}
+
+		task ("And Then I can see erc equals to the key in the body response") {
+			var keyValue = HeadlessWebcontentAPI.getKeyFromResponse(responseToParse = "${response}");
+
+			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${keyValue}",
 				responseToParse = "${response}");
 		}
 	}


### PR DESCRIPTION
**Background**
Add a test to assert structured content is created with erc by default and the default value equals to key value

**Test Plan**
Given asset library is created
When with POST request I create a structured Content without a custom erc in asset library
Then structured content is being created and I can see erc value is the key value in the body response

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157569