### PR TITLE
LPS-159320 | Add supported query params to Headless Admin Taxonomy API Explorer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -1,5 +1,33 @@
 definition {
 
+	macro _curlTaxonomyKeywords {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}/keywords";
+		}
+		else if (isSet(keywordId)) {
+			var api = "keywords/${keywordId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+			var api = "sites/${siteId}/keywords";
+		}
+
+		if (isSet(parameter)) {
+			var api = StringUtil.add("${api}", "?${parameter}=${parameterValue}", "");
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-admin-taxonomy/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+
+		return "${curl}";
+	}
+
 	macro _curlTaxonomyVocabulary {
 		var portalURL = JSONCompany.getPortalURL();
 
@@ -7,6 +35,8 @@ definition {
 			var api = "asset-libraries/${assetLibraryId}/taxonomy-vocabularies";
 		}
 		else {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
 			var api = "sites/${siteId}/taxonomy-vocabularies";
 		}
 
@@ -20,6 +50,10 @@ definition {
 			var api = StringUtil.add("${api}", "?filter=${filterValue}", "");
 		}
 
+		if (isSet(parameter)) {
+			var api = StringUtil.add("${api}", "?${parameter}=${parameterValue}", "");
+		}
+
 		var curl = '''
 			${portalURL}/o/headless-admin-taxonomy/v1.0/${api} \
 			-u test@liferay.com:test \
@@ -27,6 +61,16 @@ definition {
 		''';
 
 		return "${curl}";
+	}
+
+	macro assertInFacetsWithCorrectValue {
+		Variables.assertDefined(parameterList = "${expectedValue},${taxonomyVocabularyId}");
+
+		var actualValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.facets..facetValues[?(@.term=='${taxonomyVocabularyId}' && @.numberOfOccurrences==${expectedValue})].numberOfOccurrences");
+
+		TestUtils.assertEquals(
+			actual = "${actualValue}",
+			expected = "${expectedValue}");
 	}
 
 	macro assertProperVocabularyTotalCount {
@@ -45,8 +89,29 @@ definition {
 			expected = "${expectedTotalCount}");
 	}
 
