### PR TITLE
LPS-156881 Using lowercase 'a' as object field name is displayed as '%A'

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.frontend.data.set.constants,\
 	com.liferay.frontend.data.set.filter,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
@@ -52,6 +52,10 @@ public class FDSTableSchemaField {
 		return _expand;
 	}
 
+	public boolean isLocalizeLabel() {
+		return _localizeLabel;
+	}
+
 	public boolean isSortable() {
 		return _sortable;
 	}
@@ -94,6 +98,12 @@ public class FDSTableSchemaField {
 		return this;
 	}
 
+	public FDSTableSchemaField setLocalizeLabel(boolean localizeLabel) {
+		_localizeLabel = localizeLabel;
+
+		return this;
+	}
+
 	public FDSTableSchemaField setSortable(boolean sortable) {
 		_sortable = sortable;
 
@@ -127,6 +137,8 @@ public class FDSTableSchemaField {
 				return fieldName;
 			}
 		).put(
+			"localizeLabel", isLocalizeLabel()
+		).put(
 			"sortable", isSortable()
 		).put(
 			"sortingOrder",
@@ -155,6 +167,7 @@ public class FDSTableSchemaField {
 	private boolean _expand;
 	private String _fieldName;
 	private String _label;
+	private boolean _localizeLabel;
 	private boolean _sortable;
 	private SortingOrder _sortingOrder;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/view/table/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/table/TableFDSViewContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/view/table/TableFDSViewContextContributor.java
@@ -73,8 +73,12 @@ public class TableFDSViewContextContributor
 			locale);
 
 		for (FDSTableSchemaField fdsTableSchemaField : fieldsMap.values()) {
-			String label = _language.get(
-				resourceBundle, fdsTableSchemaField.getLabel());
+			String label = fdsTableSchemaField.getLabel();
+
+			if (fdsTableSchemaField.isLocalizeLabel()) {
+				label = _language.get(
+					resourceBundle, fdsTableSchemaField.getLabel());
+			}
 
 			if (Validator.isNull(label)) {
 				label = StringPool.BLANK;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/view/table/ObjectEntriesTableFDSView.java
@@ -136,9 +136,11 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 	private void _addFDSTableSchemaField(
 		String businessType, String contentRenderer, String dbType,
 		FDSTableSchemaBuilder fdsTableSchemaBuilder, String fieldName,
-		String label, boolean sortable) {
+		String label, boolean sortable, boolean localizeLabel) {
 
 		FDSTableSchemaField fdsTableSchemaField = new FDSTableSchemaField();
+
+		fdsTableSchemaField.setLocalizeLabel(localizeLabel);
 
 		if (Objects.equals(
 				businessType, ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT) ||
@@ -151,6 +153,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 			stringFDSTableSchemaField.setFieldName(fieldName);
 			stringFDSTableSchemaField.setLabel(label);
 			stringFDSTableSchemaField.setTruncate(true);
+			stringFDSTableSchemaField.setLocalizeLabel(localizeLabel);
 
 			fdsTableSchemaBuilder.add(stringFDSTableSchemaField);
 
@@ -163,6 +166,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 			dateFDSTableSchemaField.setFieldName(fieldName);
 			dateFDSTableSchemaField.setFormat("short");
 			dateFDSTableSchemaField.setLabel(label);
+			dateFDSTableSchemaField.setLocalizeLabel(localizeLabel);
 
 			fdsTableSchemaBuilder.add(dateFDSTableSchemaField);
 
@@ -199,32 +203,32 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 		if (Objects.equals(fieldName, "creator")) {
 			_addFDSTableSchemaField(
 				null, null, null, fdsTableSchemaBuilder, fieldName + ".name",
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "createDate")) {
 			_addFDSTableSchemaField(
 				null, null, "Date", fdsTableSchemaBuilder, "dateCreated",
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "externalReferenceCode")) {
 			_addFDSTableSchemaField(
 				null, "actionLink", null, fdsTableSchemaBuilder,
-				"externalReferenceCode", fieldLabel, true);
+				"externalReferenceCode", fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "id")) {
 			_addFDSTableSchemaField(
 				null, "actionLink", null, fdsTableSchemaBuilder, "id",
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "modifiedDate")) {
 			_addFDSTableSchemaField(
 				null, null, "Date", fdsTableSchemaBuilder, "dateModified",
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 		else if (Objects.equals(fieldName, "status")) {
 			_addFDSTableSchemaField(
 				null, "status", null, fdsTableSchemaBuilder, fieldName,
-				fieldLabel, true);
+				fieldLabel, true, true);
 		}
 	}
 
@@ -242,7 +246,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 				fdsTableSchemaBuilder,
 				_getFieldName(
 					objectField.getBusinessType(), objectField.getName()),
-				label, objectField.isIndexed());
+				label, objectField.isIndexed(), false);
 		}
 		else if (Objects.equals(
 					objectField.getRelationshipType(),
@@ -265,7 +269,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 				_addFDSTableSchemaField(
 					objectField.getBusinessType(), null,
 					objectField.getDBType(), fdsTableSchemaBuilder,
-					objectField.getName(), label, false);
+					objectField.getName(), label, false, false);
 			}
 			else {
 				_addFDSTableSchemaField(
@@ -277,7 +281,7 @@ public class ObjectEntriesTableFDSView extends BaseTableFDSView {
 							StringUtil.replaceLast(
 								objectField.getName(), "Id", ""),
 							StringPool.PERIOD, titleObjectField.getName())),
-					label, false);
+					label, false, false);
 			}
 		}
 	}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/object_definition/details.jsp
@@ -107,7 +107,7 @@ renderResponse.setTitle(LanguageUtil.format(request, "edit-x", objectDefinition.
 								}
 							%>
 
-								<aui:option label="<%= HtmlUtil.escape(objectField.getLabel(locale)) %>" selected="<%= Objects.equals(objectField.getObjectFieldId(), objectDefinition.getTitleObjectFieldId()) %>" value="<%= objectField.getObjectFieldId() %>" />
+								<aui:option label="<%= HtmlUtil.escape(objectField.getLabel(locale)) %>" localizeLabel="<%= false %>" selected="<%= Objects.equals(objectField.getObjectFieldId(), objectDefinition.getTitleObjectFieldId()) %>" value="<%= objectField.getObjectFieldId() %>" />
 
 							<%
 							}


### PR DESCRIPTION
Motivation
=======
This work solves the problem reported in the [LPS-156881](https://issues.liferay.com/browse/LPS-156881) ticket.
My solution was accepted by the liferay-object team. PR: liferay-objects#818
cc: @sontruongces

Proposed Solution
========
What we did to solve this problem.
1. Disable localize label for aui:option in object_definition/details.jsp
2. Check isLocalizeLabel for objectField and nonObjectField.

Steps to Verify
========
1. Start a clean 7.4 update 28 bundle (or master)
2. Create an Object by navigating to control panel > objects > "+"
3. Edit the newly created Object
4. From the Fields tab, add a new field with the label "a" and any
5. From the Details tab, navigate to Entry Display and select the Title Field dropdown menu.

- Expected Results: There will be a title field named "a".
- Actual Results: There is a title field named "%A".

You can also view this issue by following these additional steps after step 4.
1. From the Details tab, enable Show Widget and click Publish
2. Go to the Home Page and edit it.
3. Navigate to the widget in the sidebar and add the newly created object from the Object section by dragging it on the page. Then click Publish.
4. From the Object portlet, create a new Object with the field and click Save and then Cancel to view the Object on the Home Page.

- Expected Results: There is a table column label named "a".
- Actual Results: There is a table column label named "%A".

