### PR TITLE
LPS-157502 Icon and text misaligned in alert

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -158,7 +158,8 @@ public class AlertTag extends BaseContainerTag {
 			jspWriter.write("container-fluid-max-xl\">");
 		}
 
-		jspWriter.write("<div class=\"alert-autofit-row align-items-baseline autofit-row\"><div ");
+		jspWriter.write("<div class=\"alert-autofit-row align-items-baseline ");
+		jspWriter.write("autofit-row\"><div ");
 		jspWriter.write("class=\"autofit-col\"><div ");
 		jspWriter.write("class=\"autofit-section\"><span ");
 		jspWriter.write("class=\"alert-indicator\">");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -158,7 +158,7 @@ public class AlertTag extends BaseContainerTag {
 			jspWriter.write("container-fluid-max-xl\">");
 		}
 
-		jspWriter.write("<div class=\"alert-autofit-row autofit-row\"><div ");
+		jspWriter.write("<div class=\"alert-autofit-row align-items-baseline autofit-row\"><div ");
 		jspWriter.write("class=\"autofit-col\"><div ");
 		jspWriter.write("class=\"autofit-section\"><span ");
 		jspWriter.write("class=\"alert-indicator\">");


### PR DESCRIPTION
[Jira issue](https://issues.liferay.com/browse/LPS-157502)
[Lexicon](https://liferay.design/lexicon/core-components/alerts)

## Motivation

The icon in the alert tag component seems misaligned with the text

## Solution proposed

Use the baseline alignment for the flex children

## How to verify

In any use case of the tag, check the icon + text alignment.

## Screenshots

#### Before

![image](https://user-images.githubusercontent.com/19485114/177292946-1f48d5d8-f921-4e4b-83a2-30bc3086e531.png)


#### After

![image](https://user-images.githubusercontent.com/19485114/177292863-30056c01-af0b-468d-bc97-6d2d6f4e903f.png)
