### PR TITLE
LPS-160293 Add type definition to FrontendDataSet component in frontend-data-set-web module

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export function FrontendDataSet({
+	actionParameterName,
+	activeViewSettings,
+	apiURL,
+	appURL,
+	bulkActions,
+	creationMenu,
+	currentURL,
+	customDataRenderers,
+	customViewsEnabled,
+	filters,
+	formId,
+	formName,
+	id,
+	initialSelectedItemsValues,
+	inlineAddingSettings,
+	inlineEditingSettings,
+	items,
+	itemsActions,
+	namespace,
+	nestedItemsKey,
+	nestedItemsReferenceKey,
+	onActionDropdownItemClick,
+	onBulkActionItemClick,
+	overrideEmptyResultView,
+	pagination,
+	portletId,
+	selectedItemsKey,
+	selectionType,
+	showManagementBar,
+	showPagination,
+	showSearch,
+	sidePanelId,
+	sorting,
+	style,
+	views,
+}: IFrontendDataSetProps): JSX.Element;
+
+interface IFrontendDataSetProps {
+	actionParameterName?: string;
+	activeViewSettings?: string;
+	apiURL?: string;
+	appURL?: string;
+	bulkActions?: any[];
+	creationMenu?: {
+		primaryItems?: any[];
+		secondaryItems?: any[];
+	};
+	currentURL?: string;
+	customDataRenderers?: any;
+	customViewsEnabled?: boolean;
+	enableInlineAddModeSetting?: {
+		defaultBodyContent?: object;
+	};
+	filters?: (
+		| IAutocompleteFilter
+		| ICustomFilter
+		| ICheckboxFilter
+		| IDateRangeFilter
+		| IRadioFilter
+	)[];
+	formId?: string;
+	formName?: string;
+	id: string;
+	initialSelectedItemsValues?: any[];
+	inlineAddingSettings?: {
+		apiURL: string;
+		defaultBodyContent: object;
+	};
+	inlineEditingSettings?: [
+		boolean,
+		{
+			alwaysOn: boolean;
+			defaultBodyContent: object;
+		}
+	];
+	items?: any[];
+	itemsActions?: TItemsActions[];
+	namespace?: string;
+	nestedItemsKey?: string;
+	nestedItemsReferenceKey?: string;
+	onActionDropdownItemClick?: any;
+	onBulkActionItemClick?: any;
+	overrideEmptyResultView?: boolean;
+	pagination?: {
+		deltas?: [
+			{
+				href?: string;
+				label: number;
+			}
+		];
+		initialDelta: number;
+	};
+	portletId?: string;
+	selectedItemsKey?: string;
+	selectionType?: ['single', 'multiple'];
+	showManagementBar?: boolean;
+	showPagination?: boolean;
+	showSearch?: boolean;
+	sidePanelId?: string;
+	sorting?: [
+		{
+			direction?: ['asc', 'desc'];
+			key?: string;
+		}
+	];
+	style?: ['default', 'fluid', 'stacked'];
+	views: [
+		{
+			component?: any;
+			contentRenderer?: string;
+			contentRendererModuleURL?: string;
+			label?: string;
+			name?: string;
+			schema?: object;
+			thumbnail?: string;
+		}
+	];
+}
+
+type TItemsActions = {
+	data?: {
+		confirmationMessage?: string;
+		id?: string;
+		method?: 'delete' | 'get';
+		permissionKey?: string;
+	};
+	href?: string;
+	icon?: string;
+	label?: string;
+	target?: 'async' | 'headless' | 'link' | 'modal' | 'sidePanel';
+};
+
+type TFilters = {
+	id: string;
+	label: string;
+	type:
+		| 'autocomplete'
+		| 'checkbox'
+		| 'dateRange'
+		| 'number'
+		| 'radio'
+		| 'text';
+};
+
+interface IAutocompleteFilter extends TFilters {
+	apiURL: string;
+	inputPlaceholder: string;
+	itemKey: string;
+	itemLabel: string;
+	preloadedData: {
+		exclude?: boolean;
+		items?: object[];
+	};
+	type: 'autocomplete';
+}
+
+interface ICheckboxFilter extends TFilters {
+	items: object[];
+	preloadedData?: {
+		exclude?: boolean;
+		items?: object[];
+	};
+	type: 'checkbox';
+}
+
+type TDate = {
+	day: number;
+	month: number;
+	year: number;
+};
+
+interface IDateRangeFilter extends TFilters {
+	max?: TDate;
+	min?: TDate;
+	preloadedData?: {
+		from: TDate;
+		to: TDate;
+	};
+	type: 'dateRange';
+}
+
+interface IRadioFilter extends TFilters {
+	items: object[];
+	preloadedData?: {
+		exclude?: boolean;
+		itemsValues?: string[] | number[];
+	};
+	type: 'radio';
+}
+
+interface ICustomFilter extends Omit<TFilters, 'type'> {
+	updateFilterState: (
+		value?: any,
+		formattedValue?: any,
+		dataFilter?: string
+	) => void;
+	value?: string;
+}

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
@@ -13,9 +13,6 @@
  */
 
 import ClayPanel from '@clayui/panel';
-
-// @ts-ignore
-
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 
 // @ts-ignore

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/frontend-data-set-web.d.ts
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/frontend-data-set-web.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare module '@liferay/frontend-data-set-web' {
+	export * from '@liferay/frontend-data-set-web/src/main/resources/META-INF/resources/index';
+}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-160293

### Motivation

Hey Reviewer, This PR follows the same idea as https://github.com/liferay-frontend/liferay-portal/pull/2608, but in this case I created the type definitions for the `FrontendDataSet` component.

 I'm working on a technical debt to remove some `@ts-ignore` annotations from the Objects and Notification code. For this I have to create some type declarations for components that were not developed in `Typescript`, I can declare these types in the `notification-web` module, but I think it will be restricted just for our case, so I decided to declare the types in the `frontend-data-set-web` which is the root of the `FrontendDataSet` component I had to remove the `@ts-ignore`, so anyone who wants to use this component with typescript in the future doesn't need to declare the same types in their own module, avoiding code repetition. What do you think?