### PR TITLE
LPS-158255 Create a list of files to ignore by our minifier

### DIFF
--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
@@ -69,16 +69,16 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 				CompilerOptions.LanguageMode.ECMASCRIPT_NEXT);
 			compilerOptions.setResolveSourceMapAnnotations(false);
 
-			boolean fileToIgnore = false;
+			boolean ignoreFile = false;
 
 			for (String ignoredFile : _IGNORED_FILES) {
 				if (resourceName.endsWith(ignoredFile)) {
-					fileToIgnore = true;
+					ignoreFile = true;
 					break;
 				}
 			}
 
-			if (!fileToIgnore) {
+			if (!ignoreFile) {
 				compiler.compile(
 					SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
 					compilerOptions);

--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
@@ -69,17 +69,22 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 				CompilerOptions.LanguageMode.ECMASCRIPT_NEXT);
 			compilerOptions.setResolveSourceMapAnnotations(false);
 
-			compiler.compile(
-				SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
-				compilerOptions);
+			boolean fileToIgnore = false;
 
-			boolean ignoredFile = Stream.of(
-				_IGNORED_FILES
-			).anyMatch(
-				resourceName::endsWith
-			);
+			for (String ignoredFile : _IGNORED_FILES) {
+				if (resourceName.endsWith(ignoredFile)) {
+					fileToIgnore = true;
+					break;
+				}
+			}
 
-			if (compiler.hasErrors() || ignoredFile) {
+			if (!fileToIgnore) {
+				compiler.compile(
+					SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
+					compilerOptions);
+			}
+
+			if (compiler.hasErrors()) {
 				return content;
 			}
 

--- a/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/main/java/com/liferay/frontend/js/minifier/internal/GoogleJavaScriptMinifier.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -72,7 +73,13 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 				SourceFile.fromCode("extern", StringPool.BLANK), sourceFile,
 				compilerOptions);
 
-			if (compiler.hasErrors()) {
+			boolean ignoredFile = Stream.of(
+				_IGNORED_FILES
+			).anyMatch(
+				resourceName::endsWith
+			);
+
+			if (compiler.hasErrors() || ignoredFile) {
 				return content;
 			}
 
@@ -111,6 +118,8 @@ public class GoogleJavaScriptMinifier implements JavaScriptMinifier {
 			}
 		}
 	}
+
+	private static final String[] _IGNORED_FILES = {"ReactFlow.js"};
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		GoogleJavaScriptMinifier.class);


### PR DESCRIPTION
Hi guys,

Recently, we added to our portal some dependencies from `react-flow-renderer`, which includes some dependencies from `d3-selection` which adds some code unable to correctly process by our old minifier. 

Initial ideas were:
* Trying to fix syntax, but we rejected it because it belongs to a third party.
* Modify dependencies, but we rejected it because there is no set of dependencies which could avoid this issue.
* Tweak our minifier, but even the simplest customization was causing this issue, so we rejected it.
* We directly rejected it to upgrade our compiler since runtime minification is deprecated and we don't want to spend more time on it.

So we ended up deciding this could be the best option. This way, if we face a similar issue in the future with another file, we just need to added to that list, similar to what we do with errors we want to ignore.

Thanks.

Regards.

/cc @jgarcialr