### PR TITLE
Master LPS 157910 | Add tests on delete structured content by asset library id and erc

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -223,6 +223,29 @@ definition {
 		return "${curl}";
 	}
 
+	macro _deleteStructuredContentByExternalReferenceCode {
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/structured-contents/by-external-reference-code/${externalReferenceCode}";
+		}
+		else {
+			var api = "sites/${siteId}/structured-contents/by-external-reference-code/${externalReferenceCode}";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.delete("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _editStructuredContent {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority},${structuredContentId}");
 
@@ -522,6 +545,14 @@ definition {
 			var response = HeadlessWebcontentAPI._deleteStructuredContent(structuredContentId = "${locale}");
 			var i = ${i} + 1;
 		}
+	}
+
+	macro deleteStructuredContentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+
+		HeadlessWebcontentAPI._deleteStructuredContentByExternalReferenceCode(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}");
 	}
 
 	macro editStructuredContent {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -364,6 +364,46 @@ definition {
 		}
 	}
 
+	@description = "Structured content is not able to delete with a nonexistent erc in asset library"
+	@priority = "3"
+	test StructruedContentDeletionImpossibleByAssetLibraryIdAndNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content with custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				externalReferenceCode = "erc",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When I make a DELETE request by assetLibraryId and a non-existent erc") {
+			HeadlessWebcontentAPI.deleteStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc");
+		}
+
+		task ("Then the structured content with a custom erc created earlier still exists") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
+
+			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "1",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Structured content is created by put nonexistent erc in asset library without erc in the body"
 	@priority = "5"
 	test StructuredContentIsCreatedInAssetLibraryByPutNonexistentErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -40,6 +40,42 @@ definition {
 		}
 	}
 
+	@description = "Structured content is deleted in an asset library by custom erc"
+	@priority = "4"
+	test CanDeleteStructuredContentInAssetLibraryByAssetLibraryIdAndCustomErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				externalReferenceCode = "erc",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When I make a DELETE request by assetLibraryId and the custom erc") {
+			HeadlessWebcontentAPI.deleteStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then the structured content is correctly deleted") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "0",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Structured content is deleted in an asset library by default erc"
 	@priority = "4"
 	test CanDeleteStructuredContentInAssetLibraryByAssetLibraryIdAndDefaultErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContents.testcase
@@ -40,6 +40,43 @@ definition {
 		}
 	}
 
+	@description = "Structured content is deleted in an asset library by default erc"
+	@priority = "4"
+	test CanDeleteStructuredContentInAssetLibraryByAssetLibraryIdAndDefaultErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content without custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			var response = HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When I make a DELETE request by assetLibraryId and uuid as the erc") {
+			var structuredContentUuid = HeadlessWebcontentAPI.getUuidOfStructuredContent(responseToParse = "${response}");
+
+			HeadlessWebcontentAPI.deleteStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${structuredContentUuid}");
+		}
+
+		task ("Then the structured content is correctly deleted") {
+			var response = HeadlessWebcontentAPI.filterStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				filtervalue = "title%20eq%20%27WC%20WebContent%20Title%27");
+
+			HeadlessWebcontentAPI.assertProperNumberOfItems(
+				expectedTotalElement = "0",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Get structured content in asset library by existing custom erc"
 	@priority = "5"
 	test CanGetStructuredContentInAssetLibraryByExistingCustomErc {


### PR DESCRIPTION
**Background**
- Add test to delete structured content in asset library by uuid as erc
- Add test to delete structured content by asset library id and custom erc
- Add test on unable to delete structured content by nonexistent erc in asset library

**Test Plan**
- LPS-157910
Given asset library is created
And Given a structured content without custom erc is created with a POST request in asset library
When I make a DELETE request by assetLibraryId and key as the erc
Then the structured content is correctly deleted
- LPS-157958
Given asset library is created
And Given a structured content with a custom erc is created with a POST request in asset library
When I make a DELETE request by assetLibraryId and erc
Then the structured content is correctly deleted
- LPS-158226
Given asset library is created
And Given a structured content with a custom erc is created with a POST request in asset library
When I make a DELETE request by assetLibraryId and use internal ID as erc
Then the structured content with a custom erc created earlier still exists

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-157910
- https://issues.liferay.com/browse/LPS-157958
- https://issues.liferay.com/browse/LPS-158226