### PR TITLE
LPS-158116 | Can get first object entires related to second object by ManyToMany

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -265,6 +265,23 @@ definition {
 		return "${objectName}";
 	}
 
+	macro _getObjectEntryRelation {
+		Variables.assertDefined(parameterList = "${en_US_plural_label},${objectId},${relationshipName}");
+
+		var en_US_plural_label_lowercase = StringUtil.lowerCase("${en_US_plural_label}");
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+        	${portalURL}/o/c/${en_US_plural_label_lowercase}/${objectId}/${relationshipName} \
+			-H accept: application/json \
+			-u test@liferay.com:test
+		''';
+
+		var json = JSONCurlUtil.get("${curl}");
+
+		return "${json}";
+	}
+
 	macro _getObjectFirstnameById {
 		var objectFirstname = JSONUtil.getWithJSONPath("${responseToParse}", "$.items[?(@.id==${objectId})].firstname");
 
@@ -445,6 +462,14 @@ definition {
 			expected = "${expectedValue}");
 	}
 
+	macro assertResponseHasCorrectDetailsRelatedToObjectEntry {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items[?(@.id==${objectEntryId})].name");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedValue}");
+	}
+
 	macro assertResponseIncludeCorrectDetailsOfNotDeletedObject {
 		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$..universitiesSubjects[?(@.id==${objectEntryId})].name");
 
@@ -583,6 +608,15 @@ definition {
 		ObjectDefinitionAPI._deleteObjectEntry(
 			en_US_plural_label = "${en_US_plural_label}",
 			objectEntryId = "${objectEntryId}");
+	}
+
+	macro getObjectEntryRelation {
+		var getObjectEntryRelation = ObjectDefinitionAPI._getObjectEntryRelation(
+			en_US_plural_label = "${en_US_plural_label}",
+			objectId = "${objectId}",
+			relationshipName = "${relationshipName}");
+
+		return "${getObjectEntryRelation}";
 	}
 
 	macro getObjectsWithAggregationTerms {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -171,6 +171,55 @@ definition {
 	}
 
 	@priority = "5"
+	test CanGetFirstObjectEntiresRelatedToSecondObjectByManyToMany {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${staticObjectId1}",
+				objectDefinitionId2 = "${staticObjectId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("And Given subject entry related to the university entry created") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("When I call universities GET endpoint with {universityId}/universitySubjects") {
+			var responseToParse = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "universities",
+				objectId = "${universityId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("Then I receive the correct information about the subjects related to it") {
+			ObjectDefinitionAPI.assertResponseHasCorrectDetailsRelatedToObjectEntry(
+				expectedValue = "Liferay Foundations",
+				objectEntryId = "${subjectId}",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
+	@priority = "5"
 	test CanGetManyToManyRelationshipDetailsAsNestedFields_1 {
 		property portal.acceptance = "true";
 


### PR DESCRIPTION
**Background**
Add a test to can get first object entires related to second object by ManyToMany

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects created
And Given university entry created
And Given subject entry related to the university entry created
When in c/universities I use GET /{universityId}/universitySubjects
Then I receive the correct information about the subjects related to it

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-158116