### PR TITLE
LPS-159735 | Add support for nestedFields query param to API Explorer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -198,10 +198,10 @@ definition {
 		}
 
 		var curl = '''
-            ${portalURL}/o/headless-delivery/v1.0/${api} \
-            -u test@liferay.com:test \
-            -H Content-Type: application/json
-        ''';
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
 
 		var curl = JSONCurlUtil.get("${curl}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentFolderAPI.macro
@@ -189,6 +189,25 @@ definition {
 		return "${curl}";
 	}
 
+	macro _getStructuredContentFoldersWithDifferentParameters {
+		var portalURL = JSONCompany.getPortalURL();
+		var api = "asset-libraries/${assetLibraryId}/structured-content-folders";
+
+		if (isSet(parameter)) {
+			var api = StringUtil.add("${api}", "?${parameter}=${parameterValue}", "");
+		}
+
+		var curl = '''
+            ${portalURL}/o/headless-delivery/v1.0/${api} \
+            -u test@liferay.com:test \
+            -H Content-Type: application/json
+        ''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _updateStructureContentFolderByErc {
 		Variables.assertDefined(parameterList = "${externalReferenceCode},${name}");
 
@@ -383,6 +402,17 @@ definition {
 		var response = HeadlessWebcontentFolderAPI._getStructuredContentFoldersByErcInAssetLibrary(
 			assetLibraryId = "${assetLibraryId}",
 			externalReferenceCode = "${externalReferenceCode}");
+
+		return "${response}";
+	}
+
+	macro getStructuredContentFoldersWithDifferentParameters {
+		Variables.assertDefined(parameterList = "${assetLibraryId}");
+
+		var response = HeadlessWebcontentFolderAPI._getStructuredContentFoldersWithDifferentParameters(
+			assetLibraryId = "${assetLibraryId}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}");
 
 		return "${response}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/HeadlessAdminContentSupprotDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/HeadlessAdminContentSupprotDifferentParameters.testcase
@@ -110,6 +110,40 @@ definition {
 	}
 
 	@priority = "4"
+	test CanReceiveCorrectValueWithProfileURLFieldInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a display page templates of a site") {
+			JSONLayoutpagetemplate.addDisplayPageTemplateEntry(
+				contentType = "Web Content Article",
+				displayPageTemplateEntryName = "Display Page Name",
+				groupName = "Test Site Name",
+				subType = "Basic Web Content");
+
+			DisplayPageTemplatesAdmin.openDisplayPagesAdmin(siteURLKey = "test-site-name");
+
+			DisplayPageTemplatesAdmin.gotoDisplayPage(displayPageName = "Display Page Name");
+
+			Button.clickPublish();
+		}
+
+		task ("When with curl I request getSiteDisplayPageTemplatesPage with restrictFields equal all fields except title field") {
+			var response = DisplayPageTemplateAPI.getDisplayPageTemplatesWithDifferentParameters(
+				groupName = "Test Site Name",
+				parameter = "nestedFields",
+				parameterValue = "profileURL");
+		}
+
+		task ("Then in a response I receive a with profileURL field values in the creator field have appeared") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$..creator.profileURL");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "/web/test");
+		}
+	}
+
+	@priority = "4"
 	test CanReceiveIdFieldValuesOnlyInResponse {
 		property portal.acceptance = "true";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliverySupportDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliverySupportDifferentParameters.testcase
@@ -1,0 +1,131 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+
+		BlogPostingAPI.deleteAllBlogPostings();
+
+		JSONDepot.deleteDepot(depotName = "Test Depot Name");
+	}
+
+	@priority = "4"
+	test CanReceiveABodyWithAssetLibraryKeyOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+
+		task ("Given a content structure created in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			WebContentNavigator.openWebContentStructuresAdminInAssetLibrary(depotId = "${assetLibraryId}");
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("Given a structured content is created with a POST request in asset library") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+
+			HeadlessWebcontentAPI.createStructuredContentInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with curl I request GET getAssetLibraryContentElementsPage with assetLibraryId and fields=content.assetLibraryKey") {
+			var response = ContentElementAPI.getAssetLibraryContentElementsByDifferentParameters(
+				assetLibraryId = "${assetLibraryId}",
+				fieldValue = "content.assetLibraryKey",
+				parameter = "fields");
+		}
+
+		task ("Then in a response I receive a body with assetLibraryKey only") {
+			ContentElementAPI.assertResponseHasABodyWithAssetLibraryKeyOnly(
+				expectedValue = "{content={assetLibraryKey=Test Depot Name}}",
+				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveCorrectValueWithProfileURLFieldInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
+
+		task ("Given a Web Content Folder created") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			HeadlessWebcontentFolderAPI.createStructuredContentFolderInAssetLibrary(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				name = "Test Folder");
+		}
+
+		task ("When with curl I request GET getAssetLibraryStructuredContentFoldersPage with assetLibraryId and nestedFields = profileURL") {
+			var response = HeadlessWebcontentFolderAPI.getStructuredContentFoldersWithDifferentParameters(
+				assetLibraryId = "${assetLibraryId}",
+				parameter = "nestedFields",
+				parameterValue = "profileURL");
+		}
+
+		task ("Then in a response I receive a with profileURL field values in the creator field have appeared") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$..creator.profileURL");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "/web/test");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponse {
+		property portal.acceptance = "true";
+
+		task ("Given a blog-posting created") {
+			var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
+				articleBody = "ArticleBody",
+				headline = "Headline");
+		}
+
+		task ("When with curl I request GET getSiteBlogPostingsPage with siteId and restrictFields equal all fields except id field") {
+			var response = BlogPostingAPI.getBlogPostingsbyDifferentParameters(
+				parameter = "restrictFields",
+				restrictFieldsValue = "aggregateRating,alternativeHeadline,articleBody,creator,customFields,dateCreated,dateModified,datePublished,description,encodingFormat,externalReferenceCode,friendlyUrlPath,headline,image,keywords,numberOfComments,relatedContents,renderedContents,siteId,taxonomyCategoryBriefs,x-class-name,facets,actions");
+		}
+
+		task ("Then in a response I receive a with id field values only") {
+			BlogPostingAPI.assertResponseHasIdFieldValueOnly(
+				expectedValue = "{id=${blogPostingId}}",
+				responseToParse = "${response}");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Add support for nestedFields query param to API Explorer

**Test Plan**
Given a display page templates created
When with curl I request GET getSiteDisplayPageTemplatesPage with siteId and nestedFields = "profileURL"
Then in a response I receive a with profileURL field values in the creator field have appeared

Given an Asset Library with a Web Content Folder created
When with curl I request GET getAssetLibraryStructuredContentFoldersPage with assetLibraryId and nestedFields = "profileURL"
Then in a response I receive a with profileURL field values in the creator field have appeared

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-159735