### PR TITLE
LPS-158486 Add CanCreateCommentWithValueInternalIdPreviouslyCreated testcase

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -68,11 +68,16 @@ definition {
 			var parentCommentId = "0";
 		}
 
+		if (!(isSet(idComment))) {
+			var idComment = "";
+		}
+
 		var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 		var body = '''
 			-d {
 				"externalReferenceCode": "${externalReferenceCode}",
 				"parentCommentId": "${parentCommentId}",
+				"id":"${idComment}",
 				"text": "${commentText}"
 			}
 		''';

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -68,10 +68,6 @@ definition {
 			var parentCommentId = "0";
 		}
 
-		if (!(isSet(idComment))) {
-			var idComment = "";
-		}
-
 		var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 		var body = '''
 			-d {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -77,7 +77,6 @@ definition {
 			-d {
 				"externalReferenceCode": "${externalReferenceCode}",
 				"parentCommentId": "${parentCommentId}",
-				"id":"${idComment}",
 				"text": "${commentText}"
 			}
 		''';

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -49,21 +49,33 @@ definition {
 	test CanCreateCommentWithValueInternalIdPreviouslyCreated {
 		property portal.acceptance = "true";
 
-		task ("When with POST request I create a comment with a custom external reference code") {
+		task ("And Given with POST request I create a comment with a custom external reference code") {
 			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
 
-			CommentAPI.createCommentInBlogPosting(
+			var response = CommentAPI.createCommentInBlogPosting(
 				blogPostingId = "${blogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
 
-		task ("with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
-			var response = CommentAPI.createCommentInBlogPosting(
+		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
+			var idComment = JSONUtil.getWithJSONPath("${response}", "$.id");
+			
+			var response2 = CommentAPI.createCommentInBlogPosting(
 				blogPostingId = "${blogPostingId}",
 				commentText = "CommentTwo",
-				externalReferenceCode = "ercComment2",
+				externalReferenceCode = "${idComment}",
 				idComment = "1");
+		}
+
+		task ("Then another comment with the same external reference code is being created") {
+			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingId = "${blogPostingId}",
+				fieldName = "totalCount");
+
+			TestUtils.assertEquals(
+				actual = "${commentsTotalCount}",
+				expected = "2");
 		}
 
 		task ("And Then can see the custom external reference code in the body response") {
@@ -73,7 +85,7 @@ definition {
 
 			TestUtils.assertEquals(
 				actual = "${externalReferenceCodes}",
-				expected = "ercComment,ercComment2");
+				expected = "ercComment,${idComment}");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -46,6 +46,39 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = "4"
+	test CanCreateCommentWithValueInternalIdPreviouslyCreated {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentTwo",
+				externalReferenceCode = "ercComment2",
+				idComment = "1");
+		}
+
+		task ("And Then can see the custom external reference code in the body response") {
+			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingId = "${blogPostingId}",
+				fieldName = "externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = "${externalReferenceCodes}",
+				expected = "ercComment,ercComment2");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
 	test CannotCreateTwoCommentsWithCustomExternalReferenceCode {
 		property portal.acceptance = "true";
 
@@ -79,39 +112,6 @@ definition {
 			TestUtils.assertEquals(
 				actual = "${commentsTotalCount}",
 				expected = "1");
-		}
-	}
-
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CanCreateCommentWithValueInternalIdPreviouslyCreated {
-		property portal.acceptance = "true";
-
-		task ("When with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne",
-				externalReferenceCode = "ercComment");
-		}
-
-		task ("with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
-			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				idComment = "1",
-				commentText = "CommentTwo",
-				externalReferenceCode = "ercComment2");
-		}
-
-		task ("And Then can see the custom external reference code in the body response") {
-			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
-				fieldName = "externalReferenceCode");
-
-			TestUtils.assertEquals(
-				actual = "${externalReferenceCodes}",
-				expected = "ercComment,ercComment2");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -60,7 +60,7 @@ definition {
 
 		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
 			var idComment = JSONUtil.getWithJSONPath("${response}", "$.id");
-			
+
 			var response2 = CommentAPI.createCommentInBlogPosting(
 				blogPostingId = "${blogPostingId}",
 				commentText = "CommentTwo",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -82,4 +82,37 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateCommentWithValueInternalIdPreviouslyCreated {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				idComment = "1",
+				commentText = "CommentTwo",
+				externalReferenceCode = "ercComment2");
+		}
+
+		task ("And Then can see the custom external reference code in the body response") {
+			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingId = "${blogPostingId}",
+				fieldName = "externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = "${externalReferenceCodes}",
+				expected = "ercComment,ercComment2");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -64,8 +64,7 @@ definition {
 			var response2 = CommentAPI.createCommentInBlogPosting(
 				blogPostingId = "${blogPostingId}",
 				commentText = "CommentTwo",
-				externalReferenceCode = "${idComment}",
-				idComment = "1");
+				externalReferenceCode = "${idComment}");
 		}
 
 		task ("Then another comment with the same external reference code is being created") {


### PR DESCRIPTION
Background:
Create automated test CanCreateCommentWithValueInternalIdPreviouslyCreated

Test Plan:
**Given** blog post is created
**And Given** comment with a custom external reference code is created with a POST request
**When** with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment
**Then** comment is being created
**And Then** I can see the custom external reference code in the body response

JIRA Link:
https://issues.liferay.com/browse/LPS-158486