### PR TITLE
[TS] LPP46502 > LPS-159504 The height of the embedded documents and media widget (iframe) is not adapted when the view mode is changed to a shorter one

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -22,16 +22,20 @@
 
 		iframe.on('load', () => {
 			var height = A.Plugin.AutosizeIframe.getContentHeight(iframe);
+			var heightNormal = 600;
 
 			if (height == null) {
 				if (themeDisplay.isStateMaximized()) {
 					height = A.getDoc().get('docHeight');
 				}
 				else {
-					height = 600;
+					height = heightNormal;
 
 					iframe.autosizeiframe.set('monitorHeight', false);
 				}
+			}
+			if (height < heightNormal) {
+				height = heightNormal;
 			}
 
 			iframe.setStyle('height', height);


### PR DESCRIPTION
# Motivation

Dear Team,
Our customer found an issue that the height of the embedded documents and media widget (iframe) is not adapted when the view mode is changed to a shorter one
This PR is to solve that problem.
# Proposed Solution

Check if the content height is lower than default normal height, then set it to this value

# Steps to Verify

see https://issues.liferay.com/browse/LPS-159504 and https://issues.liferay.com/browse/LPS-159504

# References to existing code (if applies)

https://github.com/liferay-core-infra/liferay-portal/blob/master/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/configuration/IFramePortletInstanceConfiguration.java line 84