### PR TITLE
LPS-158532 | Relationship enpoint gets deleted when objectDefinition deleted

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -192,6 +192,22 @@ definition {
 		return "${response}";
 	}
 
+	macro _deleteRelationship {
+		Variables.assertDefined(parameterList = "${relationshipId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-relationships/${relationshipId} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var response = JSONCurlUtil.delete("${curl}");
+
+		return "${response}";
+	}
+
 	macro _getEmployeeFirstnameById {
 		Variables.assertDefined(parameterList = "${employeeId}");
 
@@ -486,6 +502,14 @@ definition {
 			expected = "${managerId2}");
 	}
 
+	macro assertResponseIncludesErrorMessage {
+		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.title");
+
+		TestUtils.assertEquals(
+			actual = "${actual}",
+			expected = "${expectedValue}");
+	}
+
 	macro assertResponseMessageAfterDeletingObjectEntry {
 		var actual = JSONUtil.getWithJSONPath("${responseToParse}", "$.status");
 
@@ -608,6 +632,12 @@ definition {
 		ObjectDefinitionAPI._deleteObjectEntry(
 			en_US_plural_label = "${en_US_plural_label}",
 			objectEntryId = "${objectEntryId}");
+	}
+
+	macro deleteRelationship {
+		var relationshipId = ObjectDefinitionAPI._getRelationshipId(objectDefinitionId = "${objectDefinitionId}");
+
+		ObjectDefinitionAPI._deleteRelationship(relationshipId = "${relationshipId}");
 	}
 
 	macro getObjectEntryRelation {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/SupportManyToManyRelationships.testcase
@@ -1092,4 +1092,58 @@ definition {
 		}
 	}
 
+	@priority = "5"
+	test RelationshipEnpointGetsDeletedWhenObjectDefinitionDeleted {
+		property portal.acceptance = "true";
+
+		task ("Given manyToMany relationship universitySubjects created") {
+			var relationshipName = ObjectDefinitionAPI.createRelationship(
+				deletionType = "cascade",
+				en_US_label = "universitiesSubjects",
+				name = "universitiesSubjects",
+				objectDefinitionId1 = "${staticObjectId1}",
+				objectDefinitionId2 = "${staticObjectId2}",
+				type = "manyToMany");
+		}
+
+		task ("Given university entry created") {
+			var universityId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "universities",
+				name = "Liferay University");
+		}
+
+		task ("Given subject entry created") {
+			var subjectId = ObjectDefinitionAPI.createObjectEntryWithName(
+				en_US_plural_label = "subjects",
+				name = "Liferay Foundations");
+		}
+
+		task ("Given subject entry related to university entry through universities PUT endpoint") {
+			ObjectDefinitionAPI.relateObjectEntries(
+				en_US_plural_label = "universities",
+				objectEntry1 = "${universityId}",
+				objectEntry2 = "${subjectId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("Given I delete the subject object definition") {
+			ObjectDefinitionAPI.deleteRelationship(objectDefinitionId = "${staticObjectId1}");
+
+			ObjectAdmin.deleteObjectViaAPI(objectName = "Subject");
+		}
+
+		task ("When I call universities GET endpoint with {universityId}/universitySubjects") {
+			var responseToParse = ObjectDefinitionAPI.getObjectEntryRelation(
+				en_US_plural_label = "universities",
+				objectId = "${universityId}",
+				relationshipName = "universitiesSubjects");
+		}
+
+		task ("Then I receive an error message of relationship not present") {
+			ObjectDefinitionAPI.assertResponseIncludesErrorMessage(
+				expectedValue = "No ObjectRelationship exists with the key {objectDefinitionId1=${staticObjectId1}, name=${relationshipName}}",
+				responseToParse = "${responseToParse}");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Add a test to assert relationship enpoint gets deleted when objectDefinition deleted

**Test Plan**
Given university created
And Given subject created
And Given manyToMany relationship universitySubjects created
And Given university entry created
And Given subject entry related to the university entry created
And Given I delete the subject object definition
When in c/universities I use GET /{universityId}/universitySubjects
Then I receive an error message of relationship not present

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-158532