### PR TITLE
LPS-158214 Expose extended properties in OpenAPI for schemas/DTOs that are extended by ExtensionProviders

### DIFF
--- a/modules/apps/analytics/analytics-dxp-entity-rest-impl/src/main/java/com/liferay/analytics/dxp/entity/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/analytics/analytics-dxp-entity-rest-impl/src/main/java/com/liferay/analytics/dxp/entity/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,17 @@
 
 package com.liferay.analytics.dxp.entity.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +62,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,10 +99,17 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
+
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/src/main/java/com/liferay/batch/planner/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,20 @@
 
 package com.liferay.batch.planner.rest.internal.resource.v1_0;
 
+import com.liferay.batch.planner.rest.dto.v1_0.Field;
+import com.liferay.batch.planner.rest.dto.v1_0.Plan;
+import com.liferay.batch.planner.rest.dto.v1_0.SiteScope;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +65,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,16 +102,21 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(FieldResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(FieldResourceImpl.class, Field.class);
+				put(PlanResourceImpl.class, Plan.class);
+				put(SiteScopeResourceImpl.class, SiteScope.class);
 
-			add(PlanResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(SiteScopeResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/java/com/liferay/bulk/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,22 @@
 
 package com.liferay.bulk.rest.internal.resource.v1_0;
 
+import com.liferay.bulk.rest.dto.v1_0.Keyword;
+import com.liferay.bulk.rest.dto.v1_0.Selection;
+import com.liferay.bulk.rest.dto.v1_0.Status;
+import com.liferay.bulk.rest.dto.v1_0.TaxonomyCategory;
+import com.liferay.bulk.rest.dto.v1_0.TaxonomyVocabulary;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +67,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,20 +104,25 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(KeywordResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(KeywordResourceImpl.class, Keyword.class);
+				put(SelectionResourceImpl.class, Selection.class);
+				put(StatusResourceImpl.class, Status.class);
+				put(TaxonomyCategoryResourceImpl.class, TaxonomyCategory.class);
+				put(
+					TaxonomyVocabularyResourceImpl.class,
+					TaxonomyVocabulary.class);
 
-			add(SelectionResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(StatusResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(TaxonomyCategoryResourceImpl.class);
-
-			add(TaxonomyVocabularyResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/src/main/java/com/liferay/headless/commerce/admin/account/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,23 @@
 
 package com.liferay.headless.commerce.admin.account.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.account.dto.v1_0.Account;
+import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountAddress;
+import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountGroup;
+import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountMember;
+import com.liferay.headless.commerce.admin.account.dto.v1_0.AccountOrganization;
+import com.liferay.headless.commerce.admin.account.dto.v1_0.User;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +69,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,22 +106,26 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AccountResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AccountAddressResourceImpl.class, AccountAddress.class);
+				put(AccountGroupResourceImpl.class, AccountGroup.class);
+				put(AccountMemberResourceImpl.class, AccountMember.class);
+				put(
+					AccountOrganizationResourceImpl.class,
+					AccountOrganization.class);
+				put(AccountResourceImpl.class, Account.class);
+				put(UserResourceImpl.class, User.class);
 
-			add(AccountAddressResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(AccountGroupResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(AccountMemberResourceImpl.class);
-
-			add(AccountOrganizationResourceImpl.class);
-
-			add(UserResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,41 @@
 
 package com.liferay.headless.commerce.admin.catalog.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Attachment;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Catalog;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Category;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Diagram;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.MappedProduct;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Option;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.OptionCategory;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.OptionValue;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Pin;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Product;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductAccountGroup;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductChannel;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductConfiguration;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductGroup;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductGroupProduct;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOption;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductOptionValue;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductShippingConfiguration;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductSpecification;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductSubscriptionConfiguration;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.ProductTaxConfiguration;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.RelatedProduct;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Sku;
+import com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +87,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,58 +124,58 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AttachmentResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AttachmentResourceImpl.class, Attachment.class);
+				put(CatalogResourceImpl.class, Catalog.class);
+				put(CategoryResourceImpl.class, Category.class);
+				put(DiagramResourceImpl.class, Diagram.class);
+				put(MappedProductResourceImpl.class, MappedProduct.class);
+				put(OptionCategoryResourceImpl.class, OptionCategory.class);
+				put(OptionResourceImpl.class, Option.class);
+				put(OptionValueResourceImpl.class, OptionValue.class);
+				put(PinResourceImpl.class, Pin.class);
+				put(
+					ProductAccountGroupResourceImpl.class,
+					ProductAccountGroup.class);
+				put(ProductChannelResourceImpl.class, ProductChannel.class);
+				put(
+					ProductConfigurationResourceImpl.class,
+					ProductConfiguration.class);
+				put(
+					ProductGroupProductResourceImpl.class,
+					ProductGroupProduct.class);
+				put(ProductGroupResourceImpl.class, ProductGroup.class);
+				put(ProductOptionResourceImpl.class, ProductOption.class);
+				put(
+					ProductOptionValueResourceImpl.class,
+					ProductOptionValue.class);
+				put(ProductResourceImpl.class, Product.class);
+				put(
+					ProductShippingConfigurationResourceImpl.class,
+					ProductShippingConfiguration.class);
+				put(
+					ProductSpecificationResourceImpl.class,
+					ProductSpecification.class);
+				put(
+					ProductSubscriptionConfigurationResourceImpl.class,
+					ProductSubscriptionConfiguration.class);
+				put(
+					ProductTaxConfigurationResourceImpl.class,
+					ProductTaxConfiguration.class);
+				put(RelatedProductResourceImpl.class, RelatedProduct.class);
+				put(SkuResourceImpl.class, Sku.class);
+				put(SpecificationResourceImpl.class, Specification.class);
 
-			add(CatalogResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(CategoryResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(DiagramResourceImpl.class);
-
-			add(MappedProductResourceImpl.class);
-
-			add(OptionResourceImpl.class);
-
-			add(OptionCategoryResourceImpl.class);
-
-			add(OptionValueResourceImpl.class);
-
-			add(PinResourceImpl.class);
-
-			add(ProductResourceImpl.class);
-
-			add(ProductAccountGroupResourceImpl.class);
-
-			add(ProductChannelResourceImpl.class);
-
-			add(ProductConfigurationResourceImpl.class);
-
-			add(ProductGroupResourceImpl.class);
-
-			add(ProductGroupProductResourceImpl.class);
-
-			add(ProductOptionResourceImpl.class);
-
-			add(ProductOptionValueResourceImpl.class);
-
-			add(ProductShippingConfigurationResourceImpl.class);
-
-			add(ProductSpecificationResourceImpl.class);
-
-			add(ProductSubscriptionConfigurationResourceImpl.class);
-
-			add(ProductTaxConfigurationResourceImpl.class);
-
-			add(RelatedProductResourceImpl.class);
-
-			add(SkuResourceImpl.class);
-
-			add(SpecificationResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/src/main/java/com/liferay/headless/commerce/admin/channel/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,26 @@
 
 package com.liferay.headless.commerce.admin.channel.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.Channel;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.OrderType;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.PaymentMethodGroupRelOrderType;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.PaymentMethodGroupRelTerm;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingFixedOptionOrderType;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingFixedOptionTerm;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.ShippingMethod;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.TaxCategory;
+import com.liferay.headless.commerce.admin.channel.dto.v1_0.Term;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +72,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,28 +109,35 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ChannelResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ChannelResourceImpl.class, Channel.class);
+				put(OrderTypeResourceImpl.class, OrderType.class);
+				put(
+					PaymentMethodGroupRelOrderTypeResourceImpl.class,
+					PaymentMethodGroupRelOrderType.class);
+				put(
+					PaymentMethodGroupRelTermResourceImpl.class,
+					PaymentMethodGroupRelTerm.class);
+				put(
+					ShippingFixedOptionOrderTypeResourceImpl.class,
+					ShippingFixedOptionOrderType.class);
+				put(
+					ShippingFixedOptionTermResourceImpl.class,
+					ShippingFixedOptionTerm.class);
+				put(ShippingMethodResourceImpl.class, ShippingMethod.class);
+				put(TaxCategoryResourceImpl.class, TaxCategory.class);
+				put(TermResourceImpl.class, Term.class);
 
-			add(OrderTypeResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(PaymentMethodGroupRelOrderTypeResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(PaymentMethodGroupRelTermResourceImpl.class);
-
-			add(ShippingFixedOptionOrderTypeResourceImpl.class);
-
-			add(ShippingFixedOptionTermResourceImpl.class);
-
-			add(ShippingMethodResourceImpl.class);
-
-			add(TaxCategoryResourceImpl.class);
-
-			add(TermResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/src/main/java/com/liferay/headless/commerce/admin/inventory/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,19 @@
 
 package com.liferay.headless.commerce.admin.inventory.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.inventory.dto.v1_0.Warehouse;
+import com.liferay.headless.commerce.admin.inventory.dto.v1_0.WarehouseItem;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +65,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,14 +102,20 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(WarehouseResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(WarehouseItemResourceImpl.class, WarehouseItem.class);
+				put(WarehouseResourceImpl.class, Warehouse.class);
 
-			add(WarehouseItemResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/src/main/java/com/liferay/headless/commerce/admin/order/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,34 @@
 
 package com.liferay.headless.commerce.admin.order.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.order.dto.v1_0.Account;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.AccountGroup;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.BillingAddress;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.Channel;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.Order;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderItem;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderNote;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRule;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleAccount;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleAccountGroup;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleChannel;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderRuleOrderType;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderType;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.OrderTypeChannel;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.ShippingAddress;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.Term;
+import com.liferay.headless.commerce.admin.order.dto.v1_0.TermOrderType;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +80,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,44 +117,39 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AccountResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AccountGroupResourceImpl.class, AccountGroup.class);
+				put(AccountResourceImpl.class, Account.class);
+				put(BillingAddressResourceImpl.class, BillingAddress.class);
+				put(ChannelResourceImpl.class, Channel.class);
+				put(OrderItemResourceImpl.class, OrderItem.class);
+				put(OrderNoteResourceImpl.class, OrderNote.class);
+				put(OrderResourceImpl.class, Order.class);
+				put(
+					OrderRuleAccountGroupResourceImpl.class,
+					OrderRuleAccountGroup.class);
+				put(OrderRuleAccountResourceImpl.class, OrderRuleAccount.class);
+				put(OrderRuleChannelResourceImpl.class, OrderRuleChannel.class);
+				put(
+					OrderRuleOrderTypeResourceImpl.class,
+					OrderRuleOrderType.class);
+				put(OrderRuleResourceImpl.class, OrderRule.class);
+				put(OrderTypeChannelResourceImpl.class, OrderTypeChannel.class);
+				put(OrderTypeResourceImpl.class, OrderType.class);
+				put(ShippingAddressResourceImpl.class, ShippingAddress.class);
+				put(TermOrderTypeResourceImpl.class, TermOrderType.class);
+				put(TermResourceImpl.class, Term.class);
 
-			add(AccountGroupResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(BillingAddressResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(ChannelResourceImpl.class);
-
-			add(OrderResourceImpl.class);
-
-			add(OrderItemResourceImpl.class);
-
-			add(OrderNoteResourceImpl.class);
-
-			add(OrderRuleResourceImpl.class);
-
-			add(OrderRuleAccountResourceImpl.class);
-
-			add(OrderRuleAccountGroupResourceImpl.class);
-
-			add(OrderRuleChannelResourceImpl.class);
-
-			add(OrderRuleOrderTypeResourceImpl.class);
-
-			add(OrderTypeResourceImpl.class);
-
-			add(OrderTypeChannelResourceImpl.class);
-
-			add(ShippingAddressResourceImpl.class);
-
-			add(TermResourceImpl.class);
-
-			add(TermOrderTypeResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,26 @@
 
 package com.liferay.headless.commerce.admin.pricing.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.Discount;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountAccountGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountCategory;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountProduct;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.DiscountRule;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceEntry;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceList;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.PriceListAccountGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v1_0.TierPrice;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +72,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,28 +109,31 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(DiscountResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					DiscountAccountGroupResourceImpl.class,
+					DiscountAccountGroup.class);
+				put(DiscountCategoryResourceImpl.class, DiscountCategory.class);
+				put(DiscountProductResourceImpl.class, DiscountProduct.class);
+				put(DiscountResourceImpl.class, Discount.class);
+				put(DiscountRuleResourceImpl.class, DiscountRule.class);
+				put(PriceEntryResourceImpl.class, PriceEntry.class);
+				put(
+					PriceListAccountGroupResourceImpl.class,
+					PriceListAccountGroup.class);
+				put(PriceListResourceImpl.class, PriceList.class);
+				put(TierPriceResourceImpl.class, TierPrice.class);
 
-			add(DiscountAccountGroupResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(DiscountCategoryResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(DiscountProductResourceImpl.class);
-
-			add(DiscountRuleResourceImpl.class);
-
-			add(PriceEntryResourceImpl.class);
-
-			add(PriceListResourceImpl.class);
-
-			add(PriceListAccountGroupResourceImpl.class);
-
-			add(TierPriceResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/src/main/java/com/liferay/headless/commerce/admin/pricing/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -14,13 +14,47 @@
 
 package com.liferay.headless.commerce.admin.pricing.internal.resource.v2_0;
 
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Account;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.AccountGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Category;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Channel;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Discount;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountAccount;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountAccountGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountCategory;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountChannel;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountOrderType;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountProduct;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountProductGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountRule;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.DiscountSku;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.OrderType;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceEntry;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceList;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListAccount;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListAccountGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListChannel;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListDiscount;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceListOrderType;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifier;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierCategory;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierProduct;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceModifierProductGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Product;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.ProductGroup;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.Sku;
+import com.liferay.headless.commerce.admin.pricing.dto.v2_0.TierPrice;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +93,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,70 +130,66 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AccountResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AccountGroupResourceImpl.class, AccountGroup.class);
+				put(AccountResourceImpl.class, Account.class);
+				put(CategoryResourceImpl.class, Category.class);
+				put(ChannelResourceImpl.class, Channel.class);
+				put(
+					DiscountAccountGroupResourceImpl.class,
+					DiscountAccountGroup.class);
+				put(DiscountAccountResourceImpl.class, DiscountAccount.class);
+				put(DiscountCategoryResourceImpl.class, DiscountCategory.class);
+				put(DiscountChannelResourceImpl.class, DiscountChannel.class);
+				put(
+					DiscountOrderTypeResourceImpl.class,
+					DiscountOrderType.class);
+				put(
+					DiscountProductGroupResourceImpl.class,
+					DiscountProductGroup.class);
+				put(DiscountProductResourceImpl.class, DiscountProduct.class);
+				put(DiscountResourceImpl.class, Discount.class);
+				put(DiscountRuleResourceImpl.class, DiscountRule.class);
+				put(DiscountSkuResourceImpl.class, DiscountSku.class);
+				put(OrderTypeResourceImpl.class, OrderType.class);
+				put(PriceEntryResourceImpl.class, PriceEntry.class);
+				put(
+					PriceListAccountGroupResourceImpl.class,
+					PriceListAccountGroup.class);
+				put(PriceListAccountResourceImpl.class, PriceListAccount.class);
+				put(PriceListChannelResourceImpl.class, PriceListChannel.class);
+				put(
+					PriceListDiscountResourceImpl.class,
+					PriceListDiscount.class);
+				put(
+					PriceListOrderTypeResourceImpl.class,
+					PriceListOrderType.class);
+				put(PriceListResourceImpl.class, PriceList.class);
+				put(
+					PriceModifierCategoryResourceImpl.class,
+					PriceModifierCategory.class);
+				put(
+					PriceModifierProductGroupResourceImpl.class,
+					PriceModifierProductGroup.class);
+				put(
+					PriceModifierProductResourceImpl.class,
+					PriceModifierProduct.class);
+				put(PriceModifierResourceImpl.class, PriceModifier.class);
+				put(ProductGroupResourceImpl.class, ProductGroup.class);
+				put(ProductResourceImpl.class, Product.class);
+				put(SkuResourceImpl.class, Sku.class);
+				put(TierPriceResourceImpl.class, TierPrice.class);
 
-			add(AccountGroupResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(CategoryResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(ChannelResourceImpl.class);
-
-			add(DiscountResourceImpl.class);
-
-			add(DiscountAccountResourceImpl.class);
-
-			add(DiscountAccountGroupResourceImpl.class);
-
-			add(DiscountCategoryResourceImpl.class);
-
-			add(DiscountChannelResourceImpl.class);
-
-			add(DiscountOrderTypeResourceImpl.class);
-
-			add(DiscountProductResourceImpl.class);
-
-			add(DiscountProductGroupResourceImpl.class);
-
-			add(DiscountRuleResourceImpl.class);
-
-			add(DiscountSkuResourceImpl.class);
-
-			add(OrderTypeResourceImpl.class);
-
-			add(PriceEntryResourceImpl.class);
-
-			add(PriceListResourceImpl.class);
-
-			add(PriceListAccountResourceImpl.class);
-
-			add(PriceListAccountGroupResourceImpl.class);
-
-			add(PriceListChannelResourceImpl.class);
-
-			add(PriceListDiscountResourceImpl.class);
-
-			add(PriceListOrderTypeResourceImpl.class);
-
-			add(PriceModifierResourceImpl.class);
-
-			add(PriceModifierCategoryResourceImpl.class);
-
-			add(PriceModifierProductResourceImpl.class);
-
-			add(PriceModifierProductGroupResourceImpl.class);
-
-			add(ProductResourceImpl.class);
-
-			add(ProductGroupResourceImpl.class);
-
-			add(SkuResourceImpl.class);
-
-			add(TierPriceResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
@@ -350,7 +350,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID
-        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.14'."
+        'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.15'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/src/main/java/com/liferay/headless/commerce/admin/shipment/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,20 @@
 
 package com.liferay.headless.commerce.admin.shipment.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.shipment.dto.v1_0.Shipment;
+import com.liferay.headless.commerce.admin.shipment.dto.v1_0.ShipmentItem;
+import com.liferay.headless.commerce.admin.shipment.dto.v1_0.ShippingAddress;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -48,7 +55,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.14'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Admin Shipment API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.shipment.client', and version '1.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Admin Shipment API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -59,18 +66,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,16 +103,21 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ShipmentResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ShipmentItemResourceImpl.class, ShipmentItem.class);
+				put(ShipmentResourceImpl.class, Shipment.class);
+				put(ShippingAddressResourceImpl.class, ShippingAddress.class);
 
-			add(ShipmentItemResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(ShippingAddressResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/src/main/java/com/liferay/headless/commerce/admin/site/setting/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,21 @@
 
 package com.liferay.headless.commerce.admin.site.setting.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.admin.site.setting.dto.v1_0.AvailabilityEstimate;
+import com.liferay.headless.commerce.admin.site.setting.dto.v1_0.MeasurementUnit;
+import com.liferay.headless.commerce.admin.site.setting.dto.v1_0.TaxCategory;
+import com.liferay.headless.commerce.admin.site.setting.dto.v1_0.Warehouse;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +67,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,18 +104,24 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AvailabilityEstimateResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					AvailabilityEstimateResourceImpl.class,
+					AvailabilityEstimate.class);
+				put(MeasurementUnitResourceImpl.class, MeasurementUnit.class);
+				put(TaxCategoryResourceImpl.class, TaxCategory.class);
+				put(WarehouseResourceImpl.class, Warehouse.class);
 
-			add(MeasurementUnitResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(TaxCategoryResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(WarehouseResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/src/main/java/com/liferay/headless/commerce/delivery/cart/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,23 @@
 
 package com.liferay.headless.commerce.delivery.cart.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.delivery.cart.dto.v1_0.Address;
+import com.liferay.headless.commerce.delivery.cart.dto.v1_0.Cart;
+import com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartComment;
+import com.liferay.headless.commerce.delivery.cart.dto.v1_0.CartItem;
+import com.liferay.headless.commerce.delivery.cart.dto.v1_0.PaymentMethod;
+import com.liferay.headless.commerce.delivery.cart.dto.v1_0.ShippingMethod;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +69,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,22 +106,24 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AddressResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AddressResourceImpl.class, Address.class);
+				put(CartCommentResourceImpl.class, CartComment.class);
+				put(CartItemResourceImpl.class, CartItem.class);
+				put(CartResourceImpl.class, Cart.class);
+				put(PaymentMethodResourceImpl.class, PaymentMethod.class);
+				put(ShippingMethodResourceImpl.class, ShippingMethod.class);
 
-			add(CartResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(CartCommentResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(CartItemResourceImpl.class);
-
-			add(PaymentMethodResourceImpl.class);
-
-			add(ShippingMethodResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/src/main/java/com/liferay/headless/commerce/delivery/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,26 @@
 
 package com.liferay.headless.commerce.delivery.catalog.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Attachment;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Category;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.MappedProduct;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Pin;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Product;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductOption;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.ProductSpecification;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.RelatedProduct;
+import com.liferay.headless.commerce.delivery.catalog.dto.v1_0.Sku;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +72,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,28 +109,29 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AttachmentResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AttachmentResourceImpl.class, Attachment.class);
+				put(CategoryResourceImpl.class, Category.class);
+				put(MappedProductResourceImpl.class, MappedProduct.class);
+				put(PinResourceImpl.class, Pin.class);
+				put(ProductOptionResourceImpl.class, ProductOption.class);
+				put(ProductResourceImpl.class, Product.class);
+				put(
+					ProductSpecificationResourceImpl.class,
+					ProductSpecification.class);
+				put(RelatedProductResourceImpl.class, RelatedProduct.class);
+				put(SkuResourceImpl.class, Sku.class);
 
-			add(CategoryResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(MappedProductResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(PinResourceImpl.class);
-
-			add(ProductResourceImpl.class);
-
-			add(ProductOptionResourceImpl.class);
-
-			add(ProductSpecificationResourceImpl.class);
-
-			add(RelatedProductResourceImpl.class);
-
-			add(SkuResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/resource/v2_0/OpenAPIResourceImpl.java
@@ -14,13 +14,23 @@
 
 package com.liferay.data.engine.rest.internal.resource.v2_0;
 
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionFieldLink;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
+import com.liferay.data.engine.rest.dto.v2_0.DataListView;
+import com.liferay.data.engine.rest.dto.v2_0.DataRecord;
+import com.liferay.data.engine.rest.dto.v2_0.DataRecordCollection;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +68,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,22 +105,28 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(DataDefinitionResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					DataDefinitionFieldLinkResourceImpl.class,
+					DataDefinitionFieldLink.class);
+				put(DataDefinitionResourceImpl.class, DataDefinition.class);
+				put(DataLayoutResourceImpl.class, DataLayout.class);
+				put(DataListViewResourceImpl.class, DataListView.class);
+				put(
+					DataRecordCollectionResourceImpl.class,
+					DataRecordCollection.class);
+				put(DataRecordResourceImpl.class, DataRecord.class);
 
-			add(DataDefinitionFieldLinkResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(DataLayoutResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(DataListViewResourceImpl.class);
-
-			add(DataRecordResourceImpl.class);
-
-			add(DataRecordCollectionResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,18 @@
 
 package com.liferay.digital.signature.rest.internal.resource.v1_0;
 
+import com.liferay.digital.signature.rest.dto.v1_0.DSEnvelope;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +63,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,12 +100,19 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(DSEnvelopeResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(DSEnvelopeResourceImpl.class, DSEnvelope.class);
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
+
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-impl/src/main/java/com/liferay/frontend/view/state/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,17 @@
 
 package com.liferay.frontend.view.state.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +62,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,12 +99,19 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ActiveViewResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ActiveViewResourceImpl.class, null);
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
+
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,19 @@
 
 package com.liferay.headless.admin.address.internal.resource.v1_0;
 
+import com.liferay.headless.admin.address.dto.v1_0.Country;
+import com.liferay.headless.admin.address.dto.v1_0.Region;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +64,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,14 +101,20 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(CountryResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(CountryResourceImpl.class, Country.class);
+				put(RegionResourceImpl.class, Region.class);
 
-			add(RegionResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,18 @@
 
 package com.liferay.headless.admin.content.internal.resource.v1_0;
 
+import com.liferay.headless.admin.content.dto.v1_0.DisplayPageTemplate;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +63,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,16 +100,23 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(DisplayPageTemplateResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					DisplayPageTemplateResourceImpl.class,
+					DisplayPageTemplate.class);
+				put(PageDefinitionResourceImpl.class, null);
+				put(StructuredContentResourceImpl.class, null);
 
-			add(PageDefinitionResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(StructuredContentResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/src/main/java/com/liferay/headless/admin/list/type/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,19 @@
 
 package com.liferay.headless.admin.list.type.internal.resource.v1_0;
 
+import com.liferay.headless.admin.list.type.dto.v1_0.ListTypeDefinition;
+import com.liferay.headless.admin.list.type.dto.v1_0.ListTypeEntry;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +64,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,14 +101,22 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ListTypeDefinitionResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					ListTypeDefinitionResourceImpl.class,
+					ListTypeDefinition.class);
+				put(ListTypeEntryResourceImpl.class, ListTypeEntry.class);
 
-			add(ListTypeEntryResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -363,7 +363,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.taxonomy.client', and version '4.0.15'."
+        'com.liferay.headless.admin.taxonomy.client', and version '4.0.16'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,20 @@
 
 package com.liferay.headless.admin.taxonomy.internal.resource.v1_0;
 
+import com.liferay.headless.admin.taxonomy.dto.v1_0.Keyword;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyCategory;
+import com.liferay.headless.admin.taxonomy.dto.v1_0.TaxonomyVocabulary;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -47,7 +54,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.15'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.16'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,18 +65,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,16 +102,23 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(KeywordResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(KeywordResourceImpl.class, Keyword.class);
+				put(TaxonomyCategoryResourceImpl.class, TaxonomyCategory.class);
+				put(
+					TaxonomyVocabularyResourceImpl.class,
+					TaxonomyVocabulary.class);
 
-			add(TaxonomyCategoryResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(TaxonomyVocabularyResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1042,7 +1042,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.28'."
+        'com.liferay.headless.admin.user.client', and version '4.0.29'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,31 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Account;
+import com.liferay.headless.admin.user.dto.v1_0.AccountRole;
+import com.liferay.headless.admin.user.dto.v1_0.EmailAddress;
+import com.liferay.headless.admin.user.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.dto.v1_0.PostalAddress;
+import com.liferay.headless.admin.user.dto.v1_0.Role;
+import com.liferay.headless.admin.user.dto.v1_0.Segment;
+import com.liferay.headless.admin.user.dto.v1_0.SegmentUser;
+import com.liferay.headless.admin.user.dto.v1_0.Site;
+import com.liferay.headless.admin.user.dto.v1_0.Subscription;
+import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
+import com.liferay.headless.admin.user.dto.v1_0.UserGroup;
+import com.liferay.headless.admin.user.dto.v1_0.WebUrl;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -47,7 +65,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.28'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.29'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,18 +76,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,38 +113,32 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AccountResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AccountResourceImpl.class, Account.class);
+				put(AccountRoleResourceImpl.class, AccountRole.class);
+				put(EmailAddressResourceImpl.class, EmailAddress.class);
+				put(OrganizationResourceImpl.class, Organization.class);
+				put(PhoneResourceImpl.class, Phone.class);
+				put(PostalAddressResourceImpl.class, PostalAddress.class);
+				put(RoleResourceImpl.class, Role.class);
+				put(SegmentResourceImpl.class, Segment.class);
+				put(SegmentUserResourceImpl.class, SegmentUser.class);
+				put(SiteResourceImpl.class, Site.class);
+				put(SubscriptionResourceImpl.class, Subscription.class);
+				put(UserAccountResourceImpl.class, UserAccount.class);
+				put(UserGroupResourceImpl.class, UserGroup.class);
+				put(WebUrlResourceImpl.class, WebUrl.class);
 
-			add(AccountRoleResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(EmailAddressResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OrganizationResourceImpl.class);
-
-			add(PhoneResourceImpl.class);
-
-			add(PostalAddressResourceImpl.class);
-
-			add(RoleResourceImpl.class);
-
-			add(SegmentResourceImpl.class);
-
-			add(SegmentUserResourceImpl.class);
-
-			add(SiteResourceImpl.class);
-
-			add(SubscriptionResourceImpl.class);
-
-			add(UserAccountResourceImpl.class);
-
-			add(UserGroupResourceImpl.class);
-
-			add(WebUrlResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/java/com/liferay/headless/admin/workflow/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,25 @@
 
 package com.liferay.headless.admin.workflow.internal.resource.v1_0;
 
+import com.liferay.headless.admin.workflow.dto.v1_0.Assignee;
+import com.liferay.headless.admin.workflow.dto.v1_0.Transition;
+import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowDefinition;
+import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowInstance;
+import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowLog;
+import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTask;
+import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskAssignableUsers;
+import com.liferay.headless.admin.workflow.dto.v1_0.WorkflowTaskTransitions;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +70,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,26 +107,32 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AssigneeResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AssigneeResourceImpl.class, Assignee.class);
+				put(TransitionResourceImpl.class, Transition.class);
+				put(
+					WorkflowDefinitionResourceImpl.class,
+					WorkflowDefinition.class);
+				put(WorkflowInstanceResourceImpl.class, WorkflowInstance.class);
+				put(WorkflowLogResourceImpl.class, WorkflowLog.class);
+				put(
+					WorkflowTaskAssignableUsersResourceImpl.class,
+					WorkflowTaskAssignableUsers.class);
+				put(WorkflowTaskResourceImpl.class, WorkflowTask.class);
+				put(
+					WorkflowTaskTransitionsResourceImpl.class,
+					WorkflowTaskTransitions.class);
 
-			add(TransitionResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(WorkflowDefinitionResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(WorkflowInstanceResourceImpl.class);
-
-			add(WorkflowLogResourceImpl.class);
-
-			add(WorkflowTaskResourceImpl.class);
-
-			add(WorkflowTaskAssignableUsersResourceImpl.class);
-
-			add(WorkflowTaskTransitionsResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,19 @@
 
 package com.liferay.headless.batch.engine.internal.resource.v1_0;
 
+import com.liferay.headless.batch.engine.dto.v1_0.ExportTask;
+import com.liferay.headless.batch.engine.dto.v1_0.ImportTask;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +64,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,14 +101,20 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ExportTaskResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ExportTaskResourceImpl.class, ExportTask.class);
+				put(ImportTaskResourceImpl.class, ImportTask.class);
 
-			add(ImportTaskResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5265,7 +5265,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.32'."
+        'com.liferay.headless.delivery.client', and version '4.0.34'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,41 @@
 
 package com.liferay.headless.delivery.internal.resource.v1_0;
 
+import com.liferay.headless.delivery.dto.v1_0.BlogPosting;
+import com.liferay.headless.delivery.dto.v1_0.BlogPostingImage;
+import com.liferay.headless.delivery.dto.v1_0.Comment;
+import com.liferay.headless.delivery.dto.v1_0.ContentElement;
+import com.liferay.headless.delivery.dto.v1_0.ContentSetElement;
+import com.liferay.headless.delivery.dto.v1_0.ContentStructure;
+import com.liferay.headless.delivery.dto.v1_0.ContentTemplate;
+import com.liferay.headless.delivery.dto.v1_0.Document;
+import com.liferay.headless.delivery.dto.v1_0.DocumentFolder;
+import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseArticle;
+import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseAttachment;
+import com.liferay.headless.delivery.dto.v1_0.KnowledgeBaseFolder;
+import com.liferay.headless.delivery.dto.v1_0.Language;
+import com.liferay.headless.delivery.dto.v1_0.MessageBoardAttachment;
+import com.liferay.headless.delivery.dto.v1_0.MessageBoardMessage;
+import com.liferay.headless.delivery.dto.v1_0.MessageBoardSection;
+import com.liferay.headless.delivery.dto.v1_0.MessageBoardThread;
+import com.liferay.headless.delivery.dto.v1_0.NavigationMenu;
+import com.liferay.headless.delivery.dto.v1_0.SitePage;
+import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
+import com.liferay.headless.delivery.dto.v1_0.StructuredContentFolder;
+import com.liferay.headless.delivery.dto.v1_0.WikiNode;
+import com.liferay.headless.delivery.dto.v1_0.WikiPage;
+import com.liferay.headless.delivery.dto.v1_0.WikiPageAttachment;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -47,7 +75,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.32'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.34'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,18 +86,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,58 +123,64 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(BlogPostingResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(BlogPostingImageResourceImpl.class, BlogPostingImage.class);
+				put(BlogPostingResourceImpl.class, BlogPosting.class);
+				put(CommentResourceImpl.class, Comment.class);
+				put(ContentElementResourceImpl.class, ContentElement.class);
+				put(
+					ContentSetElementResourceImpl.class,
+					ContentSetElement.class);
+				put(ContentStructureResourceImpl.class, ContentStructure.class);
+				put(ContentTemplateResourceImpl.class, ContentTemplate.class);
+				put(DocumentFolderResourceImpl.class, DocumentFolder.class);
+				put(DocumentResourceImpl.class, Document.class);
+				put(
+					KnowledgeBaseArticleResourceImpl.class,
+					KnowledgeBaseArticle.class);
+				put(
+					KnowledgeBaseAttachmentResourceImpl.class,
+					KnowledgeBaseAttachment.class);
+				put(
+					KnowledgeBaseFolderResourceImpl.class,
+					KnowledgeBaseFolder.class);
+				put(LanguageResourceImpl.class, Language.class);
+				put(
+					MessageBoardAttachmentResourceImpl.class,
+					MessageBoardAttachment.class);
+				put(
+					MessageBoardMessageResourceImpl.class,
+					MessageBoardMessage.class);
+				put(
+					MessageBoardSectionResourceImpl.class,
+					MessageBoardSection.class);
+				put(
+					MessageBoardThreadResourceImpl.class,
+					MessageBoardThread.class);
+				put(NavigationMenuResourceImpl.class, NavigationMenu.class);
+				put(SitePageResourceImpl.class, SitePage.class);
+				put(
+					StructuredContentFolderResourceImpl.class,
+					StructuredContentFolder.class);
+				put(
+					StructuredContentResourceImpl.class,
+					StructuredContent.class);
+				put(WikiNodeResourceImpl.class, WikiNode.class);
+				put(
+					WikiPageAttachmentResourceImpl.class,
+					WikiPageAttachment.class);
+				put(WikiPageResourceImpl.class, WikiPage.class);
 
-			add(BlogPostingImageResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(CommentResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(ContentElementResourceImpl.class);
-
-			add(ContentSetElementResourceImpl.class);
-
-			add(ContentStructureResourceImpl.class);
-
-			add(ContentTemplateResourceImpl.class);
-
-			add(DocumentResourceImpl.class);
-
-			add(DocumentFolderResourceImpl.class);
-
-			add(KnowledgeBaseArticleResourceImpl.class);
-
-			add(KnowledgeBaseAttachmentResourceImpl.class);
-
-			add(KnowledgeBaseFolderResourceImpl.class);
-
-			add(LanguageResourceImpl.class);
-
-			add(MessageBoardAttachmentResourceImpl.class);
-
-			add(MessageBoardMessageResourceImpl.class);
-
-			add(MessageBoardSectionResourceImpl.class);
-
-			add(MessageBoardThreadResourceImpl.class);
-
-			add(NavigationMenuResourceImpl.class);
-
-			add(SitePageResourceImpl.class);
-
-			add(StructuredContentResourceImpl.class);
-
-			add(StructuredContentFolderResourceImpl.class);
-
-			add(WikiNodeResourceImpl.class);
-
-			add(WikiPageResourceImpl.class);
-
-			add(WikiPageAttachmentResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/java/com/liferay/headless/form/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,21 @@
 
 package com.liferay.headless.form.internal.resource.v1_0;
 
+import com.liferay.headless.form.dto.v1_0.Form;
+import com.liferay.headless.form.dto.v1_0.FormDocument;
+import com.liferay.headless.form.dto.v1_0.FormRecord;
+import com.liferay.headless.form.dto.v1_0.FormStructure;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +66,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,18 +103,22 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(FormResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(FormDocumentResourceImpl.class, FormDocument.class);
+				put(FormRecordResourceImpl.class, FormRecord.class);
+				put(FormResourceImpl.class, Form.class);
+				put(FormStructureResourceImpl.class, FormStructure.class);
 
-			add(FormDocumentResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(FormRecordResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(FormStructureResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,18 @@
 
 package com.liferay.headless.portal.instances.internal.resource.v1_0;
 
+import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +63,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,12 +100,19 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(PortalInstanceResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(PortalInstanceResourceImpl.class, PortalInstance.class);
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
+
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-openapi.yaml
@@ -105,7 +105,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.notification.rest.client', and version '1.0.4'."
+        'com.liferay.notification.rest.client', and version '1.0.6'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/notification/notification-rest-impl/src/main/java/com/liferay/notification/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,19 @@
 
 package com.liferay.notification.rest.internal.resource.v1_0;
 
+import com.liferay.notification.rest.dto.v1_0.NotificationQueueEntry;
+import com.liferay.notification.rest.dto.v1_0.NotificationTemplate;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -47,7 +53,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.notification.rest.client', and version '1.0.6'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,18 +64,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,14 +101,24 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(NotificationQueueEntryResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					NotificationQueueEntryResourceImpl.class,
+					NotificationQueueEntry.class);
+				put(
+					NotificationTemplateResourceImpl.class,
+					NotificationTemplate.class);
 
-			add(NotificationTemplateResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -501,7 +501,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.object.admin.rest.client', and version '1.0.32'."
+        'com.liferay.object.admin.rest.client', and version '1.0.33'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/object/object-admin-rest-impl/src/main/java/com/liferay/object/admin/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,24 @@
 
 package com.liferay.object.admin.rest.internal.resource.v1_0;
 
+import com.liferay.object.admin.rest.dto.v1_0.ObjectAction;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectField;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectLayout;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectRelationship;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectValidationRule;
+import com.liferay.object.admin.rest.dto.v1_0.ObjectView;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -47,7 +58,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.32'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.object.admin.rest.client', and version '1.0.33'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Object", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,18 +69,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,24 +106,29 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ObjectActionResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ObjectActionResourceImpl.class, ObjectAction.class);
+				put(ObjectDefinitionResourceImpl.class, ObjectDefinition.class);
+				put(ObjectFieldResourceImpl.class, ObjectField.class);
+				put(ObjectLayoutResourceImpl.class, ObjectLayout.class);
+				put(
+					ObjectRelationshipResourceImpl.class,
+					ObjectRelationship.class);
+				put(
+					ObjectValidationRuleResourceImpl.class,
+					ObjectValidationRule.class);
+				put(ObjectViewResourceImpl.class, ObjectView.class);
 
-			add(ObjectDefinitionResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(ObjectFieldResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(ObjectLayoutResourceImpl.class);
-
-			add(ObjectRelationshipResourceImpl.class);
-
-			add(ObjectValidationRuleResourceImpl.class);
-
-			add(ObjectViewResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -318,12 +318,13 @@ public class ObjectEntryOpenAPIResourceImpl
 		}
 
 		return new DTOProperty(
-			HashMapBuilder.<String, Object>put(
-				"x-parent-map", "properties"
-			).put(
-				"x-required", String.valueOf(objectField.isRequired())
-			).build(),
-			objectField.getName(), objectField.getDBType());
+			Collections.singletonMap("x-parent-map", "properties"),
+			objectField.getName(), objectField.getDBType()) {
+
+			{
+				setRequired(objectField.isRequired());
+			}
+		};
 	}
 
 	private OpenAPISchemaFilter _getOpenAPISchemaFilter(

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/openapi/v1_0/ObjectEntryOpenAPIResourceImpl.java
@@ -342,7 +342,7 @@ public class ObjectEntryOpenAPIResourceImpl
 					_objectDefinition.getObjectDefinitionId()),
 				this::_getDTOProperty));
 
-		openAPISchemaFilter.setDTOProperty(dtoProperty);
+		openAPISchemaFilter.setDTOProperties(Arrays.asList(dtoProperty));
 
 		openAPISchemaFilter.setSchemaMappings(
 			HashMapBuilder.put(

--- a/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-search/portal-search-rest-impl/src/main/java/com/liferay/portal/search/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,18 @@
 
 package com.liferay.portal.search.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.search.rest.dto.v1_0.Suggestion;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +63,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,12 +100,19 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(SuggestionResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(SuggestionResourceImpl.class, Suggestion.class);
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
+
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 11.0.2
+Bundle-Version: 12.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
@@ -20,6 +20,7 @@ import com.liferay.portal.vulcan.extension.validation.PropertyValidator;
 
 import java.math.BigDecimal;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -28,10 +29,15 @@ import java.util.Map;
 public class PropertyDefinition {
 
 	public PropertyDefinition(
-		Class<?> propertyClass, String propertyName, PropertyType propertyType,
+		Class<?> propertyClass, String propertyClassDescription,
+		String propertyClassName, String propertyDescription,
+		String propertyName, PropertyType propertyType,
 		PropertyValidator propertyValidator, boolean required) {
 
 		_propertyClass = propertyClass;
+		_propertyClassDescription = propertyClassDescription;
+		_propertyClassName = propertyClassName;
+		_propertyDescription = propertyDescription;
 		_propertyName = propertyName;
 		_propertyType = propertyType;
 		_propertyValidator = propertyValidator;
@@ -39,8 +45,10 @@ public class PropertyDefinition {
 	}
 
 	public PropertyDefinition(
-		String propertyName, PropertyType propertyType, boolean required) {
+		String propertyDescription, String propertyName,
+		PropertyType propertyType, boolean required) {
 
+		_propertyDescription = propertyDescription;
 		_propertyName = propertyName;
 		_propertyType = propertyType;
 		_required = required;
@@ -50,9 +58,11 @@ public class PropertyDefinition {
 	}
 
 	public PropertyDefinition(
-		String propertyName, PropertyType propertyType,
-		PropertyValidator propertyValidator, boolean required) {
+		String propertyDescription, String propertyName,
+		PropertyType propertyType, PropertyValidator propertyValidator,
+		boolean required) {
 
+		_propertyDescription = propertyDescription;
 		_propertyName = propertyName;
 		_propertyType = propertyType;
 		_propertyValidator = propertyValidator;
@@ -63,6 +73,22 @@ public class PropertyDefinition {
 
 	public Class<?> getPropertyClass() {
 		return _propertyClass;
+	}
+
+	public String getPropertyClassDescription() {
+		return _propertyClassDescription;
+	}
+
+	public String getPropertyClassName() {
+		return _propertyClassName;
+	}
+
+	public List<PropertyDefinition> getPropertyDefinitions() {
+		return _propertyDefinitions;
+	}
+
+	public String getPropertyDescription() {
+		return _propertyDescription;
 	}
 
 	public String getPropertyName() {
@@ -79,6 +105,12 @@ public class PropertyDefinition {
 
 	public boolean isRequired() {
 		return _required;
+	}
+
+	public void setPropertyDefinitions(
+		List<PropertyDefinition> propertyDefinitions) {
+
+		_propertyDefinitions = propertyDefinitions;
 	}
 
 	public enum PropertyType {
@@ -106,6 +138,10 @@ public class PropertyDefinition {
 		).build();
 
 	private final Class<?> _propertyClass;
+	private String _propertyClassDescription;
+	private String _propertyClassName;
+	private List<PropertyDefinition> _propertyDefinitions;
+	private final String _propertyDescription;
 	private final String _propertyName;
 	private final PropertyType _propertyType;
 	private final PropertyValidator _propertyValidator;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/DTOProperty.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/DTOProperty.java
@@ -40,6 +40,10 @@ public class DTOProperty {
 		this(new HashMap<>(), name, type);
 	}
 
+	public String getDescription() {
+		return _description;
+	}
+
 	public List<DTOProperty> getDTOProperties() {
 		return _dtoProperties;
 	}
@@ -56,6 +60,14 @@ public class DTOProperty {
 		return _type;
 	}
 
+	public boolean isRequired() {
+		return _required;
+	}
+
+	public void setDescription(String description) {
+		_description = description;
+	}
+
 	public void setDTOProperties(List<DTOProperty> dtoProperties) {
 		_dtoProperties = dtoProperties;
 	}
@@ -64,13 +76,19 @@ public class DTOProperty {
 		_name = name;
 	}
 
+	public void setRequired(boolean required) {
+		_required = required;
+	}
+
 	public void setType(String type) {
 		_type = type;
 	}
 
+	private String _description;
 	private List<DTOProperty> _dtoProperties = new ArrayList<>();
 	private final Map<String, Object> _extensions;
 	private String _name;
+	private boolean _required;
 	private String _type;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/OpenAPISchemaFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/openapi/OpenAPISchemaFilter.java
@@ -14,7 +14,9 @@
 
 package com.liferay.portal.vulcan.openapi;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -26,8 +28,8 @@ public class OpenAPISchemaFilter {
 		return _applicationPath;
 	}
 
-	public DTOProperty getDTOProperty() {
-		return _dtoProperty;
+	public List<DTOProperty> getDTOProperties() {
+		return _dtoProperties;
 	}
 
 	public Map<String, String> getSchemaMappings() {
@@ -38,8 +40,8 @@ public class OpenAPISchemaFilter {
 		_applicationPath = applicationPath;
 	}
 
-	public void setDTOProperty(DTOProperty dtoProperty) {
-		_dtoProperty = dtoProperty;
+	public void setDTOProperties(List<DTOProperty> dtoProperties) {
+		_dtoProperties = dtoProperties;
 	}
 
 	public void setSchemaMappings(Map<String, String> schemaMappings) {
@@ -47,7 +49,7 @@ public class OpenAPISchemaFilter {
 	}
 
 	private String _applicationPath;
-	private DTOProperty _dtoProperty;
+	private List<DTOProperty> _dtoProperties = new ArrayList<>();
 	private Map<String, String> _schemaMappings = new HashMap<>();
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/OpenAPIResource.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/resource/OpenAPIResource.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.resource;
 
 import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
 
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.ServletConfig;
@@ -37,6 +38,14 @@ public interface OpenAPIResource {
 		throws Exception {
 
 		return getOpenAPI(resourceClasses, type);
+	}
+
+	public default Response getOpenAPI(
+			long companyId, Map<Class<?>, Class<?>> resourceDTOClasses,
+			String type, UriInfo uriInfo)
+		throws Exception {
+
+		return getOpenAPI(resourceDTOClasses.keySet(), type, uriInfo);
 	}
 
 	public default Response getOpenAPI(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/extension/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/extension/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/openapi/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 2.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/resource/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/resource/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
@@ -50,7 +50,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.BIG_DECIMAL,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -64,7 +64,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.BOOLEAN, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -79,6 +79,8 @@ public class DefaultPropertyValidatorTest {
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
 			String.class, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.DATE_TIME, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -92,7 +94,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.DECIMAL, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -106,7 +108,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.DOUBLE, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -120,7 +122,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.INTEGER, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -134,7 +136,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.BIG_DECIMAL,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -149,6 +151,8 @@ public class DefaultPropertyValidatorTest {
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
 			String.class, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.DATE_TIME, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -163,6 +167,8 @@ public class DefaultPropertyValidatorTest {
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
 			TestInvalidClass.class, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -178,6 +184,8 @@ public class DefaultPropertyValidatorTest {
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
 			TestInvalidClass.class, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -191,7 +199,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.BOOLEAN, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -205,8 +213,9 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(), PropertyDefinition.PropertyType.LONG,
-			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.LONG, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
 
 		defaultPropertyValidator.validate(
 			propertyDefinition, RandomTestUtil.randomLong());
@@ -219,6 +228,8 @@ public class DefaultPropertyValidatorTest {
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
 			TestClass.class, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -233,7 +244,8 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			null, RandomTestUtil.randomString(),
+			null, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.BOOLEAN, defaultPropertyValidator,
 			RandomTestUtil.randomBoolean());
 
@@ -248,6 +260,8 @@ public class DefaultPropertyValidatorTest {
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
 			TestClass.class, RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -261,8 +275,9 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			RandomTestUtil.randomString(), PropertyDefinition.PropertyType.TEXT,
-			defaultPropertyValidator, RandomTestUtil.randomBoolean());
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			PropertyDefinition.PropertyType.TEXT, defaultPropertyValidator,
+			RandomTestUtil.randomBoolean());
 
 		defaultPropertyValidator.validate(
 			propertyDefinition, RandomTestUtil.randomString());

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandler.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandler.java
@@ -56,6 +56,20 @@ public class EntityExtensionHandler {
 		return extendedProperties;
 	}
 
+	public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(
+		long companyId, String className) {
+
+		Map<String, PropertyDefinition> propertyDefinitions = new HashMap<>();
+
+		for (ExtensionProvider extensionProvider : _extensionProviders) {
+			propertyDefinitions.putAll(
+				extensionProvider.getExtendedPropertyDefinitions(
+					companyId, className));
+		}
+
+		return propertyDefinitions;
+	}
+
 	public Set<String> getFilteredPropertyNames(long companyId, Object entity) {
 		Set<String> filteredPropertyNames = new HashSet<>();
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/extension/util/ExtensionUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/extension/util/ExtensionUtil.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.extension.util;
+
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.vulcan.extension.ExtensionProvider;
+import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
+import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
+
+import java.util.List;
+
+/**
+ * @author Carlos Correa
+ */
+public class ExtensionUtil {
+
+	public static EntityExtensionHandler getEntityExtensionHandler(
+		String className, long companyId,
+		ExtensionProviderRegistry extensionProviderRegistry) {
+
+		List<ExtensionProvider> extensionProviders =
+			extensionProviderRegistry.getExtensionProviders(
+				companyId, className);
+
+		if (ListUtil.isEmpty(extensionProviders)) {
+			return null;
+		}
+
+		return new EntityExtensionHandler(className, extensionProviders);
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/EntityExtensionHandlerContextResolver.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/context/resolver/EntityExtensionHandlerContextResolver.java
@@ -15,11 +15,9 @@
 package com.liferay.portal.vulcan.internal.jaxrs.context.resolver;
 
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.vulcan.extension.ExtensionProvider;
 import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
 import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
-
-import java.util.List;
+import com.liferay.portal.vulcan.internal.extension.util.ExtensionUtil;
 
 import javax.ws.rs.core.Context;
 import javax.ws.rs.ext.ContextResolver;
@@ -40,15 +38,9 @@ public class EntityExtensionHandlerContextResolver
 
 	@Override
 	public EntityExtensionHandler getContext(Class<?> clazz) {
-		List<ExtensionProvider> extensionProviders =
-			_extensionProviderRegistry.getExtensionProviders(
-				_company.getCompanyId(), clazz.getName());
-
-		if (extensionProviders.isEmpty()) {
-			return null;
-		}
-
-		return new EntityExtensionHandler(clazz.getName(), extensionProviders);
+		return ExtensionUtil.getEntityExtensionHandler(
+			clazz.getName(), _company.getCompanyId(),
+			_extensionProviderRegistry);
 	}
 
 	@Context

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -14,7 +14,6 @@
 
 package com.liferay.portal.vulcan.internal.resource;
 
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -544,13 +543,7 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 							childDTOProperty.getName(),
 							_addSchema(childDTOProperty));
 
-						Map<String, Object> extensions =
-							childDTOProperty.getExtensions();
-
-						if ((extensions != null) &&
-							GetterUtil.getBoolean(
-								extensions.get("x-required"))) {
-
+						if (childDTOProperty.isRequired()) {
 							schema.addRequiredItem(childDTOProperty.getName());
 						}
 					}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -15,12 +15,19 @@
 package com.liferay.portal.vulcan.internal.resource;
 
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
 import com.liferay.portal.vulcan.internal.configuration.util.ConfigurationUtil;
+import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
+import com.liferay.portal.vulcan.internal.extension.util.ExtensionUtil;
 import com.liferay.portal.vulcan.openapi.DTOProperty;
 import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
+import com.liferay.portal.vulcan.util.TransformUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
 import io.swagger.v3.core.filter.AbstractSpecFilter;
@@ -48,8 +55,10 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.servers.Server;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -69,6 +78,21 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(service = OpenAPIResource.class)
 public class OpenAPIResourceImpl implements OpenAPIResource {
+
+	@Override
+	public Response getOpenAPI(
+			long companyId, Map<Class<?>, Class<?>> resourceDTOClasses,
+			String type, UriInfo uriInfo)
+		throws Exception {
+
+		OpenAPISchemaFilter openAPISchemaFilter = _getOpenAPISchemaFilter(
+			UriInfoUtil.getBasePath(uriInfo),
+			new HashSet<>(resourceDTOClasses.values()), companyId,
+			_extensionProviderRegistry);
+
+		return getOpenAPI(
+			openAPISchemaFilter, resourceDTOClasses.keySet(), type, uriInfo);
+	}
 
 	@Override
 	public Response getOpenAPI(
@@ -164,8 +188,173 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 		return getOpenAPI(null, resourceClasses, type, uriInfo);
 	}
 
+	private DTOProperty _getDTOProperty(PropertyDefinition propertyDefinition) {
+		PropertyDefinition.PropertyType propertyType =
+			propertyDefinition.getPropertyType();
+
+		DTOProperty dtoProperty;
+
+		String type = null;
+
+		if ((propertyType ==
+				PropertyDefinition.PropertyType.MULTIPLE_ELEMENT) ||
+			(propertyType == PropertyDefinition.PropertyType.SINGLE_ELEMENT)) {
+
+			if (propertyType ==
+					PropertyDefinition.PropertyType.MULTIPLE_ELEMENT) {
+
+				type = "Array";
+			}
+			else {
+				type = "Object";
+			}
+
+			dtoProperty = new DTOProperty(
+				null, propertyDefinition.getPropertyName(), type);
+
+			DTOProperty objectDTOProperty = new DTOProperty(
+				null, propertyDefinition.getPropertyClassName(), "Object");
+
+			dtoProperty.setDTOProperties(Arrays.asList(objectDTOProperty));
+
+			if (ListUtil.isNotEmpty(
+					propertyDefinition.getPropertyDefinitions())) {
+
+				List<DTOProperty> dtoProperties = new ArrayList<>();
+
+				for (PropertyDefinition definition :
+						propertyDefinition.getPropertyDefinitions()) {
+
+					dtoProperties.add(_getDTOProperty(definition));
+				}
+
+				objectDTOProperty.setDTOProperties(dtoProperties);
+			}
+		}
+		else {
+			if (propertyType == PropertyDefinition.PropertyType.BIG_DECIMAL) {
+				type = "Double";
+			}
+			else if (propertyType == PropertyDefinition.PropertyType.BOOLEAN) {
+				type = "Boolean";
+			}
+			else if (propertyType ==
+						PropertyDefinition.PropertyType.DATE_TIME) {
+
+				type = "Date";
+			}
+			else if (propertyType == PropertyDefinition.PropertyType.DECIMAL) {
+				type = "Float";
+			}
+			else if (propertyType == PropertyDefinition.PropertyType.DOUBLE) {
+				type = "Double";
+			}
+			else if (propertyType == PropertyDefinition.PropertyType.INTEGER) {
+				type = "Integer";
+			}
+			else if (propertyType == PropertyDefinition.PropertyType.LONG) {
+				type = "Long";
+			}
+			else if (propertyType == PropertyDefinition.PropertyType.TEXT) {
+				type = "String";
+			}
+			else {
+				type = "Object";
+			}
+
+			dtoProperty = new DTOProperty(
+				null, propertyDefinition.getPropertyName(), type);
+		}
+
+		dtoProperty.setDescription(propertyDefinition.getPropertyDescription());
+
+		return dtoProperty;
+	}
+
+	private List<PropertyDefinition> _getExtendedPropertyDefinitions(
+		Class<?> clazz, long companyId,
+		ExtensionProviderRegistry extensionProviderRegistry) {
+
+		List<PropertyDefinition> propertyDefinitions = new ArrayList<>();
+
+		String className = clazz.getName();
+
+		EntityExtensionHandler entityExtensionHandler =
+			ExtensionUtil.getEntityExtensionHandler(
+				className, companyId, extensionProviderRegistry);
+
+		if (entityExtensionHandler != null) {
+			Map<String, PropertyDefinition> extendedPropertyDefinitions =
+				entityExtensionHandler.getExtendedPropertyDefinitions(
+					companyId, className);
+
+			propertyDefinitions.addAll(extendedPropertyDefinitions.values());
+		}
+
+		return propertyDefinitions;
+	}
+
+	private OpenAPISchemaFilter _getOpenAPISchemaFilter(
+		String applicationPath,
+		Map<Class<?>, List<PropertyDefinition>> propertyDefinitions) {
+
+		List<DTOProperty> dtoProperties = new ArrayList<>();
+
+		for (Map.Entry<Class<?>, List<PropertyDefinition>> entry :
+				propertyDefinitions.entrySet()) {
+
+			Class<?> clazz = entry.getKey();
+
+			DTOProperty dtoProperty = new DTOProperty(
+				null, clazz.getSimpleName(), "object");
+
+			dtoProperty.setDTOProperties(
+				TransformUtil.transform(
+					entry.getValue(), this::_getDTOProperty));
+
+			dtoProperties.add(dtoProperty);
+		}
+
+		return new OpenAPISchemaFilter() {
+			{
+				setApplicationPath(applicationPath);
+				setDTOProperties(dtoProperties);
+			}
+		};
+	}
+
+	private OpenAPISchemaFilter _getOpenAPISchemaFilter(
+		String basePath, Set<Class<?>> classes, long companyId,
+		ExtensionProviderRegistry extensionProviderRegistry) {
+
+		Map<Class<?>, List<PropertyDefinition>> propertyDefinitions =
+			new HashMap<>();
+		OpenAPISchemaFilter openAPISchemaFilter = null;
+
+		for (Class<?> clazz : classes) {
+			if (clazz == null) {
+				continue;
+			}
+
+			propertyDefinitions.put(
+				clazz,
+				_getExtendedPropertyDefinitions(
+					clazz, companyId, extensionProviderRegistry));
+		}
+
+		if (MapUtil.isNotEmpty(propertyDefinitions)) {
+			openAPISchemaFilter = _getOpenAPISchemaFilter(
+				basePath, propertyDefinitions);
+		}
+
+		return openAPISchemaFilter;
+	}
+
 	private OpenAPISpecFilter _toOpenAPISpecFilter(
 		OpenAPISchemaFilter openAPISchemaFilter) {
+
+		List<DTOProperty> dtoProperties =
+			openAPISchemaFilter.getDTOProperties();
 
 		Map<String, String> schemaMappings =
 			openAPISchemaFilter.getSchemaMappings();
@@ -194,6 +383,21 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 					schemas.remove(key);
 
 					_replaceParameters(key, openAPI.getPaths());
+				}
+
+				for (DTOProperty dtoProperty : dtoProperties) {
+					Map<DTOProperty, Schema> newSchemas = _getNewSchemas(
+						dtoProperty);
+
+					if (MapUtil.isEmpty(newSchemas)) {
+						continue;
+					}
+
+					_fixNewSchemaNames(newSchemas, schemas);
+
+					for (Schema schema : newSchemas.values()) {
+						openAPI.schema(schema.getName(), schema);
+					}
 				}
 
 				return super.filterOpenAPI(openAPI, params, cookies, headers);
@@ -326,9 +530,13 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 					schema.addProperties("x-schema-name", stringSchema);
 				}
 
-				DTOProperty dtoProperty = openAPISchemaFilter.getDTOProperty();
+				for (DTOProperty dtoProperty : dtoProperties) {
+					if (!StringUtil.equals(
+							dtoProperty.getName(), schema.getName())) {
 
-				if (Objects.equals(dtoProperty.getName(), schema.getName())) {
+						continue;
+					}
+
 					for (DTOProperty childDTOProperty :
 							dtoProperty.getDTOProperties()) {
 
@@ -376,12 +584,47 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 			}
 
 			private Schema<Object> _addSchema(DTOProperty dtoProperty) {
+				String type = dtoProperty.getType();
+
+				if (type.equals("Array")) {
+					ArraySchema arraySchema = new ArraySchema();
+
+					arraySchema.setDescription(dtoProperty.getDescription());
+					arraySchema.setExtensions(dtoProperty.getExtensions());
+					arraySchema.setName(dtoProperty.getName());
+					arraySchema.setType("array");
+
+					List<DTOProperty> dtoProperties =
+						dtoProperty.getDTOProperties();
+
+					if (ListUtil.isNotEmpty(dtoProperties)) {
+						DTOProperty childDTOProperty = dtoProperties.get(0);
+
+						String childType = childDTOProperty.getType();
+
+						if (childType.equals("Object")) {
+							arraySchema.setItems(
+								new Schema() {
+									{
+										set$ref(
+											"#/components/schemas/" +
+												childDTOProperty.getName());
+									}
+								});
+						}
+						else {
+							arraySchema.setItems(_addSchema(childDTOProperty));
+						}
+					}
+
+					return arraySchema;
+				}
+
 				Schema<Object> schema = new Schema<>();
 
+				schema.setDescription(dtoProperty.getDescription());
 				schema.setExtensions(dtoProperty.getExtensions());
 				schema.setName(dtoProperty.getName());
-
-				String type = dtoProperty.getType();
 
 				if (type.equals("Boolean")) {
 					schema.setType("boolean");
@@ -394,6 +637,10 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 					schema.setFormat("double");
 					schema.setType("number");
 				}
+				else if (type.equals("Float")) {
+					schema.setFormat("float");
+					schema.setType("number");
+				}
 				else if (type.equals("Integer")) {
 					schema.setFormat("int32");
 					schema.setType("integer");
@@ -402,6 +649,31 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 					schema.setFormat("int64");
 					schema.setType("integer");
 				}
+				else if (type.equals("Object")) {
+					schema.setType("object");
+
+					for (DTOProperty childDTOProperty :
+							dtoProperty.getDTOProperties()) {
+
+						if (StringUtil.equals(
+								childDTOProperty.getType(), "Object")) {
+
+							schema.set$ref(
+								"#/components/schemas/" +
+									childDTOProperty.getName());
+						}
+						else {
+							schema.addProperties(
+								childDTOProperty.getName(),
+								_addSchema(childDTOProperty));
+
+							if (childDTOProperty.isRequired()) {
+								schema.addRequiredItem(
+									childDTOProperty.getName());
+							}
+						}
+					}
+				}
 				else if (type.equals("String")) {
 					schema.setType("string");
 				}
@@ -409,15 +681,82 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 					schema.setType("object");
 				}
 
-				for (DTOProperty childDTOProperty :
-						dtoProperty.getDTOProperties()) {
+				return schema;
+			}
 
-					schema.addProperties(
-						childDTOProperty.getName(),
-						_addSchema(childDTOProperty));
+			private void _fixNewSchemaNames(
+				Map<DTOProperty, Schema> newSchemas,
+				Map<String, Schema> schemas) {
+
+				for (Map.Entry<DTOProperty, Schema> entry :
+						newSchemas.entrySet()) {
+
+					Schema schema = entry.getValue();
+
+					if (schemas.containsKey(schema.getName())) {
+						String newName = "C." + schema.getName();
+
+						schema.setName(newName);
+
+						DTOProperty dtoProperty = entry.getKey();
+
+						dtoProperty.setName(newName);
+					}
+				}
+			}
+
+			private Map<DTOProperty, Schema> _getNewSchemas(
+				DTOProperty dtoProperty) {
+
+				Map<DTOProperty, Schema> schemas = new HashMap<>();
+
+				if (StringUtil.equals(dtoProperty.getType(), "Array") ||
+					StringUtil.equals(dtoProperty.getType(), "Object")) {
+
+					for (DTOProperty childDTOProperty1 :
+							dtoProperty.getDTOProperties()) {
+
+						if (StringUtil.equals(
+								childDTOProperty1.getType(), "Object")) {
+
+							Schema schema = new Schema();
+
+							schema.setDescription(
+								childDTOProperty1.getDescription());
+							schema.setExtensions(
+								childDTOProperty1.getExtensions());
+							schema.setName(childDTOProperty1.getName());
+							schema.setType("object");
+
+							for (DTOProperty childDTOProperty2 :
+									childDTOProperty1.getDTOProperties()) {
+
+								schema.addProperties(
+									childDTOProperty2.getName(),
+									_addSchema(childDTOProperty2));
+
+								if (childDTOProperty2.isRequired()) {
+									schema.addRequiredItem(
+										childDTOProperty2.getName());
+								}
+
+								schemas.putAll(
+									_getNewSchemas(childDTOProperty2));
+							}
+
+							schemas.put(childDTOProperty1, schema);
+						}
+					}
+				}
+				else {
+					for (DTOProperty childDTOProperty :
+							dtoProperty.getDTOProperties()) {
+
+						schemas.putAll(_getNewSchemas(childDTOProperty));
+					}
 				}
 
-				return schema;
+				return schemas;
 			}
 
 			private void _replaceContentReference(Content content) {
@@ -479,5 +818,8 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 
 	@Reference
 	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference
+	private ExtensionProviderRegistry _extensionProviderRegistry;
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImpl.java
@@ -274,7 +274,7 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 		Class<?> clazz, long companyId,
 		ExtensionProviderRegistry extensionProviderRegistry) {
 
-		List<PropertyDefinition> propertyDefinitions = new ArrayList<>();
+		List<PropertyDefinition> propertyDefinitions = null;
 
 		String className = clazz.getName();
 
@@ -287,7 +287,8 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 				entityExtensionHandler.getExtendedPropertyDefinitions(
 					companyId, className);
 
-			propertyDefinitions.addAll(extendedPropertyDefinitions.values());
+			propertyDefinitions = new ArrayList<>(
+				extendedPropertyDefinitions.values());
 		}
 
 		return propertyDefinitions;
@@ -326,7 +327,7 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 		String basePath, Set<Class<?>> classes, long companyId,
 		ExtensionProviderRegistry extensionProviderRegistry) {
 
-		Map<Class<?>, List<PropertyDefinition>> propertyDefinitions =
+		Map<Class<?>, List<PropertyDefinition>> propertyDefinitionMap =
 			new HashMap<>();
 		OpenAPISchemaFilter openAPISchemaFilter = null;
 
@@ -335,15 +336,18 @@ public class OpenAPIResourceImpl implements OpenAPIResource {
 				continue;
 			}
 
-			propertyDefinitions.put(
-				clazz,
+			List<PropertyDefinition> propertyDefinitions =
 				_getExtendedPropertyDefinitions(
-					clazz, companyId, extensionProviderRegistry));
+					clazz, companyId, extensionProviderRegistry);
+
+			if (ListUtil.isNotEmpty(propertyDefinitions)) {
+				propertyDefinitionMap.put(clazz, propertyDefinitions);
+			}
 		}
 
-		if (MapUtil.isNotEmpty(propertyDefinitions)) {
+		if (MapUtil.isNotEmpty(propertyDefinitionMap)) {
 			openAPISchemaFilter = _getOpenAPISchemaFilter(
-				basePath, propertyDefinitions);
+				basePath, propertyDefinitionMap);
 		}
 
 		return openAPISchemaFilter;

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
@@ -227,13 +227,17 @@ public class EntityExtensionHandlerTest {
 		String propertyName4 = RandomTestUtil.randomString();
 
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName1,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName2,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName3,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			propertyName4, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName4,
+			PropertyDefinition.PropertyType.TEXT, false);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -301,13 +305,17 @@ public class EntityExtensionHandlerTest {
 		String propertyName4 = RandomTestUtil.randomString();
 
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName1,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName2,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName3,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
+			RandomTestUtil.randomString(), propertyName4,
+			PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -375,13 +383,17 @@ public class EntityExtensionHandlerTest {
 		String propertyName4 = RandomTestUtil.randomString();
 
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName1,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName2,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName3,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
+			RandomTestUtil.randomString(), propertyName4,
+			PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -447,13 +459,17 @@ public class EntityExtensionHandlerTest {
 		String propertyName4 = RandomTestUtil.randomString();
 
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName1,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName2,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName3,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
+			RandomTestUtil.randomString(), propertyName4,
+			PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(
@@ -519,13 +535,17 @@ public class EntityExtensionHandlerTest {
 		String propertyName4 = RandomTestUtil.randomString();
 
 		PropertyDefinition propertyDefinition1 = new PropertyDefinition(
-			propertyName1, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName1,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition2 = new PropertyDefinition(
-			propertyName2, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName2,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition3 = new PropertyDefinition(
-			propertyName3, PropertyDefinition.PropertyType.TEXT, false);
+			RandomTestUtil.randomString(), propertyName3,
+			PropertyDefinition.PropertyType.TEXT, false);
 		PropertyDefinition propertyDefinition4 = new PropertyDefinition(
-			propertyName4, PropertyDefinition.PropertyType.TEXT, true);
+			RandomTestUtil.randomString(), propertyName4,
+			PropertyDefinition.PropertyType.TEXT, true);
 
 		Mockito.when(
 			extensionProviderMock1.getExtendedPropertyDefinitions(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/extension/EntityExtensionHandlerTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.extension;
 
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.extension.ExtensionProvider;
 import com.liferay.portal.vulcan.extension.PropertyDefinition;
@@ -107,6 +108,62 @@ public class EntityExtensionHandlerTest {
 			propertyValue1, extendedProperties.get(propertyName1));
 		Assert.assertEquals(
 			propertyValue2, extendedProperties.get(propertyName2));
+	}
+
+	@Test
+	public void testGetExtendedPropertyDefinitions() throws Exception {
+		String propertyName1 = RandomTestUtil.randomString();
+		String propertyName2 = RandomTestUtil.randomString();
+		PropertyDefinition propertyDefinition1 = Mockito.mock(
+			PropertyDefinition.class);
+		PropertyDefinition propertyDefinition2 = Mockito.mock(
+			PropertyDefinition.class);
+
+		Map<String, PropertyDefinition> testMap1 = Collections.singletonMap(
+			propertyName1, propertyDefinition1);
+
+		Mockito.when(
+			_mockedExtensionProvider1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			testMap1
+		);
+
+		Map<String, PropertyDefinition> testMap2 = Collections.singletonMap(
+			propertyName2, propertyDefinition2);
+
+		Mockito.when(
+			_mockedExtensionProvider2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			testMap2
+		);
+
+		Map<String, PropertyDefinition> extendedPropertyDefinitions =
+			_entityExtensionHandler.getExtendedPropertyDefinitions(
+				_COMPANY_ID, _CLASS_NAME);
+
+		Mockito.verify(
+			_mockedExtensionProvider1
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+
+		Mockito.verify(
+			_mockedExtensionProvider2
+		).getExtendedPropertyDefinitions(
+			_COMPANY_ID, _CLASS_NAME
+		);
+
+		Assert.assertEquals(
+			MapUtil.toString(extendedPropertyDefinitions), 2,
+			extendedPropertyDefinitions.size());
+		Assert.assertSame(
+			propertyDefinition1,
+			extendedPropertyDefinitions.get(propertyName1));
+		Assert.assertSame(
+			propertyDefinition2,
+			extendedPropertyDefinitions.get(propertyName2));
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImplTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/resource/OpenAPIResourceImplTest.java
@@ -1,0 +1,300 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.resource;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.extension.ExtensionProvider;
+import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+import com.liferay.portal.vulcan.openapi.OpenAPISchemaFilter;
+
+import java.lang.reflect.Field;
+
+import java.net.URI;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Carlos Correa
+ */
+public class OpenAPIResourceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testOpenAPIResourceImplWithExtensions() throws Exception {
+		OpenAPIResourceImpl openAPIResourceImpl = Mockito.spy(
+			_setDefaultProperties(new OpenAPIResourceImpl()));
+
+		Mockito.when(
+			_uriBuilder.build()
+		).thenReturn(
+			URI.create(_BASE_PATH)
+		);
+		Mockito.when(
+			_uriInfo.getBaseUriBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		ExtensionProvider extensionProvider1 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProvider2 = Mockito.mock(
+			ExtensionProvider.class);
+		ExtensionProvider extensionProvider3 = Mockito.mock(
+			ExtensionProvider.class);
+
+		Mockito.when(
+			_extensionProviderRegistry.getExtensionProviders(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			Arrays.asList(extensionProvider1, extensionProvider2)
+		).thenReturn(
+			Arrays.asList(extensionProvider3)
+		);
+
+		Mockito.when(
+			extensionProvider1.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				RandomTestUtil.randomString(),
+				Mockito.mock(PropertyDefinition.class)
+			).put(
+				RandomTestUtil.randomString(),
+				Mockito.mock(PropertyDefinition.class)
+			).build()
+		);
+		Mockito.when(
+			extensionProvider2.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				RandomTestUtil.randomString(),
+				Mockito.mock(PropertyDefinition.class)
+			).put(
+				RandomTestUtil.randomString(),
+				Mockito.mock(PropertyDefinition.class)
+			).build()
+		);
+		Mockito.when(
+			extensionProvider3.getExtendedPropertyDefinitions(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			HashMapBuilder.put(
+				RandomTestUtil.randomString(),
+				Mockito.mock(PropertyDefinition.class)
+			).build()
+		);
+
+		Response responseMock = Mockito.mock(Response.class);
+
+		Mockito.doReturn(
+			responseMock
+		).when(
+			openAPIResourceImpl
+		).getOpenAPI(
+			Mockito.any(OpenAPISchemaFilter.class), Mockito.anySet(),
+			Mockito.anyString(), Mockito.any(UriInfo.class)
+		);
+
+		Response response = openAPIResourceImpl.getOpenAPI(
+			_COMPANY_ID, _resourceDTOClasses, _TYPE, _uriInfo);
+
+		Assert.assertSame(responseMock, response);
+
+		Mockito.verify(
+			_uriBuilder
+		).build();
+		Mockito.verify(
+			_uriInfo
+		).getBaseUriBuilder();
+		Mockito.verify(
+			_extensionProviderRegistry
+		).getExtensionProviders(
+			_COMPANY_ID, ClassDTOTest1.class.getName()
+		);
+		Mockito.verify(
+			_extensionProviderRegistry
+		).getExtensionProviders(
+			_COMPANY_ID, ClassDTOTest2.class.getName()
+		);
+		Mockito.verify(
+			openAPIResourceImpl
+		).getOpenAPI(
+			Mockito.notNull(OpenAPISchemaFilter.class),
+			Mockito.eq(
+				SetUtil.fromArray(
+					ClassTest1.class, ClassTest2.class, ClassTest3.class)),
+			Mockito.eq(_TYPE), Mockito.eq(_uriInfo)
+		);
+	}
+
+	@Test
+	public void testOpenAPIResourceImplWithNoExtensions() throws Exception {
+		OpenAPIResourceImpl openAPIResourceImpl = Mockito.spy(
+			_setDefaultProperties(new OpenAPIResourceImpl()));
+
+		Mockito.when(
+			_uriBuilder.build()
+		).thenReturn(
+			URI.create(_BASE_PATH)
+		);
+		Mockito.when(
+			_uriInfo.getBaseUriBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+		Mockito.when(
+			_extensionProviderRegistry.getExtensionProviders(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			null
+		);
+
+		Response responseMock = Mockito.mock(Response.class);
+
+		Mockito.doReturn(
+			responseMock
+		).when(
+			openAPIResourceImpl
+		).getOpenAPI(
+			Mockito.any(OpenAPISchemaFilter.class), Mockito.anySet(),
+			Mockito.anyString(), Mockito.any(UriInfo.class)
+		);
+
+		Response response = openAPIResourceImpl.getOpenAPI(
+			_COMPANY_ID, _resourceDTOClasses, _TYPE, _uriInfo);
+
+		Assert.assertSame(responseMock, response);
+
+		Mockito.verify(
+			_uriBuilder
+		).build();
+		Mockito.verify(
+			_uriInfo
+		).getBaseUriBuilder();
+		Mockito.verify(
+			_extensionProviderRegistry
+		).getExtensionProviders(
+			_COMPANY_ID, ClassDTOTest1.class.getName()
+		);
+		Mockito.verify(
+			_extensionProviderRegistry
+		).getExtensionProviders(
+			_COMPANY_ID, ClassDTOTest2.class.getName()
+		);
+		Mockito.verify(
+			openAPIResourceImpl
+		).getOpenAPI(
+			null,
+			SetUtil.fromArray(
+				ClassTest1.class, ClassTest2.class, ClassTest3.class),
+			_TYPE, _uriInfo
+		);
+	}
+
+	private void _set(Object object, String fieldName, Object value) {
+		Class<?> clazz = object.getClass();
+
+		try {
+			Field field = clazz.getDeclaredField(fieldName);
+
+			field.setAccessible(true);
+
+			field.set(object, value);
+		}
+		catch (Exception exception) {
+			throw new IllegalArgumentException(exception);
+		}
+	}
+
+	private OpenAPIResourceImpl _setDefaultProperties(
+		OpenAPIResourceImpl openAPIResourceImpl) {
+
+		_set(
+			openAPIResourceImpl, "_extensionProviderRegistry",
+			_extensionProviderRegistry);
+
+		return openAPIResourceImpl;
+	}
+
+	private static final String _BASE_PATH = RandomTestUtil.randomString();
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final String _TYPE = RandomTestUtil.randomString();
+
+	private static final Map<Class<?>, Class<?>> _resourceDTOClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ClassTest1.class, ClassDTOTest1.class);
+				put(ClassTest2.class, ClassDTOTest2.class);
+				put(ClassTest3.class, null);
+			}
+		};
+
+	@Mock
+	private ExtensionProviderRegistry _extensionProviderRegistry;
+
+	@Mock
+	private UriBuilder _uriBuilder;
+
+	@Mock
+	private UriInfo _uriInfo;
+
+	private static class ClassDTOTest1 {
+	}
+
+	private static class ClassDTOTest2 {
+	}
+
+	private static class ClassTest1 {
+	}
+
+	private static class ClassTest2 {
+	}
+
+	private static class ClassTest3 {
+	}
+
+}

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/src/main/java/com/liferay/headless/commerce/punchout/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,18 @@
 
 package com.liferay.headless.commerce.punchout.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.punchout.dto.v1_0.PunchOutSession;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +64,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,12 +101,19 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(PunchOutSessionResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(PunchOutSessionResourceImpl.class, PunchOutSession.class);
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
+
+	@Context
+	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/src/main/java/com/liferay/headless/commerce/machine/learning/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,20 @@
 
 package com.liferay.headless.commerce.machine.learning.internal.resource.v1_0;
 
+import com.liferay.headless.commerce.machine.learning.dto.v1_0.AccountCategoryForecast;
+import com.liferay.headless.commerce.machine.learning.dto.v1_0.AccountForecast;
+import com.liferay.headless.commerce.machine.learning.dto.v1_0.SkuForecast;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -59,18 +66,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -79,16 +103,23 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AccountCategoryForecastResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(
+					AccountCategoryForecastResourceImpl.class,
+					AccountCategoryForecast.class);
+				put(AccountForecastResourceImpl.class, AccountForecast.class);
+				put(SkuForecastResourceImpl.class, SkuForecast.class);
 
-			add(AccountForecastResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(SkuForecastResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/src/main/java/com/liferay/portal/workflow/metrics/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,34 @@
 
 package com.liferay.portal.workflow.metrics.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Assignee;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.AssigneeMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Calendar;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.HistogramMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Index;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Instance;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Node;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.NodeMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Process;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessMetric;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ProcessVersion;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.ReindexStatus;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Role;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLA;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.SLAResult;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.Task;
+import com.liferay.portal.workflow.metrics.rest.dto.v1_0.TimeRange;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +79,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,44 +116,35 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(AssigneeResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(AssigneeMetricResourceImpl.class, AssigneeMetric.class);
+				put(AssigneeResourceImpl.class, Assignee.class);
+				put(CalendarResourceImpl.class, Calendar.class);
+				put(HistogramMetricResourceImpl.class, HistogramMetric.class);
+				put(IndexResourceImpl.class, Index.class);
+				put(InstanceResourceImpl.class, Instance.class);
+				put(NodeMetricResourceImpl.class, NodeMetric.class);
+				put(NodeResourceImpl.class, Node.class);
+				put(ProcessMetricResourceImpl.class, ProcessMetric.class);
+				put(ProcessResourceImpl.class, Process.class);
+				put(ProcessVersionResourceImpl.class, ProcessVersion.class);
+				put(ReindexStatusResourceImpl.class, ReindexStatus.class);
+				put(RoleResourceImpl.class, Role.class);
+				put(SLAResourceImpl.class, SLA.class);
+				put(SLAResultResourceImpl.class, SLAResult.class);
+				put(TaskResourceImpl.class, Task.class);
+				put(TimeRangeResourceImpl.class, TimeRange.class);
 
-			add(AssigneeMetricResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(CalendarResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(HistogramMetricResourceImpl.class);
-
-			add(IndexResourceImpl.class);
-
-			add(InstanceResourceImpl.class);
-
-			add(NodeResourceImpl.class);
-
-			add(NodeMetricResourceImpl.class);
-
-			add(ProcessResourceImpl.class);
-
-			add(ProcessMetricResourceImpl.class);
-
-			add(ProcessVersionResourceImpl.class);
-
-			add(ReindexStatusResourceImpl.class);
-
-			add(RoleResourceImpl.class);
-
-			add(SLAResourceImpl.class);
-
-			add(SLAResultResourceImpl.class);
-
-			add(TaskResourceImpl.class);
-
-			add(TimeRangeResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-openapi.yaml
@@ -523,7 +523,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.search.experiences.rest.client', and version '3.0.3'."
+        'com.liferay.search.experiences.rest.client', and version '3.0.4'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,27 @@
 
 package com.liferay.search.experiences.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
+import com.liferay.search.experiences.rest.dto.v1_0.FieldMappingInfo;
+import com.liferay.search.experiences.rest.dto.v1_0.KeywordQueryContributor;
+import com.liferay.search.experiences.rest.dto.v1_0.ModelPrefilterContributor;
+import com.liferay.search.experiences.rest.dto.v1_0.QueryPrefilterContributor;
+import com.liferay.search.experiences.rest.dto.v1_0.SXPBlueprint;
+import com.liferay.search.experiences.rest.dto.v1_0.SXPElement;
+import com.liferay.search.experiences.rest.dto.v1_0.SXPParameterContributorDefinition;
+import com.liferay.search.experiences.rest.dto.v1_0.SearchResponse;
+import com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetName;
+import com.liferay.search.experiences.rest.dto.v1_0.SearchableAssetNameDisplay;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -47,7 +61,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.3'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.search.experiences.rest.client', and version '3.0.4'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {
@@ -58,18 +72,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,30 +109,40 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(FieldMappingInfoResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(FieldMappingInfoResourceImpl.class, FieldMappingInfo.class);
+				put(
+					KeywordQueryContributorResourceImpl.class,
+					KeywordQueryContributor.class);
+				put(
+					ModelPrefilterContributorResourceImpl.class,
+					ModelPrefilterContributor.class);
+				put(
+					QueryPrefilterContributorResourceImpl.class,
+					QueryPrefilterContributor.class);
+				put(
+					SearchableAssetNameDisplayResourceImpl.class,
+					SearchableAssetNameDisplay.class);
+				put(
+					SearchableAssetNameResourceImpl.class,
+					SearchableAssetName.class);
+				put(SearchResponseResourceImpl.class, SearchResponse.class);
+				put(SXPBlueprintResourceImpl.class, SXPBlueprint.class);
+				put(SXPElementResourceImpl.class, SXPElement.class);
+				put(
+					SXPParameterContributorDefinitionResourceImpl.class,
+					SXPParameterContributorDefinition.class);
 
-			add(KeywordQueryContributorResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(ModelPrefilterContributorResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(QueryPrefilterContributorResourceImpl.class);
-
-			add(SXPBlueprintResourceImpl.class);
-
-			add(SXPElementResourceImpl.class);
-
-			add(SXPParameterContributorDefinitionResourceImpl.class);
-
-			add(SearchResponseResourceImpl.class);
-
-			add(SearchableAssetNameResourceImpl.class);
-
-			add(SearchableAssetNameDisplayResourceImpl.class);
-
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/src/main/java/com/liferay/segments/asah/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -14,13 +14,20 @@
 
 package com.liferay.segments.asah.rest.internal.resource.v1_0;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
+import com.liferay.segments.asah.rest.dto.v1_0.Experiment;
+import com.liferay.segments.asah.rest.dto.v1_0.ExperimentRun;
+import com.liferay.segments.asah.rest.dto.v1_0.Status;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Generated;
@@ -58,18 +65,35 @@ public class OpenAPIResourceImpl {
 	public Response getOpenAPI(@PathParam("type") String type)
 		throws Exception {
 
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		}
+		else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(
+				_resourceClasses.keySet(), type, _uriInfo);
+		}
+		else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz =
 				_openAPIResource.getClass();
 
-			clazz.getMethod(
-				"getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", parameterClasses);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -78,16 +102,21 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
-		{
-			add(ExperimentResourceImpl.class);
+	private final Map<Class<?>, Class<?>> _resourceClasses =
+		new HashMap<Class<?>, Class<?>>() {
+			{
+				put(ExperimentResourceImpl.class, Experiment.class);
+				put(ExperimentRunResourceImpl.class, ExperimentRun.class);
+				put(StatusResourceImpl.class, Status.class);
 
-			add(ExperimentRunResourceImpl.class);
+				put(OpenAPIResourceImpl.class, null);
+			}
+		};
 
-			add(StatusResourceImpl.class);
+	@Context
+	private Company _company;
 
-			add(OpenAPIResourceImpl.class);
-		}
-	};
+	private static final Log _log = LogFactoryUtil.getLog(
+		OpenAPIResourceImpl.class);
 
 }

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/FreeMarkerTool.java
@@ -136,9 +136,9 @@ public class FreeMarkerTool {
 			return Collections.emptyMap();
 		}
 
-		Set<Map.Entry<String, PathItem>> entries = pathItems.entrySet();
+		Map<String, Schema> allSchemas = new HashMap<>(schemas);
 
-		for (Map.Entry<String, PathItem> entry : entries) {
+		for (Map.Entry<String, PathItem> entry : pathItems.entrySet()) {
 			List<Operation> operations = OpenAPIParserUtil.getOperations(
 				entry.getValue());
 
@@ -146,21 +146,21 @@ public class FreeMarkerTool {
 				List<String> tags = operation.getTags();
 
 				for (String tag : tags) {
-					if (!schemas.containsKey(tag)) {
+					if (!allSchemas.containsKey(tag)) {
 						if ((allExternalSchemas != null) &&
 							allExternalSchemas.containsKey(tag)) {
 
-							schemas.put(tag, allExternalSchemas.get(tag));
+							allSchemas.put(tag, allExternalSchemas.get(tag));
 						}
 						else {
-							schemas.put(tag, new Schema());
+							allSchemas.put(tag, new Schema());
 						}
 					}
 				}
 			}
 		}
 
-		return schemas;
+		return allSchemas;
 	}
 
 	public List<JavaMethodParameter> getBodyJavaMethodParameters(

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/openapi_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/openapi_resource_impl.ftl
@@ -1,13 +1,34 @@
 package ${configYAML.apiPackagePath}.internal.resource.${escapedVersion};
 
+<#assign
+	schemas = freeMarkerTool.getSchemas(openAPIYAML)
+	allSchemas = freeMarkerTool.getAllSchemas(null, openAPIYAML, schemas)
+
+	resourceSchemaNameClasses = {}
+/>
+
+<#list allSchemas?keys as schemaName>
+	<#assign javaMethodSignatures = freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName) />
+
+	<#if javaMethodSignatures?has_content>
+		<#if schemas?keys?seq_contains(schemaName)>
+			<#assign resourceSchemaNameClasses = resourceSchemaNameClasses + {schemaName + "ResourceImpl.class": schemaName + ".class"} />
+			import ${configYAML.apiPackagePath}.dto.${escapedVersion}.${schemaName};
+		<#else>
+			<#assign resourceSchemaNameClasses = resourceSchemaNameClasses + {schemaName + "ResourceImpl.class": "null"} />
+		</#if>
+	</#if>
+</#list>
+
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.annotation.Generated;
 
@@ -58,13 +79,13 @@ public class OpenAPIResourceImpl {
 		try {
 			Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
 
-			clazz.getMethod("getOpenAPI", Set.class, String.class, UriInfo.class);
+			clazz.getMethod("getOpenAPI", long.class, Map.class, String.class, UriInfo.class);
 		}
 		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses, type);
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
 		}
 
-		return _openAPIResource.getOpenAPI(_resourceClasses, type, _uriInfo);
+		return _openAPIResource.getOpenAPI(_company.getCompanyId(), _resourceClasses, type, _uriInfo);
 	}
 
 	@Reference
@@ -73,18 +94,17 @@ public class OpenAPIResourceImpl {
 	@Context
 	private UriInfo _uriInfo;
 
-	private final Set<Class<?>> _resourceClasses = new HashSet<Class<?>>() {
+	private final Map<Class<?>, Class<?>> _resourceClasses = new HashMap<Class<?>, Class<?>>() {
 		{
-			<#list freeMarkerTool.getAllSchemas(null, openAPIYAML, freeMarkerTool.getSchemas(openAPIYAML))?keys as schemaName>
-				<#assign javaMethodSignatures = freeMarkerTool.getResourceJavaMethodSignatures(configYAML, openAPIYAML, schemaName) />
-
-				<#if javaMethodSignatures?has_content>
-					add(${schemaName}ResourceImpl.class);
-				</#if>
+			<#list resourceSchemaNameClasses?keys?sort as resourceClass>
+				put(${resourceClass}, ${resourceSchemaNameClasses[resourceClass]});
 			</#list>
 
-			add(OpenAPIResourceImpl.class);
+			put(OpenAPIResourceImpl.class, null);
 		}
 	};
+
+	@Context
+	private Company _company;
 
 }

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/openapi_resource_impl.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/openapi_resource_impl.ftl
@@ -20,6 +20,8 @@ package ${configYAML.apiPackagePath}.internal.resource.${escapedVersion};
 	</#if>
 </#list>
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.resource.OpenAPIResource;
 
@@ -29,6 +31,7 @@ import io.swagger.v3.oas.annotations.info.License;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Generated;
 
@@ -76,16 +79,29 @@ public class OpenAPIResourceImpl {
 	@Path("/openapi.{type:json|yaml}")
 	@Produces({MediaType.APPLICATION_JSON, "application/yaml"})
 	public Response getOpenAPI(@PathParam("type") String type) throws Exception {
+		if (_methodExists(long.class, Map.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		} else if (_methodExists(Set.class, String.class, UriInfo.class)) {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type, _uriInfo);
+		} else {
+			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+		}
+	}
+
+	private boolean _methodExists(Class<?>... parameterClasses) {
 		try {
 			Class<? extends OpenAPIResource> clazz = _openAPIResource.getClass();
 
-			clazz.getMethod("getOpenAPI", long.class, Map.class, String.class, UriInfo.class);
-		}
-		catch (NoSuchMethodException noSuchMethodException) {
-			return _openAPIResource.getOpenAPI(_resourceClasses.keySet(), type);
+			clazz.getMethod("getOpenAPI", parameterClasses);
+		} catch (NoSuchMethodException noSuchMethodException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchMethodException);
+			}
+
+			return false;
 		}
 
-		return _openAPIResource.getOpenAPI(_company.getCompanyId(), _resourceClasses, type, _uriInfo);
+		return true;
 	}
 
 	@Reference
@@ -106,5 +122,7 @@ public class OpenAPIResourceImpl {
 
 	@Context
 	private Company _company;
+
+	private static final Log _log = LogFactoryUtil.getLog(OpenAPIResourceImpl.class);
 
 }


### PR DESCRIPTION
Related PR: https://github.com/liferay-frontend/liferay-portal/pull/2527

The differences between the current pull request and the related one are the following:

- The declaration and the implementation of the getOpenAPI new method have been splitted in two commits to allow an easy backport just with the API commit.
- Some validations have been included to avoid making extra executions of unneeded code.
- A unit test has been included to verify that, when there are no ExtensionProvider available, the OpenAPI file is generated the same way as before.
- Some validations has been included to verify which method should be invoked to create the OpenAPI File

---

**NOTE**: It is necessary to backport the code of the `OpenAPIResource` Vulcan interface (apart from the buildREST command output) to have a succeed compilation of the dependant modules. By the time this pull request has been created, the commit is b1acc67fb8ec608fb5a651e571b5195a4bce3b2e.

---

This PR contains the code to expose the Extended Properties in the OpenAPI file. Those properties are exposed in the Schemas whose DTO class is extended by a list of ExtensionProvider.

For that, a new method has been created in the `OpenAPIResource` Vulcan interface and in its implementation `OpenAPIResourceImpl`. That new method contains a default implementation in the API:

```
public default Response getOpenAPI(
		long companyId, Map<Class<?>, Class<?>> resourceDTOClasses,
		String type, UriInfo uriInfo)
	throws Exception {

	return getOpenAPI(resourceDTOClasses.keySet(), type, uriInfo);
}
```
The default implementation is just invoking the method thas is being called from the OpenAPI Resource Implementation of all the APIs.

---

Based on the `PropertyDefinition` objects returned by the `ExtensionProvider` interfaces, the properties will be exposed in the OpenAPI as follows:

- For "basic" properties (`PropertyType in [BIG_DECIMAL, BOOLEAN, DATE_TIME, DECIMAL, DOUBLE, INTEGER, LONG, TEXT]`): the property will be added to the current Schema with the name provided by the field `PropertyDefinition.propertyName`.

- For a Single element property (`PropertyType == SINGLE_ELEMENT`) (for example, a Custom Object related to a System Object with a 1toM or 1to1 relationship):
  - A schema will be created with the name provided by the field `PropertyDefinition.propertyClassName` (or with the prefix "C." in case there is another existing Schema with that name). 
  - A property with type = "object" with a reference to the recently created schema and whose name is provided by the field `PropertyDefinition.propertyName`.

- For a Multiple element property (`PropertyType == MULTIPLE_ELEMENT`) (for example, a Custom Object related to a System Object with a Mto1 or MtoM relationship):
  - A schema will be created with the name provided by the field `PropertyDefinition.propertyClassName` (or with the prefix "C." in case there is another existing Schema with that name). 
  - A property with type = "array" with a reference to the recently created schema and whose name is provided by the field `PropertyDefinition.propertyName`.

---

### Example with a possible Extension with Objects:

Given an ExtensionProvider for managing Objects, and the System Object **UserAccount** of the **Headless Admin User** API, having the following fields and relationships:
- `additionalName_ext`: String field
- `emailAddress_ext`: String field
- `givenName_ext`: String field
- `uuid_ext`: String field
- `universityUsers`: 1 to Many relationship between the Custom Object `University` and the System Object `UserAccount`
- `usersSubjects`: Many to Many relationship between the Custom Object `Subject` and the System Object `UserAccount`.

For that case:

1. The fields `additionalName_ext`, `emailAddress_ext`, `givenName_ext` and `uuid_ext` are added to the existing schema `UserAccount` in the OpenAPI
2. A new Schema `University` is created with the properties of the Custom Object `University`.
![image](https://user-images.githubusercontent.com/32699538/178957856-87cd0aa3-07e4-494e-9e47-2aa464527be8.png)
3. A new Schema `Subject` is created with the properties of the Custom Object `Subject`.
![image](https://user-images.githubusercontent.com/32699538/178957928-76859ad5-48d1-467c-b9f1-5be833b074a3.png)
4. A new field `universityUsers` of type `object` is added to the existing Schema `UserAccount` in the OpenAPI.
5. A new field `usersSubjects` of type `array` is added to the existing Schema `UserAccount` in the OpenAPI.

![image](https://user-images.githubusercontent.com/32699538/178956622-e26abb3c-bf2d-48c4-87fd-8bd7ebb06166.png)

