### PR TITLE
LPS-144199 Rich Text predefined value cannot be deleted

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -276,21 +276,6 @@ name = HtmlUtil.escapeJS(name);
 			},
 		</c:if>
 
-		<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-			onChangeCallback: function () {
-				var ckEditor = CKEDITOR.instances['<%= name %>'];
-				var dirty = ckEditor.checkDirty();
-
-				if (dirty) {
-					window['<%= HtmlUtil.escapeJS(onChangeMethod) %>'](
-						window['<%= name %>'].getHTML()
-					);
-
-					ckEditor.resetDirty();
-				}
-			},
-		</c:if>
-
 		<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
 			onFocusCallback: function () {
 				window['<%= HtmlUtil.escapeJS(onFocusMethod) %>'](
@@ -558,25 +543,6 @@ name = HtmlUtil.escapeJS(name);
 				);
 			</c:if>
 
-			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-				var contentChangeHandle = setInterval(() => {
-					try {
-						window['<%= name %>'].onChangeCallback();
-					}
-					catch (e) {}
-				}, 300);
-
-				var clearContentChangeHandle = function (event) {
-					if (event.portletId === '<%= portletId %>') {
-						clearInterval(contentChangeHandle);
-
-						Liferay.detach('destroyPortlet', clearContentChangeHandle);
-					}
-				};
-
-				Liferay.on('destroyPortlet', clearContentChangeHandle);
-			</c:if>
-
 			<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
 				CKEDITOR.instances['<%= name %>'].on(
 					'focus',
@@ -623,6 +589,14 @@ name = HtmlUtil.escapeJS(name);
 				);
 			</c:if>
 		});
+
+		<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+			ckEditor.on('change', (event) => {
+				window['<%= HtmlUtil.escapeJS(onChangeMethod) %>'](
+					window['<%= name %>'].getHTML()
+				);
+			});
+		</c:if>
 
 		ckEditor.on('dataReady', (event) => {
 			if (instancePendingData !== null) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -65,17 +65,11 @@ const BaseEditor = forwardRef(
 				return;
 			}
 
-			const editor = editorRef.current.editor;
-
-			if (editor.checkDirty()) {
-				if (onChangeMethodName) {
-					window[onChangeMethodName](getHTML());
-				}
-				else {
-					onChange(getHTML());
-				}
-
-				editor.resetDirty();
+			if (onChangeMethodName) {
+				window[onChangeMethodName](getHTML());
+			}
+			else {
+				onChange(getHTML());
 			}
 		};
 


### PR DESCRIPTION
### References

- [LPS-144199 Rich Text predefined value cannot be deleted (On change is not being called)](https://issues.liferay.com/browse/LPS-144199)

### What is the goal of this PR?

There are two aspects of this bugfix.

On one side, there is the easy fix, where we are removing `editor.checkDirty()` check. It was fun tracking down when and why we added this. It was more than 12 years ago, in https://github.com/liferay/liferay-portal/commit/a192c8d3d3adce019da2470512bce18de80afa8a . LPS-10749 :smile: The check was to ensure that the hacky timeout doesn't make an unwanted callback. Back then, it was [CKEditor v3.2](https://github.com/liferay/liferay-portal/blob/a192c8d3d3adce019da2470512bce18de80afa8a/portal-web/docroot/html/js/editor/_ckeditor/ckeditor.js#L6).  Through many many versions and rewrites, this check survived. Nowadays, it is unnecessary, as it probably was for a long time. The change event firing is [under the full control of `CKEditor` from `ckeditor4-react`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js#L104). We are only providing callback, that should unconditionally resolve if the event happened.

As such, I believe we can safely merge this PR and call the bug fixed.

But, the awkward question remains: _why_ does `checkDirty` does not work? It is unnecessary, but it should not be bugged. It should recognize the difference between preloaded text and deleted text. This means that either (1) setting of preloaded text does not correctly set content in some internal CKeditor state, or (2) there is a bug with `checkDirty` in the base editor. I am especially fearful of (1), as it may be a symptom of [unclear content control](https://liferay.slack.com/archives/CNBG06JS3/p1634832024012200?thread_ts=1634823002.007900&cid=CNBG06JS3). Fortunately, we can ignore this, for the scope of this bug. 

### What does it look like?

#### Before PR

See JIRA ticket.

#### After PR

![after](https://user-images.githubusercontent.com/5435511/179783423-73f65f00-182e-470d-a67f-59996e3805d5.gif)

### Steps to reproduce

See JIRA ticket.
