### PR TITLE
LPS-158211 |  Can get second object entires related to first object by ManyToMany

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -462,7 +462,7 @@ definition {
 			expected = "${expectedValue}");
 	}
 
-	macro assertResponseHasCorrectDetailsRelatedToObjectEntry {
+	macro assertResponseHasCorrectObjectEntryName {
 		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.items[?(@.id==${objectEntryId})].name");
 
 		TestUtils.assertEquals(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -212,7 +212,7 @@ definition {
 		}
 
 		task ("Then I receive the correct information about the subjects related to it") {
-			ObjectDefinitionAPI.assertResponseHasCorrectDetailsRelatedToObjectEntry(
+			ObjectDefinitionAPI.assertResponseHasCorrectObjectEntryName(
 				expectedValue = "Liferay Foundations",
 				objectEntryId = "${subjectId}",
 				responseToParse = "${responseToParse}");
@@ -661,6 +661,55 @@ definition {
 				nestedField = "universitiesStudents",
 				objectEntryId = "${universityId}",
 				objectField = "name");
+		}
+	}
+
+	@priority = "5"
+	test CanGetSecondObjectEntiresRelatedToFirstObjectByManyToMany {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${staticObjectId1}",
+				objectDefinitionId2 = "${staticObjectId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("And Given university entry related to the subject entry created") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "subjects",
+				objectEntry1 = "${subjectId}",
+				objectEntry2 = "${universityId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("When I call universities GET endpoint with {universityId}/universitySubjects") {
+			var responseToParse = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "subjects",
+				objectId = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("Then I receive the correct information about the subjects related to it") {
+			ObjectDefinitionAPI.assertResponseHasCorrectObjectEntryName(
+				expectedValue = "Liferay University",
+				objectEntryId = "${universityId}",
+				responseToParse = "${responseToParse}");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Add a test to can get second object entires related to first object by ManyToMany

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects created
And Given subject entry created
And Given university entry related to the subject entry created
When in c/subjects I use GET /{subjectId}/universitiesSubjects
Then I receive the correct information about the universities related to it

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-158211