-	macro createTaxonomyVocabulary {
+	macro assertResponseHasNameFieldValueOnly {
+		var actualValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.items");
+
+		TestUtils.assertEquals(
+			actual = "${actualValue}",
+			expected = "${expectedValue}");
+	}
+
+	macro createAssetLibraryWithKeyWords {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${name}");
+
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyKeywords(assetLibraryId = "${assetLibraryId}");
+		var body = '''-d {"name": "${name}"}''';
+
+		var curl = StringUtil.add("${curl}", "${body}", " ");
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+	macro createTaxonomyVocabulary {
+		Variables.assertDefined(parameterList = "${name}");
 
 		if (!(isSet(externalReferenceCode))) {
 			var externalReferenceCode = "";
@@ -54,7 +119,7 @@ definition {
 
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
 			assetLibraryId = "${assetLibraryId}",
-			siteId = "${siteId}");
+			groupName = "${groupName}");
 		var body = '''-d {
 				"name": "${name}",
 				"externalReferenceCode": "${externalReferenceCode}"
@@ -73,7 +138,7 @@ definition {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
 			assetLibraryId = "${assetLibraryId}",
 			externalReferenceCode = "${externalReferenceCode}",
-			siteId = "${siteId}");
+			groupName = "${groupName}");
 
 		JSONCurlUtil.delete("${curl}");
 	}
@@ -84,7 +149,18 @@ definition {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
 			assetLibraryId = "${assetLibraryId}",
 			filterValue = "${filterValue}",
-			siteId = "${siteId}");
+			groupName = "${groupName}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+	macro getAssetLibraryKeywordsWithDifferentParameters {
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyKeywords(
+			assetLibraryId = "${assetLibraryId}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}");
 
 		var response = JSONCurlUtil.get("${curl}");
 
@@ -105,7 +181,19 @@ definition {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
 			assetLibraryId = "${assetLibraryId}",
 			externalReferenceCode = "${externalReferenceCode}",
-			siteId = "${siteId}");
+			groupName = "${groupName}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+	macro getTaxonomyVocabularyWithDifferentParameters {
+		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			groupName = "${groupName}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}");
 
 		var response = JSONCurlUtil.get("${curl}");
 
@@ -124,7 +212,7 @@ definition {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyVocabulary(
 			assetLibraryId = "${assetLibraryId}",
 			externalReferenceCode = "${externalReferenceCode}",
-			siteId = "${siteId}");
+			groupName = "${groupName}");
 
 		var curl = StringUtil.add("${curl}", "${body}", " ");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/HeadlessAdminTaxonomySupportDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/HeadlessAdminTaxonomySupportDifferentParameters.testcase
@@ -1,0 +1,121 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+
+		TaxonomyVocabularyAPI.deleteTaxonomyVocabularyByErc(
+			externalReferenceCode = "erc",
+			groupName = "Guest");
+
+		JSONDepot.deleteDepot(depotName = "Test Depot Name");
+	}
+
+	@priority = "4"
+	test CanReceiveABodyWithNameOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a AssetLibrary with keyword created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			TaxonomyVocabularyAPI.createAssetLibraryWithKeyWords(
+				assetLibraryId = "${assetLibraryId}",
+				name = "Liferay");
+		}
+
+		task ("When with curl I request getAssetLibraryKeywordsPage with fields=name") {
+			var response = TaxonomyVocabularyAPI.getAssetLibraryKeywordsWithDifferentParameters(
+				assetLibraryId = "${assetLibraryId}",
+				parameter = "fields",
+				parameterValue = "name");
+
+			var name = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$..name",
+				responseToParse = "${response}");
+		}
+
+		task ("Then in a response I receive a body with name values only") {
+			TaxonomyVocabularyAPI.assertResponseHasNameFieldValueOnly(
+				expectedValue = "{name=${name}}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveCorrectValueOfAggregationTermsInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a Taxonomy Vocabulary") {
+			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				externalReferenceCode = "erc",
+				groupName = "Guest",
+				name = "Vocabulary Name");
+		}
+
+		task ("When with curl I request getSiteTaxonomyVocabulariesPage with aggregationTerms=id") {
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(
+				groupName = "Guest",
+				parameter = "aggregationTerms",
+				parameterValue = "id");
+
+			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$..[0]['id']",
+				responseToParse = "${response}");
+		}
+
+		task ("Then in a response I receive numberOfOccurrences and term with correct value in facets fields") {
+			TaxonomyVocabularyAPI.assertInFacetsWithCorrectValue(
+				expectedValue = "1",
+				responseToParse = "${response}",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveNameFieldValuesOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a Taxonomy Vocabulary with assetLibrary") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Vocabulary Name");
+		}
+
+		task ("When with curl I request getAssetLibraryTaxonomyVocabulariesPage with restrictFields equal all fields except name field") {
+			var response = TaxonomyVocabularyAPI.getTaxonomyVocabularyWithDifferentParameters(
+				assetLibraryId = "${assetLibraryId}",
+				parameter = "restrictFields",
+				parameterValue = "actions,assetLibraryKey,assetTypes,availableLanguages,creator,dateCreated,dateModified,description,externalReferenceCode,id,numberOfTaxonomyCategories");
+
+			var taxonomyVocabularyName = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$..name",
+				responseToParse = "${response}");
+		}
+
+		task ("Then in a response I receive a with name field values only") {
+			TaxonomyVocabularyAPI.assertResponseHasNameFieldValueOnly(
+				expectedValue = "{name=${taxonomyVocabularyName}}",
+				responseToParse = "${response}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a test to assert to support query params to Headless Delivery API Explorer

**Test Plan**
Given a Taxonomy Vocabulary with assetLibrary
When with curl I request getAssetLibraryTaxonomyVocabulariesPage with restrictFields=actions,assetLibraryKey,assetTypes,availableLanguages,creator,dateCreated,dateModified,
description,externalReferenceCode,id,numberOfTaxonomyCategories
Then in a response I receive a with name field values only

Given a Taxonomy Vocabulary
When with curl I request getSiteTaxonomyVocabulariesPage with aggregationTerms=id
Then in a response I receive numberOfOccurrences and term with correct value in facets fields

Given a AssetLibrary with keyword created
When with curl I request getAssetLibraryKeywordsPage with fields=name
Then in a response I receive a body with name values only

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-159320