### PR TITLE
master Lps 157982 | Add tests on delete and get structured content folder by erc in asset library 

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -73,6 +73,29 @@ definition {
 		return "${response}";
 	}
 
+	macro _filterStructuredContentFolders {
+		Variables.assertDefined(parameterList = "${filterValue}");
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/structured-content-folders";
+		}
+		else {
+			var api = "sites/${siteId}/structured-contents";
+		}
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+            ${portalURL}/o/headless-delivery/v1.0/${api}?filter=${filterValue} \
+            -u test@liferay.com:test \
+            -H Content-Type: application/json
+        ''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _getStructuredContentFoldersByErcInAssetLibrary {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
 
@@ -107,6 +130,20 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualExternalReferenceCodeValue}",
 			expected = "${expectedExternalReferenceCodeValue}");
+	}
+
+	macro assertProperTotalCountOfStructuredContentFoldersInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${expectedStructuredContentFolderTotalCount}");
+
+		var response = HeadlessWebcontentFolderAPI._filterStructuredContentFolders(
+			assetLibraryId = "${assetLibraryId}",
+			filterValue = "${filterValue}");
+
+		var actualTotalCount = JSONUtil.getWithJSONPath("${response}", "$..['totalCount']");
+
+		TestUtils.assertEquals(
+			actual = "${actualTotalCount}",
+			expected = "${expectedStructuredContentFolderTotalCount}");
 	}
 
 	macro assetProperNumberOfStructuredContentFolders {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -114,15 +114,7 @@ definition {
 
 	macro assertExternalReferenceCodeWithCorrectValue {
 		if (!(isSet(expectedExternalReferenceCodeValue))) {
-			var folderId = JSONUtil.getWithJSONPath("${responseToParse}", "$.id");
-
-			var mysqlStatement = "SELECT uuid_ FROM JournalFolder WHERE folderid = '${folderId}';";
-
-			var sqlResults = SQL.executeMySQLStatement(mysqlStatement = "${mysqlStatement}");
-
-			var uuidResult = StringUtil.regexReplaceAll("${sqlResults}", "[\r\n]", "");
-
-			var expectedExternalReferenceCodeValue = StringUtil.extractLast("${uuidResult}", "uuid_");
+			var expectedExternalReferenceCodeValue = HeadlessWebcontentFolderAPI.getUuidOfCreatedStructuredContentFolder(responseToParse = "${responseToParse}");
 		}
 
 		var actualExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
@@ -198,6 +190,22 @@ definition {
 			externalReferenceCode = "${externalReferenceCode}");
 
 		return "${response}";
+	}
+
+	macro getUuidOfCreatedStructuredContentFolder {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		var folderId = JSONUtil.getWithJSONPath("${responseToParse}", "$.id");
+
+		var mysqlStatement = "SELECT uuid_ FROM JournalFolder WHERE folderid = '${folderId}';";
+
+		var sqlResults = SQL.executeMySQLStatement(mysqlStatement = "${mysqlStatement}");
+
+		var uuidResult = StringUtil.regexReplaceAll("${sqlResults}", "[\r\n]", "");
+
+		var structuredContentUuid = StringUtil.extractLast("${uuidResult}", "uuid_");
+
+		return "${structuredContentUuid}";
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -176,10 +176,12 @@ definition {
 		return "${response}";
 	}
 
-	macro getIdOfCreateStructuredContentFolder {
-		var folderId = JSONUtil.getWithJSONPath("${responseToParse}", "$.id");
+	macro getElementOfCreatedStructuredContentFolder {
+		Variables.assertDefined(parameterList = "${responseToParse},${element}");
 
-		return "${folderId}";
+		var elementValue = JSONUtil.getWithJSONPath("${responseToParse}", "${element}");
+
+		return "${elementValue}";
 	}
 
 	macro getStructuredContentFoldersByErcInAssetLibrary {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -26,6 +26,42 @@ definition {
 		}
 	}
 
+	@description = "Get structured content folder with erc of parent folder in an asset library"
+	@priority = "5"
+	test CanGetParentStructuredContentFolderInAssetLibraryByErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder with a custom erc is created with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("Given a subfolder with another custom erc is create with a POST request") {
+			var folderId = HeadlessWebcontentFolderAPI.getIdOfCreatedStructuredContentFolder(responseToParse = "${response}");
+
+			HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
+				externalReferenceCode = "subfolder-erc",
+				name = "Sub Folder",
+				parentStructuredContentFolderId = "${folderId}");
+		}
+
+		task ("When I make a GET request by the erc of the parent structured content folder") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive a correct body response with numberOfStructuredContentFolders is 1") {
+			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(
+				expectedNumbers = "1",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Get structured content folder in asset library by existing custom erc"
 	@priority = "5"
 	test CanGetStructuredContentFolderInAssetLibraryByExistingCustomErc {
@@ -240,7 +276,6 @@ definition {
 	@description = "Sub folder is created with erc equals to uuid by default in structured content folder in asset library"
 	@priority = "5"
 	test SubfolderIsCreatedInStructuredContentInAssetLibraryWithErcByDefault {
-		property database.types = "mysql";
 		property portal.acceptance = "true";
 
 		task ("Given a structured content folder with a custom erc is created with POST request") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -53,6 +53,34 @@ definition {
 		}
 	}
 
+	@description = "Get structured content folder in asset library by existing uuid as erc"
+	@priority = "5"
+	test CanGetStructuredContentFolderInAssetLibraryByExistingDefaultErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder without a custom erc is created with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				name = "Test Folder");
+		}
+
+		task ("WWhen I make a GET request by erc and set erc value to the uuid of previous created structured content folder") {
+			var structuredContentId = HeadlessWebcontentFolderAPI.getUuidOfCreatedStructuredContentFolder(responseToParse = "${response}");
+
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${structuredContentId}");
+		}
+
+		task ("Then I receive a correct body response") {
+			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${structuredContentId}",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Structured content folder is not able to create with existing erc in asset library"
 	@priority = "5"
 	test CannotCreateStructuredContentFolderInAssetLibraryWithExistingErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -26,6 +26,33 @@ definition {
 		}
 	}
 
+	@description = "Get structured content folder in asset library by existing custom erc"
+	@priority = "5"
+	test CanGetStructuredContentFolderInAssetLibraryByExistingCustomErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder with a custom erc is created with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("When I make a GET request by assetLibraryId and erc") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive a correct body response") {
+			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Structured content folder is not able to create with existing erc in asset library"
 	@priority = "5"
 	test CannotCreateStructuredContentFolderInAssetLibraryWithExistingErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -83,6 +83,26 @@ definition {
 		}
 	}
 
+	@description = "Unable to get structured content folder by nonexistent erc"
+	@priority = "4"
+	test CanReturnErrorWithGetStructuredContentFolderInAssetLibraryByNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a GET request by assetLibraryID and non-existent erc") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc");
+		}
+
+		task ("Then I receive error message in response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "No JournalFolder exists with the key");
+		}
+	}
+
 	@description = "Structured content folder is created with custom erc in an asset library"
 	@priority = "5"
 	test StructuredContentFolderIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -41,7 +41,9 @@ definition {
 		}
 
 		task ("Given a subfolder with another custom erc is create with a POST request") {
-			var folderId = HeadlessWebcontentFolderAPI.getIdOfCreatedStructuredContentFolder(responseToParse = "${response}");
+			var folderId = HeadlessWebcontentFolderAPI.getElementOfCreatedStructuredContentFolder(
+				element = "$.id",
+				responseToParse = "${response}");
 
 			HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
 				externalReferenceCode = "subfolder-erc",
@@ -113,6 +115,54 @@ definition {
 		task ("Then I receive a correct body response") {
 			HeadlessWebcontentFolderAPI.assertExternalReferenceCodeWithCorrectValue(
 				expectedExternalReferenceCodeValue = "${structuredContentId}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@description = "Get subfolder of structured content folder with erc in an asset library"
+	@priority = "5"
+	test CanGetSubStructuredContentFolderInAssetLibraryWithErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder with a custom erc is created with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("Given a subfolder with another custom erc is create with a POST request") {
+			var folderId = HeadlessWebcontentFolderAPI.getElementOfCreatedStructuredContentFolder(
+				element = "$.id",
+				responseToParse = "${response}");
+
+			HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
+				externalReferenceCode = "subfolder-erc",
+				name = "Sub Folder",
+				parentStructuredContentFolderId = "${folderId}");
+		}
+
+		task ("When I make a GET request by the erc of subfolder") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "subfolder-erc");
+		}
+
+		task ("Then I receive a correct body response with id of parent structured content folder") {
+			var parentFolderIdInResponse = HeadlessWebcontentFolderAPI.getElementOfCreatedStructuredContentFolder(
+				element = "$.parentStructuredContentFolderId",
+				responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${parentFolderIdInResponse}",
+				expected = "${folderId}");
+		}
+
+		task ("And Then numberOfStructuredContentFolders in body response is 0") {
+			HeadlessWebcontentFolderAPI.assetProperNumberOfStructuredContentFolders(
+				expectedNumbers = "0",
 				responseToParse = "${response}");
 		}
 	}
