### PR TITLE
LPS-157812 Improve page matching algorithm

### DIFF
--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -82,8 +83,13 @@ public class WalkthroughBottomJSPDynamicInclude implements DynamicInclude {
 		String resolvedModuleName = _npmResolver.resolveModuleName(
 			"@liferay/frontend-js-walkthrough-web/index");
 
+		Group siteGroup = themeDisplay.getSiteGroup();
+
 		scriptData.append(
-			null, "WalkthroughRender.default(" + steps + ")",
+			null,
+			StringBundler.concat(
+				"WalkthroughRender.default(", steps, ",'",
+				siteGroup.getFriendlyURL(), "')"),
 			resolvedModuleName + " as WalkthroughRender",
 			ScriptData.ModulesType.ES6);
 

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
@@ -83,13 +83,9 @@ public class WalkthroughBottomJSPDynamicInclude implements DynamicInclude {
 		String resolvedModuleName = _npmResolver.resolveModuleName(
 			"@liferay/frontend-js-walkthrough-web/index");
 
-		Group siteGroup = themeDisplay.getSiteGroup();
-
 		scriptData.append(
 			null,
-			StringBundler.concat(
-				"WalkthroughRender.default(", steps, ",'",
-				siteGroup.getFriendlyURL(), "')"),
+			StringBundler.concat("WalkthroughRender.default(", steps, ")"),
 			resolvedModuleName + " as WalkthroughRender",
 			ScriptData.ModulesType.ES6);
 

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -323,19 +323,15 @@ const Step = ({
 
 	useObserveRect(align, popoverRef?.current);
 
-	const path = themeDisplay.getLayoutRelativeURL();
+	const currentPage = useMemo(
+		() =>
+			Object.keys(pages).find((url) =>
+				themeDisplay.getLayoutRelativeURL().includes(url)
+			),
+		[pages]
+	);
 
-	const locationURL =
-		themeDisplay.getPathContext() +
-		location.pathname +
-		location.search +
-		location.hash;
-
-	if (
-		!pages[path]?.includes(id) ||
-		!urlSearchParamsContainsAnother(path, locationURL) ||
-		!pathContainsLayoutRelativeURL(locationURL)
-	) {
+	if (!pages[currentPage]?.includes(id)) {
 		return null;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -120,40 +120,16 @@ function isVisibleInViewport(element, maybeRect) {
 }
 
 /**
- * Checks if the search parameters of the provided URL are contained in the browser's current URL.
- * @param {String} jsonPath Received path string to be checked if it contains the parameters of locationPath
- * @param {String} locationPath Received path string to be compared
- * @returns {boolean}
+ * Given a `layoutRelativeURL,` this function will match the paths
+ * of the pages contained in it and return the longest path.
+ * @param {String} currentLayoutRelativeURL
+ * @param {Array<String>} pagesArray
+ * @returns {String} longest path
  */
-function urlSearchParamsContainsAnother(jsonPath, locationPath) {
-	const locationURLInstance = new URL(locationPath, window.location.origin);
-	const jsonURLInstance = new URL(jsonPath, window.location.origin);
-
-	let contains = true;
-
-	jsonURLInstance.searchParams.forEach((value, key) => {
-		if (
-			!locationURLInstance.searchParams.has(key) ||
-			locationURLInstance.searchParams.get(key) !== value
-		) {
-			contains = false;
-		}
-	});
-
-	return contains;
-}
-
-/**
- * Checks if a given path contains a layoutRelativeURL
- * @param {String} path
- * @returns {boolean}
- */
-function pathContainsLayoutRelativeURL(path) {
-	const layoutRelativeURLWithoutSearchParams = themeDisplay
-		.getLayoutRelativeURL()
-		.split('?')[0];
-
-	return layoutRelativeURLWithoutSearchParams.includes(path);
+function findLongestMatch(currentLayoutRelativeURL, pagesArray) {
+	return pagesArray
+		.filter((pagePath) => currentLayoutRelativeURL.includes(pagePath))
+		.sort((a, b) => (a.length > b.length ? -1 : 1))[0];
 }
 
 const Step = ({
@@ -323,12 +299,11 @@ const Step = ({
 
 	useObserveRect(align, popoverRef?.current);
 
+	const currentLayoutRelativeURL = `${themeDisplay.getLayoutRelativeURL()}/`;
+
 	const currentPage = useMemo(
-		() =>
-			Object.keys(pages).find((url) =>
-				themeDisplay.getLayoutRelativeURL().includes(url)
-			),
-		[pages]
+		() => findLongestMatch(currentLayoutRelativeURL, Object.keys(pages)),
+		[pages, currentLayoutRelativeURL]
 	);
 
 	if (!pages[currentPage]?.includes(id)) {

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -149,9 +149,17 @@ const Step = ({
 	currentStep,
 	onCurrentStep,
 	pages,
+	siteGroupFriendlyURL,
 	skippable,
 	steps,
 }) => {
+
+	/**
+	 * Given a page url like:
+	 * `http://localhost:8080/web/fiona/home`, it will give us `web/fiona`
+	 */
+	const SITE_PREFIX_PATH = `/web${siteGroupFriendlyURL}`;
+
 	const popoverRef = useRef(null);
 
 	const hotspotRef = useRef(null);
@@ -310,7 +318,9 @@ const Step = ({
 
 	useObserveRect(align, popoverRef?.current);
 
-	const currentLayoutRelativeURL = themeDisplay.getLayoutRelativeURL();
+	const currentLayoutRelativeURL = themeDisplay
+		.getLayoutRelativeURL()
+		.replace(SITE_PREFIX_PATH, '');
 
 	const currentPage = useMemo(
 		() => findLongestMatch(currentLayoutRelativeURL, Object.keys(pages)),
@@ -404,7 +414,11 @@ const Step = ({
 												onPrevious(previous);
 
 												if (previous) {
-													navigate(previous);
+													navigate(
+														SITE_PREFIX_PATH.concat(
+															previous
+														)
+													);
 												}
 											}}
 											small
@@ -419,7 +433,11 @@ const Step = ({
 												onNext(next);
 
 												if (next) {
-													navigate(next);
+													navigate(
+														SITE_PREFIX_PATH.concat(
+															next
+														)
+													);
 												}
 											}}
 											small
@@ -451,6 +469,7 @@ const Walkthrough = ({
 	closeOnClickOutside,
 	closeable,
 	pages,
+	siteGroupFriendlyURL,
 	skippable,
 	steps,
 }) => {
@@ -472,6 +491,7 @@ const Walkthrough = ({
 			currentStep={currentStepIndex}
 			onCurrentStep={setCurrentStepIndex}
 			pages={pages}
+			siteGroupFriendlyURL={siteGroupFriendlyURL}
 			skippable={skippable}
 			steps={steps}
 		/>

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -120,6 +120,15 @@ function isVisibleInViewport(element, maybeRect) {
 }
 
 /**
+ * Removes search params on a given url
+ * @param {String} url
+ * @returns {String} url without the search params
+ */
+function stripSearchParams(url) {
+	return url.split('?')[0];
+}
+
+/**
  * Given a `layoutRelativeURL,` this function will match the paths
  * of the pages contained in it and return the longest path.
  * @param {String} currentLayoutRelativeURL
@@ -128,7 +137,9 @@ function isVisibleInViewport(element, maybeRect) {
  */
 function findLongestMatch(currentLayoutRelativeURL, pagesArray) {
 	return pagesArray
-		.filter((pagePath) => currentLayoutRelativeURL.includes(pagePath))
+		.filter((pagePath) =>
+			stripSearchParams(currentLayoutRelativeURL).endsWith(pagePath)
+		)
 		.sort((a, b) => (a.length > b.length ? -1 : 1))[0];
 }
 
@@ -299,7 +310,7 @@ const Step = ({
 
 	useObserveRect(align, popoverRef?.current);
 
-	const currentLayoutRelativeURL = `${themeDisplay.getLayoutRelativeURL()}/`;
+	const currentLayoutRelativeURL = themeDisplay.getLayoutRelativeURL();
 
 	const currentPage = useMemo(
 		() => findLongestMatch(currentLayoutRelativeURL, Object.keys(pages)),

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
@@ -43,6 +43,6 @@ function Root(props) {
 	return <Walkthrough {...DEFAULT_PROPS} {...props} />;
 }
 
-export default function main(props = {}) {
-	render(Root, props, getDefaultContainer());
+export default function main(props = {}, siteGroupFriendlyURL) {
+	render(Root, {...props, siteGroupFriendlyURL}, getDefaultContainer());
 }


### PR DESCRIPTION
Now, we're considering:

* Inside page definition, you are using the respective page-friendly URL
~~* We added checks for preventing other search params being considered a new page. Like adding &js_fast_load=0 may break walkthrough~~
~~* Also, we're matching if the given page URL contains layoutRelativeURL to render walkthrough~~



See: https://github.com/liferay-frontend/liferay-portal/pull/2507#issuecomment-1183622450

Link to the ticket: https://issues.liferay.com/browse/LPS-157812