### PR TITLE
master Lps 158639 | Add tests on expose erc using assetLibraryId in headless taxonomy

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -88,6 +88,19 @@ definition {
 		return "${elementValue}";
 	}
 
+	macro getTaxonomyVocabularyByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
+
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			siteId = "${siteId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
 	macro updateTaxonomyVocabularyByErc {
 		Variables.assertDefined(parameterList = "${externalReferenceCode},${name}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -1,0 +1,57 @@
+definition {
+
+	macro _curlTaxonomyVocabulary {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/taxonomy-vocabularies";
+		}
+		else {
+			var api = "sites/${siteId}/taxonomy-vocabularies";
+		}
+
+		if (isSet(externalReferenceCode)) {
+			var apiWithErc = "by-external-reference-code/${externalReferenceCode}";
+
+			var api = StringUtil.add("${api}", "${apiWithErc}", "/");
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-admin-taxonomy/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+
+		return "${curl}";
+	}
+
+	macro getElementOfCreatedVocabulary {
+		Variables.assertDefined(parameterList = "${responseToParse},${element}");
+
+		var elementValue = JSONUtil.getWithJSONPath("${responseToParse}", "${element}");
+
+		return "${elementValue}";
+	}
+
+	macro updateTaxonomyVocabularyByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${name}");
+
+		var body = '''-d {"name": "${name}"}''';
+
+		if (isSet(externalReferenceCodeInBody)) {
+			var body = '''-d {"name": "${name}","externalReferenceCode": "${externalReferenceCodeInBody}"}''';
+		}
+
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			siteId = "${siteId}");
+
+		var curl = StringUtil.add("${curl}", "${body}", " ");
+
+		var response = JSONCurlUtil.put("${curl}");
+
+		return "${response}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -16,6 +16,10 @@ definition {
 			var api = StringUtil.add("${api}", "${apiWithErc}", "/");
 		}
 
+		if (isSet(filterValue)) {
+			var api = StringUtil.add("${api}", "?filter=${filterValue}", "");
+		}
+
 		var curl = '''
 			${portalURL}/o/headless-admin-taxonomy/v1.0/${api} \
 			-u test@liferay.com:test \
@@ -23,6 +27,57 @@ definition {
 		''';
 
 		return "${curl}";
+	}
+
+	macro assertProperVocabularyTotalCount {
+		Variables.assertDefined(parameterList = "${expectedTotalCount}");
+
+		var response = TaxonomyVocabularyAPI.filterTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			filterValue = "${filterValue}");
+
+		var actualTotalCount = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+			element = "$..['totalCount']",
+			responseToParse = "${response}");
+
+		TestUtils.assertEquals(
+			actual = "${actualTotalCount}",
+			expected = "${expectedTotalCount}");
+	}
+
+	macro createTaxonomyVocabulary {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${name}");
+
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			siteId = "${siteId}");
+		var body = '''-d {
+				"name": "${name}",
+				"externalReferenceCode": "${externalReferenceCode}"
+			}''';
+
+		var curl = StringUtil.add("${curl}", "${body}", " ");
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+	macro filterTaxonomyVocabulary {
+		Variables.assertDefined(parameterList = "${filterValue}");
+
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			filterValue = "${filterValue}",
+			siteId = "${siteId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
 	}
 
 	macro getElementOfCreatedVocabulary {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -67,6 +67,17 @@ definition {
 		return "${response}";
 	}
 
+	macro deleteTaxonomyVocabularyByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode}");
+
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			externalReferenceCode = "${externalReferenceCode}",
+			siteId = "${siteId}");
+
+		JSONCurlUtil.delete("${curl}");
+	}
+
 	macro filterTaxonomyVocabulary {
 		Variables.assertDefined(parameterList = "${filterValue}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -105,6 +105,25 @@ definition {
 		}
 	}
 
+	@priority = "3"
+	test CanReturnErrorWithGetVocabularyWithNonExistingErc {
+		property portal.acceptance = "true";
+
+		task ("When user makes a GET request to retrieve the vocabulary with assetLibraryId and a nonexisting ERC") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc");
+		}
+
+		task ("Then response body is No AssetVocabulary exists with the key {groupId=${GROUPID}, externalReferenceCode=${ERC}}") {
+			TestUtils.assertPartialEquals(
+				actual = "${response}",
+				expected = "No AssetVocabulary exists with the key");
+		}
+	}
+
 	@priority = "5"
 	test CanUpdateVocabularyByErc {
 		property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -76,6 +76,36 @@ definition {
 	}
 
 	@priority = "5"
+	test CanGetVocabularyByErc {
+		property portal.acceptance = "true";
+
+		task ("Given an existing vocabulary with ERC") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Vocabulary Name");
+		}
+
+		task ("When user makes a GET request to retrieve the vocabulary with assetLibraryId and ERC") {
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then a vocabulary is retrieved with the ERC in response body") {
+			var actualExternalReferenceCodeValue = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$..externalReferenceCode",
+				responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${actualExternalReferenceCodeValue}",
+				expected = "erc");
+		}
+	}
+
+	@priority = "5"
 	test CanUpdateVocabularyByErc {
 		property portal.acceptance = "true";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -76,6 +76,33 @@ definition {
 	}
 
 	@priority = "5"
+	test CanDeleteVocabularyByErc {
+		property portal.acceptance = "true";
+
+		task ("Given an existing vocabulary with ERC") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Vocabulary Name");
+		}
+
+		task ("When user makes a DELETE request to delete the vocabulary with ERC") {
+			TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc");
+		}
+
+		task ("Then the vocabulary is deleted") {
+			TaxonomyVocabularyAPI.assertProperVocabularyTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedTotalCount = "0",
+				filterValue = "name%20eq%20%27Vocabulary%20Name%27");
+		}
+	}
+
+	@priority = "5"
 	test CanGetVocabularyByErc {
 		property portal.acceptance = "true";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -1,0 +1,53 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+		}
