### PR TITLE
LPS-153319 Add set/update extended properties validation tests and randomize others

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
@@ -1,0 +1,319 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.extension.validation;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+
+import java.io.Serializable;
+
+import java.math.BigDecimal;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Map;
+
+import javax.validation.ValidationException;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Carlos Correa
+ */
+public class DefaultPropertyValidatorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testValidateBigDecimal() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.BIG_DECIMAL,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, new BigDecimal(RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testValidateBoolean() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.BOOLEAN, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testValidateDateTime() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			String.class, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.DATE_TIME, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, _dateFormat.format(RandomTestUtil.nextDate()));
+	}
+
+	@Test
+	public void testValidateDecimal() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.DECIMAL, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomFloat());
+	}
+
+	@Test
+	public void testValidateDouble() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.DOUBLE, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomDouble());
+	}
+
+	@Test
+	public void testValidateInteger() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.INTEGER, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomInt());
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidBigDecimal() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.BIG_DECIMAL,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomString());
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidDateTime() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			String.class, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.DATE_TIME, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomString());
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidMultipleElements() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestInvalidClass.class, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition,
+			new Map[] {_getTestClassAsMap(), _getTestClassAsMap()});
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidSingleElement() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestInvalidClass.class, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, _getTestClassAsMap());
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateInvalidValue() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.BOOLEAN, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testValidateLong() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(), PropertyDefinition.PropertyType.LONG,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testValidateMultipleElements() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestClass.class, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition,
+			new Map[] {_getTestClassAsMap(), _getTestClassAsMap()});
+	}
+
+	@Test(expected = ValidationException.class)
+	public void testValidateNullClass() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			null, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.BOOLEAN, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomBoolean());
+	}
+
+	@Test
+	public void testValidateSingleElement() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			TestClass.class, RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, _getTestClassAsMap());
+	}
+
+	@Test
+	public void testValidateText() {
+		DefaultPropertyValidator defaultPropertyValidator =
+			new DefaultPropertyValidator();
+
+		PropertyDefinition propertyDefinition = new PropertyDefinition(
+			RandomTestUtil.randomString(), PropertyDefinition.PropertyType.TEXT,
+			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomString());
+	}
+
+	public static class TestClass implements Serializable {
+
+		public String getField1() {
+			return _field1;
+		}
+
+		public String getField2() {
+			return _field2;
+		}
+
+		public Long getField3() {
+			return _field3;
+		}
+
+		public void setField1(String field1) {
+			_field1 = field1;
+		}
+
+		public void setField2(String field2) {
+			_field2 = field2;
+		}
+
+		public void setField3(Long field3) {
+			_field3 = field3;
+		}
+
+		private String _field1;
+		private String _field2;
+		private Long _field3;
+
+	}
+
+	public static class TestInvalidClass implements Serializable {
+	}
+
+	private Map<String, Object> _getTestClassAsMap() {
+		return new HashMapBuilder<>().<String, Object>put(
+			"field1", RandomTestUtil.randomString()
+		).<String, Object>put(
+			"field2", RandomTestUtil.randomString()
+		).<String, Object>put(
+			"field3", RandomTestUtil.randomLong()
+		).build();
+	}
+
+	private static final DateFormat _dateFormat = new SimpleDateFormat(
+		"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.vulcan.internal.extension;
 
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
@@ -60,8 +61,13 @@ public class EntityExtensionHandlerTest {
 
 	@Test
 	public void testGetExtendedProperties() throws Exception {
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyValue1 = RandomTestUtil.randomString();
+		long propertyValue2 = RandomTestUtil.randomLong();
+
 		Map<String, Serializable> testMap1 = Collections.singletonMap(
-			"test1", "test");
+			propertyName1, propertyValue1);
 
 		Mockito.when(
 			_mockedExtensionProvider1.getExtendedProperties(
@@ -71,7 +77,7 @@ public class EntityExtensionHandlerTest {
 		);
 
 		Map<String, Serializable> testMap2 = Collections.singletonMap(
-			"test2", 5);
+			propertyName2, propertyValue2);
 
 		Mockito.when(
 			_mockedExtensionProvider2.getExtendedProperties(
@@ -97,13 +103,18 @@ public class EntityExtensionHandlerTest {
 
 		Assert.assertEquals(
 			extendedProperties.toString(), 2, extendedProperties.size());
-		Assert.assertEquals("test", extendedProperties.get("test1"));
-		Assert.assertEquals(5, extendedProperties.get("test2"));
+		Assert.assertEquals(
+			propertyValue1, extendedProperties.get(propertyName1));
+		Assert.assertEquals(
+			propertyValue2, extendedProperties.get(propertyName2));
 	}
 
 	@Test
 	public void testGetFilteredPropertyNames() {
-		Set<String> testSet1 = Collections.singleton("test1");
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+
+		Set<String> testSet1 = Collections.singleton(propertyName1);
 
 		Mockito.doReturn(
 			testSet1
@@ -113,7 +124,7 @@ public class EntityExtensionHandlerTest {
 			Mockito.anyLong(), Mockito.anyObject()
 		);
 
-		Set<String> testSet2 = Collections.singleton("test2");
+		Set<String> testSet2 = Collections.singleton(propertyName2);
 
 		Mockito.doReturn(
 			testSet2
@@ -141,31 +152,36 @@ public class EntityExtensionHandlerTest {
 
 		Assert.assertEquals(
 			filteredProperties.toString(), 2, filteredProperties.size());
-		Assert.assertTrue(filteredProperties.contains("test1"));
-		Assert.assertTrue(filteredProperties.contains("test2"));
+		Assert.assertTrue(filteredProperties.contains(propertyName1));
+		Assert.assertTrue(filteredProperties.contains(propertyName2));
 	}
 
 	@Test
 	public void testSetExtendedProperties() throws Exception {
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyValue1 = RandomTestUtil.randomString();
+		long propertyValue2 = RandomTestUtil.randomLong();
+
 		Map<String, Serializable> testExtendedProperties =
 			HashMapBuilder.<String, Serializable>put(
-				"test1", "test"
+				propertyName1, propertyValue1
 			).put(
-				"test2", 5
+				propertyName2, propertyValue2
 			).build();
 
 		Mockito.when(
 			_mockedExtensionProvider1.getExtendedPropertyDefinitions(
 				Mockito.anyLong(), Mockito.anyString())
 		).thenReturn(
-			Collections.singletonMap("test1", null)
+			Collections.singletonMap(propertyName1, null)
 		);
 
 		Mockito.when(
 			_mockedExtensionProvider2.getExtendedPropertyDefinitions(
 				Mockito.anyLong(), Mockito.anyString())
 		).thenReturn(
-			Collections.singletonMap("test2", null)
+			Collections.singletonMap(propertyName2, null)
 		);
 
 		_entityExtensionHandler.setExtendedProperties(
@@ -187,14 +203,14 @@ public class EntityExtensionHandlerTest {
 			_mockedExtensionProvider1
 		).setExtendedProperties(
 			Mockito.eq(_COMPANY_ID), Mockito.eq(_OBJECT),
-			Mockito.eq(Collections.singletonMap("test1", "test"))
+			Mockito.eq(Collections.singletonMap(propertyName1, propertyValue1))
 		);
 
 		Mockito.verify(
 			_mockedExtensionProvider2
 		).setExtendedProperties(
 			Mockito.eq(_COMPANY_ID), Mockito.eq(_OBJECT),
-			Mockito.eq(Collections.singletonMap("test2", 5))
+			Mockito.eq(Collections.singletonMap(propertyName2, propertyValue2))
 		);
 	}
 
@@ -205,14 +221,19 @@ public class EntityExtensionHandlerTest {
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
 			ExtensionProvider.class);
 
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyName3 = RandomTestUtil.randomString();
+		String propertyName4 = RandomTestUtil.randomString();
+
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			"field1", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			"field2", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			"field3", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			"field4", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName4, PropertyDefinition.PropertyType.TEXT, false);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -244,13 +265,13 @@ public class EntityExtensionHandlerTest {
 		entityExtensionHandler.validate(
 			_COMPANY_ID,
 			HashMapBuilder.<String, Serializable>put(
-				"field1", "value1"
+				propertyName1, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field2", "value2"
+				propertyName2, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field3", "value3"
+				propertyName3, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field4", "value4"
+				propertyName4, RandomTestUtil.randomString()
 			).build(),
 			false);
 
@@ -274,14 +295,19 @@ public class EntityExtensionHandlerTest {
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
 			ExtensionProvider.class);
 
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyName3 = RandomTestUtil.randomString();
+		String propertyName4 = RandomTestUtil.randomString();
+
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			"field1", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			"field2", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			"field3", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			"field4", PropertyDefinition.PropertyType.TEXT, true);
+			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -313,13 +339,13 @@ public class EntityExtensionHandlerTest {
 		entityExtensionHandler.validate(
 			_COMPANY_ID,
 			HashMapBuilder.<String, Serializable>put(
-				"field1", 1L
+				propertyName1, RandomTestUtil.randomLong()
 			).<String, Serializable>put(
-				"field2", "value2"
+				propertyName2, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field3", "value3"
+				propertyName3, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field4", "value4"
+				propertyName4, RandomTestUtil.randomString()
 			).build(),
 			false);
 
@@ -343,14 +369,19 @@ public class EntityExtensionHandlerTest {
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
 			ExtensionProvider.class);
 
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyName3 = RandomTestUtil.randomString();
+		String propertyName4 = RandomTestUtil.randomString();
+
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			"field1", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			"field2", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			"field3", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			"field4", PropertyDefinition.PropertyType.TEXT, true);
+			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -382,11 +413,11 @@ public class EntityExtensionHandlerTest {
 		entityExtensionHandler.validate(
 			_COMPANY_ID,
 			HashMapBuilder.<String, Serializable>put(
-				"field1", "value1"
+				propertyName1, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field2", "value2"
+				propertyName2, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field3", "value3"
+				propertyName3, RandomTestUtil.randomString()
 			).build(),
 			false);
 
@@ -410,14 +441,19 @@ public class EntityExtensionHandlerTest {
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
 			ExtensionProvider.class);
 
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyName3 = RandomTestUtil.randomString();
+		String propertyName4 = RandomTestUtil.randomString();
+
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			"field1", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			"field2", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			"field3", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			"field4", PropertyDefinition.PropertyType.TEXT, true);
+			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -449,11 +485,11 @@ public class EntityExtensionHandlerTest {
 		entityExtensionHandler.validate(
 			_COMPANY_ID,
 			HashMapBuilder.<String, Serializable>put(
-				"field1", "value1"
+				propertyName1, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field2", "value2"
+				propertyName2, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field3", "value3"
+				propertyName3, RandomTestUtil.randomString()
 			).build(),
 			true);
 
@@ -477,14 +513,19 @@ public class EntityExtensionHandlerTest {
 		ExtensionProvider extensionProviderMock2 = Mockito.mock(
 			ExtensionProvider.class);
 
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		String propertyName3 = RandomTestUtil.randomString();
+		String propertyName4 = RandomTestUtil.randomString();
+
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			"field1", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			"field2", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			"field3", PropertyDefinition.PropertyType.TEXT, false);
+			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			"field4", PropertyDefinition.PropertyType.TEXT, true);
+			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -516,15 +557,15 @@ public class EntityExtensionHandlerTest {
 		entityExtensionHandler.validate(
 			_COMPANY_ID,
 			HashMapBuilder.<String, Serializable>put(
-				"field1", "value1"
+				propertyName1, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field2", "value2"
+				propertyName2, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field3", "value3"
+				propertyName3, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"field4", "value4"
+				propertyName4, RandomTestUtil.randomString()
 			).<String, Serializable>put(
-				"unknownField", "value5"
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
 			).build(),
 			false);
 

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 13.1.1
+Bundle-Version: 13.2.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
@@ -78,6 +78,19 @@ public class RandomTestUtil {
 		return enumConstants[_random.nextInt(enumConstants.length)];
 	}
 
+	public static float randomFloat() {
+		float value = _random.nextFloat();
+
+		if (value > 0) {
+			return value;
+		}
+		else if (value == 0) {
+			return randomFloat();
+		}
+
+		return -value;
+	}
+
 	public static int randomInt() {
 		return randomInt(1, Integer.MAX_VALUE);
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.0
+version 5.2.0


### PR DESCRIPTION
Related PR: https://github.com/brianchandotcom/liferay-portal/pull/119985

This PR contains unit tests for validating the Default Property Validator implemented for the Set/Update extended properties functionality for the APIs.

Furthermore, the tests of the `EntityExtensionHandler` class have been randomized.