### PR TITLE
LPS-158646 Set Extended Properties in a JAX-RS Response Filter to ensure transactionality

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-annotations", version: "2.0.5"
 	compileOnly group: "io.swagger.core.v3", name: "swagger-models", version: "2.0.6"
+	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/request/filter/TransactionContainerRequestFilter.java
@@ -31,6 +31,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.annotation.Priority;
+
+import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -41,6 +44,7 @@ import javax.ws.rs.ext.Provider;
 /**
  * @author Javier Gamarra
  */
+@Priority(Priorities.USER - 10)
 @Provider
 @Transactional(rollbackFor = Exception.class)
 public class TransactionContainerRequestFilter

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.container.response.filter;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
+import com.liferay.portal.vulcan.internal.extension.EntityExtensionThreadLocal;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import java.util.Map;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.Providers;
+
+/**
+ * @author Carlos Correa
+ */
+@Provider
+public class EntityExtensionContainerResponseFilter
+	implements ContainerResponseFilter {
+
+	@Override
+	public void filter(
+			ContainerRequestContext containerRequestContext,
+			ContainerResponseContext containerResponseContext)
+		throws IOException {
+
+		Map<String, Serializable> extendedProperties =
+			EntityExtensionThreadLocal.getExtendedProperties();
+
+		if (extendedProperties == null) {
+			return;
+		}
+
+		MediaType mediaType = containerResponseContext.getMediaType();
+
+		ContextResolver<EntityExtensionHandler> contextResolver =
+			_providers.getContextResolver(
+				EntityExtensionHandler.class, mediaType);
+
+		if (contextResolver == null) {
+			return;
+		}
+
+		EntityExtensionHandler entityExtensionHandler =
+			_getEntityExtensionHandler(
+				containerResponseContext.getEntityClass(), contextResolver,
+				mediaType);
+
+		if (entityExtensionHandler == null) {
+			return;
+		}
+
+		try {
+			entityExtensionHandler.setExtendedProperties(
+				_company.getCompanyId(), containerResponseContext.getEntity(),
+				extendedProperties);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			throw new WebApplicationException(exception);
+		}
+	}
+
+	private EntityExtensionHandler _getEntityExtensionHandler(
+		Class<?> clazz, ContextResolver<EntityExtensionHandler> contextResolver,
+		MediaType mediaType) {
+
+		if (clazz == null) {
+			return null;
+		}
+
+		EntityExtensionHandler entityExtensionHandler =
+			contextResolver.getContext(clazz);
+
+		if (entityExtensionHandler == null) {
+			entityExtensionHandler = _getEntityExtensionHandler(
+				clazz.getSuperclass(), contextResolver, mediaType);
+		}
+
+		return entityExtensionHandler;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EntityExtensionContainerResponseFilter.class);
+
+	@Context
+	private Company _company;
+
+	@Context
+	private Providers _providers;
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilter.java
@@ -25,6 +25,9 @@ import java.io.Serializable;
 
 import java.util.Map;
 
+import javax.annotation.Priority;
+
+import javax.ws.rs.Priorities;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -38,6 +41,7 @@ import javax.ws.rs.ext.Providers;
 /**
  * @author Carlos Correa
  */
+@Priority(Priorities.USER + 10)
 @Provider
 public class EntityExtensionContainerResponseFilter
 	implements ContainerResponseFilter {

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -37,6 +37,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.Context
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.LogContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.NestedFieldsContainerRequestFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.container.request.filter.TransactionContainerRequestFilter;
+import com.liferay.portal.vulcan.internal.jaxrs.container.response.filter.EntityExtensionContainerResponseFilter;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AcceptLanguageContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.AggregationContextProvider;
 import com.liferay.portal.vulcan.internal.jaxrs.context.provider.CompanyContextProvider;
@@ -108,6 +109,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(BeanValidationInterceptor.class);
 		featureContext.register(CTContainerRequestFilter.class);
 		featureContext.register(DateParamConverterProvider.class);
+		featureContext.register(EntityExtensionContainerResponseFilter.class);
 		featureContext.register(EntityExtensionWriterInterceptor.class);
 		featureContext.register(ExceptionMapper.class);
 		featureContext.register(FieldsQueryParamContextProvider.class);

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptor.java
@@ -18,13 +18,9 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
-import com.liferay.portal.vulcan.internal.extension.EntityExtensionThreadLocal;
 import com.liferay.portal.vulcan.internal.jaxrs.extension.ExtendedEntity;
 
 import java.io.IOException;
-import java.io.Serializable;
-
-import java.util.Map;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
@@ -49,46 +45,36 @@ public class EntityExtensionWriterInterceptor implements WriterInterceptor {
 			_getEntityExtensionHandler(
 				writerInterceptorContext.getType(),
 				writerInterceptorContext.getMediaType());
-		Map<String, Serializable> extendedProperties =
-			EntityExtensionThreadLocal.getExtendedProperties();
 
-		try {
-			if ((entityExtensionHandler != null) &&
-				(extendedProperties != null)) {
-
-				entityExtensionHandler.setExtendedProperties(
-					_company.getCompanyId(),
-					writerInterceptorContext.getEntity(), extendedProperties);
-			}
-
-			if (entityExtensionHandler != null) {
-				_extendEntity(entityExtensionHandler, writerInterceptorContext);
-			}
-		}
-		catch (Exception exception) {
-			_log.error(exception);
-
-			throw new WebApplicationException(exception);
+		if (entityExtensionHandler != null) {
+			_extendEntity(entityExtensionHandler, writerInterceptorContext);
 		}
 
 		writerInterceptorContext.proceed();
 	}
 
 	private void _extendEntity(
-			EntityExtensionHandler entityExtensionHandler,
-			WriterInterceptorContext writerInterceptorContext)
-		throws Exception {
+		EntityExtensionHandler entityExtensionHandler,
+		WriterInterceptorContext writerInterceptorContext) {
 
-		writerInterceptorContext.setEntity(
-			ExtendedEntity.extend(
-				writerInterceptorContext.getEntity(),
-				entityExtensionHandler.getExtendedProperties(
-					_company.getCompanyId(),
-					writerInterceptorContext.getEntity()),
-				entityExtensionHandler.getFilteredPropertyNames(
-					_company.getCompanyId(),
-					writerInterceptorContext.getEntity())));
-		writerInterceptorContext.setGenericType(ExtendedEntity.class);
+		try {
+			writerInterceptorContext.setEntity(
+				ExtendedEntity.extend(
+					writerInterceptorContext.getEntity(),
+					entityExtensionHandler.getExtendedProperties(
+						_company.getCompanyId(),
+						writerInterceptorContext.getEntity()),
+					entityExtensionHandler.getFilteredPropertyNames(
+						_company.getCompanyId(),
+						writerInterceptorContext.getEntity())));
+
+			writerInterceptorContext.setGenericType(ExtendedEntity.class);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+
+			throw new WebApplicationException(exception);
+		}
 	}
 
 	private EntityExtensionHandler _getEntityExtensionHandler(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilterTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/container/response/filter/EntityExtensionContainerResponseFilterTest.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.jaxrs.container.response.filter;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
+import com.liferay.portal.vulcan.internal.extension.EntityExtensionThreadLocal;
+
+import java.io.Serializable;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Carlos Correa
+ */
+public class EntityExtensionContainerResponseFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+
+		EntityExtensionThreadLocal.setExtendedProperties(null);
+
+		ReflectionTestUtil.setFieldValue(
+			_entityExtensionContainerResponseFilter, "_providers", _providers);
+		ReflectionTestUtil.setFieldValue(
+			_entityExtensionContainerResponseFilter, "_company", _company);
+	}
+
+	@Test
+	public void testFilter() throws Exception {
+		Mockito.when(
+			_providers.getContextResolver(
+				Mockito.any(Class.class), Mockito.any(MediaType.class))
+		).thenReturn(
+			_contextResolver
+		);
+
+		Mockito.when(
+			_contextResolver.getContext(Mockito.any())
+		).thenReturn(
+			_entityExtensionHandler
+		);
+
+		Long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_company.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			_containerResponseContext.getEntity()
+		).thenReturn(
+			_TEST_ENTITY
+		);
+
+		Mockito.doReturn(
+			TestEntity.class
+		).when(
+			_containerResponseContext
+		).getEntityClass();
+
+		Mockito.when(
+			_containerResponseContext.getMediaType()
+		).thenReturn(
+			MediaType.APPLICATION_JSON_TYPE
+		);
+
+		Mockito.doNothing(
+		).when(
+			_entityExtensionHandler
+		).setExtendedProperties(
+			Mockito.anyLong(), Mockito.any(), Mockito.anyMap()
+		);
+
+		Map<String, Serializable> extendedProperties = Collections.singletonMap(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		EntityExtensionThreadLocal.setExtendedProperties(extendedProperties);
+
+		_entityExtensionContainerResponseFilter.filter(
+			_containerRequestContext, _containerResponseContext);
+
+		Mockito.verify(
+			_company
+		).getCompanyId();
+
+		Mockito.verify(
+			_containerResponseContext
+		).getEntity();
+
+		Mockito.verify(
+			_containerResponseContext
+		).getEntityClass();
+
+		Mockito.verify(
+			_containerResponseContext
+		).getMediaType();
+
+		Mockito.verify(
+			_contextResolver
+		).getContext(
+			TestEntity.class
+		);
+
+		Mockito.verify(
+			_entityExtensionHandler
+		).setExtendedProperties(
+			companyId, _TEST_ENTITY, extendedProperties
+		);
+
+		Mockito.verify(
+			_providers
+		).getContextResolver(
+			EntityExtensionHandler.class, MediaType.APPLICATION_JSON_TYPE
+		);
+
+		Mockito.verifyNoMoreInteractions(_entityExtensionHandler);
+	}
+
+	@Test
+	public void testFilterWithNoContextResolver() throws Exception {
+		Mockito.when(
+			_providers.getContextResolver(
+				Mockito.any(Class.class), Mockito.any(MediaType.class))
+		).thenReturn(
+			null
+		);
+
+		Mockito.when(
+			_containerResponseContext.getMediaType()
+		).thenReturn(
+			MediaType.APPLICATION_JSON_TYPE
+		);
+
+		Map<String, Serializable> extendedProperties = Collections.singletonMap(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		EntityExtensionThreadLocal.setExtendedProperties(extendedProperties);
+
+		_entityExtensionContainerResponseFilter.filter(
+			_containerRequestContext, _containerResponseContext);
+
+		Mockito.verify(
+			_containerResponseContext
+		).getMediaType();
+
+		Mockito.verify(
+			_providers
+		).getContextResolver(
+			EntityExtensionHandler.class, MediaType.APPLICATION_JSON_TYPE
+		);
+
+		Mockito.verifyNoMoreInteractions(_entityExtensionHandler);
+	}
+
+	@Test
+	public void testFilterWithNoExtendedProperties() throws Exception {
+		_entityExtensionContainerResponseFilter.filter(
+			_containerRequestContext, _containerResponseContext);
+
+		Mockito.verifyNoMoreInteractions(_entityExtensionHandler);
+	}
+
+	private static final TestEntity _TEST_ENTITY = new TestEntity();
+
+	@Mock
+	private Company _company;
+
+	@Mock
+	private ContainerRequestContext _containerRequestContext;
+
+	@Mock
+	private ContainerResponseContext _containerResponseContext;
+
+	@Mock
+	private ContextResolver<EntityExtensionHandler> _contextResolver;
+
+	private final EntityExtensionContainerResponseFilter
+		_entityExtensionContainerResponseFilter =
+			new EntityExtensionContainerResponseFilter();
+
+	@Mock
+	private EntityExtensionHandler _entityExtensionHandler;
+
+	@Mock
+	private Providers _providers;
+
+	private static class TestEntity {
+	}
+
+}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/test/java/com/liferay/portal/vulcan/internal/jaxrs/writer/interceptor/EntityExtensionWriterInterceptorTest.java
@@ -16,6 +16,7 @@ package com.liferay.portal.vulcan.internal.jaxrs.writer.interceptor;
 
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.vulcan.internal.extension.EntityExtensionHandler;
 import com.liferay.portal.vulcan.internal.extension.EntityExtensionThreadLocal;
@@ -50,6 +51,8 @@ public class EntityExtensionWriterInterceptorTest {
 
 	@Before
 	public void setUp() {
+		EntityExtensionThreadLocal.setExtendedProperties(null);
+
 		ReflectionTestUtil.setFieldValue(
 			_entityExtensionWriterInterceptor, "_company", _company);
 		ReflectionTestUtil.setFieldValue(
@@ -59,7 +62,7 @@ public class EntityExtensionWriterInterceptorTest {
 	@Test
 	public void testAroundWrite() throws Exception {
 		Map<String, Serializable> extendedProperties = Collections.singletonMap(
-			"test", "test");
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 		EntityExtensionThreadLocal.setExtendedProperties(extendedProperties);
 
@@ -103,15 +106,6 @@ public class EntityExtensionWriterInterceptorTest {
 
 		_entityExtensionWriterInterceptor.aroundWriteTo(
 			_writerInterceptorContext);
-
-		EntityExtensionThreadLocal.setExtendedProperties(null);
-
-		Mockito.verify(
-			_entityExtensionHandler
-		).setExtendedProperties(
-			Mockito.eq(_COMPANY_ID), Mockito.eq(_TEST_ENTITY),
-			Mockito.eq(extendedProperties)
-		);
 
 		Mockito.verify(
 			_entityExtensionHandler
@@ -187,8 +181,6 @@ public class EntityExtensionWriterInterceptorTest {
 
 	@Test
 	public void testAroundWriteWithNoExtendedProperties() throws Exception {
-		EntityExtensionThreadLocal.setExtendedProperties(null);
-
 		Mockito.when(
 			_company.getCompanyId()
 		).thenReturn(
@@ -228,12 +220,6 @@ public class EntityExtensionWriterInterceptorTest {
 
 		_entityExtensionWriterInterceptor.aroundWriteTo(
 			_writerInterceptorContext);
-
-		Mockito.verify(
-			_entityExtensionHandler, Mockito.never()
-		).setExtendedProperties(
-			Mockito.anyLong(), Mockito.any(), Mockito.any()
-		);
 
 		Mockito.verify(
 			_entityExtensionHandler

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/EntityExtensionTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/extension/test/EntityExtensionTest.java
@@ -1,0 +1,290 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.internal.extension.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.extension.ExtensionProvider;
+import com.liferay.portal.vulcan.extension.ExtensionProviderRegistry;
+import com.liferay.portal.vulcan.extension.PropertyDefinition;
+import com.liferay.portal.vulcan.internal.test.util.URLConnectionUtil;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Serializable;
+
+import java.net.HttpURLConnection;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Carlos Correa
+ */
+@RunWith(Arquillian.class)
+public class EntityExtensionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		Bundle bundle = FrameworkUtil.getBundle(EntityExtensionTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+
+		_group = GroupTestUtil.addGroup();
+
+		_serviceRegistrations.add(
+			_bundleContext.registerService(
+				Application.class, new TestApplication(),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"liferay.auth.verifier", true
+				).put(
+					"liferay.jackson", false
+				).put(
+					"liferay.oauth2", false
+				).put(
+					"osgi.jaxrs.application.base", "/test-vulcan"
+				).put(
+					"osgi.jaxrs.extension.select",
+					"(osgi.jaxrs.name=Liferay.Vulcan)"
+				).build()));
+	}
+
+	@After
+	public void tearDown() {
+		for (ServiceRegistration<?> serviceRegistration :
+				_serviceRegistrations) {
+
+			serviceRegistration.unregister();
+		}
+
+		_serviceRegistrations.clear();
+	}
+
+	@Test
+	public void testProcessCommitedRequest() throws Exception {
+		_serviceRegistrations.add(
+			_bundleContext.registerService(
+				ExtensionProvider.class, new TestExtensionProvider(false),
+				null));
+
+		int users = UserLocalServiceUtil.getUsersCount();
+
+		Assert.assertEquals(
+			200, _getResponseCode("http://localhost:8080/o/test-vulcan/test"));
+
+		Assert.assertEquals(users + 1, UserLocalServiceUtil.getUsersCount());
+	}
+
+	@Test
+	public void testProcessRollbackedRequest() throws Exception {
+		_serviceRegistrations.add(
+			_bundleContext.registerService(
+				ExtensionProvider.class, new TestExtensionProvider(true),
+				null));
+
+		int users = UserLocalServiceUtil.getUsersCount();
+
+		try (LogCapture logCapture1 = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_EXCEPTION_MAPPER, LoggerTestUtil.ERROR);
+			LogCapture logCapture2 = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME_RESPONSE_FILTER, LoggerTestUtil.ERROR)) {
+
+			Assert.assertEquals(
+				500,
+				_getResponseCode("http://localhost:8080/o/test-vulcan/test"));
+		}
+
+		Assert.assertEquals(users, UserLocalServiceUtil.getUsersCount());
+	}
+
+	public static class TestApplication extends Application {
+
+		@Override
+		public Set<Object> getSingletons() {
+			return Collections.singleton(this);
+		}
+
+		@Consumes(MediaType.APPLICATION_JSON)
+		@Path("/test")
+		@POST
+		@Produces(MediaType.APPLICATION_JSON)
+		public TestClass test(TestClass testClass) throws Exception {
+			UserTestUtil.addUser(testClass.getGroupId());
+
+			return testClass;
+		}
+
+	}
+
+	private int _getResponseCode(String urlString) throws Exception {
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)URLConnectionUtil.createURLConnection(urlString);
+
+		httpURLConnection.setRequestMethod(HttpMethod.POST);
+
+		httpURLConnection.setRequestProperty(
+			HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
+		httpURLConnection.setRequestProperty(
+			HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+		httpURLConnection.setDoOutput(true);
+
+		OutputStream outputStream = httpURLConnection.getOutputStream();
+
+		try (PrintWriter printWriter = new PrintWriter(
+				new OutputStreamWriter(outputStream, "UTF-8"), true)) {
+
+			printWriter.append("{ \"groupId\": " + _group.getGroupId() + " }");
+
+			printWriter.flush();
+		}
+
+		return httpURLConnection.getResponseCode();
+	}
+
+	private static final String _CLASS_NAME_EXCEPTION_MAPPER =
+		"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+			"WebApplicationExceptionMapper";
+
+	private static final String _CLASS_NAME_RESPONSE_FILTER =
+		"com.liferay.portal.vulcan.internal.jaxrs.container.response.filter." +
+			"EntityExtensionContainerResponseFilter";
+
+	private BundleContext _bundleContext;
+
+	@Inject
+	private ExtensionProviderRegistry _extensionProviderRegistry;
+
+	private Group _group;
+	private final List<ServiceRegistration<?>> _serviceRegistrations =
+		new ArrayList<>();
+
+	private static class TestClass {
+
+		public long getGroupId() {
+			return groupId;
+		}
+
+		public void setGroupId(long groupId) {
+			this.groupId = groupId;
+		}
+
+		protected long groupId;
+
+	}
+
+	private static class TestExtensionProvider implements ExtensionProvider {
+
+		public TestExtensionProvider(boolean fail) {
+			_fail = fail;
+
+			_propertyName = RandomTestUtil.randomString();
+		}
+
+		@Override
+		public Map<String, Serializable> getExtendedProperties(
+			long companyId, Object entity) {
+
+			return HashMapBuilder.<String, Serializable>put(
+				_propertyName, RandomTestUtil.randomString()
+			).build();
+		}
+
+		@Override
+		public Map<String, PropertyDefinition> getExtendedPropertyDefinitions(
+			long companyId, String className) {
+
+			return HashMapBuilder.<String, PropertyDefinition>put(
+				_propertyName,
+				new PropertyDefinition(
+					_propertyName, PropertyDefinition.PropertyType.TEXT, false)
+			).build();
+		}
+
+		@Override
+		public Collection<String> getFilteredPropertyNames(
+			long companyId, Object entity) {
+
+			return Collections.emptyList();
+		}
+
+		@Override
+		public boolean isApplicableExtension(long companyId, String className) {
+			if (className.equals(TestClass.class.getName())) {
+				return true;
+			}
+
+			return false;
+		}
+
+		@Override
+		public void setExtendedProperties(
+				long companyId, Object entity,
+				Map<String, Serializable> extendedProperties)
+			throws Exception {
+
+			if (_fail) {
+				throw new Exception("The request has failed");
+			}
+		}
+
+		private final boolean _fail;
+		private final String _propertyName;
+
+	}
+
+}


### PR DESCRIPTION
This PR contains the code to ensure that all the operations executed in both: the JAX-RS resource and in the setExtendedProperties method, are executed over the same transaction.

Currently, the `TransactionContainerRequestFilter` class is in charge of creating and commiting/rollbacking every transaction inside a JAX-RS processing pipeline. As the setExtendedProperties was being executed after commiting/rollbacking the transaction, if there was any kind of error, the main operation executed ended successfully even if the problem happened.

To solve the issue, a new JAX-RS Container Response Filter class `EntityExtensionContainerResponseFilter` has been created, and its priority has been set to be executed **always before the code in charge of commiting/rollbacking the transaction**.

---

**Before the PR:**

1. `TransactionContainerRequestFilter`: It starts a new transaction
2. `BaseMessageBodyReader`: It checks if there are ExtensionProviders that could extend properties for the current operation.
3. The operation is executed (for example, to create a User Account).
4. `TransactionContainerRequestFilter`: It checks if the operation is successfully. In that case, the transaction is commited; otherwise is rollbacked.
5. `EntityExtensionWriterInterceptor`: The `setExtendedProperties` method is invoked. If there is any error, the transaction has been already commited, so it is not possible to rollback the main operation (for example, the User Account is already created).

**After the PR:**

1. `TransactionContainerRequestFilter`: It starts a new transaction
2. `BaseMessageBodyReader`: It checks if there are ExtensionProviders that could extend properties for the current operation.
3. The operation is executed (for example, to create a User Account).
4. `EntityExtensionContainerResponseFilter`: The `setExtendedProperties` method is invoked. If there is any error, the transaction has not been commited yet.
5. `TransactionContainerRequestFilter`: It checks if the operation is successfully. In that case, the transaction is commited; otherwise is rollbacked. If there was an error in the previous step, the transaction is rollbacked as well.
6. `EntityExtensionWriterInterceptor`: Only the `getExtendedProperties` method is invoked; the creating/updating operation has been successfully executed and commited.

---

**NOTE:** As the requests involves different JAX-RS Filters and Interceptors to be executed, an Integration Test has been created to ensure that transactionality keeps unaltered over the time.



