### PR TITLE
LPS-149770 Show cookie banner when implicit mode is enabled

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesBannerBottomJSPDynamicInclude.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesBannerBottomJSPDynamicInclude.java
@@ -71,7 +71,6 @@ public class CookiesBannerBottomJSPDynamicInclude
 						group.getGroupId());
 
 			if (!cookiesPreferenceHandlingConfiguration.enabled()) {
-
 				return;
 			}
 		}

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesBannerBottomJSPDynamicInclude.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesBannerBottomJSPDynamicInclude.java
@@ -70,8 +70,7 @@ public class CookiesBannerBottomJSPDynamicInclude
 						CookiesPreferenceHandlingConfiguration.class,
 						group.getGroupId());
 
-			if (!cookiesPreferenceHandlingConfiguration.enabled() ||
-				!cookiesPreferenceHandlingConfiguration.explicitConsentMode()) {
+			if (!cookiesPreferenceHandlingConfiguration.enabled()) {
 
 				return;
 			}

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
@@ -168,13 +168,9 @@ public class CookiesPreAction extends Action {
 			return;
 		}
 
-		if (!cookiesPreferenceHandlingConfiguration.explicitConsentMode() ||
-			!userConsent) {
-
-			_expireCookies(
-				cookieValues, httpServletRequest, httpServletResponse,
-				CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
-		}
+		_expireCookies(
+			cookieValues, httpServletRequest, httpServletResponse,
+			CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
 
 		if (!necessaryConsent) {
 			_addCookies(
@@ -183,10 +179,7 @@ public class CookiesPreAction extends Action {
 					CookiesConstants.NAME_CONSENT_TYPE_NECESSARY, "true"));
 		}
 
-		if (!optionalConsent ||
-			(cookiesPreferenceHandlingConfiguration.explicitConsentMode() &&
-			 !userConsent)) {
-
+		if (!optionalConsent || !userConsent) {
 			String cookieValue = "true";
 
 			if (cookiesPreferenceHandlingConfiguration.explicitConsentMode()) {

--- a/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/events/CookiesPreActionTest.java
+++ b/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/events/CookiesPreActionTest.java
@@ -254,7 +254,7 @@ public class CookiesPreActionTest {
 
 		Cookie[] cookies = mockHttpServletResponse.getCookies();
 
-		Assert.assertEquals(Arrays.toString(cookies), 0, cookies.length);
+		Assert.assertEquals(Arrays.toString(cookies), 3, cookies.length);
 	}
 
 	@Test


### PR DESCRIPTION
### References

- [LPS-149770](https://issues.liferay.com/browse/LPS-149770)

### What is the goal?

* Display cookie banner when implicit mode is enabled and user hasn't set their preferences

### What does it look like?

https://user-images.githubusercontent.com/6642927/183925620-c1bba273-8a8c-4fa3-96ff-4f5b39dd16ac.mov



### How to replicate
* Enable feature flag:
   * Stop portal
   * Add `feature.flag.LPS-142518=true` at the end of `../bundles/portal-ext.properties`
   * Restart portal
* Go to `System Settings > Cookies > Preference handling`
* Check `Enabled`, click on `Update`
* See that you are prompted to accept/decline cookies, but ignore it
* Uncheck `Explicit Cookie Consent Mode`, click on `Update`
* See that you are still prompted to accept/decline cookies
