### PR TITLE
LPS-159555  Add type declaration to ClassicEditor component in frontend-editor-ckeditor-web module

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@types/ckeditor4": "4.16.2",
 		"ckeditor4-react": "1.4.2",
 		"liferay-ckeditor": "4.18.0-liferay.2"
 	},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts
@@ -12,6 +12,14 @@
  * details.
  */
 
+import 'ckeditor4';
+
+export function BalloonEditor({
+	config,
+	contents,
+	name,
+}: IBalloonEditorProps): JSX.Element;
+
 export function ClassicEditor({
 	contents,
 	editorConfig,
@@ -20,15 +28,18 @@ export function ClassicEditor({
 }: IClassicEditorProps): JSX.Element;
 
 export interface IEditor {
-	editor: {
-		config: {contentsLangDirection: unknown; contentsLanguage: unknown};
-		setData: (data: unknown) => void;
-	};
+	editor: CKEDITOR.editor;
+}
+
+interface IBalloonEditorProps {
+	config?: CKEDITOR.config;
+	contents: string;
+	name: string;
 }
 
 interface IClassicEditorProps {
 	contents: string;
-	editorConfig: object;
+	editorConfig: CKEDITOR.config;
 	initialToolbarSet?: string;
 	name: string;
 	onChange: (content: string) => void;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export function ClassicEditor({
+	contents,
+	editorConfig,
+	onChange,
+	ref,
+}: IClassicEditorProps): JSX.Element;
+
+export interface IEditor {
+	editor: {
+		config: {contentsLangDirection: unknown; contentsLanguage: unknown};
+		setData: (data: unknown) => void;
+	};
+}
+
+interface IClassicEditorProps {
+	contents: string;
+	editorConfig: object;
+	initialToolbarSet?: string;
+	name: string;
+	onChange: (content: string) => void;
+	ref: React.RefObject<IEditor>;
+	title?: string;
+}

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.tsx
@@ -370,7 +370,7 @@ export default function EditNotificationTemplate({
 
 interface IProps {
 	baseResourceURL: string;
-	editorConfig: string;
+	editorConfig: object;
 	notificationTemplateId: number;
 }
 

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare module 'frontend-editor-ckeditor-web' {
+	export * from 'frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index';
+}

--- a/modules/apps/notification/notification-web/types/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.d.ts
+++ b/modules/apps/notification/notification-web/types/src/main/resources/META-INF/resources/js/components/EditNotificationTemplate.d.ts
@@ -22,7 +22,7 @@ export default function EditNotificationTemplate({
 }: IProps): JSX.Element;
 interface IProps {
 	baseResourceURL: string;
-	editorConfig: string;
+	editorConfig: object;
 	notificationTemplateId: number;
 }
 export declare type TNotificationTemplate = {

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
@@ -17,10 +17,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
-
-// @ts-ignore
-
-import {ClassicEditor} from 'frontend-editor-ckeditor-web';
+import {ClassicEditor, IEditor} from 'frontend-editor-ckeditor-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {FieldBase} from './FieldBase';
@@ -76,8 +73,9 @@ export function RichTextLocalized({
 			<div className="lfr-notification__rich-text-localized">
 				<div className="lfr-notification__rich-text-localized-editor">
 					<ClassicEditor
-						contents={translations[selectedLocale]}
+						contents={translations[selectedLocale] as string}
 						editorConfig={editorConfig}
+						name="richTextLocalizedEditor"
 						onChange={(content: string) => {
 							onTranslationsChange({
 								...translations,
@@ -171,13 +169,6 @@ export function RichTextLocalized({
 		</FieldBase>
 	);
 }
-
-interface IEditor {
-	editor: {
-		config: {contentsLangDirection: unknown; contentsLanguage: unknown};
-		setData: (data: unknown) => void;
-	};
-}
 interface IItem {
 	label: Locale;
 	symbol: string;
@@ -189,7 +180,7 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 		translated: string;
 		untranslated: string;
 	};
-	editorConfig: string;
+	editorConfig: object;
 	helpMessage?: string;
 	label: string;
 	onSelectedLocaleChange: (val: IItem) => void;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
@@ -63,7 +63,9 @@ export function RichTextLocalized({
 
 			editor.config.contentsLanguage = selectedLocale;
 
-			editor.setData(translations[selectedLocale]);
+			if (translations[selectedLocale]) {
+				editor.setData(translations[selectedLocale] as string);
+			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [selectedLocale]);
@@ -180,7 +182,7 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 		translated: string;
 		untranslated: string;
 	};
-	editorConfig: object;
+	editorConfig: CKEDITOR.config;
 	helpMessage?: string;
 	label: string;
 	onSelectedLocaleChange: (val: IItem) => void;

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare module 'frontend-editor-ckeditor-web' {
+	export * from 'frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index';
+}

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/RichTextLocalized.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/RichTextLocalized.d.ts
@@ -35,7 +35,7 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 		translated: string;
 		untranslated: string;
 	};
-	editorConfig: string;
+	editorConfig: object;
 	helpMessage?: string;
 	label: string;
 	onSelectedLocaleChange: (val: IItem) => void;

--- a/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/RichTextLocalized.d.ts
+++ b/modules/apps/object/object-js-components-web/types/src/main/resources/META-INF/resources/components/RichTextLocalized.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="ckeditor4" />
+
 import React from 'react';
 import './RichTextLocalized.scss';
 export declare function RichTextLocalized({
@@ -35,7 +37,7 @@ interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
 		translated: string;
 		untranslated: string;
 	};
-	editorConfig: object;
+	editorConfig: CKEDITOR.config;
 	helpMessage?: string;
 	label: string;
 	onSelectedLocaleChange: (val: IItem) => void;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/ts_modules/frontend-editor-ckeditor-web.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare module 'frontend-editor-ckeditor-web' {
+	export * from 'frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index';
+}

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -2089,6 +2089,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/ckeditor4@4.16.2":
+  version "4.16.2"
+  resolved "https://registry.yarnpkg.com/@types/ckeditor4/-/ckeditor4-4.16.2.tgz#2de1738a6837c16141a69f82ce6146815ede621e"
+  integrity sha512-AS/NOEXDmM/mKDc+6yxlq5/QRmxhOWA23zDbb26pxR0dgeGSCIZ7yUgP0UukGqQbX+dW3YUuvH3yHhqfQfYtMA==
+
 "@types/codemirror@^5.60.5":
   version "5.60.5"
   resolved "https://registry.yarnpkg.com/@types/codemirror/-/codemirror-5.60.5.tgz#5b989a3b4bbe657458cf372c92b6bfda6061a2b7"


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-159555

### Motivation

Hello Reviewer, I'm working on a technical debt to remove some `@ts-ignore` annotations from the object code. For this I have to create some type declarations for components that were not developed in typescript, I can declare these types in the `object-js-components-web` module, but I think it will be restricted just for our case, so I decided to declare the types in the `frontend -editor-ckeditor-web` which is the root of the `ClassicEditor` component I had to remove the `@ts-ignore`, so anyone who wants to use this component with typescript in the future doesn't need to declare the same types in their own module, avoiding code repetition. If this idea is approved, I will send other PRs with new type declarations for other components we are using. What do you think?