### PR TITLE
LPS-153319 Add set/update extended properties validation and include some type validations

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
@@ -14,13 +14,29 @@
 
 package com.liferay.portal.vulcan.extension;
 
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.vulcan.extension.validation.DefaultPropertyValidator;
 import com.liferay.portal.vulcan.extension.validation.PropertyValidator;
+
+import java.math.BigDecimal;
+
+import java.util.Map;
 
 /**
  * @author Carlos Correa
  */
 public class PropertyDefinition {
+
+	public PropertyDefinition(
+		Class<?> propertyClass, String propertyName, PropertyType propertyType,
+		PropertyValidator propertyValidator, boolean required) {
+
+		_propertyClass = propertyClass;
+		_propertyName = propertyName;
+		_propertyType = propertyType;
+		_propertyValidator = propertyValidator;
+		_required = required;
+	}
 
 	public PropertyDefinition(
 		String propertyName, PropertyType propertyType, boolean required) {
@@ -29,7 +45,8 @@ public class PropertyDefinition {
 		_propertyType = propertyType;
 		_required = required;
 
-		_propertyValidator = new DefaultPropertyValidator(propertyType);
+		_propertyClass = _propertyTypeClassMap.getOrDefault(propertyType, null);
+		_propertyValidator = new DefaultPropertyValidator();
 	}
 
 	public PropertyDefinition(
@@ -40,6 +57,12 @@ public class PropertyDefinition {
 		_propertyType = propertyType;
 		_propertyValidator = propertyValidator;
 		_required = required;
+
+		_propertyClass = _propertyTypeClassMap.getOrDefault(propertyType, null);
+	}
+
+	public Class<?> getPropertyClass() {
+		return _propertyClass;
 	}
 
 	public String getPropertyName() {
@@ -60,10 +83,29 @@ public class PropertyDefinition {
 
 	public enum PropertyType {
 
-		BIG_DECIMAL, BOOLEAN, DECIMAL, DOUBLE, INTEGER, LONG, TEXT
+		BIG_DECIMAL, BOOLEAN, DATE_TIME, DECIMAL, DOUBLE, INTEGER, LONG,
+		MULTIPLE_ELEMENT, SINGLE_ELEMENT, TEXT
 
 	}
 
+	private static final Map<PropertyType, Class<?>> _propertyTypeClassMap =
+		HashMapBuilder.<PropertyType, Class<?>>put(
+			PropertyType.BIG_DECIMAL, BigDecimal.class
+		).<PropertyType, Class<?>>put(
+			PropertyType.BOOLEAN, Boolean.class
+		).<PropertyType, Class<?>>put(
+			PropertyType.DECIMAL, Float.class
+		).<PropertyType, Class<?>>put(
+			PropertyType.DOUBLE, Double.class
+		).<PropertyType, Class<?>>put(
+			PropertyType.INTEGER, Integer.class
+		).<PropertyType, Class<?>>put(
+			PropertyType.LONG, Long.class
+		).<PropertyType, Class<?>>put(
+			PropertyType.TEXT, String.class
+		).build();
+
+	private final Class<?> _propertyClass;
 	private final String _propertyName;
 	private final PropertyType _propertyType;
 	private final PropertyValidator _propertyValidator;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/validation/PropertyValidator.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/validation/PropertyValidator.java
@@ -14,11 +14,14 @@
 
 package com.liferay.portal.vulcan.extension.validation;
 
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+
 /**
  * @author Carlos Correa
  */
 public interface PropertyValidator {
 
-	public void validate(String propertyName, Object propertyValue);
+	public void validate(
+		PropertyDefinition propertyDefinition, Object propertyValue);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/ObjectMapperUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/ObjectMapperUtil.java
@@ -32,6 +32,19 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
  */
 public class ObjectMapperUtil {
 
+	public static <T> T readValue(Class<?> clazz, Object element) {
+		try {
+			return readValue(clazz, _objectMapper.writeValueAsString(element));
+		}
+		catch (JsonProcessingException jsonProcessingException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(jsonProcessingException);
+			}
+
+			return null;
+		}
+	}
+
 	public static <T> T readValue(Class<?> clazz, String json) {
 		try {
 			return (T)_objectMapper.readValue(json, clazz);

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.4.0
+version 3.5.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
@@ -1,0 +1,332 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.extension.validation;
+
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+
+import java.io.Serializable;
+
+import java.math.BigDecimal;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.ValidationException;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Carlos Correa
+ */
+public class DefaultPropertyValidatorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testValidateBigDecimal() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.BIG_DECIMAL,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, new BigDecimal(Long.MAX_VALUE));
+	}
+
+	@Test
+	public void testValidateBoolean() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.BOOLEAN,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(propertyDefinition, true);
+	}
+
+	@Test
+	public void testValidateDateTime() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			String.class, "field", PropertyDefinition.PropertyType.DATE_TIME,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, "2021-07-04T12:12:02Z");
+	}
+
+	@Test
+	public void testValidateDecimal() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.DECIMAL,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(propertyDefinition, Float.MAX_VALUE);
+	}
+
+	@Test
+	public void testValidateDouble() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.DOUBLE,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(propertyDefinition, Double.MAX_VALUE);
+	}
+
+	@Test
+	public void testValidateInteger() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.INTEGER,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, Integer.MAX_VALUE);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidBigDecimal() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.BIG_DECIMAL,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, "This is a invalid value");
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidDateTime() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			String.class, "field", PropertyDefinition.PropertyType.DATE_TIME,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, "2021-07-04T12:12:02");
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidMultipleElements() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestInvalidClass.class, "field",
+			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
+			defaultPropertyValidator, false);
+
+		List<Map<String, Object>> multipleElements = Arrays.asList(
+			new HashMapBuilder<>().<String, Object>put(
+				"field1", "field1Text1"
+			).<String, Object>put(
+				"field2", "field1Text2"
+			).<String, Object>put(
+				"field3", 1L
+			).build(),
+			new HashMapBuilder<>().<String, Object>put(
+				"field1", "field2Text1"
+			).<String, Object>put(
+				"field2", "field2Text2"
+			).<String, Object>put(
+				"field3", 2L
+			).build());
+
+		defaultPropertyValidator.validate(propertyDefinition, multipleElements);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidSingleElement() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestInvalidClass.class, "field",
+			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition,
+			new HashMapBuilder<>().<String, Object>put(
+				"field1", "field1Text1"
+			).<String, Object>put(
+				"field2", "field1Text2"
+			).<String, Object>put(
+				"field3", 1L
+			).build());
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidValue() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.BOOLEAN,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, "This is a invalid value");
+	}
+
+	@Test
+	public void testValidateLong() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.LONG,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(propertyDefinition, Long.MAX_VALUE);
+	}
+
+	@Test
+	public void testValidateMultipleElements() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestClass.class, "field",
+			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
+			defaultPropertyValidator, false);
+
+		Map<String, Object>[] multipleElements = new Map[] {
+			new HashMapBuilder<>().<String, Object>put(
+				"field1", "field1Text1"
+			).<String, Object>put(
+				"field2", "field1Text2"
+			).<String, Object>put(
+				"field3", 1L
+			).build(),
+			new HashMapBuilder<>().<String, Object>put(
+				"field1", "field2Text1"
+			).<String, Object>put(
+				"field2", "field2Text2"
+			).<String, Object>put(
+				"field3", 2L
+			).build()
+		};
+
+		defaultPropertyValidator.validate(propertyDefinition, multipleElements);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateNullClass() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			null, "field", PropertyDefinition.PropertyType.BOOLEAN,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(propertyDefinition, true);
+	}
+
+	@Test
+	public void testValidateSingleElement() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestClass.class, "field",
+			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition,
+			new HashMapBuilder<>().<String, Object>put(
+				"field1", "field1Text1"
+			).<String, Object>put(
+				"field2", "field1Text2"
+			).<String, Object>put(
+				"field3", 1L
+			).build());
+	}
+
+	@Test
+	public void testValidateText() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			"field", PropertyDefinition.PropertyType.TEXT,
+			defaultPropertyValidator, false);
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, "This is a valid text");
+	}
+
+	public static class TestClass implements Serializable {
+
+		public String getField1() {
+			return _field1;
+		}
+
+		public String getField2() {
+			return _field2;
+		}
+
+		public Long getField3() {
+			return _field3;
+		}
+
+		public void setField1(String field1) {
+			_field1 = field1;
+		}
+
+		public void setField2(String field2) {
+			_field2 = field2;
+		}
+
+		public void setField3(Long field3) {
+			_field3 = field3;
+		}
+
+		private String _field1;
+		private String _field2;
+		private Long _field3;
+
+	}
+
+	public static class TestInvalidClass implements Serializable {
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/message/body/BaseMessageBodyReader.java
@@ -187,6 +187,10 @@ public abstract class BaseMessageBodyReader
 			return (Serializable)objectMapper.readValue(
 				jsonNode.traverse(), Object.class);
 		}
