### PR TITLE
LPS-157796 - Only render header JS and header CSS if combo loader is disabled

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPathsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/PortletPathsUtil.java
@@ -216,33 +216,44 @@ public class PortletPathsUtil {
 				headerJavaScriptSet.add(headerPortalJavaScript);
 			}
 
-			for (String headerPortletCss : portlet.getHeaderPortletCss()) {
-				if (!HttpComponentsUtil.hasProtocol(headerPortletCss)) {
-					headerPortletCss =
-						portlet.getStaticResourcePath() + headerPortletCss;
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
 
-					headerPortletCss = PortalUtil.getStaticResourceURL(
-						httpServletRequest, headerPortletCss,
-						rootPortlet.getTimestamp());
+			if (!themeDisplay.isThemeCssFastLoad()) {
+				for (String headerPortletCss : portlet.getHeaderPortletCss()) {
+					if (!HttpComponentsUtil.hasProtocol(headerPortletCss)) {
+						headerPortletCss =
+							portlet.getStaticResourcePath() + headerPortletCss;
+
+						headerPortletCss = PortalUtil.getStaticResourceURL(
+							httpServletRequest, headerPortletCss,
+							rootPortlet.getTimestamp());
+					}
+
+					headerCssSet.add(headerPortletCss);
 				}
-
-				headerCssSet.add(headerPortletCss);
 			}
 
-			for (String headerPortletJavaScript :
-					portlet.getHeaderPortletJavaScript()) {
+			if (!themeDisplay.isThemeJsFastLoad()) {
+				for (String headerPortletJavaScript :
+						portlet.getHeaderPortletJavaScript()) {
 
-				if (!HttpComponentsUtil.hasProtocol(headerPortletJavaScript)) {
-					headerPortletJavaScript =
-						portlet.getStaticResourcePath() +
-							headerPortletJavaScript;
+					if (!HttpComponentsUtil.hasProtocol(
+							headerPortletJavaScript)) {
 
-					headerPortletJavaScript = PortalUtil.getStaticResourceURL(
-						httpServletRequest, headerPortletJavaScript,
-						rootPortlet.getTimestamp());
+						headerPortletJavaScript =
+							portlet.getStaticResourcePath() +
+								headerPortletJavaScript;
+
+						headerPortletJavaScript =
+							PortalUtil.getStaticResourceURL(
+								httpServletRequest, headerPortletJavaScript,
+								rootPortlet.getTimestamp());
+					}
+
+					headerJavaScriptSet.add(headerPortletJavaScript);
 				}
-
-				headerJavaScriptSet.add(headerPortletJavaScript);
 			}
 		}
 


### PR DESCRIPTION
Not really sure if this is really the proper place to add these checks, but I couldn't really find a better place to do so.

Before (the bottom 3 requests duplicate the CSS found in the combo):
![Screen Shot 2022-07-07 at 1 58 57 PM](https://user-images.githubusercontent.com/6843530/177747581-f25d000f-d878-461c-8feb-e492c73e993a.png)

After:
![Screen Shot 2022-07-07 at 2 03 13 PM](https://user-images.githubusercontent.com/6843530/177748123-be6321cb-5962-409a-a15a-9155924d21d6.png)

