### PR TITLE
LPS-156407: Align default value for ERC of structured content with other entities

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -503,6 +503,10 @@ public class JournalArticleModelValidator
 			String externalReferenceCode, long groupId)
 		throws PortalException {
 
+		if (Validator.isNull(externalReferenceCode)) {
+			return;
+		}
+
 		List<JournalArticle> articles = _journalArticlePersistence.findByG_ERC(
 			groupId, externalReferenceCode);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -531,10 +531,6 @@ public class JournalArticleLocalServiceImpl
 			articleId = String.valueOf(counterLocalService.increment());
 		}
 
-		if (Validator.isNull(externalReferenceCode)) {
-			externalReferenceCode = articleId;
-		}
-
 		sanitize(user.getCompanyId(), groupId, userId, classPK, descriptionMap);
 
 		if (validate) {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
@@ -208,17 +208,18 @@ public class JournalArticleServiceTest {
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, articleId, false);
 
+		String externalReferenceCode = _article.getExternalReferenceCode();
+
 		Assert.assertNotNull(_article);
 		Assert.assertEquals(articleId, _article.getArticleId());
-		Assert.assertEquals(articleId, _article.getExternalReferenceCode());
+		Assert.assertEquals(externalReferenceCode, _article.getUuid());
 
 		_latestArticle =
 			JournalArticleServiceUtil.fetchLatestArticleByExternalReferenceCode(
-				_group.getGroupId(), articleId);
+				_group.getGroupId(), externalReferenceCode);
 
 		Assert.assertNotNull(_latestArticle);
-		Assert.assertEquals(
-			articleId, _latestArticle.getExternalReferenceCode());
+		Assert.assertEquals(_article, _latestArticle);
 	}
 
 	@Test(expected = StructureDefinitionException.class)


### PR DESCRIPTION
**What is new?**

- Update `JournalArticleLocalService` and `JournalArticleModelValidator` to update ERC using the UUID.
- Update `JournalArticleServiceTest` checking that ERC is the UUID.

**Note:** The rest of entities validates the ERC using the UUID instead of entity ID.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-156407