### PR TITLE
Master Lps 157569 | Add test case to assert structured content created with erc by default

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -244,6 +244,24 @@ definition {
 		return "${curl}";
 	}
 
+	macro _filterStructuredContentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${filtervalue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-contents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _sortStructureContent {
 		Variables.assertDefined(parameterList = "${sortvalue}");
 
@@ -281,11 +299,15 @@ definition {
 	}
 
 	macro assertExternalReferenceCodeWithCorrectValue {
+		if (!(isSet(expectedExternalReferenceCodeValue))) {
+			var expectedExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.['uuid']");
+		}
+
 		var actualExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
 
 		TestUtils.assertEquals(
 			actual = "${actualExternalReferenceCodeValue}",
-			expected = "${expectedactualExternalReferenceCodeValueValue}");
+			expected = "${expectedExternalReferenceCodeValue}");
 	}
 
 	macro assertPriorityFieldWithCorrectValue {
@@ -390,6 +412,14 @@ definition {
 
 	macro filterStructuredContent {
 		var response = HeadlessWebcontentAPI._filterStructuredContent(filtervalue = "${filtervalue}");
+
+		return "${response}";
+	}
+
+	macro filterStructuredContentInAssetLibrary {
+		var response = HeadlessWebcontentAPI._filterStructuredContentInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			filtervalue = "${filtervalue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -424,6 +424,14 @@ definition {
 		return "${response}";
 	}
 
+	macro getWebContentIdFromResponse {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		var idFromResponse = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
+
+		return "${idFromResponse}";
+	}
+
 	macro sortStructureContent {
 		var response = HeadlessWebcontentAPI._sortStructureContent(sortvalue = "${sortvalue}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -109,4 +109,52 @@ definition {
 		}
 	}
 
+	@description = "Structured content is created in an asset library with structured content id as erc"
+	@priority = "5"
+	test StructuredContentIsCreatedInAssetLibraryWithStructuredContentIdAsErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content with custom erc is created with a POST request in asset library") {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var response = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				externalReferenceCode = "erc",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with POST request I create a structured content with erc equals to the internal id of the previously created structured content") {
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${response}");
+			var response = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				externalReferenceCode = "${customErc}",
+				label = "Text",
+				name = "Text",
+				title = "WC Second WebContent Title");
+		}
+
+		task ("Then I can see erc equals to the previous id in the body response") {
+			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedactualExternalReferenceCodeValueValue = "${structuredContentId}",
+				responseToParse = "${response}");
+		}
+
+		task ("Then structured content is created properly") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "1",
+				responseToParse = "${response}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -40,12 +40,12 @@ definition {
 		}
 	}
 
-	@description = "Structured Content is created in an asset library with custom erc"
+	@description = "Structured content is created in an asset library with custom erc"
 	@priority = "5"
 	test StructuredContentIsCreatedInAssetLibraryWithCustomErc {
 		property portal.acceptance = "true";
 
-		task ("When with POST request I create a structured Content with a custom erc in asset library") {
+		task ("When with POST request I create a structured content with a custom erc in asset library") {
 			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
 
@@ -59,9 +59,52 @@ definition {
 				title = "WC WebContent Title");
 		}
 
-		task ("Then structured Content is being createdAnd Then I can see the custom erc in the body response") {
+		task ("Then I can see the custom erc in the body response") {
 			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
-				expectedactualExternalReferenceCodeValueValue = "erc",
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then structured content is created properly") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "1",
+				responseToParse = "${response}");
+		}
+	}
+
+	@description = "Structured content is created in an asset library with default erc"
+	@priority = "5"
+	test StructuredContentIsCreatedInAssetLibraryWithErcByDefault {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a structured content without erc in asset library") {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var response = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("Then I can see erc equals to the uuid in the body response") {
+			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(responseToParse = "${response}");
+		}
+
+		task ("And Then the structured content is created properly") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "1",
 				responseToParse = "${response}");
 		}
 	}


### PR DESCRIPTION
**Background**
 - Add a test to assert structured content is created with erc by default and the default value equals to key value
 - Add test to create structured content with id as erc in asset Library

**Test Plan**
 - First test plan for LPS-157569
Given asset library is created
When with POST request I create a structured Content without a custom erc in asset library
Then I can see erc value is the key value in the body response
And Then structured content is being created
 - Second test plan for LPS-157666
Given asset library is created
And Given a structured content with a custom erc is created with a POST request in asset library
When with POST request I create a structured content with a custom erc with a value of the internal id of the previously created structured content
Then structured content is being created
And Then I can see the custom erc in the body response

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-157569
- https://issues.liferay.com/browse/LPS-157666

