### PR TITLE
Master LPS 158119 | Add test on create doucment with post request in asset library

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -1,0 +1,59 @@
+definition {
+
+	macro _addDocument {
+		Variables.assertDefined(parameterList = "${filePath}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/documents";
+		}
+		else {
+			var api = "sites/${siteId}/documents";
+		}
+
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: multipart/form-data \
+            -F document={"externalReferenceCode": "${externalReferenceCode}"} \
+			-F file=@${filePath} 
+		''';
+
+		var curl = JSONCurlUtil.post("${curl}");
+
+		return "${curl}";
+	}
+
+	macro addDocumentInAssetLibraryByUploadFile {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
+
+		var response = DocumentAPI._addDocument(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			filePath = "${filePath}");
+
+		return "${response}";
+	}
+
+	macro assertExternalReferenceCodeWithCorrectValue {
+		if (!(isSet(expectedExternalReferenceCodeValue))) {
+			var contentURL = JSONUtil.getWithJSONPath("${responseToParse}", "$.['contentUrl']");
+
+			var contentURLSubString = StringUtil.extractFirst("${contentURL}", "?");
+
+			var expectedExternalReferenceCodeValue = StringUtil.extractLast("${contentURLSubString}", "/");
+		}
+
+		var actualExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
+
+		TestUtils.assertEquals(
+			actual = "${actualExternalReferenceCodeValue}",
+			expected = "${expectedExternalReferenceCodeValue}");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -1,0 +1,48 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	@description = "Document is created in an asset library with erc by default"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryWithErcByDefault {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a new document without a custom erc") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				filePath = "${filePath}");
+		}
+
+		task ("Then the document is being created with erc value equals to uuid in the body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(responseToParse = "${response}");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,28 @@ definition {
 		}
 	}
 
+	@description = "Document is created in an asset library with custom erc"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryWithCustomErc {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a new document with a custom erc in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("Then the document is being created with custom erc in the body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Document is created in an asset library with erc by default"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithErcByDefault {


### PR DESCRIPTION
**Background**
- Add test on document is created with uuid as erc by default in asset library
- Add test to create document with a custom erc in asset library

**Test Plan**
- LPS-158119 
Given asset library is created
When with POST request I create a new document without erc
Then the document is being created with erc value is the UUID in the body response
- LPS-158120
Given asset library is created
When with POST request I create a new document with a custom erc in asset library
Then the document is being created with custom erc  in the body response

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-158119
- https://issues.liferay.com/browse/LPS-158120