### PR TITLE
LPS-153144, LPS-153145, LPS-153146, LPS-153149 | Add test cases to filter and sort draft web content | Headless

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -88,6 +88,23 @@ definition {
 		return "${articleId}";
 	}
 
+	macro _allStructuredContent {
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _createStructuredContent {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority}");
 
@@ -190,6 +207,22 @@ definition {
 		return "${curl}";
 	}
 
+	macro _deleteStructuredContent {
+		Variables.assertDefined(parameterList = "${structuredContentId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/structured-contents/${structuredContentId} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.delete("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _editStructuredContent {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority},${structuredContentId}");
 
@@ -221,6 +254,44 @@ definition {
 		''';
 
 		var curl = JSONCurlUtil.put("${curl}");
+
+		return "${curl}";
+	}
+
+	macro _filterAdminStructuredContent {
+		Variables.assertDefined(parameterList = "${filtervalue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
+	macro _filterAndSortAdminStructuredContent {
+		Variables.assertDefined(parameterList = "${filtervalue},${sortvalue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/sites/${siteId}/structured-contents?filter=${filtervalue}\&sort=${sortvalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
 
 		return "${curl}";
 	}
@@ -335,6 +406,14 @@ definition {
 			expected = "${editStructuredContentId}");
 	}
 
+	macro assertTitleFieldWithCorrectName {
+		var actualTitleName = JSONUtil.getWithJSONPath("${responseToParse}", "$..title");
+
+		TestUtils.assertEquals(
+			actual = "${actualTitleName}",
+			expected = "${expectedTitleName}");
+	}
+
 	macro createStructuredContent {
 		if (!(isSet(priority))) {
 			var priority = "";
@@ -389,6 +468,20 @@ definition {
 		return "${response}";
 	}
 
+	macro deleteAllStructuredContent {
+		var structuredContentId = ListUtil.newListFromString("${structuredContentId}");
+
+		var size = ListUtil.size("${structuredContentId}");
+		var i = "0";
+
+		while ("${i}" != "${size}") {
+			var locale = ListUtil.get("${structuredContentId}", "${i}");
+
+			var response = HeadlessWebcontentAPI._deleteStructuredContent(structuredContentId = "${locale}");
+			var i = ${i} + 1;
+		}
+	}
+
 	macro editStructuredContent {
 		Variables.assertDefined(parameterList = "${responseToParse},${data},${ddmStructureId},${label},${name},${priority},${title}");
 
@@ -406,6 +499,20 @@ definition {
 			priority = "${priority}",
 			structuredContentId = "${structuredContentId}",
 			title = "${title}");
+
+		return "${response}";
+	}
+
+	macro filterAdminStructuredContent {
+		var response = HeadlessWebcontentAPI._filterAdminStructuredContent(filtervalue = "${filtervalue}");
+
+		return "${response}";
+	}
+
+	macro filterAndSortAdminStructuredContent {
+		var response = HeadlessWebcontentAPI._filterAndSortAdminStructuredContent(
+			filtervalue = "${filtervalue}",
+			sortvalue = "${sortvalue}");
 
 		return "${response}";
 	}
@@ -430,6 +537,14 @@ definition {
 		var idFromResponse = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
 
 		return "${idFromResponse}";
+	}
+
+	macro returnAllstructuredContentId {
+		var response = HeadlessWebcontentAPI._allStructuredContent();
+
+		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..id");
+
+		return "${structuredContentId}";
 	}
 
 	macro sortStructureContent {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
@@ -85,7 +85,7 @@ definition {
 
 		task ("Then the response body only includes items with priority 1.0") {
 			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
-				expectedTitleName = "Web Content 2,Web Content 1",
+				expectedTitleName = "Web Content 1,Web Content 2",
 				responseToParse = "${response}");
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
@@ -1,0 +1,142 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("Given I create four structuredContent draft with different priority field set") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var responseToParse1 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1.0",
+				title = "Web Content 1");
+			var responseToParse2 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "1.0",
+				title = "Web Content 2");
+			var responseToParse3 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "2.99",
+				title = "Web Content 3");
+			var responseToParse4 = HeadlessWebcontentAPI.createStructuredContentDraft(
+				data = "Text",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				priority = "0.99",
+				title = "Web Content 4");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			var response = HeadlessWebcontentAPI.returnAllstructuredContentId();
+
+			HeadlessWebcontentAPI.deleteAllStructuredContent(structuredContentId = "${response}");
+
+			WebContentStructures.tearDownCP();
+		}
+	}
+
+	@priority = "4"
+	test CanFilterEqualToPriorityValuesSortedByPriorityAscendingByDefault {
+		property portal.acceptance = "true";
+
+		task ("When web contents are filtered with 1.0 priority and sorted with default priority") {
+			var response = HeadlessWebcontentAPI.filterAndSortAdminStructuredContent(
+				filtervalue = "priority%20eq%201.0",
+				sortvalue = "priority");
+		}
+
+		task ("Then the response body only includes items with priority 1.0") {
+			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
+				expectedTitleName = "Web Content 2,Web Content 1",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanFilterGreaterEqualPriorityValues {
+		property portal.acceptance = "true";
+
+		task ("When web contents are filtered with priority greater than to 0.99") {
+			var response = HeadlessWebcontentAPI.filterAdminStructuredContent(filtervalue = "priority%20ge%200.99");
+		}
+
+		task ("Then the response body only includes items with priority  greater than to 0.99") {
+			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
+				expectedTitleName = "Web Content 1,Web Content 2,Web Content 3,Web Content 4",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanFilterGreaterThanPriorityValuesSortedDescending {
+		property portal.acceptance = "true";
+
+		task ("When web contents are filtered with greater than 0.99 priority and sorted with descending priority") {
+			var response = HeadlessWebcontentAPI.filterAndSortAdminStructuredContent(
+				filtervalue = "priority%20gt%200.99",
+				sortvalue = "priority%3Adesc");
+		}
+
+		task ("Then the response body only includes items with priority greater than 0.99") {
+			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
+				expectedTitleName = "Web Content 3,Web Content 1,Web Content 2",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanFilterNotEqualToPriorityValuesSortedAscending {
+		property portal.acceptance = "true";
+
+		task ("When web contents are filtered with not equal to 1.0 priority and sorted with ascending priority") {
+			var response = HeadlessWebcontentAPI.filterAndSortAdminStructuredContent(
+				filtervalue = "priority%20ne%201.0",
+				sortvalue = "priority%3Aasc");
+		}
+
+		task ("Then the response body only includes itens without priority 1.0") {
+			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
+				expectedTitleName = "Web Content 4,Web Content 3",
+				responseToParse = "${response}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background:** 
PR resubmitted due to rebase issues mentioned in this [comment](https://github.com/brianchandotcom/liferay-portal/pull/119962#issuecomment-1176371866)
[liferay-frontend#2450](https://github.com/liferay-frontend/liferay-portal/pull/2450)

**Background to all the tests listed below:**
**Given** a content structure with a content-field of dataType "string" and label "content" and name "content" created in the portal
**And Given** with Headless Admin Content POST "/v1.0/sites/ {siteId}/structured-contents/draft" a structured content draft "content1" with a priority 1.0 set is created
**And Given** with Headless Admin Content POST "/v1.0/sites/{siteId}
/structured-contents/draft" a structured content draft "content2" with a priority 1.0 set is created
**And Given** with Headless Admin Content POST "/v1.0/sites/ {siteId}/structured-contents/draft" a structured content draft "content3" with a priority 2.99 set is created
**And Given** with Headless Admin Content POST "/v1.0/sites/{siteId}
/structured-contents/draft" a structured content draft "content4" with a priority 0.99 set is created

**Test Plan**
[CanFilterEqualToPriorityValuesSortedByPriorityAscendingByDefault](https://issues.liferay.com/browse/LPS-153144)
**When** with Headless Admin Content GET "/v1.0/sites/{siteId}/structured-contents" and filter set to "priority eq 1.0" and sort set to "priority"
**Then** I should see in response "content1" and "content2"

[CanFilterNotEqualToPriorityValuesSortedAscending](https://issues.liferay.com/browse/LPS-153145) | 
**When** with Headless Admin Content GET "/v1.0/sites/{siteId}/structured-contents" and filter set to "priority ne 1.0" and sort set to "priority:asc"
**Then** I should see in response "content3" and "content4" sorted by priority in ascending order

[CanFilterGreaterThanPriorityValuesSortedDescending](https://issues.liferay.com/browse/LPS-153146) |
**When** with Headless Admin Content GET "/v1.0/sites/{siteId}/structured-contents" and filter set to "priority gt 0.99" and sort set to "priority:desc"
**Then** I should see in response "content1", "content2" and "content3" sorted by priority in descending order

[CanFilterGreaterEqualPriorityValues](https://issues.liferay.com/browse/LPS-153149) | 
**When** with Headless Admin Content GET "/v1.0/sites/ {siteId}/structured-contents" and filter set to "priority ge 0.99"
**Then** I should see in response "content1", "content2", "content3" and "content4"