### PR TITLE
Master Lps 157973 | Add test on expose erc from asset library for document

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -29,6 +29,22 @@ definition {
 		return "${curl}";
 	}
 
+	macro _filterDocumentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${filtervalue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/documents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro addDocumentInAssetLibraryByUploadFile {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
 
@@ -54,6 +70,20 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualExternalReferenceCodeValue}",
 			expected = "${expectedExternalReferenceCodeValue}");
+	}
+
+	macro assertProperDocumentTotalCount {
+		Variables.assertDefined(parameterList = "${expectedDocumentTotalCount}");
+
+		var response = DocumentAPI._filterDocumentInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			filtervalue = "${filtervalue}");
+
+		var actualDocumentTotalCount = JSONUtil.getWithJSONPath("${response}", "$..['totalCount']");
+
+		TestUtils.assertEquals(
+			actual = "${actualDocumentTotalCount}",
+			expected = "${expectedDocumentTotalCount}");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -86,4 +86,15 @@ definition {
 			expected = "${expectedDocumentTotalCount}");
 	}
 
+	macro getIdOfCreatedDocument {
+		var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			filePath = "${filePath}");
+
+		var documentId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
+
+		return "${documentId}";
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -86,6 +86,44 @@ definition {
 		}
 	}
 
+	@description = "Document is created in an asset library with previous document id as erc"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryWithDocumentIdAsErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with POST request I create a document with a custom erc equals to the internal id of the previously created document") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${documentId}",
+				filePath = "${filePath}");
+		}
+
+		task ("Then I can see erc equals to the id in the body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${documentId}",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then the document is created properly") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with erc by default"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithErcByDefault {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,44 @@ definition {
 		}
 	}
 
+	@description = "Document is not able to create with an existing erc in asset library"
+	@priority = "5"
+	test CannotCreateDocumentInAssetLibraryWithExistingErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with POST I create another document with an existing erc") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("Then I receive duplicate external reference code response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "Duplicate file entry external reference code erc");
+		}
+
+		task ("And Then another document with same erc is not being created") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "0",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {


### PR DESCRIPTION
**Background**
- Add test on unable to create document with existing erc in asset library
- Add test to create document using previous id as erc in asset library

**Test Plan**
- LPS-157973
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When with POST I create a document with an existing erc
Then I receive an error code responseAnd Then another document with same erc is not being created
- LPS-158443
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When with POST request I create a document with a custom erc with a value of the internal id of the previously created document
Then the document is being createdAnd Then I can see the custom erc in the body response

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-157973
- https://issues.liferay.com/browse/LPS-158443