@@ -248,7 +298,9 @@ definition {
 		}
 
 		task ("When with POST request I create a child folder with another custom erc") {
-			var folderId = HeadlessWebcontentFolderAPI.getIdOfCreateStructuredContentFolder(responseToParse = "${response}");
+			var folderId = HeadlessWebcontentFolderAPI.getElementOfCreatedStructuredContentFolder(
+				element = "$.id",
+				responseToParse = "${response}");
 
 			var response = HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
 				externalReferenceCode = "subfolder-erc",
@@ -288,7 +340,9 @@ definition {
 		}
 
 		task ("When with POST request I create a child folder without custom erc") {
-			var folderId = HeadlessWebcontentFolderAPI.getIdOfCreateStructuredContentFolder(responseToParse = "${response}");
+			var folderId = HeadlessWebcontentFolderAPI.getElementOfCreatedStructuredContentFolder(
+				element = "$.id",
+				responseToParse = "${response}");
 
 			var response = HeadlessWebcontentFolderAPI.createSubfolderInStructuredContentFolder(
 				name = "Sub Folder",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -61,6 +61,28 @@ definition {
 		}
 	}
 
+	@description = "Unable to get structured content folder by nonexistent assetLibraryId"
+	@priority = "4"
+	test CanReturnErrorWithGetStructuredContentFolderInAssetLibraryByNonexistentAssetLibraryId {
+		property portal.acceptance = "true";
+
+		task ("When I make a GET request by non-existent assetLibraryID and a erc") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersByErcInAssetLibrary(
+				assetLibraryId = "nonexistentId",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive not found error response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "NOT_FOUND");
+		}
+
+		task ("And Then I receive error message in server console") {
+			AssertConsoleTextPresent(value1 = "Unable to get a valid asset library with ID nonexistentId");
+		}
+	}
+
 	@description = "Structured content folder is created with custom erc in an asset library"
 	@priority = "5"
 	test StructuredContentFolderIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForStructuredContentFolders.testcase
@@ -26,6 +26,41 @@ definition {
 		}
 	}
 
