### PR TITLE
Master qa 157973 | Add test on delete, get and put document by erc in asset library

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -29,6 +29,29 @@ definition {
 		return "${curl}";
 	}
 
+	macro _deleteDocumentsByErcInAssetLibrary {
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode}";
+		}
+		else {
+			var api = "sites/${siteId}/documents/by-external-reference-code/${externalReferenceCode}";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.delete("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _filterDocumentInAssetLibrary {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filtervalue}");
 
@@ -96,6 +119,20 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualDocumentTotalCount}",
 			expected = "${expectedDocumentTotalCount}");
+	}
+
+	macro deleteDocumentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId}");
+
+		if (!(isSet(externalReferenceCode))) {
+			Variables.assertDefined(parameterList = "${responseToParse}");
+
+			var externalReferenceCode = DocumentAPI.getUuidOfCreatedDocument(responseToParse = "${responseToParse}");
+		}
+
+		DocumentAPI._deleteDocumentsByErcInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}");
 	}
 
 	macro getDocumentsByErcInAssetLibrary {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -29,6 +29,22 @@ definition {
 		return "${curl}";
 	}
 
+	macro _filterDocumentInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${filtervalue}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/documents?filter=${filtervalue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro addDocumentInAssetLibraryByUploadFile {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
 
@@ -54,6 +70,20 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualExternalReferenceCodeValue}",
 			expected = "${expectedExternalReferenceCodeValue}");
+	}
+
+	macro assertProperDocumentTotalCount {
+		Variables.assertDefined(parameterList = "${expectedDocumentTotalCount}");
+
+		var response = DocumentAPI._filterDocumentInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			filtervalue = "${filtervalue}");
+
+		var actualDocumentTotalCount = JSONUtil.getWithJSONPath("${response}", "$..['totalCount']");
+
+		TestUtils.assertEquals(
+			actual = "${actualDocumentTotalCount}",
+			expected = "${expectedDocumentTotalCount}");
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -45,6 +45,22 @@ definition {
 		return "${curl}";
 	}
 
