### PR TITLE
LPS-157881 Makes the Walkthrough step return to step 0 when it finishes the flow

### DIFF
--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -369,7 +369,7 @@ const Step = ({
 										<ClayButton
 											onClick={() => {
 												setPopoverVisible(false);
-												onCurrentStep(null);
+												onCurrentStep(0);
 											}}
 											small
 										>


### PR DESCRIPTION
## Recording

[Screencast from 07-08-2022 04:03:31 PM.webm](https://user-images.githubusercontent.com/7663513/178054906-c4e671fc-9de2-4e58-b180-2a138017aeb2.webm)

## What it does

It will set the localStorage/React state sync to 0 instead of `null,` which `null` makes it render nothing, and 0 points to the first step.
