### PR TITLE
LPS-158408 | Can get object entires related by OneToMany when different relationship types created

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -748,6 +748,89 @@ definition {
 	}
 
 	@priority = "5"
+	test CanGetObjectEntiresRelatedByOneToManyWhenDifferentRelationshipTypesCreated {
+		property portal.acceptance = "true";
+
+		task ("Given active student object definition created") {
+			var objectDefinitionId3 = ObjectDefinitionAPI.createAndPublishObjectDefinition(
+				en_US_label = "student",
+				en_US_plural_label = "students",
+				name = "Student",
+				requiredStringFieldName = "name");
+		}
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${staticObjectId1}",
+				objectDefinitionId2 = "${staticObjectId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given oneToMany relationship subjectStudents created") {
+			var objectDefinitionId2 = JSONObject.getObjectId(objectName = "Student");
+
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "subjectsStudents",
+				name = "subjectsStudents",
+				objectDefinitionId1 = "${staticObjectId2}",
+				objectDefinitionId2 = "${objectDefinitionId2}",
+				type = "oneToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("Given student entry created") {
+			var studentId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "students",
+				name = "Liferay Employee");
+		}
+
+		task ("Given subject entry related to university entry through universities PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("Given student entry related to subject entry through subjects PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "subjects",
+				objectEntry1 = "${subjectId}",
+				objectEntry2 = "${studentId}",
+				relationshipName = "subjectsStudents");
+		}
+
+		task ("When I call subjects GET endpoint with {subjectId}/subjectStudents") {
+			var responseToParse = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "subjects",
+				objectId = "${subjectId}",
+				relationshipName = "subjectsStudents");
+		}
+
+		task ("Then I receive the correct information about the students related to it") {
+			ObjectDefinitionAPI.assertResponseHasCorrectObjectEntryName(
+				expectedValue = "Liferay Employee",
+				objectEntryId = "${studentId}",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
+	@priority = "5"
 	test CanGetSecondObjectEntiresRelatedToFirstObjectByManyToMany {
 		property portal.acceptance = "true";
 


### PR DESCRIPTION
**Background**
Add a test to can get object entires related by ManyToMany when different relationship types created

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects created
And Given student created
And Given oneToMany relationship subjectStudents created
And Given university entry created
And Given subject entry related to the university entry created
And Given student entry related to the subject entry created
When in c/subjects I use GET /{subjectId}/subjectStudents
Then I receive the correct information about the students related to it

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-158408