### PR TITLE
LPS-153899 Adjust openAlert/Confirm modals UX to match designs

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -37,6 +37,8 @@ const openAlertModal = ({message}) => {
 				},
 			},
 		],
+		center: true,
+		disableHeader: true,
 	});
 };
 
@@ -44,11 +46,13 @@ const Modal = ({
 	bodyComponent,
 	bodyHTML,
 	buttons,
+	center,
 	containerProps = {
 		className: 'cadmin',
 	},
 	customEvents,
 	disableAutoClose,
+	disableHeader,
 	footerCssClass,
 	headerCssClass,
 	headerHTML,
@@ -199,6 +203,7 @@ const Modal = ({
 		<>
 			{visible && (
 				<ClayModal
+					center={center}
 					className="liferay-modal"
 					containerProps={{...containerProps}}
 					disableAutoClose={disableAutoClose}
@@ -209,17 +214,19 @@ const Modal = ({
 					status={status}
 					zIndex={zIndex}
 				>
-					<ClayModal.Header className={headerCssClass}>
-						{headerHTML ? (
-							<div
-								dangerouslySetInnerHTML={{
-									__html: headerHTML,
-								}}
-							></div>
-						) : (
-							title
-						)}
-					</ClayModal.Header>
+					{!disableHeader && (
+						<ClayModal.Header className={headerCssClass}>
+							{headerHTML ? (
+								<div
+									dangerouslySetInnerHTML={{
+										__html: headerHTML,
+									}}
+								></div>
+							) : (
+								title
+							)}
+						</ClayModal.Header>
+					)}
 
 					<div
 						className={classNames('modal-body', {
@@ -324,6 +331,8 @@ const openConfirmModal = ({message, onConfirm, title}) => {
 					},
 				},
 			],
+			center: true,
+			disableHeader: true,
 			onClose: () => onConfirm(false),
 			title,
 		});
@@ -722,6 +731,7 @@ Modal.propTypes = {
 			type: PropTypes.oneOf(['cancel', 'submit']),
 		})
 	),
+	center: PropTypes.bool,
 	containerProps: PropTypes.object,
 	customEvents: PropTypes.arrayOf(
 		PropTypes.shape({
@@ -729,6 +739,7 @@ Modal.propTypes = {
 			onEvent: PropTypes.func,
 		})
 	),
+	disableHeader: PropTypes.bool,
 	headerHTML: PropTypes.string,
 	height: PropTypes.string,
 	id: PropTypes.string,


### PR DESCRIPTION
References: https://www.figma.com/file/1USvQ60ZHiq7strGCfpfe3/Dialogues, https://issues.liferay.com/browse/LPS-153899


# What this PR does?

* Aligns it vertically
* Remove Header section of the Modal from openModal utility when rendering those dialogs

# Screenshots

openConfirmModal
![image](https://user-images.githubusercontent.com/7663513/184235655-688d335e-344b-44c8-acda-50e6d6de8b5e.png)

openAlertModal
![image](https://user-images.githubusercontent.com/7663513/184235740-fa421adf-021c-439b-af40-1b80d3457e2e.png)

# Comments

I decided to two flags on openModal

`disableHeader` A flag responsible for removing the Header section on the Modal created by openModal
`center` it derives from ClayModal's center. See [on Clay docs](https://clayui.com/docs/components/modal/api.html#center)
