### PR TITLE
LPS-160310 Headless API is unable to get global vocabularies on virtual instance

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -719,6 +719,8 @@ public class TaxonomyVocabularyResourceImpl
 			"Document",
 			"com.liferay.document.library.kernel.model.DLFileEntry");
 		_map(
+			"Document", "com.liferay.portal.kernel.repository.model.FileEntry");
+		_map(
 			"KnowledgeBaseArticle",
 			"com.liferay.knowledge.base.model.KBArticle");
 		_map("Organization", Organization.class.getName());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-160310

### Motivation
The search team is using the `/o/headless-admin-taxonomy/v1.0/sites/${SITE_ID}/taxonomy-vocabularies` endpoint to get vocabularies for a category selection autocompletion and modal. This was throwing an error on the virtual site. (This is a PR of the component we're building: https://github.com/liferay-search/liferay-portal/pull/496)

On the virtual instance, the global site had more asset types for the vocabularies (unknown as to why) and due to the missing `com.liferay.portal.kernel.repository.model.FileEntry` mapping, it calls `ResourceActionsUtil.getModelResource` which throws a `NullPointerException`.

### Proposed Solution
This adds the missing asset type mapping to avoid the NPE. I chose the name "Document" since this name was used also in [DisplayPageTemplateSettingsUtil.java](https://github.com/liferay/liferay-portal/blob/fc5172930fcbddb83433923a7eb64a1fe09b61f2/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/dto/v1_0/util/DisplayPageTemplateSettingsUtil.java#L141)

This is the response on the virtual instance after the fix. The 3rd "Document" (`com.liferay.portal.kernel.repository.model.FileEntry`) type is what was causing the NPE.
![Screen Shot 2022-08-10 at 5 47 18 PM](https://user-images.githubusercontent.com/4496722/184049675-035de837-49e0-4d20-ab46-7e65fb927f25.png)

On the non-virtual instance site (localhost:8080), there were no errors since the asset types of "Stage" and "Audience" only had the `AllAssetTypes` type.
![Screen Shot 2022-08-10 at 6 31 59 PM](https://user-images.githubusercontent.com/4496722/184050215-c36c2e13-b1dd-4167-a70a-9f3fe63f4d61.png)
