### PR TITLE
LPS-153444 The simple editor doesn't exist so remove this code since it is causing null pointer exceptions

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormFieldFreeMarkerRendererUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMFormFieldFreeMarkerRendererUtil.java
@@ -15,7 +15,6 @@
 package com.liferay.dynamic.data.mapping.internal.util;
 
 import com.liferay.portal.kernel.editor.Editor;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -38,10 +37,6 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 public class DDMFormFieldFreeMarkerRendererUtil {
 
 	public static Editor getEditor(HttpServletRequest httpServletRequest) {
-		if (!BrowserSnifferUtil.isRtf(httpServletRequest)) {
-			return _editors.get("simple");
-		}
-
 		if (Validator.isNull(_TEXT_HTML_EDITOR_WYSIWYG_DEFAULT) ||
 			!_editors.containsKey(_TEXT_HTML_EDITOR_WYSIWYG_DEFAULT)) {
 

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.PortalWebResourcesUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -517,10 +516,6 @@ public class EditorTag extends BaseValidatorTagSupport {
 	}
 
 	private String _getResolvedEditorName() {
-		if (!BrowserSnifferUtil.isRtf(getRequest())) {
-			return "simple";
-		}
-
 		if (Validator.isNull(_editorName)) {
 			return _EDITOR_WYSIWYG_DEFAULT;
 		}

--- a/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
-import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.PortalWebResourcesUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -65,10 +64,6 @@ public class InputEditorTag extends BaseValidatorTagSupport {
 
 	public static Editor getEditor(
 		HttpServletRequest httpServletRequest, String editorName) {
-
-		if (!BrowserSnifferUtil.isRtf(httpServletRequest)) {
-			return _serviceTrackerMap.getService("simple");
-		}
 
 		if (Validator.isNull(editorName) ||
 			!_serviceTrackerMap.containsKey(editorName)) {


### PR DESCRIPTION
Motivation
----
Since "simple" editor was archived, this means it is deprecated and not deployed with the bundle, we are facing some null pointer exceptions when the browser is not Rtf (**BrowserSnifferUtil.isRtf()**) and we are trying to get the editor.

[Link to the issue](https://issues.liferay.com/browse/LPS-153444)

Proposed Solution
----
Delete references to "simple" editor in places where we are using it, since it is causing null pointer exceptions.

How to test it
---
Step-by-Step:

1. Add a new site
2. Add a Wiki widget to a content page
3. Publish