### PR TITLE
LPS-159419 Allow several class types in PropertyDefinition to verify against more than a possible class

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 12.0.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.vulcan.extension;
 
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.vulcan.extension.validation.DefaultPropertyValidator;
 import com.liferay.portal.vulcan.extension.validation.PropertyValidator;
 
@@ -22,6 +23,7 @@ import java.math.BigDecimal;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Carlos Correa
@@ -29,12 +31,12 @@ import java.util.Map;
 public class PropertyDefinition {
 
 	public PropertyDefinition(
-		Class<?> propertyClass, String propertyClassDescription,
+		Set<Class<?>> propertyClasses, String propertyClassDescription,
 		String propertyClassName, String propertyDescription,
 		String propertyName, PropertyType propertyType,
 		PropertyValidator propertyValidator, boolean required) {
 
-		_propertyClass = propertyClass;
+		_propertyClasses = propertyClasses;
 		_propertyClassDescription = propertyClassDescription;
 		_propertyClassName = propertyClassName;
 		_propertyDescription = propertyDescription;
@@ -53,7 +55,7 @@ public class PropertyDefinition {
 		_propertyType = propertyType;
 		_required = required;
 
-		_propertyClass = _propertyTypeClasses.get(propertyType);
+		_propertyClasses = _propertyTypeClasses.get(propertyType);
 		_propertyValidator = new DefaultPropertyValidator();
 	}
 
@@ -68,15 +70,15 @@ public class PropertyDefinition {
 		_propertyValidator = propertyValidator;
 		_required = required;
 
-		_propertyClass = _propertyTypeClasses.get(propertyType);
-	}
-
-	public Class<?> getPropertyClass() {
-		return _propertyClass;
+		_propertyClasses = _propertyTypeClasses.get(propertyType);
 	}
 
 	public String getPropertyClassDescription() {
 		return _propertyClassDescription;
+	}
+
+	public Set<Class<?>> getPropertyClasses() {
+		return _propertyClasses;
 	}
 
 	public String getPropertyClassName() {
@@ -120,25 +122,25 @@ public class PropertyDefinition {
 
 	}
 
-	private static final Map<PropertyType, Class<?>> _propertyTypeClasses =
-		HashMapBuilder.<PropertyType, Class<?>>put(
-			PropertyType.BIG_DECIMAL, BigDecimal.class
-		).<PropertyType, Class<?>>put(
-			PropertyType.BOOLEAN, Boolean.class
-		).<PropertyType, Class<?>>put(
-			PropertyType.DECIMAL, Float.class
-		).<PropertyType, Class<?>>put(
-			PropertyType.DOUBLE, Double.class
-		).<PropertyType, Class<?>>put(
-			PropertyType.INTEGER, Integer.class
-		).<PropertyType, Class<?>>put(
-			PropertyType.LONG, Long.class
-		).<PropertyType, Class<?>>put(
-			PropertyType.TEXT, String.class
+	private static final Map<PropertyType, Set<Class<?>>> _propertyTypeClasses =
+		HashMapBuilder.<PropertyType, Set<Class<?>>>put(
+			PropertyType.BIG_DECIMAL, SetUtil.fromArray(BigDecimal.class)
+		).<PropertyType, Set<Class<?>>>put(
+			PropertyType.BOOLEAN, SetUtil.fromArray(Boolean.class)
+		).<PropertyType, Set<Class<?>>>put(
+			PropertyType.DECIMAL, SetUtil.fromArray(Float.class)
+		).<PropertyType, Set<Class<?>>>put(
+			PropertyType.DOUBLE, SetUtil.fromArray(Double.class, Float.class)
+		).<PropertyType, Set<Class<?>>>put(
+			PropertyType.INTEGER, SetUtil.fromArray(Integer.class)
+		).<PropertyType, Set<Class<?>>>put(
+			PropertyType.LONG, SetUtil.fromArray(Integer.class, Long.class)
+		).<PropertyType, Set<Class<?>>>put(
+			PropertyType.TEXT, SetUtil.fromArray(String.class)
 		).build();
 
-	private final Class<?> _propertyClass;
 	private String _propertyClassDescription;
+	private final Set<Class<?>> _propertyClasses;
 	private String _propertyClassName;
 	private List<PropertyDefinition> _propertyDefinitions;
 	private final String _propertyDescription;

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/extension/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/extension/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.util.Collections;
 import java.util.Map;
 
 import javax.validation.ValidationException;
@@ -78,7 +79,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			String.class, RandomTestUtil.randomString(),
+			Collections.singleton(String.class), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.DATE_TIME, defaultPropertyValidator,
@@ -114,6 +115,9 @@ public class DefaultPropertyValidatorTest {
 
 		defaultPropertyValidator.validate(
 			propertyDefinition, RandomTestUtil.randomDouble());
+
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomFloat());
 	}
 
 	@Test
@@ -150,7 +154,7 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			String.class, RandomTestUtil.randomString(),
+			Collections.singleton(String.class), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.DATE_TIME, defaultPropertyValidator,
@@ -166,9 +170,9 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			TestInvalidClass.class, RandomTestUtil.randomString(),
+			Collections.singleton(TestInvalidClass.class),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -183,9 +187,9 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			TestInvalidClass.class, RandomTestUtil.randomString(),
+			Collections.singleton(TestInvalidClass.class),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -218,6 +222,9 @@ public class DefaultPropertyValidatorTest {
 			RandomTestUtil.randomBoolean());
 
 		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomInt());
+
+		defaultPropertyValidator.validate(
 			propertyDefinition, RandomTestUtil.randomLong());
 	}
 
@@ -227,9 +234,9 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			TestClass.class, RandomTestUtil.randomString(),
+			Collections.singleton(TestClass.class),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.MULTIPLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 
@@ -259,9 +266,9 @@ public class DefaultPropertyValidatorTest {
 			new DefaultPropertyValidator();
 
 		PropertyDefinition propertyDefinition = new PropertyDefinition(
-			TestClass.class, RandomTestUtil.randomString(),
+			Collections.singleton(TestClass.class),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			PropertyDefinition.PropertyType.SINGLE_ELEMENT,
 			defaultPropertyValidator, RandomTestUtil.randomBoolean());
 


### PR DESCRIPTION
Given a PropertyDefinition, this PR contains the code to allow that PropertyDefinition to be instantiated by more than one class typology.

That is, for example, given a PropertyDefinition whose type is LONG, the value of that PropertyDefinition may be instantiated by both the Integer class and the Long java class, since Integer is less restrictive.

The following cases have been added by now:

- **LONG**: Both **Integer** and **Long** Java classes might be used for this Property
- **DOUBLE**: Both **Double** and **Float** Java classes might be used for this Property

With this, it will be possible to keep the default validation for the case of Objects