### PR TITLE
LPS-157815 - Set user config cookie when setting cookie preferences

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
@@ -17,6 +17,7 @@ import {
 	declineAllCookies,
 	getCookie,
 	setCookie,
+	setUserConfigCookie,
 } from '../../js/CookiesUtil';
 
 export default function ({
@@ -70,6 +71,8 @@ export default function ({
 				requiredConsentCookieTypeNames
 			);
 
+			setUserConfigCookie();
+
 			window.location.reload();
 		});
 
@@ -87,6 +90,8 @@ export default function ({
 				}
 			);
 
+			setUserConfigCookie();
+
 			window.location.reload();
 		});
 
@@ -95,6 +100,8 @@ export default function ({
 				optionalConsentCookieTypeNames,
 				requiredConsentCookieTypeNames
 			);
+
+			setUserConfigCookie();
 
 			window.location.reload();
 		});


### PR DESCRIPTION
### References

- [LPS-157815](https://issues.liferay.com/browse/LPS-157815)

### What is the goal?

* Set `USER_CONSENT_CONFIGURED` cookie when user sets cookie preferences from outside banner

### What does it look like?


https://user-images.githubusercontent.com/6642927/177975961-ef34065f-8753-4fcd-8c1d-7c8d794cf184.mov





### How to replicate
* Enable feature flag: feature.flag.[LPS-142518](https://issues.liferay.com/browse/LPS-142518)=true
* Create a new page
* Add Cookie Banner Configuration portlet on it
* Load the page in incognito web browser
* Modify the cookie toggle switches
* Confirm the selection
* See that when the page is reloaded, the settings are the selected ones