+	@description = "Structured content folder is not able to create with existing erc in asset library"
+	@priority = "5"
+	test CannotCreateStructuredContentFolderInAssetLibraryWithExistingErc {
+		property portal.acceptance = "true";
+
+		task ("Given a structured content folder with a custom erc is created with POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("When with POST request I create a structured content folder with an already existing custom erc") {
+			var response = HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Second Folder");
+		}
+
+		task ("Then I receive an error code response about duplicate folder erc") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "Duplicate journal folder external reference code erc");
+		}
+
+		task ("And Then another folder with same erc is not being created") {
+			HeadlessWebcontentFolderAPI.assertProperTotalCountOfStructuredContentFoldersInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				expectedStructuredContentFolderTotalCount = "0",
+				filterValue = "name%20eq%20%27Second%20Folder%27");
+		}
+	}
+
 	@description = "Structured content folder is created with custom erc in an asset library"
 	@priority = "5"
 	test StructuredContentFolderIsCreatedInAssetLibraryWithCustomErc {


### PR DESCRIPTION
**Background**
- Add test on unable to create structured content folder with existing erc in asset library
- Add test on get structured content folder with erc and nonexistent asset library id
- Add test to get structured content folder with asset library id and nonexistent erc
- Add test on get structured content folder by asset library id and custom erc
- Add test on get structured content folder with uuid as erc in asset library
- Add test to get structured content folder with erc of parent folder in asset library
- Add test to get structured content folder with erc of sub folder in asset library

**Test Plan**
- LPS-157982
Given asset library is created
And Given a structured content folder with a custom erc is created with POST request
When with POST request I create a structured content folder with an already existing custom erc
Then I receive an error code response about duplicate folder erc
And Then another folder with same erc is not being created
- LPS-158563
When I make a GET request by non-existent assetLibraryID and a erc
Then I receive error message in server console: Unable to get a valid asset library with ID
- LPS-158564
Given asset library is created
When I make a GET request by assetLibraryID and non-existent erc
Then I receive a 404 error code
with details error message about no JournalFolder exists with the key
- LPS-158565
Given asset library is created
And Given a structured content folder with a custom erc is created with a POST request
When I make a GET request by erc
Then I receive a correct body response
- LPS-158566
Given asset library is created
And Given a structured content folder without a custom erc is created with a POST request
When I make a GET request by erc and set erc value to the id of previous created structured content folder
Then I receive a correct body response
- LPS-158576
Given asset library is created
And Given a structured content folder with a custom erc is created with a POST request
And Given a sub folder with another custom erc is create with a POST request
When I make a GET request by the erc of subfolder
Then I receive a correct body response with parent structured content folder Id
And Then numberOfStructuredContentFolders in body response is 0
- LPS-158577
Given asset library is created
And Given a structured content folder with a custom erc is created with a POST request
And Given a sub folder with another custom erc is create with a POST request
When I make a GET request by the erc of the parent structured content folder
Then I receive a correct body response with numberOfStructuredContentFolders is 1

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-157982
- https://issues.liferay.com/browse/LPS-158563
- https://issues.liferay.com/browse/LPS-158564
- https://issues.liferay.com/browse/LPS-158565
- https://issues.liferay.com/browse/LPS-158566
- https://issues.liferay.com/browse/LPS-158576
- https://issues.liferay.com/browse/LPS-158577