### PR TITLE
LPS-157587 | Add supported query params to Headless Delivery API Explorer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
@@ -281,6 +281,14 @@ definition {
 		return "${response}";
 	}
 
+	macro assertResponseHasIdFieldValueOnly {
+		var actualValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.items");
+
+		TestUtils.assertEquals(
+			actual = "${actualValue}",
+			expected = "${expectedValue}");
+	}
+
 	macro deleteAllBlogPostings {
 		var numberOfItems = BlogPostingAPI.getNumberOfBlogPostingsCreated();
 
@@ -347,6 +355,21 @@ definition {
 		var idList = JSONUtil.getWithJSONPath("${response}", "$.items.[*].id");
 
 		return "${idList}";
+	macro getBlogPostingsbyDifferentParameters {
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings?${parameter}=${restrictFieldsValue} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
 	}
 
 	macro getIdOfCreatedBlogPosting {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
@@ -349,12 +349,6 @@ definition {
 		return "${curl}";
 	}
 
-	macro getBlogPostingsIdList {
-		var response = BlogPostingAPI._getBlogPostings();
-
-		var idList = JSONUtil.getWithJSONPath("${response}", "$.items.[*].id");
-
-		return "${idList}";
 	macro getBlogPostingsbyDifferentParameters {
 		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
@@ -370,6 +364,14 @@ definition {
 		var curl = JSONCurlUtil.get("${curl}");
 
 		return "${curl}";
+	}
+
+	macro getBlogPostingsIdList {
+		var response = BlogPostingAPI._getBlogPostings();
+
+		var idList = JSONUtil.getWithJSONPath("${response}", "$.items.[*].id");
+
+		return "${idList}";
 	}
 
 	macro getIdOfCreatedBlogPosting {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/ContentElementAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/ContentElementAPI.macro
@@ -1,0 +1,34 @@
+definition {
+
+	macro _getAssetLibraryContentElementsByDifferentParameters {
+		Variables.assertDefined(parameterList = "${assetLibraryId},${parameter}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/asset-libraries/${assetLibraryId}/content-elements?${parameter}=${fieldValue} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+	''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
+	macro assertResponseHasABodyWithAssetLibraryKeyOnly {
+		var actualValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.items");
+
+		TestUtils.assertEquals(
+			actual = "${actualValue}",
+			expected = "${expectedValue}");
+	}
+
+	macro getAssetLibraryContentElementsByDifferentParameters {
+		ContentElementAPI._getAssetLibraryContentElementsByDifferentParameters(
+			assetLibraryId = "${assetLibraryId}",
+			fieldValue = "${fieldValue}",
+			parameter = "${parameter}");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliverySupportRestrictFieldsAndFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliverySupportRestrictFieldsAndFields.testcase
@@ -1,0 +1,98 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+
+		BlogPostingAPI.deleteAllBlogPostings();
+
+		JSONDepot.deleteDepot(depotName = "Test Depot Name");
+	}
+
+	@priority = "4"
+	test CanReceiveABodyWithAssetLibraryKeyOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+
+		task ("Given a content structure created in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = "${assetLibraryId}");
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("Given a structured content is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with curl I request GET getAssetLibraryContentElementsPage with assetLibraryId and fields=content.assetLibraryKey") {
+			var response = ContentElementAPI.getAssetLibraryContentElementsByDifferentParameters(
+				assetLibraryId = "${assetLibraryId}",
+				fieldValue = "content.assetLibraryKey",
+				parameter = "fields");
+		}
+
+		task ("Then in a response I receive a body with assetLibraryKey only") {
+			ContentElementAPI.assertResponseHasABodyWithAssetLibraryKeyOnly(
+				expectedValue = "{content={assetLibraryKey=Test Depot Name}}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a blog-posting created") {
+			var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
+				articleBody = "ArticleBody",
+				headline = "Headline");
+		}
+
+		task ("When with curl I request GET getSiteBlogPostingsPage with siteId and restrictFields equal all fields except id field") {
+			var response = BlogPostingAPI.getBlogPostingsbyDifferentParameters(
+				parameter = "restrictFields",
+				restrictFieldsValue = "aggregateRating,alternativeHeadline,articleBody,creator,customFields,dateCreated,dateModified,datePublished,description,encodingFormat,externalReferenceCode,friendlyUrlPath,headline,image,keywords,numberOfComments,relatedContents,renderedContents,siteId,taxonomyCategoryBriefs,x-class-name,facets,actions");
+		}
+
+		task ("Then in a response I receive a with id field values only") {
+			BlogPostingAPI.assertResponseHasIdFieldValueOnly(
+				expectedValue = "{id=${blogPostingId}}",
+				responseToParse = "${response}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a test to assert to support query params to Headless Delivery API Explorer

**Test Plan**
**Given** a blog-posting created
**When** with curl I request GET getSiteBlogPostingsPage with siteId and restrictFields = "aggregateRating,alternativeHeadline,articleBody,creator,customFields,dateCreated,dateModified,datePublished,
description,encodingFormat,externalReferenceCode,friendlyUrlPath,headline,image,keywords,
numberOfComments,relatedContents,renderedContents,siteId,taxonomyCategoryBriefs,x-class-name,facets,actions"
**Then** in a response I receive a with id field values only

**Given** an Asset Library with a Web Content created
**When** with curl I request GET getAssetLibraryContentElementsPage with assetLibraryId and fields = "content.assetLibraryKey"
**Then** in a response I receive a body with assetLibraryKey only

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157587