### PR TITLE
LPS-157631 Adjust filter in GraphQL to make it possible to migrate Objects to use more DB and less Elatiscsearch

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/graphql/dto/v1_0/ObjectDefinitionGraphQLDTOContributor.java
@@ -32,7 +32,6 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -208,8 +207,7 @@ public class ObjectDefinitionGraphQLDTOContributor
 				aggregation, dtoConverterContext, pagination,
 				PredicateUtil.toPredicate(
 					_filterParserProvider,
-					ParamUtil.getString(
-						dtoConverterContext.getHttpServletRequest(), "filter"),
+					(String)dtoConverterContext.getAttribute("filter"),
 					_objectDefinition.getObjectDefinitionId(),
 					_objectFieldLocalService),
 				search, sorts);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/GraphQLServletExtender.java
@@ -2025,6 +2025,10 @@ public class GraphQLServletExtender {
 							HashMapBuilder.<String, Serializable>put(
 								"companyId", CompanyThreadLocal.getCompanyId()
 							).put(
+								"filter",
+								(String)dataFetchingEnvironment.getArgument(
+									"filter")
+							).put(
 								"scopeKey",
 								(String)dataFetchingEnvironment.getArgument(
 									"scopeKey")


### PR DESCRIPTION
**Related Issue:** https://issues.liferay.com/browse/LPS-157631

After enabling the FF for [LPS-153768](https://issues.liferay.com/browse/LPS-153768), which allows the `Objects` to use more `DB` and less `Elasticsearch`, the Solutions team found this issue when trying to get the object entries using GraphQL.

The solution proposed in this PR allows us to have access to the filter string compatible with the `OData Filter` during the search.