### PR TITLE
LPS-159037 Expose binary content in the REST builder auto-generated client to use it for binary contents (as a zip folder)

### DIFF
--- a/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/http/HttpInvoker.java
+++ b/modules/apps/batch-planner/batch-planner-rest-client/src/main/java/com/liferay/batch/planner/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.batch.planner.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/http/HttpInvoker.java
+++ b/modules/apps/bulk/bulk-rest-client/src/main/java/com/liferay/bulk/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.bulk.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-client/src/main/java/com/liferay/headless/commerce/admin/account/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.account.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-client/src/main/java/com/liferay/headless/commerce/admin/catalog/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.catalog.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-client/src/main/java/com/liferay/headless/commerce/admin/channel/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.channel.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-client/src/main/java/com/liferay/headless/commerce/admin/inventory/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.inventory.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-client/src/main/java/com/liferay/headless/commerce/admin/order/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.order.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-client/src/main/java/com/liferay/headless/commerce/admin/pricing/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.pricing.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-client/src/main/java/com/liferay/headless/commerce/admin/shipment/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.shipment.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-client/src/main/java/com/liferay/headless/commerce/admin/site/setting/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.admin.site.setting.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-client/src/main/java/com/liferay/headless/commerce/delivery/cart/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.delivery.cart.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-client/src/main/java/com/liferay/headless/commerce/delivery/catalog/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.delivery.catalog.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/http/HttpInvoker.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-client/src/main/java/com/liferay/headless/commerce/delivery/order/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.delivery.order.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/http/HttpInvoker.java
+++ b/modules/apps/data-engine/data-engine-rest-client/src/main/java/com/liferay/data/engine/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.data.engine.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/http/HttpInvoker.java
+++ b/modules/apps/digital-signature/digital-signature-rest-client/src/main/java/com/liferay/digital/signature/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.digital.signature.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/http/HttpInvoker.java
+++ b/modules/apps/frontend-view-state/frontend-view-state-rest-client/src/main/java/com/liferay/frontend/view/state/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.frontend.view.state.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-client/src/main/java/com/liferay/headless/admin/address/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.admin.address.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-client/src/main/java/com/liferay/headless/admin/content/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.admin.content.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-client/src/main/java/com/liferay/headless/admin/list/type/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.admin.list.type.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.admin.taxonomy.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.admin.user.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-client/src/main/java/com/liferay/headless/admin/workflow/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.admin.workflow.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-client/src/main/java/com/liferay/headless/batch/engine/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.batch.engine.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.delivery.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-form/headless-form-client/src/main/java/com/liferay/headless/form/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.form.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/http/HttpInvoker.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.portal.instances.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/http/HttpInvoker.java
+++ b/modules/apps/notification/notification-rest-client/src/main/java/com/liferay/notification/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.notification.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/http/HttpInvoker.java
+++ b/modules/apps/object/object-admin-rest-client/src/main/java/com/liferay/object/admin/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.object.admin.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/http/HttpInvoker.java
+++ b/modules/apps/portal-search/portal-search-rest-client/src/main/java/com/liferay/portal/search/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.portal.search.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-client/src/main/java/com/liferay/headless/commerce/machine/learning/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.headless.commerce.machine.learning.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-client/src/main/java/com/liferay/portal/workflow/metrics/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.portal.workflow.metrics.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-client/src/main/java/com/liferay/search/experiences/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.search.experiences.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;

