### PR TITLE
Master Lps 158444 | Add tests on get document by asset library id and erc

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -29,6 +29,22 @@ definition {
 		return "${curl}";
 	}
 
+	macro _filterDocumentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${filtervalue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/documents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro addDocumentInAssetLibraryByUploadFile {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
 
@@ -54,6 +70,20 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualExternalReferenceCodeValue}",
 			expected = "${expectedExternalReferenceCodeValue}");
+	}
+
+	macro assertProperDocumentTotalCount {
+		Variables.assertDefined(parameterList = "${expectedDocumentTotalCount}");
+
+		var response = DocumentAPI._filterDocumentInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			filtervalue = "${filtervalue}");
+
+		var actualDocumentTotalCount = JSONUtil.getWithJSONPath("${response}", "$..['totalCount']");
+
+		TestUtils.assertEquals(
+			actual = "${actualDocumentTotalCount}",
+			expected = "${expectedDocumentTotalCount}");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -45,6 +45,22 @@ definition {
 		return "${curl}";
 	}
 
+	macro _getDocumentsByErcInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro addDocumentInAssetLibraryByUploadFile {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
 
@@ -84,6 +100,14 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualDocumentTotalCount}",
 			expected = "${expectedDocumentTotalCount}");
+	}
+
+	macro getDocumentsByErcInAssetLibrary {
+		var response = DocumentAPI._getDocumentsByErcInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}");
+
+		return "${response}";
 	}
 
 	macro getIdOfCreatedDocument {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -74,11 +74,7 @@ definition {
 
 	macro assertExternalReferenceCodeWithCorrectValue {
 		if (!(isSet(expectedExternalReferenceCodeValue))) {
-			var contentURL = JSONUtil.getWithJSONPath("${responseToParse}", "$.['contentUrl']");
-
-			var contentURLSubString = StringUtil.extractFirst("${contentURL}", "?");
-
-			var expectedExternalReferenceCodeValue = StringUtil.extractLast("${contentURLSubString}", "/");
+			var expectedExternalReferenceCodeValue = DocumentAPI.getUuidOfCreatedDocument(responseToParse = "${responseToParse}");
 		}
 
 		var actualExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
@@ -119,6 +115,18 @@ definition {
 		var documentId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
 
 		return "${documentId}";
+	}
+
+	macro getUuidOfCreatedDocument {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		var contentURL = JSONUtil.getWithJSONPath("${responseToParse}", "$.['contentUrl']");
+
+		var contentURLSubString = StringUtil.extractFirst("${contentURL}", "?");
+
+		var documentUuid = StringUtil.extractLast("${contentURLSubString}", "/");
+
+		return "${documentUuid}";
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -86,4 +86,15 @@ definition {
 			expected = "${expectedDocumentTotalCount}");
 	}
 
+	macro getIdOfCreatedDocument {
+		var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			filePath = "${filePath}");
+
+		var documentId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
+
+		return "${documentId}";
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -86,6 +86,44 @@ definition {
 		}
 	}
 
+	@description = "Document is created in an asset library with previous document id as erc"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryWithDocumentIdAsErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with POST request I create a document with a custom erc equals to the internal id of the previously created document") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${documentId}",
+				filePath = "${filePath}");
+		}
+
+		task ("Then I can see erc equals to the id in the body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${documentId}",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then the document is created properly") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with erc by default"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithErcByDefault {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,44 @@ definition {
 		}
 	}
 
+	@description = "Document is not able to create with an existing erc in asset library"
+	@priority = "5"
+	test CannotCreateDocumentInAssetLibraryWithExistingErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with POST I create another document with an existing erc") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("Then I receive duplicate external reference code response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "Duplicate file entry external reference code erc");
+		}
+
+		task ("And Then another document with same erc is not being created") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "0",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -64,6 +64,28 @@ definition {
 		}
 	}
 
+	@description = "Unable to get document by nonexistent assetLibraryId"
+	@priority = "4"
+	test CanReturnErrorWithGetDocumentInAssetLibraryByNonexistentAssetLibraryId {
+		property portal.acceptance = "true";
+
+		task ("When I make a GET request by non-existent assetLibraryID and a erc") {
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "nonexistentId",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive not found error response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "NOT_FOUND");
+		}
+
+		task ("And Then I receive error message in server console") {
+			AssertConsoleTextPresent(value1 = "Unable to get a valid asset library with ID nonexistentId");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -86,6 +86,26 @@ definition {
 		}
 	}
 
+	@description = "Unable to get document by nonexistent erc"
+	@priority = "4"
+	test CanReturnErrorWithGetDocumentInAssetLibraryByNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a GET request by assetLibraryID and non-existent erc") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc");
+		}
+
+		task ("Then I receive error message in response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "No DLFileEntry exists with the key");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -54,6 +54,35 @@ definition {
 		}
 	}
 
+	@description = "Get document in asset library by existing uuid as erc"
+	@priority = "5"
+	test CanGetDocumentInAssetLibraryByExistingUuidAsErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document without a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a GET request by assetLibraryId and UUID as the erc") {
+			var documentUuid = DocumentAPI.getUuidOfCreatedDocument(responseToParse = "${response}");
+
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${documentUuid}");
+		}
+
+		task ("Then I receive a correct body response") {
+			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${documentUuid}",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Document is not able to create with an existing erc in asset library"
 	@priority = "5"
 	test CannotCreateDocumentInAssetLibraryWithExistingErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,34 @@ definition {
 		}
 	}
 
+	@description = "Get document in asset library by existing custom erc"
+	@priority = "5"
+	test CanGetDocumentInAssetLibraryByExistingCustomErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a GET request by assetLibraryId and erc") {
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive a correct body response") {
+			HeadlessWebcontentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Document is not able to create with an existing erc in asset library"
 	@priority = "5"
 	test CannotCreateDocumentInAssetLibraryWithExistingErc {


### PR DESCRIPTION
**Background**

- Add test on unable to create document with existing erc in asset library
- Add test to create document using previous id as erc in asset library
- Add test on get document with erc and nonexistent asset library id
- Add test on get document by nonexistent erc in asset library
- Add test to get document by asset library id and custom erc 
- Add test to get document using asset library id and uuid as erc

**Test Plan**

- LPS-157973
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When with POST I create a document with an existing erc
Then I receive an error code responseAnd Then another document with same erc is not being created
- LPS-158443
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When with POST request I create a document with a custom erc with a value of the internal id of the previously created document
Then the document is being createdAnd Then I can see the custom erc in the body response
- LPS-158444
When I make a GET request by non-existent assetLibraryID and a erc
Then I receive a 404 error codeAnd Then I receive error message in server console: Unable to get a valid asset library with ID
- LPS-158445
Given asset library is created
When I make a GET request by assetLibraryID and non-existent erc
Then I receive a 404 error codeAnd Then I receive details error message about no JournalArticle exists with the key
- LPS-158446
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When I make a GET request by assetLibraryId and erc
Then I receive a correct body response
- LPS-158447
Given asset library is created
And Given a document without a custom erc is created with a POST request in asset library
When I make a GET request by assetLibraryId and erc, and using UUID as the erc
Then I receive a correct body response

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-157973
- https://issues.liferay.com/browse/LPS-158443
- https://issues.liferay.com/browse/LPS-158444
- https://issues.liferay.com/browse/LPS-158445
- https://issues.liferay.com/browse/LPS-158446
- https://issues.liferay.com/browse/LPS-158447