### PR TITLE
LPS-159474 Add test MultipageWalkthrough#CanNavigateToPreviousPage

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -50,6 +50,14 @@ definition {
 			locator1 = "Walkthrough#POPOVER_TITLE");
 	}
 
+	macro goToPreviousStep {
+		Click(locator1 = "Button#PREVIOUS");
+
+		VerifyElementPresent(
+			key_title = "Step ${key_step}",
+			locator1 = "Walkthrough#POPOVER_TITLE");
+	}
+
 	macro goToSpecificStep {
 		while (IsElementNotPresent(key_title = "Step ${key_step}", locator1 = "Walkthrough#POPOVER_TITLE")) {
 			Click(locator1 = "Button#OK");

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/MultipageWalkthrough.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/MultipageWalkthrough.testcase
@@ -86,4 +86,36 @@ definition {
 		}
 	}
 
+	@description = "LPS-159474. Assert walkthrough can navigate back to the previous page."
+	@priority = "5"
+	test CanNavigateToPreviousPage {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("When on step 2") {
+			Walkthrough.enablePopoverMode();
+
+			Walkthrough.goToSpecificStep(key_step = "2");
+
+			VerifyElementPresent(
+				key_title = "Step 2 of 2: Enter Your Name",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+
+		task ("And When navigate to previous step") {
+			Walkthrough.goToPreviousStep(key_step = "1");
+		}
+
+		task ("Then browser URL ends with /walkthrough-page-1") {
+			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-1");
+		}
+
+		task ("And Then popover is in step 1") {
+			AssertElementPresent(
+				key_title = "Step 1 of 2: Click the Button",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
 }

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/MultipageWalkthrough.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/MultipageWalkthrough.testcase
@@ -67,7 +67,7 @@ definition {
 			Walkthrough.enablePopoverMode();
 
 			VerifyElementPresent(
-				key_title = "Step 1 of 2: Click the button",
+				key_title = "Step 1 of 2: Click the Button",
 				locator1 = "Walkthrough#POPOVER_TITLE");
 		}
 
@@ -81,7 +81,7 @@ definition {
 
 		task ("And Then popover is in step 2") {
 			AssertElementPresent(
-				key_title = "Step 2 of 2: Enter your name",
+				key_title = "Step 2 of 2: Enter Your Name",
 				locator1 = "Walkthrough#POPOVER_TITLE");
 		}
 	}


### PR DESCRIPTION
**Background**
Create automated tests for Multipage Walkthrough. 

Also test fix CanNavigateToNextPage due to changes from https://github.com/brianchandotcom/liferay-portal/commit/698f355804fdb658742c542694972666f8cff3f5.


**Test Plan**
Given walkthrough enabled site-level with multiple pages defined
When on step 2
And When navigate to previous step
Then browser URL ends with /walkthrough-page-1
And Then popover is on step 1

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-159474