### PR TITLE
LPS-158066 Enable setting of a default FDS view

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 9.0.1
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.frontend.data.set.constants,\
 	com.liferay.frontend.data.set.filter,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/FDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/FDSView.java
@@ -40,4 +40,8 @@ public interface FDSView {
 
 	public String getThumbnail();
 
+	public default boolean isDefault() {
+		return false;
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/cards/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/cards/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/list/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/list/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/selectable/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/selectable/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/timeline/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/timeline/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/FDSViewSerializerImpl.java
@@ -52,6 +52,8 @@ public class FDSViewSerializerImpl implements FDSViewSerializer {
 				"contentRendererModuleURL",
 				fdsView.getContentRendererModuleURL()
 			).put(
+				"default", fdsView.isDefault()
+			).put(
 				"label",
 				LanguageUtil.get(
 					ResourceBundleUtil.getBundle(

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -64,6 +64,11 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 	}
 
 	@Override
+	public boolean isDefault() {
+		return true;
+	}
+
+	@Override
 	public boolean isQuickActionsEnabled() {
 		return true;
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -141,7 +141,9 @@ const FrontendDataSet = ({
 	const [total, setTotal] = useState(0);
 
 	const getInitialViewsState = () => {
-		let initialActiveView = views[0];
+		let initialActiveView =
+			views.find(({default: defaultProp}) => defaultProp) || views[0];
+
 		let initialVisibleFieldNames = {};
 
 		if (activeViewSettings) {


### PR DESCRIPTION
### References

- [LPS-158066 Enable setting of a default FDS view](https://issues.liferay.com/browse/LPS-158066)
- Related to https://github.com/liferay-frontend/liferay-portal/pull/2485

### What is the goal of this PR?

We are adding a new `isDefault` property of `FDSView`, a boolean that determines if that view is default. Since FDS now [supports multiple views](https://github.com/liferay-frontend/liferay-portal/pull/2481), we need a mechanism to set a default view. Taking a first one in the list is not a good solution. 

Notes:
- We are setting `table` as the default view for `customized` view, as that view is the most complex, showcases the most features.
- Rename of `default` to `defaultProp` in frontend in necessary because `default` is a keyword in JavaScript.


### What does it look like?

No changes in UI for the general component. In the sample FDS module, `table` view will be opened by default.

### Steps to reproduce

Place `frontend-data-set-sample-web` as a widget on any page.

If you have already used the sample module, and changed the view, your previous selection will be persisted. To see the new default, you need to reset this persistence. You can make a new database, or comment out [this block of code related to activeViewSettings](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js#L147-L161).