### PR TITLE
LPS-159418 | Add supported query params to Headless Admin Content API Explorer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmincontent/DisplayPageTemplateAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmincontent/DisplayPageTemplateAPI.macro
@@ -1,0 +1,33 @@
+definition {
+
+	macro _getDisplayPageTemplatesWithDifferentParameters {
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+		var api = "sites/${siteId}/display-page-templates";
+
+		if (isSet(parameter)) {
+			var api = StringUtil.add("${api}", "?${parameter}=${parameterValue}", "");
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+
+		return "${curl}";
+	}
+
+	macro getDisplayPageTemplatesWithDifferentParameters {
+		var curl = DisplayPageTemplateAPI._getDisplayPageTemplatesWithDifferentParameters(
+			groupName = "${groupName}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -109,9 +109,15 @@ definition {
 		Variables.assertDefined(parameterList = "${data},${label},${name},${ddmStructureId},${title},${priority}");
 
 		var portalURL = JSONCompany.getPortalURL();
-		var siteId = JSONGroupAPI._getGroupIdByName(
-			groupName = "Guest",
-			site = "true");
+
+		if (isSet(siteId)) {
+			var siteId = "${siteId}";
+		}
+		else {
+			var siteId = JSONGroupAPI._getGroupIdByName(
+				groupName = "Guest",
+				site = "true");
+		}
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/structured-contents/ \
@@ -370,6 +376,36 @@ definition {
 		return "${curl}";
 	}
 
+	macro _getStructuredContentsWithDifferentParameters {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(groupName)) {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "${groupName}");
+
+			var api = "sites/${siteId}/structured-contents";
+		}
+
+		if (isSet(structuredContentId)) {
+			var api = "structured-contents/${structuredContentId}";
+		}
+
+		if (isSet(updatedValueInAPI)) {
+			var api = StringUtil.add("${api}", "${updatedValueInAPI}", "/");
+		}
+
+		if (isSet(parameter)) {
+			var api = StringUtil.add("${api}", "?${parameter}=${parameterValue}", "");
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-admin-content/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+		''';
+
+		return "${curl}";
+	}
+
 	macro _sortStructureContent {
 		Variables.assertDefined(parameterList = "${sortvalue}");
 
@@ -452,6 +488,16 @@ definition {
 			expected = "${expectedExternalReferenceCodeValue}");
 	}
 
+	macro assertInFacetsWithCorrectValue {
+		Variables.assertDefined(parameterList = "${expectedValue},${structuredContentId}");
+
+		var actualValue = JSONUtil.getWithJSONPath("${responseToParse}", "$.facets..facetValues[?(@.term=='${structuredContentId}' && @.numberOfOccurrences==${expectedValue})].numberOfOccurrences");
+
+		TestUtils.assertEquals(
+			actual = "${actualValue}",
+			expected = "${expectedValue}");
+	}
+
 	macro assertPriorityFieldWithCorrectValue {
 		var actualPriorityValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..priority");
 
@@ -496,6 +542,7 @@ definition {
 			label = "${label}",
 			name = "${name}",
 			priority = "${priority}",
+			siteId = "${siteId}",
 			title = "${title}");
 
 		return "${response}";
@@ -610,6 +657,12 @@ definition {
 		return "${response}";
 	}
 
+	macro getItemsDetail {
+		var itemsDetail = JSONUtil.getWithJSONPath("${responseToParse}", "$.items");
+
+		return "${itemsDetail}";
+	}
+
 	macro getStructuredContentIdByTitle {
 		Variables.assertDefined(parameterList = "${title}");
 
@@ -626,6 +679,30 @@ definition {
 		var response = HeadlessWebcontentAPI._getStructuredContentsByErcInAssetLibrary(
 			assetLibraryId = "${assetLibraryId}",
 			externalReferenceCode = "${externalReferenceCode}");
+
+		return "${response}";
+	}
+
+	macro getStructuredContentsVersion {
+		var curl = HeadlessWebcontentAPI._getStructuredContentsWithDifferentParameters(
+			groupName = "${groupName}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}",
+			structuredContentId = "${structuredContentId}",
+			updatedValueInAPI = "${updatedValueInAPI}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+	macro getStructuredContentsWithDifferentParameters {
+		var curl = HeadlessWebcontentAPI._getStructuredContentsWithDifferentParameters(
+			groupName = "${groupName}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}");
+
+		var response = JSONCurlUtil.get("${curl}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/HeadlessAdminContentSupprotDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/HeadlessAdminContentSupprotDifferentParameters.testcase
@@ -1,0 +1,163 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		task ("Set up instance and sign in") {
+			TestCase.setUpPortalInstance();
+
+			User.firstLoginPG();
+		}
+
+		task ("Add a site via JSON") {
+			JSONGroup.addGroup(groupName = "Test Site Name");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONGroup.deleteGroupByName(groupName = "Test Site Name");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveABodyWithTitleOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a display page templates of a site") {
+			JSONLayoutpagetemplate.addDisplayPageTemplateEntry(
+				contentType = "Web Content Article",
+				displayPageTemplateEntryName = "Display Page Name",
+				groupName = "Test Site Name",
+				subType = "Basic Web Content");
+
+			DisplayPageTemplatesAdmin.openDisplayPagesAdmin(siteURLKey = "test-site-name");
+
+			DisplayPageTemplatesAdmin.gotoDisplayPage(displayPageName = "Display Page Name");
+
+			Button.clickPublish();
+		}
+
+		task ("When with curl I request getSiteDisplayPageTemplatesPage with restrictFields equal all fields except title field") {
+			var response = DisplayPageTemplateAPI.getDisplayPageTemplatesWithDifferentParameters(
+				groupName = "Test Site Name",
+				parameter = "restrictFields",
+				parameterValue = "actions,availableLanguages,creator,customFields,dateCreated,dateModified,displayPageTemplateKey,displayPageTemplateSettings,openGraphSettingsMapping,seoSettingsMapping,markedAsDefault,pageDefinition,settings,siteId,uuid");
+		}
+
+		task ("Then in a response I receive a body with title field values only") {
+			var actualValue = HeadlessWebcontentAPI.getItemsDetail(responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{title=Display Page Name}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveCorrectValueOfAggregationTermsInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("Given a web content created") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
+
+			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				siteId = "${siteId}",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with curl I request getSiteStructuredContentsPage with aggregationTerms=id") {
+			var response = HeadlessWebcontentAPI.getStructuredContentsWithDifferentParameters(
+				groupName = "Test Site Name",
+				parameter = "aggregationTerms",
+				parameterValue = "id");
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
+		}
+
+		task ("Then in a response I receive numberOfOccurrences and term with correct value in facets fields") {
+			HeadlessWebcontentAPI.assertInFacetsWithCorrectValue(
+				expectedValue = "1",
+				responseToParse = "${response}",
+				structuredContentId = "${structuredContentId}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("Given a web content created") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
+
+			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				siteId = "${siteId}",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with curl I request getStructuredContentsVersionsPage with fields=id") {
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
+
+			var response = HeadlessWebcontentAPI.getStructuredContentsVersion(
+				groupName = "Test Site Name",
+				parameter = "fields",
+				parameterValue = "id",
+				structuredContentId = "${structuredContentId}",
+				updatedValueInAPI = "versions");
+		}
+
+		task ("Then in a response I receive a id values only") {
+			var actualValue = HeadlessWebcontentAPI.getItemsDetail(responseToParse = "${response}");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{id=${structuredContentId}}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add a test to assert to support query params to Headless Delivery API Explorer

**Test Plan**
Given a display page templates of a site
When with curl I request getSiteDisplayPageTemplatesPage with restrictFields=actions,availableLanguages,creator,customFields,dateCreated,
dateModified,displayPageTemplateKey,displayPageTemplateSettings,openGraphSettingsMapping,
seoSettingsMapping,markedAsDefault,pageDefinition,settings,siteId,uuid
Then in a response I receive a body with title field values only

Given a content structure created
Given a structured content
When with curl I request getSiteStructuredContentsPage with aggregationTerms=id
Then in a response I receive numberOfOccurrences and term with correct value in facets fields

Given a content structure created
Given a structured content
When with curl I request getStructuredContentsVersionsPage with fields=id
Then in a response I receive a id values only

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-159418