### PR TITLE
LPS-155958 Check if user is impersonating and use impersonated user

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -246,6 +246,10 @@ export async function loadData(
 		);
 	}
 
+	if (themeDisplay.isImpersonated()) {
+		url.searchParams.append('doAsUserId', themeDisplay.getUserId());
+	}
+
 	url.searchParams.append('page', page);
 	url.searchParams.append('pageSize', delta);
 


### PR DESCRIPTION
Notes from @levanpham-lr:
> Ticket: [LPS-155958](https://issues.liferay.com/browse/LPS-155958)
> 
> Issue: While impersonating a site member with permissions to add a certain Object entry, viewing a page with a widget of that Object will display entries that the impersonated user does not have permission to view. The frontend-data-set does not have a doAsUserId parameter in the URL, where the widget pulls its parameters from. As a result, the widget would default to using the admin's userId and thus allow the impersonated user to view entries they were not intended to view.
> 
> Solution: By adding a check for impersonation during the creation of the request URL, we can append a doAsUserId parameter to the URL if impersonation is being used. We can use the isImpersonated() and getUserId() methods from themeDisplay to achieve this solution.