### PR TITLE
LPS-155304 FDSFilter#WillRenderAsInitialState

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -298,6 +298,12 @@ definition {
 			Click(
 				key_sampleTab = "Customized",
 				locator1 = "FrontendDataSet#FDS_DATASET");
+
+			Click(locator1 = "FrontendDataSet#ITEMS_VIEW_MODE_BUTTON");
+
+			Click(
+				key_viewMode = "Table",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
 		}
 
 		task ("Then the results will be displayed accordingly to the filter selected") {
@@ -308,6 +314,10 @@ definition {
 			AssertElementNotPresent(
 				key_statusName = "Pending",
 				locator1 = "FrontendDataSet#TABLE_STATUS");
+
+			AssertTextEquals(
+				locator1 = "FrontendDataSet#PAGINATION_RESULTS",
+				value1 = "Showing 1 to 10 of 100");
 		}
 
 		task ("And Then the Filters Summary boxes will be displayed  accordingly to it") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -294,12 +294,6 @@ definition {
 	@description = "LPS-155304. Assert filter is preloaded when entering on a FDS page for first time."
 	@priority = "5"
 	test WillRenderAsInitialState {
-		task ("And when it is the first time the user enters") {
- 			AssertElementNotPresent(
-				key_filter = "Status: Pending",
-				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
-		}
-
 		task ("Then a filter is preloaded") {
 			VerifyElementPresent(
 				key_filter = "Status: Approved, Draft",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -291,4 +291,31 @@ definition {
 		}
 	}
 
+	@description = "LPS-155304. Assert filter is preloaded when entering on a FDS page for first time."
+	@priority = "5"
+	test WillRenderAsInitialState {
+		task ("And when it is the first time the user enters") {
+ 			AssertElementNotPresent(
+				key_filter = "Status: Pending",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+
+		task ("Then a filter is preloaded") {
+			VerifyElementPresent(
+				key_filter = "Status: Approved, Draft",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+
+		task ("And the results will be displayed accordingly to the filter selected") {
+			AssertElementPresent(
+				key_itemName = "43466",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+		}
+
+		task ("And the Filters Summary boxes will be displayed  accordingly to it") {
+			AssertElementPresent(
+				key_filter = "Status: Approved, Draft",
+				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		}
+	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -294,22 +294,27 @@ definition {
 	@description = "LPS-155304. Assert filter is preloaded when entering on a FDS page for first time."
 	@priority = "5"
 	test WillRenderAsInitialState {
-		task ("Then a filter is preloaded") {
-			VerifyElementPresent(
-				key_filter = "Status: Approved, Draft",
-				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+		task ("And When viewing FDS Sample portlet dataset") {
+			Click(
+				key_sampleTab = "Customized",
+				locator1 = "FrontendDataSet#FDS_DATASET");
 		}
 
-		task ("And the results will be displayed accordingly to the filter selected") {
+		task ("Then the results will be displayed accordingly to the filter selected") {
 			AssertElementPresent(
-				key_itemName = "43466",
-				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+				key_statusName = "Approved",
+				locator1 = "FrontendDataSet#TABLE_STATUS");
+
+			AssertElementNotPresent(
+				key_statusName = "Pending",
+				locator1 = "FrontendDataSet#TABLE_STATUS");
 		}
 
-		task ("And the Filters Summary boxes will be displayed  accordingly to it") {
+		task ("And Then the Filters Summary boxes will be displayed  accordingly to it") {
 			AssertElementPresent(
 				key_filter = "Status: Approved, Draft",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -46,6 +46,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ITEMS_VIEW_MODE_BUTTON</td>
+	<td>//div[@class='dropdown']/parent::li[contains(@class,'nav-item')]//button[contains(@class,'nav-link')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ITEMS_VIEW_TYPE_DROPDOWN</td>
+	<td>//div[@class='dropdown-menu show']//*[@class='dropdown-item' and text()='${key_viewMode}']</td>
+	<td></td>
+</tr>
+<tr>
 	<td>VIEW_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-view')]]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -41,6 +41,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>FDS_DATASET</td>
+	<td>//a[contains(@class,'nav-link') and contains(text(),'${key_sampleTab}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>VIEW_ACTION_BUTTON</td>
 	<td>//div[contains(@class,'dnd-td') and text()='${key_title}']//..//*[*[name()='svg'][contains(@class,'lexicon-icon-view')]]</td>
 	<td></td>
@@ -58,6 +63,11 @@
 <tr>
 	<td>TABLE_ITEM_ROW</td>
 	<td>//*[normalize-space(text())='${key_itemName}']/parent::*[contains(@class,'dnd-tr')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TABLE_STATUS</td>
+	<td>//strong[contains(@class,'label-success') and text()='${key_statusName}']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Background**
The goal of this PR is the automation of the test case FDSFilter#WillRenderAsInitialState, to assure that the FDS filter and its results are preloaded when entering on a page which uses FDS.

**JIRA ticket:** 
[LPS-155304](https://issues.liferay.com/browse/LPS-155304)

Test case: 
**FDSFilter#WillRenderAsInitialState**
Given Sample FDS portlet deployed
When entering on a page which uses FDS
And When viewing FDS Sample portlet dataset
Then the results will be displayed accordingly to the filter selected
And Then the Filters Summary boxes will be displayed  accordingly to it


