### PR TITLE
LPS-158130 Configure Permission class to use Liferay.Vulcan Jackson JSON filter

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/permission/Permission.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/permission/Permission.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.vulcan.permission;
 
+import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
@@ -25,6 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @author Javier Gamarra
  */
 @GraphQLName("Permission")
+@JsonFilter("Liferay.Vulcan")
 @XmlRootElement(name = "Permission")
 public class Permission {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/permission/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/permission/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.3.1


### PR DESCRIPTION
This PR contains the code to fix the following bug:

If a request is made over any permissions endpoint, for example, the endpoint 

```
http://localhost:8080/o/headless-delivery/v1.0/blog-postings/{blogPostingId}/permissions
```
and the query parameters fields / restrictFields are used to filter fields, the fields are not being filtered.

---

For example, given a Blog Posting with an id, 49717, if we request the following permissions:

```
curl -X GET \
     -H 'accept: application/json' \
     -u 'test@liferay.com:test' \
     http://localhost:8080/o/headless-delivery/v1.0/blog-postings/49717/permissions?restrictFields=actionIds
```

**Before the PR:**

The field actionIds is returned in the body response.

```
{
  "actions" : {
    "get" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/49717/permissions"
    },
    "replace" : {
      "method" : "PUT",
      "href" : "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/49717/permissions"
    }
  },
  "facets" : [ ],
  "items" : [ {
    "actionIds" : [ "UPDATE_DISCUSSION", "DELETE", "PERMISSIONS", "DELETE_DISCUSSION", "UPDATE", "VIEW", "ADD_DISCUSSION" ],
    "roleName" : "Owner"
  } ],
  "lastPage" : 1,
  "page" : 1,
  "pageSize" : 1,
  "totalCount" : 1
}
```
 

**After the PR:**

The field actionIds is not returned in the body response.

 ```
{
  "actions" : {
    "get" : {
      "method" : "GET",
      "href" : "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/49717/permissions"
    },
    "replace" : {
      "method" : "PUT",
      "href" : "http://localhost:8080/o/headless-delivery/v1.0/blog-postings/49717/permissions"
    }
  },
  "facets" : [ ],
  "items" : [ {
    "roleName" : "Owner"
  } ],
  "lastPage" : 1,
  "page" : 1,
  "pageSize" : 1,
  "totalCount" : 1
}
```


