### PR TITLE
Master Lps 157966 | Add test on expose erc for structured content folder in asset library

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -1,5 +1,38 @@
 definition {
 
+	macro _addSubfolderInAnExistingStructuredContentFolder {
+		Variables.assertDefined(parameterList = "${name}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(userEmailAddress))) {
+			var userEmailAddress = "test@liferay.com";
+		}
+
+		if (!(isSet(userPassword))) {
+			var userPassword = "test";
+		}
+
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/structured-content-folders/${parentStructuredContentFolderId}/structured-content-folders \
+				-u ${userEmailAddress}:${userPassword} \
+				-H accept: application/json \
+				-H Content-Type: application/json \
+				-d {
+                    "externalReferenceCode": "${externalReferenceCode}",
+                    "name": "${name}"
+				}
+		''';
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
 	macro _addWebcontentFolder {
 		Variables.assertDefined(parameterList = "${name}");
 
@@ -40,6 +73,22 @@ definition {
 		return "${response}";
 	}
 
+	macro _getStructuredContentFoldersByErcInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+            ${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/structured-content-folders/by-external-reference-code/${externalReferenceCode} \
+            -u test@liferay.com:test \
+            -H Content-Type: application/json
+        ''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro assertExternalReferenceCodeWithCorrectValue {
 		if (!(isSet(expectedExternalReferenceCodeValue))) {
 			var folderId = JSONUtil.getWithJSONPath("${responseToParse}", "$.id");
@@ -60,6 +109,14 @@ definition {
 			expected = "${expectedExternalReferenceCodeValue}");
 	}
 
+	macro assetProperNumberOfStructuredContentFolders {
+		var actualNumbers = JSONUtil.getWithJSONPath("${responseToParse}", "$..['numberOfStructuredContentFolders']");
+
+		TestUtils.assertEquals(
+			actual = "${actualNumbers}",
+			expected = "${expectedNumbers}");
+	}
+
 	macro createStructuredContentFolderInAssetLibrary {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${name}");
 
@@ -71,6 +128,37 @@ definition {
 			userEmailAddress = "${userEmailAddress}",
 			userPassword = "${userPassword}",
 			viewableBy = "${viewableBy}");
+
+		return "${response}";
+	}
+
+	macro createSubfolderInStructuredContentFolder {
+		Variables.assertDefined(parameterList = "${parentStructuredContentFolderId},${name}");
+
+		var response = HeadlessWebcontentFolderAPI._addSubfolderInAnExistingStructuredContentFolder(
+			description = "${description}",
+			externalReferenceCode = "${externalReferenceCode}",
+			name = "${name}",
+			parentStructuredContentFolderId = "${parentStructuredContentFolderId}",
+			userEmailAddress = "${userEmailAddress}",
+			userPassword = "${userPassword}",
+			viewableBy = "${viewableBy}");
+
+		return "${response}";
+	}
+
+	macro getIdOfCreateStructuredContentFolder {
+		var folderId = JSONUtil.getWithJSONPath("${responseToParse}", "$.id");
+
+		return "${folderId}";
+	}
+
+	macro getStructuredContentFoldersByErcInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+
+		var response = HeadlessWebcontentFolderAPI._getStructuredContentFoldersByErcInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -1,0 +1,78 @@
+definition {
+
+	macro _addWebcontentFolder {
+		Variables.assertDefined(parameterList = "${name}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (!(isSet(userEmailAddress))) {
+			var userEmailAddress = "test@liferay.com";
+		}
+
+		if (!(isSet(userPassword))) {
+			var userPassword = "test";
+		}
+
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/structured-content-folders";
+		}
+		else {
+			var api = "sites/${siteId}/structured-contents";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+				-u ${userEmailAddress}:${userPassword} \
+				-H accept: application/json \
+				-H Content-Type: application/json \
+				-d {
+                    "externalReferenceCode": "${externalReferenceCode}",
+                    "name": "${name}"
+				}
+		''';
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+	macro assertExternalReferenceCodeWithCorrectValue {
+		if (!(isSet(expectedExternalReferenceCodeValue))) {
+			var folderId = JSONUtil.getWithJSONPath("${responseToParse}", "$.id");
+
+			var mysqlStatement = "SELECT uuid_ FROM JournalFolder WHERE folderid = '${folderId}';";
+
+			var sqlResults = SQL.executeMySQLStatement(mysqlStatement = "${mysqlStatement}");
+
+			var uuidResult = StringUtil.regexReplaceAll("${sqlResults}", "[\r\n]", "");
+
+			var expectedExternalReferenceCodeValue = StringUtil.extractLast("${uuidResult}", "uuid_");
+		}
+
+		var actualExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
+
+		TestUtils.assertEquals(
+			actual = "${actualExternalReferenceCodeValue}",
+			expected = "${expectedExternalReferenceCodeValue}");
+	}
+
+	macro createStructuredContentFolderInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${name}");
+
+		var response = HeadlessWebcontentFolderAPI._addWebcontentFolder(
+			assetLibraryId = "${assetLibraryId}",
+			description = "${description}",
+			externalReferenceCode = "${externalReferenceCode}",
+			name = "${name}",
+			userEmailAddress = "${userEmailAddress}",
+			userPassword = "${userPassword}",
+			viewableBy = "${viewableBy}");
+
+		return "${response}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -1,0 +1,47 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	@description = "Structured content folder is created in an asset library with erc equals to uuid by default"
+	@priority = "5"
+	test StructuredContentFolderIsCreatedInAssetLibraryWithErcByDefault {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a structured content folder without a custom erc") {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				name = "Test Folder");
+		}
+
+		task ("Then a new folder is being created with the erc value equals to the uuid in the body response") {
+			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(responseToParse = "${response}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -65,4 +65,44 @@ definition {
 		}
 	}
 
+	@description = "Sub folder is created with a custom erc in structured content folder in asset library"
+	@priority = "5"
+	test SubfolderIsCreatedInStructuredContentFolderInAssetLibraryWithCustomErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder with a custom erc is created with POST request") {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("When with POST request I create a child folder with another custom erc") {
+			var folderId = HeadlessWebcontentFolderAPI.getIdOfCreateStructuredContentFolder(responseToParse = "${response}");
+
+			var response = HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
+				externalReferenceCode = "subfolder-erc",
+				name = "Sub Folder",
+				parentStructuredContentFolderId = "${folderId}");
+		}
+
+		task ("Then I can see the custom erc in the body response") {
+			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "subfolder-erc",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then a child folder is being created properly") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				externalReferenceCode = "erc");
+
+			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(
+				expectedNumbers = "1",
+				responseToParse = "${response}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -26,6 +26,27 @@ definition {
 		}
 	}
 
