### PR TITLE
LPS-133578 Show default language first in TM locales list

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/components/LocalesList.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/components/LocalesList.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayTabs from '@clayui/tabs';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 const Locale = ({children, editingLocale, locale, onLocaleClicked}) => (
 	<ClayTabs.Item
@@ -38,14 +38,16 @@ export default function LocalesList({
 	onLocaleClicked,
 	onLocaleRemoved,
 }) {
-	const availableLocalesArray = Array.from(availableLocales.values());
+	const sortedLocales = useMemo(() => {
+		const availableLocalesArray = Array.from(availableLocales.values());
 
-	const sortedLocales = [
-		availableLocalesArray.find((locale) => locale.id === defaultLocale),
-		...availableLocalesArray.filter(
-			(locale) => locale.id !== defaultLocale
-		),
-	];
+		return [
+			availableLocalesArray.find((locale) => locale.id === defaultLocale),
+			...availableLocalesArray.filter(
+				(locale) => locale.id !== defaultLocale
+			),
+		];
+	}, [availableLocales, defaultLocale]);
 
 	return (
 		<>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/components/LocalesList.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/translation_manager/components/LocalesList.js
@@ -38,9 +38,18 @@ export default function LocalesList({
 	onLocaleClicked,
 	onLocaleRemoved,
 }) {
+	const availableLocalesArray = Array.from(availableLocales.values());
+
+	const sortedLocales = [
+		availableLocalesArray.find((locale) => locale.id === defaultLocale),
+		...availableLocalesArray.filter(
+			(locale) => locale.id !== defaultLocale
+		),
+	];
+
 	return (
 		<>
-			{Array.from(availableLocales.values()).map((locale) => (
+			{sortedLocales.map((locale) => (
 				<Locale
 					editingLocale={editingLocale}
 					key={locale.id}


### PR DESCRIPTION
### References

- [LPS-133578](https://issues.liferay.com/browse/LPS-133578)

### What is the goal?

* Display the default language first in the TM locales list to avoid confusion after save

### What does it look like?

#### Before fix
While your are creating the form, the default language comes first, but once you click on save the order is different

https://user-images.githubusercontent.com/6642927/178759557-9a9ca971-5cb0-4e7c-aee8-32be9cb66508.mov

#### After fix
The default language is displayed first, as requested.

https://user-images.githubusercontent.com/6642927/178759980-5238e96f-efab-44e2-bbe7-f700d5b401b3.mov

### How to replicate
* Go to Control Panel > Instance Settings > Localization
* Select Portuguese as default language
* Go to Content & Data > Forms
* Click on Add new form
* Set the title for Portuguese
* Add English translation, set the title for that one
* Add one text field
* Click on Save
* See that the default language is displayed first