+		else if (jsonNode.isArray()) {
+			return (Serializable)objectMapper.readValue(
+				jsonNode.traverse(), Object[].class);
+		}
 
 		return null;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
@@ -17,6 +17,7 @@ package com.liferay.portal.vulcan.internal.extension;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
 
 import java.io.Serializable;
 
@@ -24,6 +25,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+
+import javax.validation.ValidationException;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -192,6 +195,339 @@ public class EntityExtensionHandlerTest {
 		).setExtendedProperties(
 			Mockito.eq(_COMPANY_ID), Mockito.eq(_OBJECT),
 			Mockito.eq(Collections.singletonMap("test2", 5))
+		);
+	}
+
+	@Test
+	public void testValidate() {
+		ExtensionProvider extensionProviderMock1 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProviderMock2 = Mockito.mock(
+			ExtensionProvider.class);
+
+		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
+			"field1", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
+			"field2", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
+			"field3", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
+			"field4", PropertyDefinition.PropertyType.TEXT, false);
+
+		Mockito.when(
+			extensionProviderMock1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition1.getPropertyName(), propertyDefinition1
+			).put(
+				propertyDefinition2.getPropertyName(), propertyDefinition2
+			).build()
+		);
+		Mockito.when(
+			extensionProviderMock2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition3.getPropertyName(), propertyDefinition3
+			).put(
+				propertyDefinition4.getPropertyName(), propertyDefinition4
+			).build()
+		);
+
+		EntityExtensionHandler entityExtensionHandler =
+			new EntityExtensionHandler(
+				_CLASS_NAME,
+				Arrays.asList(extensionProviderMock1, extensionProviderMock2));
+
+		entityExtensionHandler.validate(
+			_COMPANY_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"field1", "value1"
+			).<String, Serializable>put(
+				"field2", "value2"
+			).<String, Serializable>put(
+				"field3", "value3"
+			).<String, Serializable>put(
+				"field4", "value4"
+			).build(),
+			false);
+
+		Mockito.verify(
+			extensionProviderMock1
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+		Mockito.verify(
+			extensionProviderMock2
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidProperty() {
+		ExtensionProvider extensionProviderMock1 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProviderMock2 = Mockito.mock(
+			ExtensionProvider.class);
+
+		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
+			"field1", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
+			"field2", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
+			"field3", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
+			"field4", PropertyDefinition.PropertyType.TEXT, true);
+
+		Mockito.when(
+			extensionProviderMock1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition1.getPropertyName(), propertyDefinition1
+			).put(
+				propertyDefinition2.getPropertyName(), propertyDefinition2
+			).build()
+		);
+		Mockito.when(
+			extensionProviderMock2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition3.getPropertyName(), propertyDefinition3
+			).put(
+				propertyDefinition4.getPropertyName(), propertyDefinition4
+			).build()
+		);
+
+		EntityExtensionHandler entityExtensionHandler =
+			new EntityExtensionHandler(
+				_CLASS_NAME,
+				Arrays.asList(extensionProviderMock1, extensionProviderMock2));
+
+		entityExtensionHandler.validate(
+			_COMPANY_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"field1", 1L
+			).<String, Serializable>put(
+				"field2", "value2"
+			).<String, Serializable>put(
+				"field3", "value3"
+			).<String, Serializable>put(
+				"field4", "value4"
+			).build(),
+			false);
+
+		Mockito.verify(
+			extensionProviderMock1
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+		Mockito.verify(
+			extensionProviderMock2
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateMissingMandatoryProperty() {
+		ExtensionProvider extensionProviderMock1 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProviderMock2 = Mockito.mock(
+			ExtensionProvider.class);
+
+		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
+			"field1", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
+			"field2", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
+			"field3", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
+			"field4", PropertyDefinition.PropertyType.TEXT, true);
+
+		Mockito.when(
+			extensionProviderMock1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition1.getPropertyName(), propertyDefinition1
+			).put(
+				propertyDefinition2.getPropertyName(), propertyDefinition2
+			).build()
+		);
+		Mockito.when(
+			extensionProviderMock2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition3.getPropertyName(), propertyDefinition3
+			).put(
+				propertyDefinition4.getPropertyName(), propertyDefinition4
+			).build()
+		);
+
+		EntityExtensionHandler entityExtensionHandler =
+			new EntityExtensionHandler(
+				_CLASS_NAME,
+				Arrays.asList(extensionProviderMock1, extensionProviderMock2));
+
+		entityExtensionHandler.validate(
+			_COMPANY_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"field1", "value1"
+			).<String, Serializable>put(
+				"field2", "value2"
+			).<String, Serializable>put(
+				"field3", "value3"
+			).build(),
+			false);
+
+		Mockito.verify(
+			extensionProviderMock1
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+		Mockito.verify(
+			extensionProviderMock2
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+	}
+
+	@Test
+	public void testValidateMissingMandatoryPropertyInPartialUpdate() {
+		ExtensionProvider extensionProviderMock1 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProviderMock2 = Mockito.mock(
+			ExtensionProvider.class);
+
+		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
+			"field1", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
+			"field2", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
+			"field3", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
+			"field4", PropertyDefinition.PropertyType.TEXT, true);
+
+		Mockito.when(
+			extensionProviderMock1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition1.getPropertyName(), propertyDefinition1
+			).put(
+				propertyDefinition2.getPropertyName(), propertyDefinition2
+			).build()
+		);
+		Mockito.when(
+			extensionProviderMock2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition3.getPropertyName(), propertyDefinition3
+			).put(
+				propertyDefinition4.getPropertyName(), propertyDefinition4
+			).build()
+		);
+
+		EntityExtensionHandler entityExtensionHandler =
+			new EntityExtensionHandler(
+				_CLASS_NAME,
+				Arrays.asList(extensionProviderMock1, extensionProviderMock2));
+
+		entityExtensionHandler.validate(
+			_COMPANY_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"field1", "value1"
+			).<String, Serializable>put(
+				"field2", "value2"
+			).<String, Serializable>put(
+				"field3", "value3"
+			).build(),
+			true);
+
+		Mockito.verify(
+			extensionProviderMock1
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+		Mockito.verify(
+			extensionProviderMock2
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateUnknownProperty() {
+		ExtensionProvider extensionProviderMock1 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProviderMock2 = Mockito.mock(
+			ExtensionProvider.class);
+
+		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
+			"field1", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
+			"field2", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
+			"field3", PropertyDefinition.PropertyType.TEXT, false);
+		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
+			"field4", PropertyDefinition.PropertyType.TEXT, true);
+
+		Mockito.when(
+			extensionProviderMock1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition1.getPropertyName(), propertyDefinition1
+			).put(
+				propertyDefinition2.getPropertyName(), propertyDefinition2
+			).build()
+		);
+		Mockito.when(
+			extensionProviderMock2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				propertyDefinition3.getPropertyName(), propertyDefinition3
+			).put(
+				propertyDefinition4.getPropertyName(), propertyDefinition4
+			).build()
+		);
+
+		EntityExtensionHandler entityExtensionHandler =
+			new EntityExtensionHandler(
+				_CLASS_NAME,
+				Arrays.asList(extensionProviderMock1, extensionProviderMock2));
+
+		entityExtensionHandler.validate(
+			_COMPANY_ID,
+			HashMapBuilder.<String, Serializable>put(
+				"field1", "value1"
+			).<String, Serializable>put(
+				"field2", "value2"
+			).<String, Serializable>put(
+				"field3", "value3"
+			).<String, Serializable>put(
+				"field4", "value4"
+			).<String, Serializable>put(
+				"unknownField", "value5"
+			).build(),
+			false);
+
+		Mockito.verify(
+			extensionProviderMock1
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+		Mockito.verify(
+			extensionProviderMock2
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
 		);
 	}
 


