### PR TITLE
LPS-158939 Unable to cancel out of discarding changes for a Blueprint or Element

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -328,8 +328,8 @@ const openConfirmModal = ({message, onConfirm, title}) => {
 			title,
 		});
 	}
-	else if (confirm(message)) {
-		onConfirm(true);
+	else {
+		onConfirm(confirm(message));
 	}
 };
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
@@ -158,7 +158,9 @@ export function CollectionGeneralPanel({item}) {
 						'if-you-change-the-collection-you-unlink-the-collection-filter'
 					)}\n\n${Liferay.Language.get('do-you-want-to-continue')}`,
 					onConfirm: (isConfirmed) => {
-						callback(isConfirmed);
+						if (isConfirmed) {
+							callback(isConfirmed);
+						}
 					},
 				});
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-158939 - Unable to cancel out of discarding changes for a Blueprint or Element

For one of search experience's uses of `openConfirmModal`, the action happens when `isConfirmed` is negative https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/hooks/useShouldConfirmBeforeNavigate.js#L57 so in order to fix this bug, I think it just needs a case when it's false? Let me know if that's okay.

I also tried the new feature flag for `LPS-148659` but had some issues with the new modal loading and immediately exiting out, not sure if that is just something that's a work in progress 😅 

Thanks for taking a look!