### PR TITLE
LPS-159419 Add more classes that could instantiate certain Property Definitions

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/extension/PropertyDefinition.java
@@ -124,11 +124,15 @@ public class PropertyDefinition {
 
 	private static final Map<PropertyType, Set<Class<?>>> _propertyTypeClasses =
 		HashMapBuilder.<PropertyType, Set<Class<?>>>put(
-			PropertyType.BIG_DECIMAL, SetUtil.fromArray(BigDecimal.class)
+			PropertyType.BIG_DECIMAL,
+			SetUtil.fromArray(
+				BigDecimal.class, Integer.class, Double.class, Float.class,
+				Long.class)
 		).<PropertyType, Set<Class<?>>>put(
 			PropertyType.BOOLEAN, SetUtil.fromArray(Boolean.class)
 		).<PropertyType, Set<Class<?>>>put(
-			PropertyType.DECIMAL, SetUtil.fromArray(Float.class)
+			PropertyType.DECIMAL,
+			SetUtil.fromArray(Float.class, Integer.class, Long.class)
 		).<PropertyType, Set<Class<?>>>put(
 			PropertyType.DOUBLE, SetUtil.fromArray(Double.class, Float.class)
 		).<PropertyType, Set<Class<?>>>put(

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/extension/validation/DefaultPropertyValidatorTest.java
@@ -57,6 +57,14 @@ public class DefaultPropertyValidatorTest {
 
 		defaultPropertyValidator.validate(
 			propertyDefinition, new BigDecimal(RandomTestUtil.randomLong()));
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomInt());
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomDouble());
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomFloat());
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomLong());
 	}
 
 	@Test
@@ -101,6 +109,10 @@ public class DefaultPropertyValidatorTest {
 
 		defaultPropertyValidator.validate(
 			propertyDefinition, RandomTestUtil.randomFloat());
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomInt());
+		defaultPropertyValidator.validate(
+			propertyDefinition, RandomTestUtil.randomLong());
 	}
 
 	@Test


### PR DESCRIPTION
Related PR: https://github.com/liferay-frontend/liferay-portal/pull/2588

Given a PropertyDefinition, a PropertyDefinition is allowed to be instantiated by some different classes than before. The following cases have been added:

- **BIG_DECIMAL**: Apart from BigDecimal, **Integer**, **Double**, **Float** and **Long** have been added.
- **DECIMAL**: Apart from Float, **Integer** and **Long** have beed added.

With this, it will be possible to keep the default validation for the case of Objects