### PR TITLE
LPS-131611 Show icons in the viewType options dropdown

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -20,6 +20,7 @@ import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-compon
 import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
 
+import normalizeDropdownItems from '../normalize_dropdown_items';
 import ActionControls from './ActionControls';
 import CreationMenu from './CreationMenu';
 import FeatureFlagContext from './FeatureFlagContext';
@@ -82,6 +83,10 @@ function ManagementToolbar({
 	);
 	const [active, setActive] = useState(initialCheckboxStatus !== 'unchecked');
 	const [searchMobile, setSearchMobile] = useState(false);
+	const normalizedViewTypeItems = useMemo(
+		() => normalizeDropdownItems(viewTypeItems),
+		[viewTypeItems]
+	);
 	const viewTypeIcon = useMemo(
 		() => viewTypeItems?.find((item) => item.active)?.icon,
 		[viewTypeItems]
@@ -177,10 +182,10 @@ function ManagementToolbar({
 						</>
 					) : (
 						<>
-							{viewTypeItems && (
+							{normalizedViewTypeItems && (
 								<FrontendManagementToolbar.Item>
 									<ClayDropDownWithItems
-										items={viewTypeItems}
+										items={normalizedViewTypeItems}
 										trigger={
 											showDesignImprovementsFF ? (
 												<ClayButton


### PR DESCRIPTION
### Steps to Reproduce:
1. Go to any page with management toolbar (Web Content admin, Clay Sample portlet)
2. click on change display view icon

### Expected Result:
Each dropdown menu item has an icon next to the text. Match the samples provided in [clayui.com](https://clayui.com/docs/components/management-toolbar.html)

Clay component expect the icon to be defined in the symbolLeft property, this PR uses the normalizedDropdownItem function to do that.