### PR TITLE
LPS-159770 - notify CookieBanner of default consent toggle state

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
@@ -38,12 +38,13 @@ export default function ({
 	toggleSwitches.forEach((toggleSwitch) => {
 		const cookieKey = toggleSwitch.dataset.cookieKey;
 
-		toggleSwitch.addEventListener('click', () => {
+		const notifyCookiePreferenceUpdate = () =>
 			getOpener().Liferay.fire('cookiePreferenceUpdate', {
 				key: cookieKey,
 				value: toggleSwitch.checked ? 'true' : 'false',
 			});
-		});
+
+		toggleSwitch.addEventListener('click', notifyCookiePreferenceUpdate);
 
 		if (getCookie(userConfigCookieName)) {
 			toggleSwitch.checked = getCookie(cookieKey) === 'true';
@@ -51,6 +52,8 @@ export default function ({
 		else {
 			toggleSwitch.checked = toggleSwitch.dataset.prechecked === 'true';
 		}
+
+		notifyCookiePreferenceUpdate();
 
 		toggleSwitch.removeAttribute('disabled');
 	});


### PR DESCRIPTION
### References

- [LPS-159770](https://issues.liferay.com/browse/LPS-159770)

### What is the goal?

#### Notify CookieBanner of default consent values when consent config modal opens

CookieBanner doesn't have the default values for the consent toggles in the modal, but it handles the logic for Confirm/Accept/Decline buttons of the modal, so we needed to pass this info somehow. 

We were leveraging the existing `cookiePreferenceUpdate` event to notify the CookieBanner of changes to the toggles' state, but the default values weren't being notified, so if the user didn't select anything, the stored preferences were incorrect.

Fixed this by notifying the CookieBanner of the default values when the modal is first rendered, using the same `cookiePreferenceUpdate` event.

### What does it look like?

https://user-images.githubusercontent.com/6642927/184372691-b1c300b1-fe86-44fc-b240-dfcb7e610a94.mov



### How to replicate
* Enable feature flag:
   * Stop portal
   * Add `feature.flag.LPS-142518=true` at the end of `../bundles/portal-ext.properties`
   * Restart portal
* Open Liferay in incognito mode
* See that the Cookie Banner is displayed, prompting you to accept/decline cookies
* Click on `Configuration`, the Consent Panel should open
* See that if you don't change anything (all toggles are disabled), if you click on `Confirm` all optional cookies are `false`
* See that if you check all toggles, if you click on `Confirm` all consent cookies are `true`

### Notes
This is a quick temporary solution, we will rethink this when we migrate the cookie components to React.
