### PR TITLE
LPS-152038 Generate sample FDS module data on the first render

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FDSSamplePortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FDSSamplePortlet.java
@@ -43,7 +43,6 @@ import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -78,22 +77,19 @@ public class FDSSamplePortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
+		try {
+			_generate(_portal.getCompanyId(renderRequest));
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
 		renderRequest.setAttribute(
 			FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT,
 			new FDSSampleDisplayContext(
 				_portal.getHttpServletRequest(renderRequest)));
 
 		super.doDispatch(renderRequest, renderResponse);
-	}
-
-	@Activate
-	protected void activate() {
-		try {
-			_generate(_portal.getDefaultCompanyId());
-		}
-		catch (Exception exception) {
-			_log.error(exception);
-		}
 	}
 
 	private synchronized void _generate(long companyId) throws Exception {


### PR DESCRIPTION
### References

- [LPS-152038 Improve first-render time of the FDS sample portlet](https://issues.liferay.com/browse/LPS-152038)
- This is a revert of https://github.com/liferay-frontend/liferay-portal/pull/2172

### What is the goal of this PR?

We are reverting data generation in module activation, back to data generation on first page render.

The problem with data generation in module activation is that it can result in flaky failures of data generation. These are the steps to replicate the issue:
1. Set an empty database to DXP.
2. Deploy `frontend-data-set-sample-web`. Note that this module is not included in DXP build.
3. Start server.

What happens is a race condition between DXP DB upgrade process and FDS sample module data generation. Error happens on `reindex` step of data generation:
```
2022-06-30 10:11:37.111 INFO  [main][UpgradeProcess:112] Completed upgrade process com.liferay.portal.security.sso.token.internal.upgrade.v2_0_0.TokenConfigurationUpgradeProcess in 7 ms

2022-06-30 10:11:37.833 ERROR [Portal Dependency Manager Component Executor--1][FDSSamplePortlet:95] null
java.lang.NullPointerException: null
	at com.liferay.object.service.impl.ObjectEntryLocalServiceImpl._reindex(ObjectEntryLocalServiceImpl.java:1944) ~[?:?]
	at com.liferay.object.service.impl.ObjectEntryLocalServiceImpl.updateStatus(ObjectEntryLocalServiceImpl.java:1028) ~[?:?]
...

2022-06-30 10:11:38.172 INFO  [main][UpgradeProcess:97] Upgrading com.liferay.push.notifications.web.internal.upgrade.v1_0_0.UpgradePortletId
```

To fix this, we are reverting to data generation on first page load. As we are excepting a longer load on initial rendering of the page, we may need to modify out CI test to compensate this. @Esther-OC @john-co 

/cc @beltranrengifo 
