### PR TITLE
LPS-159215 Include pathContext when building the URLs from the UriInfo in Vulcan

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "io.github.graphql-java", name: "graphql-java-annotations", version: "5.4"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.validation", name: "validation-api", version: "2.0.1.Final"
 	compileOnly group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	compileOnly group: "org.apache.cxf", name: "cxf-core", version: "3.4.4"

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/UriInfoUtil.java
@@ -15,8 +15,12 @@
 package com.liferay.portal.vulcan.util;
 
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.net.URI;
 
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -27,32 +31,21 @@ import javax.ws.rs.core.UriInfo;
 public class UriInfoUtil {
 
 	public static String getAbsolutePath(UriInfo uriInfo) {
-		if (_isHttpsEnabled()) {
-			UriBuilder uriBuilder = uriInfo.getAbsolutePathBuilder();
-
-			return String.valueOf(
-				uriBuilder.scheme(
-					"https"
-				).build());
-		}
-
-		return String.valueOf(uriInfo.getAbsolutePath());
+		return String.valueOf(
+			_updateParameters(
+				uriInfo.getAbsolutePathBuilder()
+			).build());
 	}
 
 	public static String getBasePath(UriInfo uriInfo) {
-		UriBuilder uriBuilder = getBaseUriBuilder(uriInfo);
-
-		return String.valueOf(uriBuilder.build());
+		return String.valueOf(
+			getBaseUriBuilder(
+				uriInfo
+			).build());
 	}
 
 	public static UriBuilder getBaseUriBuilder(UriInfo uriInfo) {
-		if (_isHttpsEnabled()) {
-			UriBuilder uriBuilder = uriInfo.getBaseUriBuilder();
-
-			return uriBuilder.scheme("https");
-		}
-
-		return uriInfo.getBaseUriBuilder();
+		return _updateParameters(uriInfo.getBaseUriBuilder());
 	}
 
 	private static boolean _isHttpsEnabled() {
@@ -64,6 +57,20 @@ public class UriInfoUtil {
 		}
 
 		return false;
+	}
+
+	private static UriBuilder _updateParameters(UriBuilder uriBuilder) {
+		if (!Validator.isBlank(PortalUtil.getPathContext())) {
+			URI uri = uriBuilder.build();
+
+			uriBuilder.replacePath(PortalUtil.getPathContext(uri.getPath()));
+		}
+
+		if (_isHttpsEnabled()) {
+			uriBuilder.scheme(Http.HTTPS);
+		}
+
+		return uriBuilder;
 	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/test/java/com/liferay/portal/vulcan/util/UriInfoUtilTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.vulcan.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.net.URI;
+
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Carlos Correa
+ */
+public class UriInfoUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(_portal);
+
+		PropsUtil.setProps(_props);
+	}
+
+	@Test
+	public void testGetAbsolutePath() {
+		Mockito.when(
+			_uriBuilder.build()
+		).thenReturn(
+			_uri
+		);
+		Mockito.when(
+			_uriInfo.getAbsolutePathBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		Assert.assertEquals(
+			String.valueOf(_uri), UriInfoUtil.getAbsolutePath(_uriInfo));
+
+		Mockito.verify(
+			_uriBuilder
+		).build();
+
+		Mockito.verify(
+			_uriInfo
+		).getAbsolutePathBuilder();
+	}
+
+	@Test
+	public void testGetAbsolutePathHttps() {
+		Mockito.when(
+			_uriBuilder.build()
+		).thenReturn(
+			_uri
+		);
+
+		Mockito.when(
+			_uriBuilder.scheme(Mockito.anyString())
+		).thenReturn(
+			_uriBuilder
+		);
+
+		Mockito.when(
+			_uriInfo.getAbsolutePathBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		_setProtocol(Http.HTTPS);
+
+		Assert.assertEquals(
+			String.valueOf(_uri), UriInfoUtil.getAbsolutePath(_uriInfo));
+
+		Mockito.verify(
+			_uriBuilder
+		).build();
+
+		Mockito.verify(
+			_uriBuilder
+		).scheme(
+			Http.HTTPS
+		);
+
+		Mockito.verify(
+			_uriInfo
+		).getAbsolutePathBuilder();
+	}
+
+	@Test
+	public void testGetAbsolutePathPathContext() {
+		String path = StringPool.SLASH + RandomTestUtil.randomString();
+
+		Mockito.when(
+			_uri.getPath()
+		).thenReturn(
+			path
+		);
+
+		Mockito.when(
+			_uriBuilder.build()
+		).thenReturn(
+			_uri
+		);
+
+		Mockito.when(
+			_uriBuilder.replacePath(Mockito.anyString())
+		).thenReturn(
+			_uriBuilder
+		);
+
+		Mockito.when(
+			_uriInfo.getAbsolutePathBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		String pathContext = StringPool.SLASH + RandomTestUtil.randomString();
+
+		_setPathContext(path, pathContext);
+
+		Assert.assertEquals(
+			String.valueOf(_uri), UriInfoUtil.getAbsolutePath(_uriInfo));
+
+		Mockito.verify(
+			_uri
+		).getPath();
+
+		Mockito.verify(
+			_uriBuilder, Mockito.times(2)
+		).build();
+
+		Mockito.verify(
+			_uriBuilder
+		).replacePath(
+			pathContext + path
+		);
+
+		Mockito.verify(
+			_uriInfo
+		).getAbsolutePathBuilder();
+	}
+
+	@Test
+	public void testGetBaseUriBuilder() {
+		Mockito.when(
+			_uriInfo.getBaseUriBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Mockito.verify(
+			_uriInfo
+		).getBaseUriBuilder();
+	}
+
+	@Test
+	public void testGetBaseUriBuilderHttps() {
+		Mockito.when(
+			_uriBuilder.scheme(Mockito.anyString())
+		).thenReturn(
+			_uriBuilder
+		);
+
+		Mockito.when(
+			_uriInfo.getBaseUriBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		_setProtocol(Http.HTTPS);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Mockito.verify(
+			_uriBuilder
+		).scheme(
+			Http.HTTPS
+		);
+
+		Mockito.verify(
+			_uriInfo
+		).getBaseUriBuilder();
+	}
+
+	@Test
+	public void testGetBaseUriBuilderPathContext() {
+		String path = StringPool.SLASH + RandomTestUtil.randomString();
+
+		Mockito.when(
+			_uri.getPath()
+		).thenReturn(
+			path
+		);
+
+		Mockito.when(
+			_uriBuilder.build()
+		).thenReturn(
+			_uri
+		);
+
+		Mockito.when(
+			_uriBuilder.replacePath(Mockito.anyString())
+		).thenReturn(
+			_uriBuilder
+		);
+
+		Mockito.when(
+			_uriInfo.getBaseUriBuilder()
+		).thenReturn(
+			_uriBuilder
+		);
+
+		String pathContext = StringPool.SLASH + RandomTestUtil.randomString();
+
+		_setPathContext(path, pathContext);
+
+		Assert.assertSame(_uriBuilder, UriInfoUtil.getBaseUriBuilder(_uriInfo));
+
+		Mockito.verify(
+			_uri
+		).getPath();
+
+		Mockito.verify(
+			_uriBuilder
+		).build();
+
+		Mockito.verify(
+			_uriBuilder
+		).replacePath(
+			pathContext + path
+		);
+
+		Mockito.verify(
+			_uriInfo
+		).getBaseUriBuilder();
+	}
+
+	private void _setPathContext(String path, String pathContext) {
+		Mockito.when(
+			_portal.getPathContext()
+		).thenReturn(
+			pathContext
+		);
+
+		Mockito.when(
+			_portal.getPathContext(Mockito.anyString())
+		).thenReturn(
+			pathContext + path
+		);
+	}
+
+	private void _setProtocol(String protocol) {
+		Mockito.when(
+			_props.get(PropsKeys.WEB_SERVER_PROTOCOL)
+		).thenReturn(
+			protocol
+		);
+	}
+
+	private final Portal _portal = Mockito.mock(Portal.class);
+	private final Props _props = Mockito.mock(Props.class);
+	private final URI _uri = Mockito.mock(URI.class);
+	private final UriBuilder _uriBuilder = Mockito.mock(UriBuilder.class);
+	private final UriInfo _uriInfo = Mockito.mock(UriInfo.class);
+
+}


### PR DESCRIPTION
This PR contains the code to include the pathContext when building the URLs in the UriInfoUtil in Vulcan that is used to build certain URLs in the REST APIs.

---

### **Before the PR:**

If there is a pathContext defined in the portal (see the LPS-159215 in Jira to find more details about how to configure/reproduce it) when the API Explorer is accessed, an error occurs:

![image](https://user-images.githubusercontent.com/32699538/182601869-dbae8fad-08ec-418d-ada1-d5a552852b76.png)

As the URL is not the correct one, the pathContext is not being included:

`Not Found http://localhost/o/headless-delivery/v1.0/openapi.json`

Furthermore, the URLs built in `actions` parameter are also wrong, for example, for the following request:

```
curl -X POST 'http://localhost/portal/o/headless-delivery/v1.0/sites/20121/blog-postings' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-u 'test@liferay.com:test' \
-d '{
    "headline": "Test Blog Entry headline",
    "articleBody": "Test Blog Entry article body"
}'
```

the response contains incorrect URLs:

```
{
  "actions" : {
    "get-rendered-content-by-display-page" : {
      "method" : "GET",
      "href" : "http://localhost/o/headless-delivery/v1.0/blog-postings/44908/rendered-content-by-display-page/{displayPageKey}"
    },
    "get" : {
      "method" : "GET",
      "href" : "http://localhost/o/headless-delivery/v1.0/blog-postings/44908"
    },
    "replace" : {
      "method" : "PUT",
      "href" : "http://localhost/o/headless-delivery/v1.0/blog-postings/44908"
    },
    "update" : {
      "method" : "PATCH",
      "href" : "http://localhost/o/headless-delivery/v1.0/blog-postings/44908"
    },
    "delete" : {
      "method" : "DELETE",
      "href" : "http://localhost/o/headless-delivery/v1.0/blog-postings/44908"
    }
  },
  [...]
}
```

### **After the PR:**

The OpenAPI is shown:

![image](https://user-images.githubusercontent.com/32699538/182607532-fd97e265-d42d-4d41-9fb4-843428a2c80c.png)

with the proper URL in the `Servers` combo.

For the same request:

```
curl -X POST 'http://localhost/portal/o/headless-delivery/v1.0/sites/20121/blog-postings' \
-H 'accept: application/json' \
-H 'Content-Type: application/json' \
-u 'test@liferay.com:test' \
-d '{
    "headline": "Test Blog Entry headline",
    "articleBody": "Test Blog Entry article body"
}'
```

the URLs are correct:

```
{
  "actions" : {
    "get-rendered-content-by-display-page" : {
      "method" : "GET",
      "href" : "http://localhost/portal/o/headless-delivery/v1.0/blog-postings/45001/rendered-content-by-display-page/{displayPageKey}"
    },
    "get" : {
      "method" : "GET",
      "href" : "http://localhost/portal/o/headless-delivery/v1.0/blog-postings/45001"
    },
    "replace" : {
      "method" : "PUT",
      "href" : "http://localhost/portal/o/headless-delivery/v1.0/blog-postings/45001"
    },
    "update" : {
      "method" : "PATCH",
      "href" : "http://localhost/portal/o/headless-delivery/v1.0/blog-postings/45001"
    },
    "delete" : {
      "method" : "DELETE",
      "href" : "http://localhost/portal/o/headless-delivery/v1.0/blog-postings/45001"
    }
  },
  [...]
}
```

