### PR TITLE
LPS-159555

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export function ClassicEditor({
+	contents,
+	editorConfig,
+	onChange,
+	ref,
+}: IClassicEditorProps): JSX.Element;
+
+export interface IEditor {
+	editor: {
+		config: {contentsLangDirection: unknown; contentsLanguage: unknown};
+		setData: (data: unknown) => void;
+	};
+}
+
+interface IClassicEditorProps {
+	contents?: string;
+	editorConfig: string;
+	onChange: (content: string) => void;
+	ref: React.RefObject<IEditor>;
+}

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
@@ -17,10 +17,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
-
-// @ts-ignore
-
-import {ClassicEditor} from 'frontend-editor-ckeditor-web';
+import {ClassicEditor, IEditor} from 'frontend-editor-ckeditor-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {FieldBase} from './FieldBase';
@@ -170,13 +167,6 @@ export function RichTextLocalized({
 			</div>
 		</FieldBase>
 	);
-}
-
-interface IEditor {
-	editor: {
-		config: {contentsLangDirection: unknown; contentsLanguage: unknown};
-		setData: (data: unknown) => void;
-	};
 }
 interface IItem {
 	label: Locale;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare module 'frontend-editor-ckeditor-web' {
+	export * from 'frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index';
+}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-159555

### Motivation

Hello Reviewer, I'm working on a technical debt to remove some @ts-ignore annotations from the object code. For this I have to create some type declarations for components that were not developed in typescript, I can declare these types in the object-js-components-web module, but I think it will be restricted just for our case, so I decided to declare the types in the frontend -editor-ckeditor-web which is the root of the ClassicEditor component I had to remove the @ts-ignore, so anyone who wants to use this component with typescript in the future doesn't need to declare the same types in their own module, avoiding code repetition. If this idea is approved, I will send other PRs with new type declarations for other components we are using. What do you think?