### PR TITLE
LPS-142248 Fix and enable selection of card and list FDS views

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedCardsFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedCardsFDSView.java
@@ -24,7 +24,6 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	enabled = false,
 	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSView.class
 )

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedListFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedListFDSView.java
@@ -24,7 +24,6 @@ import org.osgi.service.component.annotations.Component;
  * @author Javier de Arcos
  */
 @Component(
-	enabled = false,
 	property = "frontend.data.set.name=" + FDSSampleFDSNames.CUSTOMIZED,
 	service = FDSView.class
 )

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -145,11 +145,13 @@ const FrontendDataSet = ({
 		let initialVisibleFieldNames = {};
 
 		if (activeViewSettings) {
-			const {name, visibleFieldNames} = JSON.parse(activeViewSettings);
+			const {name: activeViewName, visibleFieldNames} = JSON.parse(
+				activeViewSettings
+			);
 
-			if (name) {
+			if (activeViewName) {
 				initialActiveView = views.find(
-					({viewName}) => viewName === name
+					({name}) => name === activeViewName
 				);
 			}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -16,132 +16,109 @@ import ClayEmptyState from '@clayui/empty-state';
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
-import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
+import FrontendDataSetContext from '../../FrontendDataSetContext';
 import Actions from '../../actions/Actions';
 import ImageRenderer from '../../data_renderers/ImageRenderer';
 
-function List({
-	dataLoading,
-	frontendDataSetContext,
-	items,
-	schema: {description, image, sticker, symbol, title},
-}) {
+const List = ({items, schema}) => {
+	const {selectedItemsKey} = useContext(FrontendDataSetContext);
+
+	return items?.length ? (
+		<ClayList>
+			{items.map((item, index) => {
+				return (
+					<ListItem
+						item={item}
+						key={item[selectedItemsKey] || index}
+						schema={schema}
+					/>
+				);
+			})}
+		</ClayList>
+	) : (
+		<ClayEmptyState
+			description={Liferay.Language.get('sorry,-no-results-were-found')}
+			imgSrc={`${themeDisplay.getPathThemeImages()}/states/search_state.gif`}
+			title={Liferay.Language.get('no-results-found')}
+		/>
+	);
+};
+
+const ListItem = ({item, schema}) => {
 	const {
-		itemActions,
+		itemsActions,
 		selectItems,
 		selectedItemsKey,
 		selectedItemsValue,
 		selectionType,
-	} = useContext(frontendDataSetContext);
+	} = useContext(FrontendDataSetContext);
 
-	if (dataLoading) {
-		return <ClayLoadingIndicator className="mt-7" />;
-	}
-
-	if (!items?.length) {
-		return (
-			<ClayEmptyState
-				description={Liferay.Language.get(
-					'sorry,-no-results-were-found'
-				)}
-				imgSrc={`${themeDisplay.getPathThemeImages()}/states/search_state.gif`}
-				title={Liferay.Language.get('no-results-found')}
-			/>
-		);
-	}
+	const {description, image, sticker, symbol, title} = schema;
 
 	return (
-		<ClayList>
-			{items.map((item, i) => (
-				<ClayList.Item
-					className={classNames(
-						i
-							? 'border-left-0 border-bottom-0 border-right-0'
-							: 'border-0'
-					)}
-					flex
-					key={item.id}
-				>
-					<ClayList.ItemField className="justify-content-center">
-						{selectionType === 'single' ? (
-							<ClayRadio
-								checked={selectedItemsValue
-									.map((element) => String(element))
-									.includes(String(item[selectedItemsKey]))}
-								onChange={() =>
-									selectItems(item[selectedItemsKey])
-								}
-							/>
-						) : (
-							<ClayCheckbox
-								checked={selectedItemsValue
-									.map((element) => String(element))
-									.includes(String(item[selectedItemsKey]))}
-								onChange={() =>
-									selectItems(item[selectedItemsKey])
-								}
-							/>
-						)}
-					</ClayList.ItemField>
+		<ClayList.Item flex>
+			<ClayList.ItemField className="justify-content-center">
+				{selectionType === 'single' ? (
+					<ClayRadio
+						checked={selectedItemsValue
+							.map((element) => String(element))
+							.includes(String(item[selectedItemsKey]))}
+						onChange={() => selectItems(item[selectedItemsKey])}
+					/>
+				) : (
+					<ClayCheckbox
+						checked={selectedItemsValue
+							.map((element) => String(element))
+							.includes(String(item[selectedItemsKey]))}
+						onChange={() => selectItems(item[selectedItemsKey])}
+					/>
+				)}
+			</ClayList.ItemField>
 
-					{image && item[image] ? (
-						<ClayList.ItemField>
-							<ImageRenderer
-								sticker={sticker && item[sticker]}
-								value={{src: item[image]}}
-							/>
-						</ClayList.ItemField>
-					) : (
-						symbol &&
-						item[symbol] && (
-							<ClayList.ItemField>
-								<ClaySticker {...(sticker && item[sticker])}>
-									{item[symbol] && (
-										<ClayIcon symbol={item[symbol]} />
-									)}
-								</ClaySticker>
-							</ClayList.ItemField>
-						)
-					)}
-
-					<ClayList.ItemField
-						className="justify-content-center"
-						expand
-					>
-						{title && (
-							<ClayList.ItemTitle>
-								{item[title]}
-							</ClayList.ItemTitle>
-						)}
-
-						{description && (
-							<ClayList.ItemText>
-								{item[description]}
-							</ClayList.ItemText>
-						)}
-					</ClayList.ItemField>
-
+			{image && item[image] ? (
+				<ClayList.ItemField>
+					<ImageRenderer
+						sticker={sticker && item[sticker]}
+						value={{src: item[image]}}
+					/>
+				</ClayList.ItemField>
+			) : (
+				symbol &&
+				item[symbol] && (
 					<ClayList.ItemField>
-						{(itemActions || item.actionDropdownItems) && (
-							<Actions
-								actions={
-									itemActions || item.actionDropdownItems
-								}
-								itemData={item}
-								itemId={item[selectedItemsKey] || i}
-							/>
-						)}
+						<ClaySticker {...(sticker && item[sticker])}>
+							{item[symbol] && <ClayIcon symbol={item[symbol]} />}
+						</ClaySticker>
 					</ClayList.ItemField>
-				</ClayList.Item>
-			))}
-		</ClayList>
+				)
+			)}
+
+			<ClayList.ItemField className="justify-content-center" expand>
+				{title && (
+					<ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>
+				)}
+
+				{description && (
+					<ClayList.ItemText>{item[description]}</ClayList.ItemText>
+				)}
+			</ClayList.ItemField>
+
+			<ClayList.ItemField>
+				{(itemsActions || item.actionDropdownItems) && (
+					<Actions
+						actions={itemsActions || item.actionDropdownItems}
+						itemData={item}
+						itemId={item[selectedItemsKey]}
+					/>
+				)}
+			</ClayList.ItemField>
+		</ClayList.Item>
 	);
-}
+};
 
 List.propTypes = {
 	context: PropTypes.any,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import getViewComponent from './getViewComponent';
+
 export const ACTION_UPDATE_ACTIVE_VIEW = 'ACTION_UPDATE_ACTIVE_VIEW';
 export const ACTION_UPDATE_VIEW_COMPONENT = 'ACTION_UPDATE_VIEW_COMPONENT';
 export const ACTION_UPDATE_VISIBLE_FIELD_NAMES =
@@ -42,9 +44,15 @@ export function viewsReducer(state, {type, value}) {
 	const {activeView, views} = state;
 
 	if (type === ACTION_UPDATE_ACTIVE_VIEW) {
+		const activeView = views.find(({name}) => name === value);
+
+		if (activeView) {
+			activeView.component = getViewComponent(value);
+		}
+
 		return {
 			...state,
-			activeView: views.find(({name}) => name === value),
+			activeView,
 		};
 	}
 	else if (type === ACTION_UPDATE_VIEW_COMPONENT) {


### PR DESCRIPTION
### References

- [LPS-142248 Fix and enable selection of card and list FDS views](https://issues.liferay.com/browse/LPS-142248)

### What is the goal of this PR?

Currently, the only functional view in FDS is `table`. In this PR, we are fixing and improving `list` and `card` views, as well as enabling them in the sample module.

Technical notes:
- Views persistence had two bugs:
  - The first one was present for a long time, where we we using `viewName` prop instead of `name`
  - The second one we introduced recently, with [the change in view component setting](https://github.com/liferay-frontend/liferay-portal/pull/2432/commits/ff338cbacc5a0fc130b3973496630562978c9938).  
- I removed unused loading indicators, in both views
- I extracted item components in both views, to 'buy space'
- Context does not need to be passed as a prop, it defeats the purpose
- I removed hardcoded style classes for `list` items. The default Clay ones look better to me, and are more consistent. If we do revise these classes, it should probably be behind the `style` prop.

### What does it look like?

![after](https://user-images.githubusercontent.com/5435511/177316917-8d05ae3d-634a-4426-bfc4-949c32e26129.gif)

### Steps to reproduce

Place `frontend-data-set-sample-web` as a widget on any page.