+	@description = "Structured content folder is created with custom erc in an asset library"
+	@priority = "5"
+	test StructuredContentFolderIsCreatedInAssetLibraryWithCustomErc {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a structured content folder without a custom erc") {
+			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${depotId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("Then a new folder is being created with the custom erc in the body response") {
+			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Structured content folder is created in an asset library with erc equals to uuid by default"
 	@priority = "5"
 	test StructuredContentFolderIsCreatedInAssetLibraryWithErcByDefault {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -32,10 +32,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a structured content folder without a custom erc") {
-			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = "${depotId}",
+				assetLibraryId = "${assetLibraryId}",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -53,10 +53,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a structured content folder without a custom erc") {
-			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = "${depotId}",
+				assetLibraryId = "${assetLibraryId}",
 				name = "Test Folder");
 		}
 
@@ -71,10 +71,10 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with POST request") {
-			var depotId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
 
 			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
-				assetLibraryId = "${depotId}",
+				assetLibraryId = "${assetLibraryId}",
 				externalReferenceCode = "erc",
 				name = "Test Folder");
 		}
@@ -96,7 +96,45 @@ definition {
 
 		task ("And Then a child folder is being created properly") {
 			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
-				assetLibraryId = "${depotId}",
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+
+			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(
+				expectedNumbers = "1",
+				responseToParse = "${response}");
+		}
+	}
+
+	@description = "Sub folder is created with erc equals to uuid by default in structured content folder in asset library"
+	@priority = "5"
+	test SubfolderIsCreatedInStructuredContentInAssetLibraryWithErcByDefault {
+		property database.types = "mysql";
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder with a custom erc is created with POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("When with POST request I create a child folder without custom erc") {
+			var folderId = HeadlessWebcontentFolderAPI.getIdOfCreateStructuredContentFolder(responseToParse = "${response}");
+
+			var response = HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
+				name = "Sub Folder",
+				parentStructuredContentFolderId = "${folderId}");
+		}
+
+		task ("Then I can see the custom erc in the body response") {
+			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(responseToParse = "${response}");
+		}
+
+		task ("And Then a child folder is being created properly") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
 				externalReferenceCode = "erc");
 
 			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(


### PR DESCRIPTION
Background
- Add test to create structured content folder with erc by default in asset library
- Add test to create a structured content folder with custom erc in asset library
- Add test to create subfolder with custom erc in structured content folder in asset library
- Add test to create a structured content subfolder with erc by default in asset library

**Test Plan**
- LPS-157667
Given asset library is created
And Given a structured content with a custom erc is created with a POST request in asset library
When with POST I create a structured content with an existing erc
Then I receive an error code response
And Then another structured content with same erc is not being created
- LPS-157975
Given asset library is created
When with POST request I create a structured content folder without a custom erc
Then a new folder is being created
And Then I can see the default erc value equals to the id in the body response
- LPS-157990
Given asset library is created
And Given a structured content folder with a custom erc is created with a POST request
When I create a child folder without custom erc with POST ${parentStructuredContentFolderId}/structured-content-folders
Then a child folder is being created
And Then I can see the erc value equals to internal id of the sub structured content folder in the body response
- LPS-157989
Given asset library is created
And Given a structured content folder with a custom erc is created with a POST request
When I create a child folder with another custom erc with POST ${parentStructuredContentFolderId}/structured-content-folders
Then a child folder is being created
And Then I can see the custom erc in the body response

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-157966
- https://issues.liferay.com/browse/LPS-157975
- https://issues.liferay.com/browse/LPS-157990
- https://issues.liferay.com/browse/LPS-157989