+	}
+
+	@priority = "5"
+	test CanCreateVocabularyWithNonExistentErc {
+		property portal.acceptance = "true";
+
+		task ("When user makes a PUT request to create a vocabulary with assetLibraryId and no ERC specified in the body") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = TaxonomyVocabularyAPI.updateTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc",
+				name = "Vocabulary Name");
+		}
+
+		task ("Then a vocabulary is created with a generated ERC in response body") {
+			var actualExternalReferenceCode = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$..externalReferenceCode",
+				responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${actualExternalReferenceCode}",
+				expected = "nonexistent-erc");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -75,4 +75,42 @@ definition {
 		}
 	}
 
+	@priority = "5"
+	test CanUpdateVocabularyByErc {
+		property portal.acceptance = "true";
+
+		task ("Given an existing vocabulary") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Vocabulary Name");
+		}
+
+		task ("When user makes a PUT request to update the vocabulary name with assetLibraryId and ERC") {
+			var response = TaxonomyVocabularyAPI.updateTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Update Vocabulary Name");
+		}
+
+		task ("Then the vocabulary name is updated with the ERC in response body") {
+			var actualName = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$.name",
+				responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${actualName}",
+				expected = "Update Vocabulary Name");
+		}
+
+		task ("And Then the previous vocabulary name is not present") {
+			TaxonomyVocabularyAPI.assertProperVocabularyTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedTotalCount = "0",
+				filterValue = "name%20eq%20%27Vocabulary%20Name%27");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -27,6 +27,31 @@ definition {
 	}
 
 	@priority = "5"
+	test CanCreateVocabularyWithCustomErc {
+		property portal.acceptance = "true";
+
+		task ("When user makes a PUT request to create a vocabulary with assetLibraryId and a custom ERC") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = TaxonomyVocabularyAPI.updateTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				externalReferenceCodeInBody = "erc-in-body",
+				name = "Vocabulary Name");
+		}
+
+		task ("Then a vocabulary is created with the custom ERC in response body") {
+			var actualExternalReferenceCode = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$..externalReferenceCode",
+				responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${actualExternalReferenceCode}",
+				expected = "erc");
+		}
+	}
+
+	@priority = "5"
 	test CanCreateVocabularyWithNonExistentErc {
 		property portal.acceptance = "true";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcFromAssetLibrariesForVocabularies.testcase
@@ -133,6 +133,33 @@ definition {
 	}
 
 	@priority = "3"
+	test CannotDeleteVocabularyWithNonExistentErc {
+		property portal.acceptance = "true";
+
+		task ("Given an existing vocabulary with ERC") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Vocabulary Name");
+		}
+
+		task ("When user makes a DELETE request to delete the vocabulary with a nonexisting ERC") {
+			TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "nonexistent-erc");
+		}
+
+		task ("Then existing vocabularies are still present") {
+			TaxonomyVocabularyAPI.assertProperVocabularyTotalCount(
+				assetLibraryId = "${assetLibraryId}",
+				expectedTotalCount = "1",
+				filterValue = "name%20eq%20%27Vocabulary%20Name%27");
+		}
+	}
+
+	@priority = "3"
 	test CanReturnErrorWithGetVocabularyWithNonExistingErc {
 		property portal.acceptance = "true";
 


### PR DESCRIPTION
**Background**
- Add test to put vocabulary by erc in asset library without erc in body
- Add test to put vocabulary by erc in asset library with erc in body
- Add test to update vocabulary by erc with put request in asset library
- Add test to get vocabulary by erc in asset library
- Add test to get vocabulary by nonexistent erc in asset library
- Add test to delete vocabulary by erc in asset library
- Add test on unable to delete vocabulary by nonexistent erc in asset library

**Test Plan**
- LPS-158840
Given an asset library
When user makes a PUT request to create a vocabulary with assetLibraryId and no ERC specified
Then a vocabulary is created with a generated ERC in response body
- LPS-158841
Given an asset library
When user makes a PUT request to create a vocabulary with assetLibraryId and a custom ERC
Then a vocabulary is created with the custom ERC in response body 
- LPS-158842
Given an asset library
And Given an existing vocabulary
When user makes a PUT request to update the vocabulary name with assetLibraryId and ERC
Then the vocabulary name is updated with the ERC in response body
And Then the previous vocabulary name is not present
- LPS-158843
Given an asset library
And Given an existing vocabulary with ERC
When user makes a GET request to retrieve the vocabulary with assetLibraryId and ERC
Then a vocabulary is retrieved with the ERC in response body
- LPS-158844
Given an asset library
When user makes a GET request to retrieve the vocabulary with assetLibraryId and a nonexisting ERC
Then response body is No AssetVocabulary exists with the key {groupId=${GROUPID}, externalReferenceCode=${ERC}}
- LPS-158845
Given an asset library
And Given an existing vocabulary with ERC
When user makes a DELETE request to delete the vocabulary with ERC
Then the vocabulary is deleted
- LPS-158846 
Given an asset library
And Given an existing vocabulary with ERC
When user makes a DELETE request to delete the vocabulary with a nonexisting ERC
Then no vocabularies are deleted
And Then existing vocabularies are still present

**JIRA Ticket**
- https://issues.liferay.com/browse/LPS-158840 
- https://issues.liferay.com/browse/LPS-158841
- https://issues.liferay.com/browse/LPS-158842
- https://issues.liferay.com/browse/LPS-158843
- https://issues.liferay.com/browse/LPS-158844
- https://issues.liferay.com/browse/LPS-158845
- https://issues.liferay.com/browse/LPS-158846