### PR TITLE
LPS-153152 Add Test Autom. StructuredContentFilteringAndSorting#CanInvokeAllStructuredContentCreated

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -397,6 +397,7 @@ definition {
 	macro _versionStructureContent {
 		if (!(isSet(structuredContentId))) {
 			Variables.assertDefined(parameterList = "${responseToParse},${versionvalue}");
+
 			var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
 		}
 		else {
@@ -614,9 +615,9 @@ definition {
 
 	macro returnAllstructuredContentId {
 		var response = HeadlessWebcontentAPI._allStructuredContent();
-			
+
 		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..['items'][?(@.creator)].id");
-		
+
 		return "${structuredContentId}";
 	}
 
@@ -651,23 +652,22 @@ definition {
 			var allStructuredContentId = HeadlessWebcontentAPI.returnAllstructuredContentId();
 
 			var structuredContentId = ListUtil.newListFromString("${allStructuredContentId}");
+
 			var size = ListUtil.size("${structuredContentId}");
 			var i = "0";
 			var response = "";
+
 			while ("${i}" != "${size}") {
 				var locale = ListUtil.get("${structuredContentId}", "${i}");
 
 				var responseuni = HeadlessWebcontentAPI._versionStructureContent(
 					structuredContentId = "${locale}",
 					versionvalue = "${versionvalue}");
-
 				var i = ${i} + 1;
-
 				var actualTitleName = JSONUtil.getWithJSONPath("${responseuni}", "$..title");
-				
+
 				var response = StringUtil.add("${response}", "${actualTitleName}");
 			}
-
 		}
 		else {
 			var response = HeadlessWebcontentAPI._versionStructureContent(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -579,6 +579,16 @@ definition {
 		return "${response}";
 	}
 
+	macro getStructuredContentIdByTitle {
+		Variables.assertDefined(parameterList = "${title}");
+
+		var response = HeadlessWebcontentAPI._allStructuredContent();
+
+		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..['items'][?(@.title == '${title}')].id");
+
+		return "${structuredContentId}";
+	}
+
 	macro getStructuredContentsByErcInAssetLibrary {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
 
@@ -621,16 +631,6 @@ definition {
 		return "${structuredContentId}";
 	}
 
-	macro getStructuredContentIdByTitle {
-		Variables.assertDefined(parameterList = "${title}");
-
-		var response = HeadlessWebcontentAPI._allStructuredContent();
-
-		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..['items'][?(@.title == '${title}')].id");
-
-		return "${structuredContentId}";
-	}
-
 	macro sortStructureContent {
 		var response = HeadlessWebcontentAPI._sortStructureContent(sortvalue = "${sortvalue}");
 
@@ -658,11 +658,11 @@ definition {
 	}
 
 	macro versionStructureContent {
-				Variables.assertDefined(parameterList = "${structuredContentId},${versionvalue}");
+		Variables.assertDefined(parameterList = "${structuredContentId},${versionvalue}");
 
-				var response = HeadlessWebcontentAPI._versionStructureContent(
-					structuredContentId = "${structuredContentId}",
-					versionvalue = "${versionvalue}");
+		var response = HeadlessWebcontentAPI._versionStructureContent(
+			structuredContentId = "${structuredContentId}",
+			versionvalue = "${versionvalue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -395,9 +395,14 @@ definition {
 	}
 
 	macro _versionStructureContent {
-		Variables.assertDefined(parameterList = "${versionvalue},${responseToParse}");
+		if (!(isSet(structuredContentId))) {
+			Variables.assertDefined(parameterList = "${responseToParse},${versionvalue}");
+			var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
+		}
+		else {
+			Variables.assertDefined(parameterList = "${versionvalue},${structuredContentId}");
+		}
 
-		var structuredContentId = JSONUtil.getWithJSONPath("${responseToParse}", "$.['id']");
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
@@ -609,9 +614,9 @@ definition {
 
 	macro returnAllstructuredContentId {
 		var response = HeadlessWebcontentAPI._allStructuredContent();
-
-		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..id");
-
+			
+		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..['items'][?(@.creator)].id");
+		
 		return "${structuredContentId}";
 	}
 
@@ -642,9 +647,33 @@ definition {
 	}
 
 	macro versionStructureContent {
-		var response = HeadlessWebcontentAPI._versionStructureContent(
-			responseToParse = "${responseToParse}",
-			versionvalue = "${versionvalue}");
+		if (!(isSet(responseToParse))) {
+			var allStructuredContentId = HeadlessWebcontentAPI.returnAllstructuredContentId();
+
+			var structuredContentId = ListUtil.newListFromString("${allStructuredContentId}");
+			var size = ListUtil.size("${structuredContentId}");
+			var i = "0";
+			var response = "";
+			while ("${i}" != "${size}") {
+				var locale = ListUtil.get("${structuredContentId}", "${i}");
+
+				var responseuni = HeadlessWebcontentAPI._versionStructureContent(
+					structuredContentId = "${locale}",
+					versionvalue = "${versionvalue}");
+
+				var i = ${i} + 1;
+
+				var actualTitleName = JSONUtil.getWithJSONPath("${responseuni}", "$..title");
+				
+				var response = StringUtil.add("${response}", "${actualTitleName}");
+			}
+
+		}
+		else {
+			var response = HeadlessWebcontentAPI._versionStructureContent(
+				responseToParse = "${responseToParse}",
+				versionvalue = "${versionvalue}");
+		}
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -621,6 +621,16 @@ definition {
 		return "${structuredContentId}";
 	}
 
+	macro getStructuredContentIdByTitle {
+		Variables.assertDefined(parameterList = "${title}");
+
+		var response = HeadlessWebcontentAPI._allStructuredContent();
+
+		var structuredContentId = JSONUtil.getWithJSONPath("${response}", "$..['items'][?(@.title == '${title}')].id");
+
+		return "${structuredContentId}";
+	}
+
 	macro sortStructureContent {
 		var response = HeadlessWebcontentAPI._sortStructureContent(sortvalue = "${sortvalue}");
 
@@ -648,32 +658,11 @@ definition {
 	}
 
 	macro versionStructureContent {
-		if (!(isSet(responseToParse))) {
-			var allStructuredContentId = HeadlessWebcontentAPI.returnAllstructuredContentId();
+				Variables.assertDefined(parameterList = "${structuredContentId},${versionvalue}");
 
-			var structuredContentId = ListUtil.newListFromString("${allStructuredContentId}");
-
-			var size = ListUtil.size("${structuredContentId}");
-			var i = "0";
-			var response = "";
-
-			while ("${i}" != "${size}") {
-				var locale = ListUtil.get("${structuredContentId}", "${i}");
-
-				var responseuni = HeadlessWebcontentAPI._versionStructureContent(
-					structuredContentId = "${locale}",
+				var response = HeadlessWebcontentAPI._versionStructureContent(
+					structuredContentId = "${structuredContentId}",
 					versionvalue = "${versionvalue}");
-				var i = ${i} + 1;
-				var actualTitleName = JSONUtil.getWithJSONPath("${responseuni}", "$..title");
-
-				var response = StringUtil.add("${response}", "${actualTitleName}");
-			}
-		}
-		else {
-			var response = HeadlessWebcontentAPI._versionStructureContent(
-				responseToParse = "${responseToParse}",
-				versionvalue = "${versionvalue}");
-		}
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
@@ -98,7 +98,7 @@ definition {
 			var response = HeadlessWebcontentAPI.filterAdminStructuredContent(filtervalue = "priority%20ge%200.99");
 		}
 
-		task ("Then the response body only includes items with priority  greater than to 0.99") {
+		task ("Then the response body only includes items with priority greater than to 0.99") {
 			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
 				expectedTitleName = "Web Content 1,Web Content 2,Web Content 3,Web Content 4",
 				responseToParse = "${response}");
@@ -132,7 +132,7 @@ definition {
 				sortvalue = "priority%3Aasc");
 		}
 
-		task ("Then the response body only includes itens without priority 1.0") {
+		task ("Then the response body only includes items without priority 1.0") {
 			HeadlessWebcontentAPI.assertTitleFieldWithCorrectName(
 				expectedTitleName = "Web Content 4,Web Content 3",
 				responseToParse = "${response}");
@@ -143,14 +143,15 @@ definition {
 	test CanInvokeAllStructuredContentCreated {
 		property portal.acceptance = "true";
 
-		task ("When returning only web content with version 1.0") {
-			var response = HeadlessWebcontentAPI.versionStructureContent(versionvalue = "1.0");
+		task ("When invoking Web Content 3 by Headless Admin Content getStructuredContentByVersion") {
+
+			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title="Web Content 3");
+
+			var response = HeadlessWebcontentAPI.versionStructureContent(versionvalue = "1.0",structuredContentId="${structuredContentId}");
 		}
 
-		task ("Then the response body only includes itens with version 1.0") {
-			TestUtils.assertEquals(
-				actual = "${response}",
-				expected = "Web Content 1,Web Content 2,Web Content 3,Web Content 4,");
+		task ("Then I should see in response Web Content 3 with a priority field set") {
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(responseToParse="${response}",expectedPriorityValue="2.99");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
@@ -139,4 +139,19 @@ definition {
 		}
 	}
 
+	@priority = "4"
+	test CanInvokeAllStructuredContentCreated {
+		property portal.acceptance = "true";
+
+		task ("When returning only web content with version 1.0") {
+			var response = HeadlessWebcontentAPI.versionStructureContent(versionvalue = "1.0");
+		}
+
+		task ("Then the response body only includes itens with version 1.0") {
+			TestUtils.assertEquals(
+				actual = "${response}",
+				expected = "Web Content 1,Web Content 2,Web Content 3,Web Content 4,");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/StructuredContentFilteringAndSorting.testcase
@@ -144,14 +144,17 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When invoking Web Content 3 by Headless Admin Content getStructuredContentByVersion") {
+			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title = "Web Content 3");
 
-			var structuredContentId = HeadlessWebcontentAPI.getStructuredContentIdByTitle(title="Web Content 3");
-
-			var response = HeadlessWebcontentAPI.versionStructureContent(versionvalue = "1.0",structuredContentId="${structuredContentId}");
+			var response = HeadlessWebcontentAPI.versionStructureContent(
+				structuredContentId = "${structuredContentId}",
+				versionvalue = "1.0");
 		}
 
 		task ("Then I should see in response Web Content 3 with a priority field set") {
-			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(responseToParse="${response}",expectedPriorityValue="2.99");
+			HeadlessWebcontentAPI.assertPriorityFieldWithCorrectValue(
+				expectedPriorityValue = "2.99",
+				responseToParse = "${response}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Create automated test StructuredContentFilteringAndSorting#CanInvokeAllStructuredContentCreated 

**Test Plan**
Given a content structure with a content-field of dataType "string" and label "content" and name "content" created in the portal
And Given with Headless Admin Content POST "/v1.0/sites/ {siteId}/structured-contents/draft" a structured content draft "content1" with a priority 1.0 set is created
And Given with Headless Admin Content POST "/v1.0/sites/{siteId}
/structured-contents/draft" a structured content draft "content2" with a priority 1.0 set is created
And Given with Headless Admin Content POST "/v1.0/sites/ {siteId}/structured-contents/draft" a structured content draft "content3" with a priority 2.99 set is created
And Given with Headless Admin Content POST "/v1.0/sites/{siteId}/\structured-contents/draft" a structured content draft "content4" with a priority 0.99 set is created
When invoking Headless Admin Content GET "/v1.0/structured-contents/ {structuredContentId}/by-version/1"
Then I should see in response "content1", "content2", "content3" and "content4" with a priority field set

**JIRA Link:**
https://issues.liferay.com/browse/LPS-153152