### PR DESCRIPTION
This PR contains the initial validation for the new API Extensibility Framework, it also provides the base validation of a group of primitive properties as well as other more complex types.

The `PropertyDefinition` class now contains a `Class<?> _propertyClass` parameter that will indicate for a given property definition, which class should implement. That will be used in the default validator as follows:

- For "primitive" property types (such as Boolean, Integer, etc): to check if the property is instanced by the indicated class:
- For more "complex" fields (such as Objects, relationships, arrays, etc): to check if the property might be mapped by ObjectMapper using that class.

Those behaviour could be overriden by defining a proper validator, implementing the `PropertyValidator` interface or extending the `DefaultPropertyValidator` class.

For example, in the specific case of Objects functionality, it could be helpful:

```
public class ObjectEntryPropertyValidator extends DefaultPropertyValidator {

	public ObjectEntryPropertyValidator(ObjectDefinition objectDefinition) {
		_objectDefinition = objectDefinition;
	}

	@Override
	public void validate(
		PropertyDefinition propertyDefinition, Object fieldValue) {

		PropertyDefinition.PropertyType propertyType =
			propertyDefinition.getPropertyType();

		if (propertyType == PropertyDefinition.PropertyType.SINGLE_ELEMENT) {
			// do something, it could be a oneToMany element related

		}
		else if (propertyType ==
					PropertyDefinition.PropertyType.MULTIPLE_ELEMENT) {
			// do something, it could be a list of manyToMany elements related

		}

		super.validate(propertyDefinition, fieldValue);
	}

	private final ObjectDefinition _objectDefinition;

}
```

To provide a specific Property Validator, it is just necessary to include the validator when creating the PropertyDefinition through its constructor, for example, for a oneToMany relationship:

```
@Component(immediate = true, service = ExtensionProvider.class)
public class ObjectEntryExtensionProvider implements ExtensionProvider {

	[...]

	@Override
	public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(
		long companyId, String className) {

		ObjectDefinition objectDefinition = _getObjectDefinition(
			companyId, className);

		Map<String, PropertyDefinition> extendedPropertyMap = new HashMap<>();

		[...]

		for (ObjectRelationship objectRelationship :
				_getObjectRelationships(objectDefinition)) {

			[...]
			
			extendedPropertyMap.put(
				objectRelationship.getName(),
				new PropertyDefinition(
					ObjectEntry.class, objectRelationship.getName(), propertyType,
					new ObjectEntryPropertyValidator(relatedObjectDefinition),
					false));
		}

		return extendedPropertyMap;
	}
```