### PR TITLE
LPS-161245 Creates a new property called `resizeDir` for liferay-editor:editor tag

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/BaseCKEditorConfigContributor.java
@@ -113,7 +113,11 @@ public class BaseCKEditorConfigContributor extends BaseEditorConfigContributor {
 				CKEditorConstants.ATTRIBUTE_NAMESPACE + ":resizable"));
 
 		if (resizable) {
-			jsonObject.put("resize_dir", "vertical");
+			String resizeDirection = GetterUtil.getString(
+				inputEditorTaglibAttributes.get(
+					CKEditorConstants.ATTRIBUTE_NAMESPACE + ":resizeDir"));
+
+			jsonObject.put("resize_dir", resizeDirection);
 		}
 
 		jsonObject.put("resize_enabled", resizable);

--- a/modules/apps/frontend-editor/frontend-editor-taglib/bnd.bnd
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-Activator: com.liferay.frontend.editor.taglib.internal.activator.EditorTaglibBundleActivator
 Bundle-Name: Liferay Frontend Editor Taglib
 Bundle-SymbolicName: com.liferay.frontend.editor.taglib
-Bundle-Version: 4.0.9
+Bundle-Version: 4.1.0
 Export-Package: com.liferay.frontend.editor.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
@@ -138,6 +138,10 @@ public class EditorTag extends BaseValidatorTagSupport {
 		return _placeholder;
 	}
 
+	public String getResizeDir() {
+		return _resizeDir;
+	}
+
 	public String getToolbarSet() {
 		return _toolbarSet;
 	}
@@ -258,6 +262,10 @@ public class EditorTag extends BaseValidatorTagSupport {
 		_resizable = resizable;
 	}
 
+	public void setResizeDir(String resizeDir) {
+		_resizeDir = resizeDir;
+	}
+
 	public void setShowSource(boolean showSource) {
 		_showSource = showSource;
 	}
@@ -299,6 +307,7 @@ public class EditorTag extends BaseValidatorTagSupport {
 		_placeholder = null;
 		_required = false;
 		_resizable = true;
+		_resizeDir = "vertical";
 		_showSource = true;
 		_skipEditorLoading = false;
 		_toolbarSet = _TOOLBAR_SET_DEFAULT;
@@ -370,6 +379,7 @@ public class EditorTag extends BaseValidatorTagSupport {
 			httpServletRequest, "required", String.valueOf(_required));
 		setNamespacedAttribute(
 			httpServletRequest, "resizable", String.valueOf(_resizable));
+		setNamespacedAttribute(httpServletRequest, "resizeDir", _resizeDir);
 		setNamespacedAttribute(
 			httpServletRequest, "showSource", String.valueOf(_showSource));
 		setNamespacedAttribute(
@@ -564,6 +574,7 @@ public class EditorTag extends BaseValidatorTagSupport {
 	private String _placeholder;
 	private boolean _required;
 	private boolean _resizable = true;
+	private String _resizeDir = "vertical";
 	private boolean _showSource = true;
 	private boolean _skipEditorLoading;
 	private String _toolbarSet = _TOOLBAR_SET_DEFAULT;

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/META-INF/liferay-editor.tld
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/META-INF/liferay-editor.tld
@@ -136,6 +136,12 @@
 			<type>boolean</type>
 		</attribute>
 		<attribute>
+			<description>Set editor's resizing directions. The default value is <![CDATA[<code>vertical</code>]]>. Possible values are <![CDATA[<code>vertical</code>]]>, <![CDATA[<code>horizontal</code>]]> and <![CDATA[<code>both</code>]]>.</description>
+			<name>resizeDir</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Whether to enable editing the HTML source code of the content. The default value is <![CDATA[<code>true</code>]]>.</description>
 			<name>showSource</name>
 			<required>false</required>
@@ -161,7 +167,7 @@
 		</attribute>
 	</tag>
 	<tag>
-		<description></description>
+		<description/>
 		<name>resources</name>
 		<tag-class>com.liferay.frontend.editor.taglib.servlet.taglib.ResourcesTag</tag-class>
 		<body-content>empty</body-content>

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/com/liferay/frontend/editor/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/resources/com/liferay/frontend/editor/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
# What it does

Given a call for liferay-editor:editor tag, it will enable users to:

```jsp
<liferay-editor:editor
    contents="<%= content %>"
    name="contentEditor"
    resizeDir="both"
/>
```

So, they can set which direction should we resize("vertical", "both", "horizontal")

# More than one possibility [1]

While implementing this, I noticed we could do the same job by adding:

```java
jsonObject
    .put("resize_dir", "both")
```

inside a Java class with the pattern of *EditorConfigContributor.

I decided to create this property/attribute on tag definition to bring one more way to extend this configuration. Like `resizable.`

# How to test

1. Deploy my code
2. Go to [this liferay-editor call](https://cs.github.com/liferay/liferay-portal/blob/29c7086d2a830e711dfa551844b2a77a62369d93/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/edit_kb_article.jsp#L176)
3. Add a new property called `resizeDir` and provide a value for it, different than "vertical"(default) and deploy the module
4. Go to Content and Data -> Knowledge Base -> Plus Button and create a new Article
5. Try to resize the editor


# Considerations

The default value is "vertical," as https://ckeditor.com/docs/ckeditor4/latest/features/resize.html#limiting-the-resizing-directions explains.

The original property name is `resize_dir` from CKEditor since we don't use snake case for things like properties, I converted it to camel case. 

You might see some limitations like there is a minimum value for the width/height and there is a doc about it here: https://ckeditor.com/docs/ckeditor4/latest/features/resize.html#limiting-the-width-and-height-for-ckeditor-4-resizing

I can't see anywhere on DXP where someone is setting this, but probably it can be overridable using [1]

/cc @pablo-agulla