--- a/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/http/HttpInvoker.java
+++ b/modules/dxp/apps/segments/segments-asah-rest-client/src/main/java/com/liferay/segments/asah/rest/client/http/HttpInvoker.java
@@ -14,12 +14,11 @@
 
 package com.liferay.segments.asah.rest.client.http;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -80,7 +79,10 @@ public class HttpInvoker {
 
 		HttpURLConnection httpURLConnection = _openHttpURLConnection();
 
-		httpResponse.setContent(_readResponse(httpURLConnection));
+		byte[] response = _readResponse(httpURLConnection);
+
+		httpResponse.setBinaryContent(response);
+		httpResponse.setContent(new String(response));
 		httpResponse.setMessage(httpURLConnection.getResponseMessage());
 		httpResponse.setStatusCode(httpURLConnection.getResponseCode());
 
@@ -163,6 +165,10 @@ public class HttpInvoker {
 
 	public class HttpResponse {
 
+		public byte[] getBinaryContent() {
+			return _binaryContent;
+		}
+
 		public String getContent() {
 			return _content;
 		}
@@ -173,6 +179,10 @@ public class HttpInvoker {
 
 		public int getStatusCode() {
 			return _statusCode;
+		}
+
+		public void setBinaryContent(byte[] binaryContent) {
+			_binaryContent = binaryContent;
 		}
 
 		public void setContent(String content) {
@@ -187,6 +197,7 @@ public class HttpInvoker {
 			_statusCode = statusCode;
 		}
 
+		private byte[] _binaryContent;
 		private String _content;
 		private String _message;
 		private int _statusCode;
@@ -343,10 +354,8 @@ public class HttpInvoker {
 		return httpURLConnection;
 	}
 
-	private String _readResponse(HttpURLConnection httpURLConnection)
+	private byte[] _readResponse(HttpURLConnection httpURLConnection)
 		throws IOException {
-
-		StringBuilder sb = new StringBuilder();
 
 		int responseCode = httpURLConnection.getResponseCode();
 
@@ -359,22 +368,23 @@ public class HttpInvoker {
 			inputStream = httpURLConnection.getInputStream();
 		}
 
-		BufferedReader bufferedReader = new BufferedReader(
-			new InputStreamReader(inputStream));
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+		byte[] data = new byte[_BUFFER_SIZE];
 
 		while (true) {
-			String line = bufferedReader.readLine();
+			int read = inputStream.read(data, 0, data.length);
 
-			if (line == null) {
+			if (read == -1) {
 				break;
 			}
 
-			sb.append(line);
+			buffer.write(data, 0, read);
 		}
 
-		bufferedReader.close();
+		buffer.flush();
 
-		return sb.toString();
+		return buffer.toByteArray();
 	}
 
 	private void _writeBody(HttpURLConnection httpURLConnection)
@@ -420,6 +430,8 @@ public class HttpInvoker {
 
 	private static final Logger _logger = Logger.getLogger(
 		HttpInvoker.class.getName());
+
+	private static final int _BUFFER_SIZE = 8092;
 
 	private String _body;
 	private String _contentType;


### PR DESCRIPTION
There are some endpoints that returns binary content (application/octet-stream), as for example, the following one:

```
curl -X GET \
      'http://localhost:8080/o/headless-batch-engine/v1.0/import-task/1/content' \
      -u 'test@liferay.com:test' \
      --output myfile.zip
```
The response of that requests is the content of a ZIP file.

Currently, REST Builder is generating a client within the `<module-name>-client` module, with the following class `HttpResponse`:

```
public class HttpResponse {

	public String getContent() {
		return _content;
	}

	public String getMessage() {
		return _message;
	}

	public int getStatusCode() {
		return _statusCode;
	}

	[...]
}
```
As the content of the body is being parsed as a String, in the case where the body contains binary characters, they are being parsed as a String with certain encoding. That makes that parsing it back produces different binary characters from the original ones.

To provide a way to get the binary content, a new method has been created and the parsing process has been modified to keep the binary content unaltered:

```
public class HttpResponse {

	public byte[] getBinaryContent() {
		return _binaryContent;
	}

	public String getContent() {
		return _content;
	}

	[...]
}
```
That method might be used to get the binary content body returned. See the following example for the same endpoint:

```
ImportTaskResource.Builder builder = ImportTaskResource.builder();

importTaskResource = builder.authentication(
	"test@liferay.com", "test"
).locale(
	LocaleUtil.getDefault()
).build();

HttpInvoker.HttpResponse httpResponse =
	importTaskResource.getImportTaskContentHttpResponse(1L);

FileOutputStream fileOutputStream = new FileOutputStream("myfile.zip");

fileOutputStream.write(httpResponse.getBinaryContent());
fileOutputStream.flush();
fileOutputStream.close();
```
