### PR TITLE
LPS-158951 Remove environment property from test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -141,7 +141,6 @@ definition {
 	test CustomElementCanBeCreatedInNonRootContext {
 		property app.server.types = "tomcat";
 		property database.types = "mysql";
-		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 		property portal.context = "liferay";
 		property skip.clean-app-server-deploy-dir = "true";


### PR DESCRIPTION
**Background**
[LocalFile.RemoteApps#CustomElementCanBeCreatedInNonRootContext](https://testray.liferay.com/home/-/testray/cases/1911520310) is running on environments other than just tomcat + mysql because both `environment.acceptance` and `portal.release` are set to true.

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-158951