### PR TITLE
LPS-159484 Makes Walkthrough localStorage keys unique depending on userId

### DIFF
--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -188,7 +188,7 @@ const Step = ({
 	const hotspotRef = useRef(null);
 
 	const [popoverVisible, setPopoverVisible] = useLocalStorage(
-		'walkthrough-popover-visible',
+		`${themeDisplay.getUserId()}-walkthrough-popover-visible`,
 		false
 	);
 
@@ -498,8 +498,9 @@ const Walkthrough = ({
 	const [
 		currentStepIndex,
 		setCurrentStepIndex,
-	] = useLocalStorage('walkthrough-current-step', () =>
-		!steps.length ? null : 0
+	] = useLocalStorage(
+		`${themeDisplay.getUserId()}-walkthrough-current-step`,
+		() => (!steps.length ? null : 0)
 	);
 
 	if (currentStepIndex === null) {


### PR DESCRIPTION
# Steps to reproduce

0. Create two users, User 1 and User 2
1. Enable Walkthrough enabled with multiple steps
2. User 1 navigates to Step 2
3. User 1 signs out, and User 2 signs in
4. User 2 navigates to Step 1
5. Logout and Login with User 1
Now, User 1 will be at Step 2, and then log in with User 2; it will be on Step 1.

# How I solved it

Found `themeDisplay.getUserId()` which can be useful for making localStorage keys unique depending on user.