+	macro _getDocumentsByErcInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro addDocumentInAssetLibraryByUploadFile {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
 
@@ -84,6 +100,14 @@ definition {
 		TestUtils.assertEquals(
 			actual = "${actualDocumentTotalCount}",
 			expected = "${expectedDocumentTotalCount}");
+	}
+
+	macro getDocumentsByErcInAssetLibrary {
+		var response = DocumentAPI._getDocumentsByErcInAssetLibrary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}");
+
+		return "${response}";
 	}
 
 	macro getIdOfCreatedDocument {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -74,11 +74,7 @@ definition {
 
 	macro assertExternalReferenceCodeWithCorrectValue {
 		if (!(isSet(expectedExternalReferenceCodeValue))) {
-			var contentURL = JSONUtil.getWithJSONPath("${responseToParse}", "$.['contentUrl']");
-
-			var contentURLSubString = StringUtil.extractFirst("${contentURL}", "?");
-
-			var expectedExternalReferenceCodeValue = StringUtil.extractLast("${contentURLSubString}", "/");
+			var expectedExternalReferenceCodeValue = DocumentAPI.getUuidOfCreatedDocument(responseToParse = "${responseToParse}");
 		}
 
 		var actualExternalReferenceCodeValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..externalReferenceCode");
@@ -119,6 +115,18 @@ definition {
 		var documentId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
 
 		return "${documentId}";
+	}
+
+	macro getUuidOfCreatedDocument {
+		Variables.assertDefined(parameterList = "${responseToParse}");
+
+		var contentURL = JSONUtil.getWithJSONPath("${responseToParse}", "$.['contentUrl']");
+
+		var contentURLSubString = StringUtil.extractFirst("${contentURL}", "?");
+
+		var documentUuid = StringUtil.extractLast("${contentURLSubString}", "/");
+
+		return "${documentUuid}";
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -84,6 +84,61 @@ definition {
 		return "${curl}";
 	}
 
+	macro _updateDocumentByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
+
+		if (!(isSet(filePath) || isSet(title) || isSet(updateExternalReferenceCode))) {
+			TestUtils.fail(message = "Please set at least one property to update the document.");
+		}
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/documents/by-external-reference-code/${externalReferenceCode}";
+		}
+		else {
+			var api = "asset-libraries/${siteId}/documents/by-external-reference-code/${externalReferenceCode}";
+		}
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			''';
+		var delimiter = " ";
+
+		if (isSet(filePath)) {
+			var fileBody = "-F file=@&quot;${filePath}&quot;";
+
+			var curl = StringUtil.add("${curl}", "${fileBody}", "${delimiter}");
+		}
+
+		if (isSet(title) && isSet(updateExternalReferenceCode)) {
+			var documentBody = '''
+				-F document={"externalReferenceCode": "${updateExternalReferenceCode}", "title": "${title}"}
+			''';
+
+			var curl = StringUtil.add("${curl}", "${documentBody}", "${delimiter}");
+		}
+		else {
+			if (isSet(title)) {
+				var documentBody = '''
+					-F document={"title": "${title}"}
+				 ''';
+			}
+			else if (isSet(updateExternalReferenceCode)) {
+				var documentBody = '''
+					-F document={"externalReferenceCode": "${updateExternalReferenceCode}"}
+				''';
+			}
+
+			var curl = StringUtil.add("${curl}", "${documentBody}", "${delimiter}");
+		}
+
+		var curl = JSONCurlUtil.put("${curl}");
+
+		return "${curl}";
+	}
+
 	macro addDocumentInAssetLibraryByUploadFile {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${filePath}");
 
@@ -154,6 +209,12 @@ definition {
 		return "${documentId}";
 	}
 
+	macro getTitleOfDocument {
+		var documentTitle = JSONUtil.getWithJSONPath("${responseToParse}", "$.['title']");
+
+		return "${documentTitle}";
+	}
+
 	macro getUuidOfCreatedDocument {
 		Variables.assertDefined(parameterList = "${responseToParse}");
 
@@ -164,6 +225,19 @@ definition {
 		var documentUuid = StringUtil.extractLast("${contentURLSubString}", "/");
 
 		return "${documentUuid}";
+	}
+
+	macro updateDocumentByErcInAssetLibrary {
+		Variables.assertDefined(parameterList = "${assetLibraryId}");
+
+		var response = DocumentAPI._updateDocumentByErc(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			filePath = "${filePath}",
+			title = "${title}",
+			updateExternalReferenceCode = "${updateExternalReferenceCode}");
+
+		return "${response}";
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -86,4 +86,15 @@ definition {
 			expected = "${expectedDocumentTotalCount}");
 	}
 
+	macro getIdOfCreatedDocument {
+		var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			filePath = "${filePath}");
+
+		var documentId = JSONUtil.getWithJSONPath("${response}", "$.['id']");
+
+		return "${documentId}";
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -54,6 +54,35 @@ definition {
 		}
 	}
 
+	@description = "Get document in asset library by existing uuid as erc"
+	@priority = "5"
+	test CanGetDocumentInAssetLibraryByExistingUuidAsErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document without a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a GET request by assetLibraryId and UUID as the erc") {
+			var documentUuid = DocumentAPI.getUuidOfCreatedDocument(responseToParse = "${response}");
+
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${documentUuid}");
+		}
+
+		task ("Then I receive a correct body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${documentUuid}",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Document is not able to create with an existing erc in asset library"
 	@priority = "5"
 	test CannotCreateDocumentInAssetLibraryWithExistingErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -86,6 +86,44 @@ definition {
 		}
 	}
 
+	@description = "Document is created in an asset library with previous document id as erc"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryWithDocumentIdAsErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with POST request I create a document with a custom erc equals to the internal id of the previously created document") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${documentId}",
+				filePath = "${filePath}");
+		}
+
+		task ("Then I can see erc equals to the id in the body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "${documentId}",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then the document is created properly") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with erc by default"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithErcByDefault {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,36 @@ definition {
 		}
 	}
 
+	@description = "Document is deleted in an asset library by default erc"
+	@priority = "4"
+	test CanDeleteDocumentInAssetLibraryByAssetLibraryIdAndDefaultErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document without custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a DELETE request by assetLibraryId and UUID as the erc") {
+			var documentUuid = DocumentAPI.getUuidOfCreatedDocument(responseToParse = "${response}");
+
+			DocumentAPI.deleteDocumentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				responseToParse = "${response}");
+		}
+
+		task ("Then the document is correctly deleted") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "0",
+				filtervalue = "title%20eq%20%27Document_1.txt%27");
+		}
+	}
+
 	@description = "Get document in asset library by existing custom erc"
 	@priority = "5"
 	test CanGetDocumentInAssetLibraryByExistingCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -318,6 +318,46 @@ definition {
 		}
 	}
 
+	@description = "Document is created by nonexistent erc with existing erc in body by put request"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryByPutNonexistentErcWithErcInBody {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created in asset library with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a PUT request by assetLibraryId and a non-existent erc with exsiting erc in the body") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc",
+				filePath = "${filePath}",
+				title = "Document_2.txt",
+				updateExternalReferenceCode = "erc");
+		}
+
+		task ("Then its erc matches the inserted one") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "nonexistent-erc",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then a document is being created") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,44 @@ definition {
 		}
 	}
 
+	@description = "Document is not able to create with an existing erc in asset library"
+	@priority = "5"
+	test CannotCreateDocumentInAssetLibraryWithExistingErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with POST I create another document with an existing erc") {
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_2.txt");
+
+			var response = DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("Then I receive duplicate external reference code response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "Duplicate file entry external reference code erc");
+		}
+
+		task ("And Then another document with same erc is not being created") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "0",
+				filtervalue = "title%20eq%20%27Document_2.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -64,6 +64,28 @@ definition {
 		}
 	}
 
+	@description = "Unable to get document by nonexistent assetLibraryId"
+	@priority = "4"
+	test CanReturnErrorWithGetDocumentInAssetLibraryByNonexistentAssetLibraryId {
+		property portal.acceptance = "true";
+
+		task ("When I make a GET request by non-existent assetLibraryID and a erc") {
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "nonexistentId",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive not found error response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "NOT_FOUND");
+		}
+
+		task ("And Then I receive error message in server console") {
+			AssertConsoleTextPresent(value1 = "Unable to get a valid asset library with ID nonexistentId");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -222,6 +222,35 @@ definition {
 		}
 	}
 
+	@description = "Document is not able to delete in an asset library by nonexistent erc"
+	@priority = "3"
+	test DocumentDeletionImpossibleByAssetLibraryIdAndNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a DELETE request by assetLibraryId and use internal ID as erc") {
+			DocumentAPI.deleteDocumentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "${documentId}");
+		}
+
+		task ("Then the document with a custom erc created earlier still exists") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27Document_1.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -180,6 +180,43 @@ definition {
 		}
 	}
 
+	@description = "Document erc is not able to update with put request in asset library"
+	@priority = "5"
+	test CannotUpdateDocumentErcInAssetLibraryByErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created in asset library with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a PUT request by assetLibraryId and erc with an erc modified in the body") {
+			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				title = "title",
+				updateExternalReferenceCode = "update-erc");
+		}
+
+		task ("Then the erc in the response body is not changed") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then another document with an erc being the modified value is not being created") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27title%27");
+		}
+	}
+
 	@description = "Unable to get document by nonexistent assetLibraryId"
 	@priority = "4"
 	test CanReturnErrorWithGetDocumentInAssetLibraryByNonexistentAssetLibraryId {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,35 @@ definition {
 		}
 	}
 
+	@description = "Document is deleted in an asset library by custom erc"
+	@priority = "4"
+	test CanDeleteDocumentInAssetLibraryByAssetLibraryIdAndCustomErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a DELETE request by assetLibraryId and custom erc") {
+			DocumentAPI.deleteDocumentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then the document is correctly deleted") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "0",
+				filtervalue = "title%20eq%20%27Document_1.txt%27");
+		}
+	}
+
 	@description = "Document is deleted in an asset library by default erc"
 	@priority = "4"
 	test CanDeleteDocumentInAssetLibraryByAssetLibraryIdAndDefaultErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -222,6 +222,44 @@ definition {
 		}
 	}
 
+	@description = "Document is updated by asset library id and erc"
+	@priority = "5"
+	test CanUpdateDocumentTitleInAssetLibraryByErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created in asset library with a POST request") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a PUT request by assetLibraryId and erc") {
+			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				title = "updated title");
+		}
+
+		task ("Then I receive a correct body response with updated title") {
+			var documentTitle = DocumentAPI.getTitleOfDocument(responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${documentTitle}",
+				expected = "updated title");
+		}
+
+		task ("And Then the document is correctly updated") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27updated%20title%27");
+		}
+	}
+
 	@description = "Document is not able to delete in an asset library by nonexistent erc"
 	@priority = "3"
 	test DocumentDeletionImpossibleByAssetLibraryIdAndNonexistentErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -289,6 +289,35 @@ definition {
 		}
 	}
 
+	@description = "Document is created by nonexistent erc in asset with put request"
+	@priority = "5"
+	test DocumentIsCreatedInAssetLibraryByPutNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a PUT request by assetLibraryId and a non-existent erc") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var response = DocumentAPI.updateDocumentByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc",
+				filePath = "${filePath}");
+		}
+
+		task ("Then its erc matches the inserted one") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "nonexistent-erc",
+				responseToParse = "${response}");
+		}
+
+		task ("And Then a document is being created") {
+			DocumentAPI.assertProperDocumentTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedDocumentTotalCount = "1",
+				filtervalue = "title%20eq%20%27Document_1.txt%27");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -86,6 +86,26 @@ definition {
 		}
 	}
 
+	@description = "Unable to get document by nonexistent erc"
+	@priority = "4"
+	test CanReturnErrorWithGetDocumentInAssetLibraryByNonexistentErc {
+		property portal.acceptance = "true";
+
+		task ("When I make a GET request by assetLibraryID and non-existent erc") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc");
+		}
+
+		task ("Then I receive error message in response") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "No DLFileEntry exists with the key");
+		}
+	}
+
 	@description = "Document is created in an asset library with custom erc"
 	@priority = "5"
 	test DocumentIsCreatedInAssetLibraryWithCustomErc {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForDocument.testcase
@@ -26,6 +26,34 @@ definition {
 		}
 	}
 
+	@description = "Get document in asset library by existing custom erc"
+	@priority = "5"
+	test CanGetDocumentInAssetLibraryByExistingCustomErc {
+		property portal.acceptance = "true";
+
+		task ("Given a document with a custom erc is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			DocumentAPI.addDocumentInAssetLibraryByUploadFile(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When I make a GET request by assetLibraryId and erc") {
+			var response = DocumentAPI.getDocumentsByErcInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then I receive a correct body response") {
+			DocumentAPI.assertExternalReferenceCodeWithCorrectValue(
+				expectedExternalReferenceCodeValue = "erc",
+				responseToParse = "${response}");
+		}
+	}
+
 	@description = "Document is not able to create with an existing erc in asset library"
 	@priority = "5"
 	test CannotCreateDocumentInAssetLibraryWithExistingErc {


### PR DESCRIPTION
**Background**
- Add test on unable to create document with existing erc in asset library
- Add test to create document using previous id as erc in asset library
- Add test on get document with erc and nonexistent asset library id
- Add test on get document by nonexistent erc in asset library
- Add test to get document by asset library id and custom erc
- Add test to get document using asset library id and uuid as erc

- Add test to delete document by uuid as erc in asset library
- Add test to delete document by custom erc in asset library
- Add test to delete document with nonexistent erc in asset library
- Add test to update document title by erc in asset library
- Add test to create a document by nonexistent erc in asset library with put request
- Add test to update document with nonexistent erc and erc in body in asset library
- Add test on not able to update erc with put request in asset library

**Test Plan**
- LPS-157973
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When with POST I create a document with an existing erc
Then I receive an error code responseAnd Then another document with same erc is not being created
- LPS-158443
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When with POST request I create a document with a custom erc with a value of the internal id of the previously created document
Then the document is being createdAnd Then I can see the custom erc in the body response
- LPS-158444
When I make a GET request by non-existent assetLibraryID and a erc
Then I receive a 404 error codeAnd Then I receive error message in server console: Unable to get a valid asset library with ID
- LPS-158445
Given asset library is created
When I make a GET request by assetLibraryID and non-existent erc
Then I receive a 404 error codeAnd Then I receive details error message about no JournalArticle exists with the key
- LPS-158446
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When I make a GET request by assetLibraryId and erc
Then I receive a correct body response
- LPS-158447
Given asset library is created
And Given a document without a custom erc is created with a POST request in asset library
When I make a GET request by assetLibraryId and erc, and using UUID as the erc
Then I receive a correct body response

- LPS-158580
Given asset library is created
And Given a document without custom erc is created with a POST request in asset library
When I make a DELETE request by assetLibraryId and UUID as the erc*Then* the document is correctly deleted
- LPS-158581
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When I make a DELETE request by assetLibraryId and erc*Then* the document is correctly deleted
- LPS-158582
And Given a document with a custom erc is created with a POST request in asset library
When I make a DELETE request by assetLibraryId and use internal ID as erc
Then I receive the correct code 204And Then the document with a custom erc created earlier still exists
- LPS-158629
Given asset library is created
And Given a document with a custom erc is created in asset library with a POST request
When I make a PUT request by assetLibraryId and erc
Then the document is correctly updatedAnd Then I receive a correct body response with updated title
- LPS-158630
Given asset library is created
When I make a PUT request by assetLibraryId and a non-existent erc
Then a document is being createdAnd Then its erc matches the inserted one
- LPS-158701
Given asset library is created
And Given a document with a custom erc is created with a POST request in asset library
When I make a PUT request by assetLibraryId and a non-existent erc with exsiting erc in the body
Then a new document is being created
And Then its erc matches the new erc value
- LPS-158700
Given asset library is created
And Given a document with a custom erc is created in asset library with a POST request
When I make a PUT request by assetLibraryId and erc with an erc modified in the body
Then I receive a correct code of 200, but the erc in the response body is not changedAnd Then another document with an erc being the modified value is not being created

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157973
https://issues.liferay.com/browse/LPS-158443
https://issues.liferay.com/browse/LPS-158444
https://issues.liferay.com/browse/LPS-158445
https://issues.liferay.com/browse/LPS-158446
https://issues.liferay.com/browse/LPS-158447

https://issues.liferay.com/browse/LPS-158580
https://issues.liferay.com/browse/LPS-158581
https://issues.liferay.com/browse/LPS-158582
https://issues.liferay.com/browse/LPS-158629
https://issues.liferay.com/browse/LPS-158630
https://issues.liferay.com/browse/LPS-158701
https://issues.liferay.com/browse/LPS-158700 