### PR TITLE
LPS-158438 Update cookie.js to enforce cookie consent at reading time

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -796,7 +796,7 @@ export function sub(
 ): string;
 
 /* Returns the stored value of a cookie, undefined if not present */
-export function getCookie(name: string): string | undefined;
+export function getCookie(name: string, type: TYPE_VALUES): string | undefined;
 
 /* Sets a cookie of a specific type if user has consented */
 export function setCookie(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -254,7 +254,10 @@ declare module Liferay {
 				| 'CONSENT_TYPE_PERSONALIZATION';
 
 			/* Returns the stored value of a cookie, undefined if not present */
-			export function get(name: string): string | undefined;
+			export function get(
+				name: string,
+				type: TYPE_VALUES
+			): string | undefined;
 
 			/* Sets a cookie of a specific type if user has consented */
 			export function set(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/consent.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/consent.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {getCookie} from './cookie';
+
+export const CONSENT_TYPES = {
+	FUNCTIONAL: 'CONSENT_TYPE_FUNCTIONAL',
+	NECESSARY: 'CONSENT_TYPE_NECESSARY',
+	PERFORMANCE: 'CONSENT_TYPE_PERFORMANCE',
+	PERSONALIZATION: 'CONSENT_TYPE_PERSONALIZATION',
+};
+
+/**
+ * Checks whether the user has consented to a specific type of cookie by looking at the config cookie value.
+ * - If it's 'true', the user has consented.
+ * - If it's 'false', the user has rejected that specific consent type.
+ * - If it doesn't exist, cookie consent doesn't apply and cookie can be set.
+ *
+ * @param {string} type Type of consent, from {@link CONSENT_TYPES}
+ * @returns {boolean} Boolean representing whether we are allowed to set the cookie
+ */
+export function checkConsent(type) {
+	return (
+		type === CONSENT_TYPES.NECESSARY ||
+		getCookie(type, CONSENT_TYPES.NECESSARY) !== 'false'
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie.js
@@ -12,12 +12,7 @@
  * details.
  */
 
-export const COOKIE_TYPES = {
-	FUNCTIONAL: 'CONSENT_TYPE_FUNCTIONAL',
-	NECESSARY: 'CONSENT_TYPE_NECESSARY',
-	PERFORMANCE: 'CONSENT_TYPE_PERFORMANCE',
-	PERSONALIZATION: 'CONSENT_TYPE_PERSONALIZATION',
-};
+import {CONSENT_TYPES, checkConsent} from './consent';
 
 const generateCookie = (name, value, options = {}) => {
 	let cookie = `${name}=${value}`;
@@ -42,25 +37,17 @@ const generateCookie = (name, value, options = {}) => {
 };
 
 /**
- * Checks whether the user has consented to a specific type of cookie by looking at the config cookie value.
- * - If it's 'true', the user has consented.
- * - If it's 'false', the user has rejected that specific cookie type.
- * - If it doesn't exist, cookie consent doesn't apply and cookie can be set.
- *
- * @param {string} type Type of consent, from {@link COOKIE_TYPES}
- * @returns {boolean} Boolean representing whether we are allowed to set the cookie
- */
-function checkConsent(type) {
-	return type === COOKIE_TYPES.NECESSARY || getCookie(type) !== 'false';
-}
-
-/**
  * Gets the current value for a specific cookie
  *
  * @param {string} name
+ * @param {string} type Type of consent the cookie requires, from {@link COOKIE_TYPES}
  * @returns {(string|undefined)} Cookie value as a string, undefined if not present
  */
-export function getCookie(name) {
+export function getCookie(name, type) {
+	if (!checkConsent(type)) {
+		return undefined;
+	}
+
 	return document.cookie
 		.split('; ')
 		.find((v) => v.startsWith(`${name}=`))
@@ -107,7 +94,7 @@ export function setCookie(name, value, type, options) {
 }
 
 export default {
-	TYPES: COOKIE_TYPES,
+	TYPES: CONSENT_TYPES,
 	get: getCookie,
 	remove: removeCookie,
 	set: setCookie,

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/cookie.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/cookie.js
@@ -48,7 +48,10 @@ describe('Liferay.Util.Cookie', () => {
 
 			expect(cookieIsSet).toBe(true);
 
-			const setCookieValue = Cookie.get(necessaryCookie);
+			const setCookieValue = Cookie.get(
+				necessaryCookie,
+				Cookie.TYPES.NECESSARY
+			);
 
 			expect(setCookieValue).not.toBeUndefined();
 			expect(setCookieValue).toBe(anyCookieValue);
@@ -69,7 +72,10 @@ describe('Liferay.Util.Cookie', () => {
 
 			expect(cookieIsSet).toBe(true);
 
-			const setCookieValue = Cookie.get(unnecessaryCookie);
+			const setCookieValue = Cookie.get(
+				unnecessaryCookie,
+				Cookie.TYPES.PERFORMANCE
+			);
 
 			expect(setCookieValue).not.toBeUndefined();
 			expect(setCookieValue).toBe(anyCookieValue);
@@ -83,7 +89,9 @@ describe('Liferay.Util.Cookie', () => {
 			);
 
 			expect(cookieIsSet).toBe(false);
-			expect(Cookie.get(unnecessaryCookie)).toBeUndefined();
+			expect(
+				Cookie.get(unnecessaryCookie, Cookie.TYPES.PERFORMANCE)
+			).toBeUndefined();
 		});
 
 		it('Allows setting a personalization cookie if enabled', () => {
@@ -101,7 +109,10 @@ describe('Liferay.Util.Cookie', () => {
 
 			expect(cookieIsSet).toBe(true);
 
-			const setCookieValue = Cookie.get(unnecessaryCookie);
+			const setCookieValue = Cookie.get(
+				unnecessaryCookie,
+				Cookie.TYPES.PERSONALIZATION
+			);
 
 			expect(setCookieValue).not.toBeUndefined();
 			expect(setCookieValue).toBe(anyCookieValue);
@@ -115,7 +126,9 @@ describe('Liferay.Util.Cookie', () => {
 			);
 
 			expect(cookieIsSet).toBe(false);
-			expect(Cookie.get(necessaryCookie)).toBe(undefined);
+			expect(
+				Cookie.get(unnecessaryCookie, Cookie.TYPES.PERSONALIZATION)
+			).toBe(undefined);
 		});
 
 		it('Allows setting a functional cookie if enabled', () => {
@@ -129,7 +142,10 @@ describe('Liferay.Util.Cookie', () => {
 
 			expect(cookieIsSet).toBe(true);
 
-			const setCookieValue = Cookie.get(unnecessaryCookie);
+			const setCookieValue = Cookie.get(
+				unnecessaryCookie,
+				Cookie.TYPES.FUNCTIONAL
+			);
 
 			expect(setCookieValue).not.toBeUndefined();
 			expect(setCookieValue).toBe(anyCookieValue);
@@ -143,7 +159,9 @@ describe('Liferay.Util.Cookie', () => {
 			);
 
 			expect(cookieIsSet).toBe(false);
-			expect(Cookie.get(necessaryCookie)).toBe(undefined);
+			expect(Cookie.get(unnecessaryCookie, Cookie.TYPES.FUNCTIONAL)).toBe(
+				undefined
+			);
 		});
 
 		it('Allows setting optional cookie settings', () => {
@@ -189,34 +207,97 @@ describe('Liferay.Util.Cookie', () => {
 
 				Cookie.set(necessaryCookie, anyCookieValue, type);
 
-				expect(Cookie.get(type)).toBeUndefined();
-				expect(Cookie.get(necessaryCookie)).toBe(anyCookieValue);
+				expect(
+					Cookie.get(type, Cookie.TYPES.NECESSARY)
+				).toBeUndefined();
+				expect(Cookie.get(necessaryCookie, type)).toBe(anyCookieValue);
 			}
 		});
 	});
 
 	describe('Liferay.Util.Cookie.get', () => {
 		it("Returns undefined if the cookie isn't set", () => {
-			expect(Cookie.get(unnecessaryCookie)).toBeUndefined();
+			expect(
+				Cookie.get(unnecessaryCookie, Cookie.TYPES.PERFORMANCE)
+			).toBeUndefined();
 		});
 
-		it('Returns value as string if the cookie is set', () => {
-			expect(Cookie.get(Cookie.TYPES.FUNCTIONAL)).toBe('false');
-			expect(Cookie.get(Cookie.TYPES.NECESSARY)).toBe('true');
+		it('Returns consent value as string if the cookie is set', () => {
+			expect(
+				Cookie.get(Cookie.TYPES.FUNCTIONAL, Cookie.TYPES.NECESSARY)
+			).toBe('false');
+			expect(
+				Cookie.get(Cookie.TYPES.NECESSARY, Cookie.TYPES.NECESSARY)
+			).toBe('true');
+		});
+
+		it('Returns value as string if cookie is set and type consented', () => {
+			Cookie.set(
+				Cookie.TYPES.PERFORMANCE,
+				'true',
+				Cookie.TYPES.NECESSARY
+			);
+
+			const cookieIsSet = Cookie.set(
+				unnecessaryCookie,
+				anyCookieValue,
+				Cookie.TYPES.PERFORMANCE
+			);
+
+			expect(cookieIsSet).toBe(true);
+			expect(
+				Cookie.get(unnecessaryCookie, Cookie.TYPES.PERFORMANCE)
+			).not.toBeUndefined();
+		});
+
+		it("Doesn't return value if the cookie is set but type not consented", () => {
+			Cookie.set(
+				Cookie.TYPES.PERFORMANCE,
+				'true',
+				Cookie.TYPES.NECESSARY
+			);
+
+			const cookieIsSet = Cookie.set(
+				unnecessaryCookie,
+				anyCookieValue,
+				Cookie.TYPES.PERFORMANCE
+			);
+
+			expect(cookieIsSet).toBe(true);
+
+			Cookie.set(
+				Cookie.TYPES.PERFORMANCE,
+				'false',
+				Cookie.TYPES.NECESSARY
+			);
+
+			expect(
+				Cookie.get(unnecessaryCookie, Cookie.TYPES.PERFORMANCE)
+			).toBeUndefined();
 		});
 	});
 
 	describe('Liferay.Util.Cookie.remove', () => {
 		it('Removes cookie if it exists', () => {
-			expect(Cookie.get(Cookie.TYPES.FUNCTIONAL)).not.toBeUndefined();
+			expect(
+				Cookie.get(Cookie.TYPES.FUNCTIONAL, Cookie.TYPES.NECESSARY)
+			).not.toBeUndefined();
 
 			Cookie.remove(Cookie.TYPES.FUNCTIONAL);
-			expect(Cookie.get(Cookie.TYPES.FUNCTIONAL)).toBeUndefined();
+
+			expect(
+				Cookie.get(Cookie.TYPES.FUNCTIONAL, Cookie.TYPES.NECESSARY)
+			).toBeUndefined();
 		});
 
 		it("Cookie still doesn't exist if it didn't exist before removal", () => {
+			Cookie.set(Cookie.TYPES.FUNCTIONAL, 'true', Cookie.TYPES.NECESSARY);
+
 			Cookie.remove(unnecessaryCookie);
-			expect(Cookie.get(unnecessaryCookie)).toBeUndefined();
+
+			expect(
+				Cookie.get(unnecessaryCookie, Cookie.TYPES.FUNCTIONAL)
+			).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
### References

- [LPS-158438](https://issues.liferay.com/browse/LPS-158438)

### What is the goal?

* Update JS Cookie utility to enforce cookie consent at reading time: since user consent can be withdrawn at any time after a cookie of a specific type is set, we should take that into account when reading cookie values. 
* Extract consent utilities (`CONSENT_TYPES` and `checkConsent`) for reusability

### What does it look like?
![imagen](https://user-images.githubusercontent.com/6642927/179721940-9b375848-d32e-4d9d-ba70-efa949b9f5d5.png)

