### PR TITLE
LPS-158440 Add web storage wrappers with user consent checks

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -829,7 +829,7 @@ export function setCookie(
 export function removeCookie(name: string): void;
 
 /**
- * Object with cookie consent types as keys
+ * Object with consent types as keys and corresponding cookie names as values
  */
 export const TYPES: {[key: string]: TYPE_VALUES};
 
@@ -864,7 +864,7 @@ type Storage = {
 
 	TYPES: typeof TYPES;
 
-	size: number;
+	length: number;
 };
 
 export const localStorage: Storage;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -829,7 +829,7 @@ export function setCookie(
 export function removeCookie(name: string): void;
 
 /**
- * Object with cookie consent types as keys, for use with {@link setCookie}
+ * Object with cookie consent types as keys
  */
 export const TYPES: {[key: string]: TYPE_VALUES};
 
@@ -838,3 +838,35 @@ export type TYPE_VALUES =
 	| 'CONSENT_TYPE_NECESSARY'
 	| 'CONSENT_TYPE_PERFORMANCE'
 	| 'CONSENT_TYPE_PERSONALIZATION';
+
+type Storage = {
+	clear(): void;
+
+	getItem(key: string, type: TYPE_VALUES): string | undefined;
+
+	key(index: number, type: TYPE_VALUES): string | undefined;
+
+	removeItem(key: string): void;
+
+	setItem(
+		key: string,
+		value: string,
+		type: TYPE_VALUES,
+		options?: {
+			'domain'?: string;
+			'expires'?: string;
+			'max-age'?: string;
+			'path'?: string;
+			'samesite'?: string;
+			'secure'?: boolean;
+		}
+	): boolean;
+
+	TYPES: typeof TYPES;
+
+	size: number;
+};
+
+export const localStorage: Storage;
+
+export const sessionStorage: Storage;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -88,6 +88,11 @@ export {
 
 export {getSessionValue, setSessionValue} from './liferay/util/session.es';
 
+// Storage APIs
+
+export {default as localStorage} from './liferay/util/local_storage';
+export {default as sessionStorage} from './liferay/util/session_storage';
+
 // Toast API
 
 export {openToast} from './liferay/toast/commands/OpenToast.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -78,6 +78,7 @@ import {
 import inBrowserView from './util/in_browser_view';
 import isPhone from './util/is_phone';
 import isTablet from './util/is_tablet';
+import localStorage from './util/local_storage';
 import navigate from './util/navigate.es';
 import normalizeFriendlyURL from './util/normalize_friendly_url';
 import ns from './util/ns.es';
@@ -90,6 +91,7 @@ import createResourceURL from './util/portlet_url/create_resource_url.es';
 import removeEntitySelection from './util/remove_entity_selection';
 import selectFolder from './util/select_folder';
 import {getSessionValue, setSessionValue} from './util/session.es';
+import sessionStorage from './util/session_storage';
 import showCapsLock from './util/show_caps_lock';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
@@ -346,5 +348,8 @@ Liferay.Util.unescape = unescape;
 Liferay.Util.unescapeHTML = unescapeHTML;
 
 Liferay.Util.Cookie = Cookie;
+
+Liferay.Util.LocalStorage = localStorage;
+Liferay.Util.SessionStorage = sessionStorage;
 
 export {portlet};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -325,6 +325,106 @@ declare module Liferay {
 			): Promise<any>;
 		}
 
+		namespace LocalStorage {
+
+			/* Removes all keys stored in localStorage */
+			export function clear(): void;
+
+			/**
+			 * Object with cookie consent types as keys
+			 */
+			export const TYPES: {[key: string]: TYPE_VALUES};
+
+			export type TYPE_VALUES =
+				| 'CONSENT_TYPE_FUNCTIONAL'
+				| 'CONSENT_TYPE_NECESSARY'
+				| 'CONSENT_TYPE_PERFORMANCE'
+				| 'CONSENT_TYPE_PERSONALIZATION';
+
+			/* Returns the value in localStorage for the corresponding key if user has consented to the type of storage */
+			export function getItem(
+				key: string,
+				type: TYPE_VALUES
+			): string | undefined;
+
+			/* Returns the value in localStorage for the corresponding index if user has consented to the type of storage */
+			export function key(
+				index: number,
+				type: TYPE_VALUES
+			): string | undefined;
+
+			/* Removes the value for the corresponding key in localStorage regardless of consent */
+			export function removeItem(key: string): void;
+
+			/* Sets the key-value pair in localStorage if user has consented to the type of storage */
+			export function setItem(
+				key: string,
+				value: string,
+				type: TYPE_VALUES,
+				options?: {
+					'domain'?: string;
+					'expires'?: string;
+					'max-age'?: string;
+					'path'?: string;
+					'samesite'?: string;
+					'secure'?: boolean;
+				}
+			): boolean;
+
+			/* Returns the number of items in localStorage */
+			export const size: number;
+		}
+
+		namespace SessionStorage {
+
+			/* Removes all keys stored in sessionStorage */
+			export function clear(): void;
+
+			/**
+			 * Object with cookie consent types as keys
+			 */
+			export const TYPES: {[key: string]: TYPE_VALUES};
+
+			export type TYPE_VALUES =
+				| 'CONSENT_TYPE_FUNCTIONAL'
+				| 'CONSENT_TYPE_NECESSARY'
+				| 'CONSENT_TYPE_PERFORMANCE'
+				| 'CONSENT_TYPE_PERSONALIZATION';
+
+			/* Returns the value in sessionStorage for the corresponding key if user has consented to the type of storage */
+			export function getItem(
+				key: string,
+				type: TYPE_VALUES
+			): string | undefined;
+
+			/* Returns the value in sessionStorage for the corresponding index if user has consented to the type of storage */
+			export function key(
+				index: number,
+				type: TYPE_VALUES
+			): string | undefined;
+
+			/* Removes the value for the corresponding key in sessionStorage regardless of consent */
+			export function removeItem(key: string): void;
+
+			/* Sets the key-value pair in sessionStorage if user has consented to the type of storage */
+			export function setItem(
+				key: string,
+				value: string,
+				type: TYPE_VALUES,
+				options?: {
+					'domain'?: string;
+					'expires'?: string;
+					'max-age'?: string;
+					'path'?: string;
+					'samesite'?: string;
+					'secure'?: boolean;
+				}
+			): boolean;
+
+			/* Returns the number of items in sessionStorage */
+			export const size: number;
+		}
+
 		/* Escapes HTML from the given string */
 		export function escapeHTML(string: string): string;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -327,12 +327,10 @@ declare module Liferay {
 
 		namespace LocalStorage {
 
-			/* Removes all keys stored in localStorage */
+			/* Removes all entries in localStorage */
 			export function clear(): void;
 
-			/**
-			 * Object with cookie consent types as keys
-			 */
+			/* Object with consent types as keys and corresponding cookie names as values */
 			export const TYPES: {[key: string]: TYPE_VALUES};
 
 			export type TYPE_VALUES =
@@ -347,11 +345,8 @@ declare module Liferay {
 				type: TYPE_VALUES
 			): string | undefined;
 
-			/* Returns the value in localStorage for the corresponding index if user has consented to the type of storage */
-			export function key(
-				index: number,
-				type: TYPE_VALUES
-			): string | undefined;
+			/*  Returns the key of the n-th entry in localStorage */
+			export function key(index: number): string | undefined;
 
 			/* Removes the value for the corresponding key in localStorage regardless of consent */
 			export function removeItem(key: string): void;
@@ -372,17 +367,15 @@ declare module Liferay {
 			): boolean;
 
 			/* Returns the number of items in localStorage */
-			export const size: number;
+			export const length: number;
 		}
 
 		namespace SessionStorage {
 
-			/* Removes all keys stored in sessionStorage */
+			/* Removes all entries in sessionStorage */
 			export function clear(): void;
 
-			/**
-			 * Object with cookie consent types as keys
-			 */
+			/* Object with consent types as keys and corresponding cookie names as values */
 			export const TYPES: {[key: string]: TYPE_VALUES};
 
 			export type TYPE_VALUES =
@@ -397,11 +390,8 @@ declare module Liferay {
 				type: TYPE_VALUES
 			): string | undefined;
 
-			/* Returns the value in sessionStorage for the corresponding index if user has consented to the type of storage */
-			export function key(
-				index: number,
-				type: TYPE_VALUES
-			): string | undefined;
+			/* Returns the key of the n-th entry in sessionStorage */
+			export function key(index: number): string | undefined;
 
 			/* Removes the value for the corresponding key in sessionStorage regardless of consent */
 			export function removeItem(key: string): void;
@@ -422,7 +412,7 @@ declare module Liferay {
 			): boolean;
 
 			/* Returns the number of items in sessionStorage */
-			export const size: number;
+			export const length: number;
 		}
 
 		/* Escapes HTML from the given string */

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/consent.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/consent.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {getCookie} from './cookie';
+import {getCookie} from './cookie/cookie';
 
 export const CONSENT_TYPES = {
 	FUNCTIONAL: 'CONSENT_TYPE_FUNCTIONAL',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie/cookie.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie/cookie.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {CONSENT_TYPES, checkConsent} from './consent';
+import {CONSENT_TYPES, checkConsent} from '../consent';
 
 const generateCookie = (name, value, options = {}) => {
 	let cookie = `${name}=${value}`;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/local_storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/local_storage.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import Storage from './storage';
+
+export default new Storage(localStorage);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session_storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session_storage.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import Storage from './storage';
+
+export default new Storage(sessionStorage);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
@@ -25,8 +25,6 @@ export default class Storage {
 
 	getItem(key, type) {
 		if (!checkConsent(type)) {
-			this.removeItem(key);
-
 			return null;
 		}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {CONSENT_TYPES, checkConsent} from './consent';
+
+export default class Storage {
+	constructor(storage) {
+		this.storage = storage;
+	}
+
+	clear() {
+		return this.storage.clear();
+	}
+
+	getItem(key, type) {
+		if (!checkConsent(type)) {
+			this.removeItem(key);
+
+			return null;
+		}
+
+		return this.storage.getItem(key);
+	}
+
+	key(index, type) {
+		if (!checkConsent(type)) {
+			return null;
+		}
+
+		return this.storage.key(index);
+	}
+
+	removeItem(key) {
+		return this.storage.removeItem(key);
+	}
+
+	setItem(key, value, type) {
+		if (!checkConsent(type)) {
+			return false;
+		}
+
+		this.storage.setItem(key, value);
+
+		return true;
+	}
+
+	get size() {
+		return this.storage.size;
+	}
+
+	TYPES = CONSENT_TYPES;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/storage.js
@@ -55,8 +55,8 @@ export default class Storage {
 		return true;
 	}
 
-	get size() {
-		return this.storage.size;
+	get length() {
+		return this.storage.length;
 	}
 
 	TYPES = CONSENT_TYPES;

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/storage.js
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {CONSENT_TYPES} from '../../../src/main/resources/META-INF/resources/liferay/util/consent';
+import Storage from '../../../src/main/resources/META-INF/resources/liferay/util/storage';
+
+const anyName = 'any-name';
+const anyValue = 'any-value';
+
+const optionalConsentTypes = [
+	CONSENT_TYPES.PERFORMANCE,
+	CONSENT_TYPES.PERSONALIZATION,
+	CONSENT_TYPES.FUNCTIONAL,
+];
+const allConsentTypes = [CONSENT_TYPES.NECESSARY, ...optionalConsentTypes];
+
+const setConsentCookies = (optional = false) => {
+	const consentCookieMap = {
+		[CONSENT_TYPES.NECESSARY]: true,
+		[CONSENT_TYPES.PERFORMANCE]: optional,
+		[CONSENT_TYPES.PERSONALIZATION]: optional,
+		[CONSENT_TYPES.FUNCTIONAL]: optional,
+	};
+
+	for (const [name, value] of Object.entries(consentCookieMap)) {
+		document.cookie = `${name}=${value}`;
+	}
+};
+
+const clearConsentCookies = () => {
+	for (const consentType of allConsentTypes) {
+		document.cookie = `${consentType}=; max-age=0;`;
+	}
+};
+
+describe.each([
+	['LocalStorage', localStorage],
+	['SessionStorage', sessionStorage],
+])(`Liferay.Util.%s`, (storageName, storage) => {
+	const LiferayStorage = new Storage(storage);
+
+	afterEach(() => {
+		storage.clear();
+		clearConsentCookies();
+		jest.restoreAllMocks();
+	});
+
+	describe(`Liferay.Util.${storageName}.setItem`, () => {
+		it('Always allows setting a necessary data', () => {
+			setConsentCookies(false);
+
+			const isValueSet = LiferayStorage.setItem(
+				anyName,
+				anyValue,
+				CONSENT_TYPES.NECESSARY
+			);
+
+			expect(isValueSet).toBe(true);
+
+			const storedValue = storage.getItem(anyName);
+
+			expect(storedValue).toBe(anyValue);
+		});
+
+		it.each(optionalConsentTypes)(
+			`Allows setting %s values if enabled`,
+			(consentType) => {
+				setConsentCookies(true);
+
+				const name = `${anyName}-${consentType}`;
+
+				const isValueSet = LiferayStorage.setItem(
+					name,
+					anyValue,
+					consentType
+				);
+
+				expect(isValueSet).toBe(true);
+
+				const storedValue = storage.getItem(name);
+
+				expect(storedValue).toBe(anyValue);
+			}
+		);
+
+		it.each(optionalConsentTypes)(
+			`Doesn't allow setting %s value if disabled`,
+			(consentType) => {
+				setConsentCookies(false);
+
+				const name = `${anyName}-${consentType}`;
+
+				const isValueSet = LiferayStorage.setItem(
+					name,
+					anyValue,
+					consentType
+				);
+
+				expect(isValueSet).toBe(false);
+
+				const storedValue = storage.getItem(name);
+
+				expect(storedValue).toBeNull();
+			}
+		);
+
+		it.each(optionalConsentTypes)(
+			'Allows setting %s values if consent is not set',
+			(consentType) => {
+				expect(document.cookie.includes(consentType)).toBe(false);
+
+				const isValueSet = LiferayStorage.setItem(
+					anyName,
+					anyValue,
+					consentType
+				);
+
+				expect(isValueSet).toBe(true);
+				expect(storage.getItem(anyName)).toBe(anyValue);
+			}
+		);
+	});
+
+	describe(`Liferay.Util.${storageName}.getItem`, () => {
+		it.each(allConsentTypes)(
+			"Returns null if value isn't set and %s enabled",
+			(consentType) => {
+				setConsentCookies(true);
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+			}
+		);
+
+		it.each(allConsentTypes)(
+			'Returns value as string if the value is set and %s enabled',
+			(consentType) => {
+				setConsentCookies(true);
+
+				storage.setItem(anyName, anyValue);
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBe(
+					anyValue
+				);
+			}
+		);
+
+		it.each(optionalConsentTypes)(
+			"Returns null if value isn't set and %s disabled",
+			(consentType) => {
+				setConsentCookies(false);
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+			}
+		);
+
+		it.each(optionalConsentTypes)(
+			'Returns null if the value is set and %s disabled',
+			(consentType) => {
+				setConsentCookies(false);
+
+				storage.setItem(anyName, anyValue);
+
+				expect(storage.getItem(anyName)).not.toBeNull();
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+			}
+		);
+	});
+
+	describe(`Liferay.Util.${storageName}.removeItem`, () => {
+		it('Removes value if it exists', () => {
+			storage.setItem(anyName, anyValue);
+
+			LiferayStorage.removeItem(anyName);
+			expect(storage.getItem(anyName)).toBeNull();
+		});
+
+		it("Value still doesn't exist if it didn't exist before removal", () => {
+			LiferayStorage.removeItem(anyName);
+			expect(storage.getItem(anyName)).toBeNull();
+		});
+	});
+
+	describe(`Liferay.Util.${storageName}.TYPES`, () => {
+		it('Exists', () => {
+			expect(LiferayStorage.TYPES).not.toBeUndefined();
+		});
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/storage.js
@@ -56,6 +56,98 @@ describe.each([
 		jest.restoreAllMocks();
 	});
 
+	describe(`Liferay.Util.${storageName}.clear`, () => {
+		it('Exists', () => {
+			expect(LiferayStorage.clear).not.toBeUndefined();
+		});
+
+		it('Removes all items from storage', () => {
+			for (let i = 0; i < 3; i++) {
+				storage.setItem(`${anyName}-${i}`, anyValue);
+			}
+
+			expect(storage.length).not.toBe(0);
+
+			LiferayStorage.clear();
+
+			expect(storage.length).toBe(0);
+		});
+	});
+
+	describe(`Liferay.Util.${storageName}.getItem`, () => {
+		it.each(allConsentTypes)(
+			"Returns null if value isn't set and %s enabled",
+			(consentType) => {
+				setConsentCookies(true);
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+			}
+		);
+
+		it.each(allConsentTypes)(
+			'Returns value as string if the value is set and %s enabled',
+			(consentType) => {
+				setConsentCookies(true);
+
+				storage.setItem(anyName, anyValue);
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBe(
+					anyValue
+				);
+			}
+		);
+
+		it.each(optionalConsentTypes)(
+			"Returns null if value isn't set and %s disabled",
+			(consentType) => {
+				setConsentCookies(false);
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+			}
+		);
+
+		it.each(optionalConsentTypes)(
+			'Returns null if the value is set and %s disabled',
+			(consentType) => {
+				setConsentCookies(false);
+
+				storage.setItem(anyName, anyValue);
+
+				expect(storage.getItem(anyName)).not.toBeNull();
+
+				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+			}
+		);
+	});
+
+	describe(`Liferay.Util.${storageName}.key`, () => {
+		it('Exists', () => {
+			expect(LiferayStorage.key).not.toBeUndefined();
+		});
+
+		it('Returns the key at the nth position', () => {
+			for (let i = 0; i < 3; i++) {
+				const name = `${anyName}-${i}`;
+				storage.setItem(name, anyValue);
+				expect(LiferayStorage.key(i)).toBe(name);
+			}
+		});
+	});
+
+	describe(`Liferay.Util.${storageName}.removeItem`, () => {
+		it('Removes value if it exists', () => {
+			storage.setItem(anyName, anyValue);
+
+			LiferayStorage.removeItem(anyName);
+			expect(storage.getItem(anyName)).toBeNull();
+		});
+
+		it("Value still doesn't exist if it didn't exist before removal", () => {
+			LiferayStorage.removeItem(anyName);
+			expect(storage.getItem(anyName)).toBeNull();
+		});
+	});
+
 	describe(`Liferay.Util.${storageName}.setItem`, () => {
 		it('Always allows setting a necessary data', () => {
 			setConsentCookies(false);
@@ -132,69 +224,27 @@ describe.each([
 		);
 	});
 
-	describe(`Liferay.Util.${storageName}.getItem`, () => {
-		it.each(allConsentTypes)(
-			"Returns null if value isn't set and %s enabled",
-			(consentType) => {
-				setConsentCookies(true);
-
-				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
-			}
-		);
-
-		it.each(allConsentTypes)(
-			'Returns value as string if the value is set and %s enabled',
-			(consentType) => {
-				setConsentCookies(true);
-
-				storage.setItem(anyName, anyValue);
-
-				expect(LiferayStorage.getItem(anyName, consentType)).toBe(
-					anyValue
-				);
-			}
-		);
-
-		it.each(optionalConsentTypes)(
-			"Returns null if value isn't set and %s disabled",
-			(consentType) => {
-				setConsentCookies(false);
-
-				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
-			}
-		);
-
-		it.each(optionalConsentTypes)(
-			'Returns null if the value is set and %s disabled',
-			(consentType) => {
-				setConsentCookies(false);
-
-				storage.setItem(anyName, anyValue);
-
-				expect(storage.getItem(anyName)).not.toBeNull();
-
-				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
-			}
-		);
-	});
-
-	describe(`Liferay.Util.${storageName}.removeItem`, () => {
-		it('Removes value if it exists', () => {
-			storage.setItem(anyName, anyValue);
-
-			LiferayStorage.removeItem(anyName);
-			expect(storage.getItem(anyName)).toBeNull();
-		});
-
-		it("Value still doesn't exist if it didn't exist before removal", () => {
-			LiferayStorage.removeItem(anyName);
-			expect(storage.getItem(anyName)).toBeNull();
-		});
-	});
-
 	describe(`Liferay.Util.${storageName}.TYPES`, () => {
 		it('Exists', () => {
 			expect(LiferayStorage.TYPES).not.toBeUndefined();
+		});
+	});
+
+	describe(`Liferay.Util.${storageName}.length`, () => {
+		it('Exists', () => {
+			expect(LiferayStorage.length).not.toBeUndefined();
+		});
+
+		it('Returns 0 if there are no items in storage', () => {
+			expect(LiferayStorage.length).toBe(0);
+		});
+
+		it('Returns the number of items in storage', () => {
+			for (let i = 0; i < 3; i++) {
+				storage.setItem(`${anyName}-${i}`, anyValue);
+
+				expect(LiferayStorage.length).toBe(i + 1);
+			}
 		});
 	});
 });

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/storage.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/storage.js
@@ -116,6 +116,8 @@ describe.each([
 				expect(storage.getItem(anyName)).not.toBeNull();
 
 				expect(LiferayStorage.getItem(anyName, consentType)).toBeNull();
+
+				expect(storage.getItem(anyName)).not.toBeNull();
 			}
 		);
 	});


### PR DESCRIPTION
### References

- [LPS-158440](https://issues.liferay.com/browse/LPS-158440)

### What is the goal?

* Add web storage wrappers with user consent checks
   * These wrappers can be accessed through `Liferay.Util.LocalStorage` and `Liferay.Util.SessionStorage`, or imported as ESM with `import {localStorage, sessionStorage} from 'frontend-js-web'`
   * They have [the same methods as window.[local|session]storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage)

### What does it look like?
<img width="1267" alt="imagen" src="https://user-images.githubusercontent.com/6642927/185890792-83064a42-40de-446d-b420-6ccd4c75630b.png">



### How to replicate
* Launch Liferay
* Open devtools, see that `Liferay.Util` has two new keys: `LocalStorage` and `SessionStorage`

