### PR TITLE
[LPS-160598] Add delete comment after delete answer 

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
@@ -176,21 +176,34 @@ export default withRouter(
 																		answer.id,
 																},
 															}).then(() => {
-																if (comments.length) {
+																if (
+																	comments.length
+																) {
 																	Promise.all(
-																		comments.map(({id}) =>
-																			deleteMessage({
-																				variables: {
-																					messageBoardMessageId: id,
-																				},
-																			})
+																		comments.map(
+																			({
+																				id,
+																			}) =>
+																				deleteMessage(
+																					{
+																						variables: {
+																							messageBoardMessageId: id,
+																						},
+																					}
+																				)
 																		)
-																	).then(() => {
-																		deleteAnswer(answer);
-																	});
+																	).then(
+																		() => {
+																			deleteAnswer(
+																				answer
+																			);
+																		}
+																	);
 																}
 																else {
-																	deleteAnswer(answer);
+																	deleteAnswer(
+																		answer
+																	);
 																}
 															});
 														}}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
@@ -176,9 +176,22 @@ export default withRouter(
 																		answer.id,
 																},
 															}).then(() => {
-																deleteAnswer(
-																	answer
-																);
+																if (comments.length) {
+																	Promise.all(
+																		comments.map(({id}) =>
+																			deleteMessage({
+																				variables: {
+																					messageBoardMessageId: id,
+																				},
+																			})
+																		)
+																	).then(() => {
+																		deleteAnswer(answer);
+																	});
+																}
+																else {
+																	deleteAnswer(answer);
+																}
 															});
 														}}
 														onClose={() => {


### PR DESCRIPTION
Dear Team,
Forwarded from [liferay-ts-reviewer#91](https://github.com/liferay-ts-reviewer/liferay-portal/pull/91)
This is the PR for fixing this ticket: https://issues.liferay.com/browse/LPS-160598. The original [PR](https://github.com/thienquach87/liferay-portal/pull/11) was passed my review.
The fix is based on the logic applied in 7.3.x.  This logic is still applied for now (https://github.com/liferay/liferay-portal-ee/blob/7.3.x/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js#L50-L64). 

cc: @sontruongces, @holatuwol

Regards,
Thien