### PR TITLE
LPS-156836 Date Filter not working on FDS Sample Portlet

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedDateRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedDateRangeFDSFilter.java
@@ -33,6 +33,11 @@ import org.osgi.service.component.annotations.Component;
 public class CustomizedDateRangeFDSFilter extends BaseDateRangeFDSFilter {
 
 	@Override
+	public String getEntityFieldType() {
+		return "date";
+	}
+
+	@Override
 	public String getId() {
 		return "date";
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/dates.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/dates.js
@@ -55,15 +55,3 @@ export function formatDateRangeObject(dateRangeObject) {
 		)}`;
 	}
 }
-
-export function convertObjectDateToIsoString(objDate, direction) {
-	const time = direction === 'from' ? [0, 0, 0, 0] : [23, 59, 59, 999];
-	const date = new Date(
-		objDate.year,
-		objDate.month - 1,
-		objDate.day,
-		...time
-	);
-
-	return date.toISOString();
-}


### PR DESCRIPTION
### References

- [LPS-156836 Date Filter not working on FDS Sample Portlet](https://issues.liferay.com/browse/LPS-156836)

### What is the goal of this PR?

We are fixing data filter in FDS sample portlet, by adding support for `entityFieldType` to `DataRangeFilter`, and setting it in the sample filter. Entity field type, in this case, as dictated by Object's REST API, is `date`, that requires filter odata string to be in ISO day-only format (for example `2022-01-02`). By default, if  `entityFieldType` is not set, we are setting full ISO format (`2022-01-02T01:01:12.333Z`). /cc @MarinhoFeliphe

In addition, by using `Date.UTC` we are fixing date setting, which is currently offset by browser timezone. This is a bit hacky, but so is most of date-related API, in JS any beyond. I will keep repeating, even if it's in vain: we should support only UNIX timestamps for odata. Any human-readable format only leads to pain. Lots of pain.

### What does it look like?

![after](https://user-images.githubusercontent.com/5435511/182177411-2077edb6-f033-44f8-b3e2-54355d36780b.gif)

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.