### PR TITLE
LPS-160258 TinyMCE and Simple editors were deprecated in 7.3 but they weren't removed in portal.properties file

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5198,8 +5198,7 @@
     #
     # You can configure individual JSP pages to use a specific implementation of
     # the available WYSIWYG editors: alloyeditor, alloyeditor_bbcode,
-    # alloyeditor_creole, ckeditor, ckeditor_bbcode, ckeditor_creole, simple,
-    # tinymce, or tinymce_simple.
+    # alloyeditor_creole, ckeditor, ckeditor_bbcode, ckeditor_creole
     #
     # Env: LIFERAY_EDITOR_PERIOD_WYSIWYG_PERIOD_DEFAULT
     # Env: LIFERAY_EDITOR_PERIOD_WYSIWYG_PERIOD_PORTAL_MINUS_IMPL_PERIOD_PORTLET_PERIOD_DDM_PERIOD_TEXT_UNDERLINE_HTML_PERIOD_FTL


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-160258

TinyMCE and Simple editors were deprecated in 7.3 (see LPS-110733 and LPS-110734) but they weren't removed in portal.properties file
