### PR TITLE
LPS-159732 Add menuElementAttrs to clay:dropdown-menu

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 11.0.2
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.contributor,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -82,5 +82,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "11.0.2"
+	"version": "11.1.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/DropdownMenuTag.java
@@ -53,8 +53,16 @@ public class DropdownMenuTag extends ButtonTag {
 		return _dropdownItems;
 	}
 
+	public Map<String, String> getMenuProps() {
+		return _menuProps;
+	}
+
 	public void setDropdownItems(List<DropdownItem> dropdownItems) {
 		_dropdownItems = dropdownItems;
+	}
+
+	public void setMenuProps(Map<String, String> menuProps) {
+		_menuProps = menuProps;
 	}
 
 	@Override
@@ -64,6 +72,7 @@ public class DropdownMenuTag extends ButtonTag {
 		_buttonType = null;
 		_dropdownItems = null;
 		_empty = null;
+		_menuProps = null;
 	}
 
 	@Override
@@ -78,6 +87,7 @@ public class DropdownMenuTag extends ButtonTag {
 	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
 		props.put("items", _dropdownItems);
+		props.put("menuProps", _menuProps);
 
 		return super.prepareProps(props);
 	}
@@ -87,5 +97,6 @@ public class DropdownMenuTag extends ButtonTag {
 	private String _buttonType;
 	private List<DropdownItem> _dropdownItems;
 	private Boolean _empty;
+	private Map<String, String> _menuProps;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -579,6 +579,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>menuProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>monospaced</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/DropdownMenu.js
@@ -30,6 +30,7 @@ export default function DropdownMenu({
 	items,
 	label,
 	locale: _locale,
+	menuProps,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
 	...otherProps
@@ -41,6 +42,7 @@ export default function DropdownMenu({
 					'dropdown-action': actionsDropdown,
 				})}
 				items={normalizeDropdownItems(items) || []}
+				menuElementAttrs={menuProps}
 				trigger={
 					<ClayButton
 						className={classNames(cssClass, {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/layout_actions.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/layout_actions.jsp
@@ -26,6 +26,7 @@ LayoutActionsDisplayContext layoutActionsDisplayContext = (LayoutActionsDisplayC
 		displayType="unstyled"
 		dropdownItems="<%= layoutActionsDisplayContext.getDropdownItems() %>"
 		icon="ellipsis-v"
+		menuProps='<%= HashMapBuilder.put("className", "cadmin").build() %>'
 		monospaced="<%= true %>"
 		propsTransformer="js/LayoutActionDropdownPropsTransformer"
 		small="<%= true %>"


### PR DESCRIPTION
As part of [this spike](https://issues.liferay.com/browse/LPS-158008), we have found that in some cases `clay:dropdown-menu` taglib is affected by user styles. In order to prevent this, we need to apply `cadmin`.

Some possible solutions have been [discussed in slack](https://liferay.slack.com/archives/CNBG06JS3/p1659424258559179), and I've decided to use `menuElementAttrs` property name, since `ClayDropdownWithItems` component has a property with that name.