### PR TITLE
LPS-158487 and LPS-158491 | Creates automated tests about comments and child comments in blog posting

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/BlogPostingAPI.macro
@@ -441,4 +441,14 @@ definition {
 		return "${numberOfBlogPostingsCreated}";
 	}
 
+	macro setUpGlobalIdOfCreatedBlogPosting {
+		var blogPostingId = BlogPostingAPI.getIdOfCreatedBlogPosting(
+			articleBody = "${articleBody}",
+			headline = "${headline}");
+
+		static var staticBlogPostingId = "${blogPostingId}";
+
+		return "${staticBlogPostingId}";
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -71,6 +71,40 @@ definition {
 		return "${curl}";
 	}
 
+	macro _curlBlogPostingCommentsByExternalReferenceCode {
+		Variables.assertDefined(parameterList = "${blogPostingERC},${blogPostingCommentERC}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/by-external-reference-code/${blogPostingERC}/comments/by-external-reference-code/${blogPostingCommentERC} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		return "${curl}";
+	}
+
+	macro _curlBlogPostingChildCommentsByExternalReferenceCode {
+		Variables.assertDefined(parameterList = "${blogPostingChildCommentERC},${blogPostingCommentERC}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/comments/by-external-reference-code/${blogPostingCommentERC}/comments/by-external-reference-code/${blogPostingChildCommentERC} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		return "${curl}";
+	}
+
 	macro createCommentInBlogPosting {
 		Variables.assertDefined(parameterList = "${commentText}");
 
@@ -116,6 +150,22 @@ definition {
 
 		if (isSet(commentId) && !(isSet(blogPostingId))) {
 			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
+
+			var response = JSONCurlUtil.get("${curl}");
+		}
+
+		if (isSet(blogPostingERC) && (isSet(blogPostingCommentERC))) {
+			var curl = CommentAPI._curlBlogPostingCommentsByExternalReferenceCode(
+				blogPostingERC = "${blogPostingERC}",
+				blogPostingCommentERC = "${blogPostingCommentERC}");
+
+			var response = JSONCurlUtil.get("${curl}");
+		}
+
+		if (isSet(blogPostingChildCommentERC) && (isSet(blogPostingCommentERC))) {
+			var curl = CommentAPI._curlBlogPostingChildCommentsByExternalReferenceCode(
+				blogPostingChildCommentERC = "${blogPostingChildCommentERC}",
+				blogPostingCommentERC = "${blogPostingCommentERC}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -142,7 +142,7 @@ definition {
 	macro getFieldValueOfBlogPostingComments {
 		Variables.assertDefined(parameterList = "${fieldName}");
 
-		if (!(isSet(responseToParse)) && (isSet(blogPostingId))) {
+		if (!(isSet(responseToParse)) && isSet(blogPostingId)) {
 			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 
 			var response = JSONCurlUtil.get("${curl}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -57,6 +57,20 @@ definition {
 		return "${curl}";
 	}
 
+	macro _curlBlogPostingChildComments {
+		Variables.assertDefined(parameterList = "${commentId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/comments/${commentId}/comments \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		return "${curl}";
+	}
+
 	macro createCommentInBlogPosting {
 		Variables.assertDefined(parameterList = "${commentText}");
 
@@ -68,7 +82,14 @@ definition {
 			var parentCommentId = "0";
 		}
 
-		var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
+		if ((isSet(blogPostingId)) && !(isSet(commentId))) {
+			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
+		}
+
+		if ((isSet(commentId)) && !(isSet(blogPostingId))) {
+			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
+		}
+
 		var body = '''
 			-d {
 				"externalReferenceCode": "${externalReferenceCode}",
@@ -87,8 +108,14 @@ definition {
 	macro getFieldValueOfBlogPostingComments {
 		Variables.assertDefined(parameterList = "${fieldName}");
 
-		if (!(isSet(responseToParse))) {
+		if ((isSet(blogPostingId)) && !(isSet(commentId))) {
 			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
+
+			var response = JSONCurlUtil.get("${curl}");
+		}
+
+		if ((isSet(commentId)) && !(isSet(blogPostingId))) {
+			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -43,20 +43,6 @@ definition {
 		return "${curl}";
 	}
 
-	macro _curlBlogPostingComments {
-		Variables.assertDefined(parameterList = "${blogPostingId}");
-
-		var portalURL = JSONCompany.getPortalURL();
-
-		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/blog-postings/${blogPostingId}/comments \
-			-u test@liferay.com:test \
-			-H Content-Type: application/json
-		''';
-
-		return "${curl}";
-	}
-
 	macro _curlBlogPostingChildComments {
 		Variables.assertDefined(parameterList = "${commentId}");
 
@@ -64,6 +50,20 @@ definition {
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/comments/${commentId}/comments \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		return "${curl}";
+	}
+
+	macro _curlBlogPostingComments {
+		Variables.assertDefined(parameterList = "${blogPostingId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/blog-postings/${blogPostingId}/comments \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json
 		''';
@@ -82,11 +82,11 @@ definition {
 			var parentCommentId = "0";
 		}
 
-		if ((isSet(blogPostingId)) && !(isSet(commentId))) {
+		if (isSet(blogPostingId) && !(isSet(commentId))) {
 			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 		}
 
-		if ((isSet(commentId)) && !(isSet(blogPostingId))) {
+		if (isSet(commentId) && !(isSet(blogPostingId))) {
 			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
 		}
 
@@ -108,13 +108,13 @@ definition {
 	macro getFieldValueOfBlogPostingComments {
 		Variables.assertDefined(parameterList = "${fieldName}");
 
-		if ((isSet(blogPostingId)) && !(isSet(commentId))) {
+		if (isSet(blogPostingId) && !(isSet(commentId))) {
 			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}
 
-		if ((isSet(commentId)) && !(isSet(blogPostingId))) {
+		if (isSet(commentId) && !(isSet(blogPostingId))) {
 			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
 
 			var response = JSONCurlUtil.get("${curl}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -66,7 +66,7 @@ definition {
 		Variables.assertDefined(parameterList = "${blogPostingCommentErc}");
 
 		var portalURL = JSONCompany.getPortalURL();
-		var siteId = JSONGroupAPI._getGroupIdByName(
+		var siteId = JSONGroupAPI._getGroupIdByNameNoSelenium(
 			groupName = "Guest",
 			site = "true");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -58,7 +58,7 @@ definition {
 	}
 
 	macro _curlBlogPostingChildCommentsByExternalReferenceCode {
-		Variables.assertDefined(parameterList = "${blogPostingChildCommentERC},${blogPostingCommentERC}");
+		Variables.assertDefined(parameterList = "${blogPostingChildCommentErc},${blogPostingCommentErc}");
 
 		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
@@ -66,7 +66,7 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/comments/by-external-reference-code/${blogPostingCommentERC}/comments/by-external-reference-code/${blogPostingChildCommentERC} \
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/comments/by-external-reference-code/${blogPostingCommentErc}/comments/by-external-reference-code/${blogPostingChildCommentErc} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
@@ -89,7 +89,7 @@ definition {
 	}
 
 	macro _curlBlogPostingCommentsByExternalReferenceCode {
-		Variables.assertDefined(parameterList = "${blogPostingERC},${blogPostingCommentERC}");
+		Variables.assertDefined(parameterList = "${blogPostingErc},${blogPostingCommentErc}");
 
 		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
@@ -97,7 +97,7 @@ definition {
 			site = "true");
 
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/by-external-reference-code/${blogPostingERC}/comments/by-external-reference-code/${blogPostingCommentERC} \
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/by-external-reference-code/${blogPostingErc}/comments/by-external-reference-code/${blogPostingCommentErc} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
@@ -116,11 +116,11 @@ definition {
 			var parentCommentId = "0";
 		}
 
-		if (isSet(blogPostingId) && !(isSet(commentId))) {
+		if (isSet(blogPostingId)) {
 			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 		}
 
-		if (isSet(commentId) && !(isSet(blogPostingId))) {
+		if (isSet(commentId)) {
 			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
 		}
 
@@ -142,30 +142,30 @@ definition {
 	macro getFieldValueOfBlogPostingComments {
 		Variables.assertDefined(parameterList = "${fieldName}");
 
-		if (isSet(blogPostingId) && !(isSet(commentId))) {
+		if (!(isSet(responseToParse)) && (isSet(blogPostingId))) {
 			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}
 
-		if (isSet(commentId) && !(isSet(blogPostingId))) {
+		if (isSet(commentId)) {
 			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}
 
-		if (isSet(blogPostingERC) && isSet(blogPostingCommentERC)) {
+		if (isSet(blogPostingErc) && isSet(blogPostingCommentErc)) {
 			var curl = CommentAPI._curlBlogPostingCommentsByExternalReferenceCode(
-				blogPostingCommentERC = "${blogPostingCommentERC}",
-				blogPostingERC = "${blogPostingERC}");
+				blogPostingCommentErc = "${blogPostingCommentErc}",
+				blogPostingErc = "${blogPostingErc}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}
 
-		if (isSet(blogPostingChildCommentERC) && isSet(blogPostingCommentERC)) {
+		if (isSet(blogPostingChildCommentErc) && isSet(blogPostingCommentErc)) {
 			var curl = CommentAPI._curlBlogPostingChildCommentsByExternalReferenceCode(
-				blogPostingChildCommentERC = "${blogPostingChildCommentERC}",
-				blogPostingCommentERC = "${blogPostingCommentERC}");
+				blogPostingChildCommentErc = "${blogPostingChildCommentErc}",
+				blogPostingCommentErc = "${blogPostingCommentErc}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -57,6 +57,23 @@ definition {
 		return "${curl}";
 	}
 
+	macro _curlBlogPostingChildCommentsByExternalReferenceCode {
+		Variables.assertDefined(parameterList = "${blogPostingChildCommentERC},${blogPostingCommentERC}");
+
+		var portalURL = JSONCompany.getPortalURL();
+		var siteId = JSONGroupAPI._getGroupIdByName(
+			groupName = "Guest",
+			site = "true");
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/comments/by-external-reference-code/${blogPostingCommentERC}/comments/by-external-reference-code/${blogPostingChildCommentERC} \
+			-u test@liferay.com:test \
+			-H accept: application/json
+		''';
+
+		return "${curl}";
+	}
+
 	macro _curlBlogPostingComments {
 		Variables.assertDefined(parameterList = "${blogPostingId}");
 
@@ -81,23 +98,6 @@ definition {
 
 		var curl = '''
 			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/by-external-reference-code/${blogPostingERC}/comments/by-external-reference-code/${blogPostingCommentERC} \
-			-u test@liferay.com:test \
-			-H accept: application/json
-		''';
-
-		return "${curl}";
-	}
-
-	macro _curlBlogPostingChildCommentsByExternalReferenceCode {
-		Variables.assertDefined(parameterList = "${blogPostingChildCommentERC},${blogPostingCommentERC}");
-
-		var portalURL = JSONCompany.getPortalURL();
-		var siteId = JSONGroupAPI._getGroupIdByName(
-			groupName = "Guest",
-			site = "true");
-
-		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/comments/by-external-reference-code/${blogPostingCommentERC}/comments/by-external-reference-code/${blogPostingChildCommentERC} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
@@ -154,15 +154,15 @@ definition {
 			var response = JSONCurlUtil.get("${curl}");
 		}
 
-		if (isSet(blogPostingERC) && (isSet(blogPostingCommentERC))) {
+		if (isSet(blogPostingERC) && isSet(blogPostingCommentERC)) {
 			var curl = CommentAPI._curlBlogPostingCommentsByExternalReferenceCode(
-				blogPostingERC = "${blogPostingERC}",
-				blogPostingCommentERC = "${blogPostingCommentERC}");
+				blogPostingCommentERC = "${blogPostingCommentERC}",
+				blogPostingERC = "${blogPostingERC}");
 
 			var response = JSONCurlUtil.get("${curl}");
 		}
 
-		if (isSet(blogPostingChildCommentERC) && (isSet(blogPostingCommentERC))) {
+		if (isSet(blogPostingChildCommentERC) && isSet(blogPostingCommentERC)) {
 			var curl = CommentAPI._curlBlogPostingChildCommentsByExternalReferenceCode(
 				blogPostingChildCommentERC = "${blogPostingChildCommentERC}",
 				blogPostingCommentERC = "${blogPostingCommentERC}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/CommentAPI.macro
@@ -35,7 +35,7 @@ definition {
 			${portalURL}/o/headless-delivery/v1.0/blog-postings/${blogPostingId}/comments/batch?createStrategy=${createStrategy} \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json \
-            -d ${body}
+			-d ${body}
 		''';
 
 		var curl = JSONCurlUtil.post("${curl}");
@@ -43,44 +43,18 @@ definition {
 		return "${curl}";
 	}
 
-	macro _curlBlogPostingChildComments {
-		Variables.assertDefined(parameterList = "${commentId}");
-
-		var portalURL = JSONCompany.getPortalURL();
-
-		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/comments/${commentId}/comments \
-			-u test@liferay.com:test \
-			-H Content-Type: application/json
-		''';
-
-		return "${curl}";
-	}
-
-	macro _curlBlogPostingChildCommentsByExternalReferenceCode {
-		Variables.assertDefined(parameterList = "${blogPostingChildCommentErc},${blogPostingCommentErc}");
-
-		var portalURL = JSONCompany.getPortalURL();
-		var siteId = JSONGroupAPI._getGroupIdByName(
-			groupName = "Guest",
-			site = "true");
-
-		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/comments/by-external-reference-code/${blogPostingCommentErc}/comments/by-external-reference-code/${blogPostingChildCommentErc} \
-			-u test@liferay.com:test \
-			-H accept: application/json
-		''';
-
-		return "${curl}";
-	}
-
 	macro _curlBlogPostingComments {
-		Variables.assertDefined(parameterList = "${blogPostingId}");
-
 		var portalURL = JSONCompany.getPortalURL();
 
+		if (isSet(commentId)) {
+			var api = "comments/${commentId}/comments";
+		}
+		else {
+			var api = "blog-postings/${blogPostingId}/comments";
+		}
+
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/blog-postings/${blogPostingId}/comments \
+			${portalURL}/o/headless-delivery/v1.0/${api} \
 			-u test@liferay.com:test \
 			-H Content-Type: application/json
 		''';
@@ -89,15 +63,22 @@ definition {
 	}
 
 	macro _curlBlogPostingCommentsByExternalReferenceCode {
-		Variables.assertDefined(parameterList = "${blogPostingErc},${blogPostingCommentErc}");
+		Variables.assertDefined(parameterList = "${blogPostingCommentErc}");
 
 		var portalURL = JSONCompany.getPortalURL();
 		var siteId = JSONGroupAPI._getGroupIdByName(
 			groupName = "Guest",
 			site = "true");
 
+		if (isSet(blogPostingChildCommentErc)) {
+			var api = "comments/by-external-reference-code/${blogPostingCommentErc}/comments/by-external-reference-code/${blogPostingChildCommentErc}";
+		}
+		else {
+			var api = "blog-postings/by-external-reference-code/${blogPostingErc}/comments/by-external-reference-code/${blogPostingCommentErc}";
+		}
+
 		var curl = '''
-			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/blog-postings/by-external-reference-code/${blogPostingErc}/comments/by-external-reference-code/${blogPostingCommentErc} \
+			${portalURL}/o/headless-delivery/v1.0/sites/${siteId}/${api} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
@@ -121,7 +102,7 @@ definition {
 		}
 
 		if (isSet(commentId)) {
-			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
+			var curl = CommentAPI._curlBlogPostingComments(commentId = "${commentId}");
 		}
 
 		var body = '''
@@ -142,35 +123,23 @@ definition {
 	macro getFieldValueOfBlogPostingComments {
 		Variables.assertDefined(parameterList = "${fieldName}");
 
-		if (!(isSet(responseToParse)) && isSet(blogPostingId)) {
-			var curl = CommentAPI._curlBlogPostingComments(blogPostingId = "${blogPostingId}");
+		if (!(isSet(responseToParse))) {
+			if (isSet(blogPostingCommentErc)) {
+				var curl = CommentAPI._curlBlogPostingCommentsByExternalReferenceCode(
+					blogPostingChildCommentErc = "${blogPostingChildCommentErc}",
+					blogPostingCommentErc = "${blogPostingCommentErc}",
+					blogPostingErc = "${blogPostingErc}");
+			}
+			else {
+				var curl = CommentAPI._curlBlogPostingComments(
+					blogPostingId = "${blogPostingId}",
+					commentId = "${commentId}");
+			}
 
-			var response = JSONCurlUtil.get("${curl}");
+			var responseToParse = JSONCurlUtil.get("${curl}");
 		}
 
-		if (isSet(commentId)) {
-			var curl = CommentAPI._curlBlogPostingChildComments(commentId = "${commentId}");
-
-			var response = JSONCurlUtil.get("${curl}");
-		}
-
-		if (isSet(blogPostingErc) && isSet(blogPostingCommentErc)) {
-			var curl = CommentAPI._curlBlogPostingCommentsByExternalReferenceCode(
-				blogPostingCommentErc = "${blogPostingCommentErc}",
-				blogPostingErc = "${blogPostingErc}");
-
-			var response = JSONCurlUtil.get("${curl}");
-		}
-
-		if (isSet(blogPostingChildCommentErc) && isSet(blogPostingCommentErc)) {
-			var curl = CommentAPI._curlBlogPostingChildCommentsByExternalReferenceCode(
-				blogPostingChildCommentErc = "${blogPostingChildCommentErc}",
-				blogPostingCommentErc = "${blogPostingCommentErc}");
-
-			var response = JSONCurlUtil.get("${curl}");
-		}
-
-		var fieldValue = JSONUtil.getWithJSONPath("${response}", "$..${fieldName}");
+		var fieldValue = JSONUtil.getWithJSONPath("${responseToParse}", "$..${fieldName}");
 
 		return "${fieldValue}";
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -126,4 +126,80 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateCommentWithoutCustomExternalReferenceCodePreviouslyCreated {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment without a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne");
+		}
+
+		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var response2 = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentTwo",
+				externalReferenceCode = "${commentId}");
+		}
+
+		task ("Then another comment with the same external reference code is being created") {
+			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingId = "${blogPostingId}",
+				fieldName = "totalCount");
+
+			TestUtils.assertEquals(
+				actual = "${commentsTotalCount}",
+				expected = "2");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateChildCommentWithCustomExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("When create a child comment with a custom external reference code") {
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var response2 = CommentAPI.createCommentInBlogPosting(
+				commentId = "${commentId}",
+				commentText = "ChildComment",
+				externalReferenceCode = "ERC_ChildComment");
+		}
+
+		task ("Then a child comment is being created") {
+			var childCommentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
+				commentId = "${commentId}",
+				fieldName = "totalCount");
+
+			TestUtils.assertEquals(
+				actual = "${childCommentsTotalCount}",
+				expected = "1");
+		}
+
+		task ("And Then can see the custom external reference code in the body response") {
+			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
+				commentId = "${commentId}",
+				fieldName = "externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = "${externalReferenceCodes}",
+				expected = "ERC_ChildComment");
+		}
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -17,6 +17,7 @@ definition {
 
 	tearDown {
 		BlogPostingAPI.deleteAllBlogPostings();
+		echo("ok");
 	}
 
 	@disable-webdriver = "true"
@@ -203,4 +204,107 @@ definition {
 		}
 	}
 
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanGetCommentByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("When I make a GET request by external reference code") {
+			task("Get Blog Posting ID"){
+				var getBlogPostings = BlogPostingAPI.getBlogPostings();
+
+				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
+			}
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingERC = "${blogPostingERC}",
+				blogPostingCommentERC = "ercComment",
+				fieldName = "text");
+		}
+
+		task ("Then I receive a correct body response") {
+			TestUtils.assertEquals(
+				actual = "${commentText}",
+				expected = "<p>CommentOne</p>");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanGetCommentByExternalReferenceCodeWithCommentID {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a comment without a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne");
+		}
+
+		task ("When I make a GET request by external reference code using comment ID as external reference code") {
+			task("Get Blog Posting ID"){
+				var getBlogPostings = BlogPostingAPI.getBlogPostings();
+
+				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
+			}
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingERC = "${blogPostingERC}",
+				blogPostingCommentERC = "${commentId}",
+				fieldName = "status");
+		}
+
+		task ("Then I receive an error about GET request by external reference code using comment ID as external reference code") {
+			TestUtils.assertPartialEquals(
+				actual = "${commentText}",
+				expected = "NOT_FOUND");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanGetChildCommentByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("When create a child comment with a custom external reference code") {
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var response2 = CommentAPI.createCommentInBlogPosting(
+				commentId = "${commentId}",
+				commentText = "ChildComment",
+				externalReferenceCode = "ERC_ChildComment");
+		}
+		
+		task ("When I make a GET request by external reference code of the child comment") {
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingChildCommentERC = "ERC_ChildComment",
+				blogPostingCommentERC = "ercComment",
+				fieldName = "text");
+		}
+
+		task ("Then I receive a correct body response") {
+			TestUtils.assertEquals(
+				actual = "${commentText}",
+				expected = "<p>ChildComment</p>");
+		}
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -221,8 +221,8 @@ definition {
 				var blogPostingId = BlogPostingAPI.getBlogPostings();
 
 				var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
-					response = "${blogPostingId}",
-					fieldName = "externalReferenceCode");
+					fieldName = "externalReferenceCode",
+					response = "${blogPostingId}");
 			}
 
 			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
@@ -256,8 +256,8 @@ definition {
 				var getBlogPostings = BlogPostingAPI.getBlogPostings();
 
 				var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
-				response = "${getBlogPostings}",
-				fieldName = "externalReferenceCode");
+					fieldName = "externalReferenceCode",
+					response = "${getBlogPostings}");
 			}
 
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -17,6 +17,7 @@ definition {
 
 	tearDown {
 		BlogPostingAPI.deleteAllBlogPostings();
+
 		echo("ok");
 	}
 
@@ -168,6 +169,112 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = "4"
+	test CanGetChildCommentByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("When create a child comment with a custom external reference code") {
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var response2 = CommentAPI.createCommentInBlogPosting(
+				commentId = "${commentId}",
+				commentText = "ChildComment",
+				externalReferenceCode = "ERC_ChildComment");
+		}
+
+		task ("When I make a GET request by external reference code of the child comment") {
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingChildCommentERC = "ERC_ChildComment",
+				blogPostingCommentERC = "ercComment",
+				fieldName = "text");
+		}
+
+		task ("Then I receive a correct body response") {
+			TestUtils.assertEquals(
+				actual = "${commentText}",
+				expected = "<p>ChildComment</p>");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanGetCommentByExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("When I make a GET request by external reference code") {
+			task ("Get Blog Posting ID") {
+				var getBlogPostings = BlogPostingAPI.getBlogPostings();
+
+				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
+			}
+
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingCommentERC = "ercComment",
+				blogPostingERC = "${blogPostingERC}",
+				fieldName = "text");
+		}
+
+		task ("Then I receive a correct body response") {
+			TestUtils.assertEquals(
+				actual = "${commentText}",
+				expected = "<p>CommentOne</p>");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanGetCommentByExternalReferenceCodeWithCommentID {
+		property portal.acceptance = "true";
+
+		task ("When with POST request I create a comment without a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne");
+		}
+
+		task ("When I make a GET request by external reference code using comment ID as external reference code") {
+			task ("Get Blog Posting ID") {
+				var getBlogPostings = BlogPostingAPI.getBlogPostings();
+
+				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
+			}
+
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingCommentERC = "${commentId}",
+				blogPostingERC = "${blogPostingERC}",
+				fieldName = "status");
+		}
+
+		task ("Then I receive an error about GET request by external reference code using comment ID as external reference code") {
+			TestUtils.assertPartialEquals(
+				actual = "${commentText}",
+				expected = "NOT_FOUND");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
 	test CannotCreateTwoCommentsWithCustomExternalReferenceCode {
 		property portal.acceptance = "true";
 
@@ -204,107 +311,4 @@ definition {
 		}
 	}
 
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CanGetCommentByExternalReferenceCode {
-		property portal.acceptance = "true";
-
-		task ("When with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne",
-				externalReferenceCode = "ercComment");
-		}
-
-		task ("When I make a GET request by external reference code") {
-			task("Get Blog Posting ID"){
-				var getBlogPostings = BlogPostingAPI.getBlogPostings();
-
-				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
-			}
-			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingERC = "${blogPostingERC}",
-				blogPostingCommentERC = "ercComment",
-				fieldName = "text");
-		}
-
-		task ("Then I receive a correct body response") {
-			TestUtils.assertEquals(
-				actual = "${commentText}",
-				expected = "<p>CommentOne</p>");
-		}
-	}
-
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CanGetCommentByExternalReferenceCodeWithCommentID {
-		property portal.acceptance = "true";
-
-		task ("When with POST request I create a comment without a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne");
-		}
-
-		task ("When I make a GET request by external reference code using comment ID as external reference code") {
-			task("Get Blog Posting ID"){
-				var getBlogPostings = BlogPostingAPI.getBlogPostings();
-
-				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
-			}
-			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
-
-			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingERC = "${blogPostingERC}",
-				blogPostingCommentERC = "${commentId}",
-				fieldName = "status");
-		}
-
-		task ("Then I receive an error about GET request by external reference code using comment ID as external reference code") {
-			TestUtils.assertPartialEquals(
-				actual = "${commentText}",
-				expected = "NOT_FOUND");
-		}
-	}
-
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CanGetChildCommentByExternalReferenceCode {
-		property portal.acceptance = "true";
-
-		task ("And Given with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne",
-				externalReferenceCode = "ercComment");
-		}
-
-		task ("When create a child comment with a custom external reference code") {
-			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
-
-			var response2 = CommentAPI.createCommentInBlogPosting(
-				commentId = "${commentId}",
-				commentText = "ChildComment",
-				externalReferenceCode = "ERC_ChildComment");
-		}
-		
-		task ("When I make a GET request by external reference code of the child comment") {
-			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingChildCommentERC = "ERC_ChildComment",
-				blogPostingCommentERC = "ercComment",
-				fieldName = "text");
-		}
-
-		task ("Then I receive a correct body response") {
-			TestUtils.assertEquals(
-				actual = "${commentText}",
-				expected = "<p>ChildComment</p>");
-		}
-	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -21,6 +21,50 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = "4"
+	test CanCreateChildCommentWithCustomExternalReferenceCode {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment with a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne",
+				externalReferenceCode = "ercComment");
+		}
+
+		task ("When create a child comment with a custom external reference code") {
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var response2 = CommentAPI.createCommentInBlogPosting(
+				commentId = "${commentId}",
+				commentText = "ChildComment",
+				externalReferenceCode = "ERC_ChildComment");
+		}
+
+		task ("Then a child comment is being created") {
+			var childCommentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
+				commentId = "${commentId}",
+				fieldName = "totalCount");
+
+			TestUtils.assertEquals(
+				actual = "${childCommentsTotalCount}",
+				expected = "1");
+		}
+
+		task ("And Then can see the custom external reference code in the body response") {
+			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
+				commentId = "${commentId}",
+				fieldName = "externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = "${externalReferenceCodes}",
+				expected = "ERC_ChildComment");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
 	test CanCreateCommentWithCustomExternalReferenceCode {
 		property portal.acceptance = "true";
 
@@ -41,6 +85,39 @@ definition {
 			TestUtils.assertEquals(
 				actual = "${commentErc}",
 				expected = "ercComment");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateCommentWithoutCustomExternalReferenceCodePreviouslyCreated {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment without a custom external reference code") {
+			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
+
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentOne");
+		}
+
+		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+			var response2 = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${blogPostingId}",
+				commentText = "CommentTwo",
+				externalReferenceCode = "${commentId}");
+		}
+
+		task ("Then another comment with the same external reference code is being created") {
+			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingId = "${blogPostingId}",
+				fieldName = "totalCount");
+
+			TestUtils.assertEquals(
+				actual = "${commentsTotalCount}",
+				expected = "2");
 		}
 	}
 
@@ -126,80 +203,4 @@ definition {
 		}
 	}
 
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CanCreateCommentWithoutCustomExternalReferenceCodePreviouslyCreated {
-		property portal.acceptance = "true";
-
-		task ("And Given with POST request I create a comment without a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne");
-		}
-
-		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
-			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
-
-			var response2 = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentTwo",
-				externalReferenceCode = "${commentId}");
-		}
-
-		task ("Then another comment with the same external reference code is being created") {
-			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
-				fieldName = "totalCount");
-
-			TestUtils.assertEquals(
-				actual = "${commentsTotalCount}",
-				expected = "2");
-		}
-	}
-
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CanCreateChildCommentWithCustomExternalReferenceCode {
-		property portal.acceptance = "true";
-
-		task ("And Given with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne",
-				externalReferenceCode = "ercComment");
-		}
-
-		task ("When create a child comment with a custom external reference code") {
-			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
-
-			var response2 = CommentAPI.createCommentInBlogPosting(
-				commentId = "${commentId}",
-				commentText = "ChildComment",
-				externalReferenceCode = "ERC_ChildComment");
-		}
-
-		task ("Then a child comment is being created") {
-			var childCommentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
-				commentId = "${commentId}",
-				fieldName = "totalCount");
-
-			TestUtils.assertEquals(
-				actual = "${childCommentsTotalCount}",
-				expected = "1");
-		}
-
-		task ("And Then can see the custom external reference code in the body response") {
-			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
-				commentId = "${commentId}",
-				fieldName = "externalReferenceCode");
-
-			TestUtils.assertEquals(
-				actual = "${externalReferenceCodes}",
-				expected = "ERC_ChildComment");
-		}
-	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -17,8 +17,6 @@ definition {
 
 	tearDown {
 		BlogPostingAPI.deleteAllBlogPostings();
-
-		echo("ok");
 	}
 
 	@disable-webdriver = "true"
@@ -38,7 +36,7 @@ definition {
 		task ("When create a child comment with a custom external reference code") {
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
-			var response2 = CommentAPI.createCommentInBlogPosting(
+			CommentAPI.createCommentInBlogPosting(
 				commentId = "${commentId}",
 				commentText = "ChildComment",
 				externalReferenceCode = "ERC_ChildComment");
@@ -106,13 +104,13 @@ definition {
 		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
-			var response2 = CommentAPI.createCommentInBlogPosting(
+			CommentAPI.createCommentInBlogPosting(
 				blogPostingId = "${blogPostingId}",
 				commentText = "CommentTwo",
 				externalReferenceCode = "${commentId}");
 		}
 
-		task ("Then another comment with the same external reference code is being created") {
+		task ("Then a new comment is created") {
 			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
 				blogPostingId = "${blogPostingId}",
 				fieldName = "totalCount");
@@ -192,8 +190,8 @@ definition {
 
 		task ("When I make a GET request by external reference code of the child comment") {
 			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingChildCommentERC = "ERC_ChildComment",
-				blogPostingCommentERC = "ercComment",
+				blogPostingChildCommentErc = "ERC_ChildComment",
+				blogPostingCommentErc = "ercComment",
 				fieldName = "text");
 		}
 
@@ -220,14 +218,16 @@ definition {
 
 		task ("When I make a GET request by external reference code") {
 			task ("Get Blog Posting ID") {
-				var getBlogPostings = BlogPostingAPI.getBlogPostings();
+				var blogPostingId = BlogPostingAPI.getBlogPostings();
 
-				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
+				var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
+					response = "${blogPostingId}",
+					fieldName = "externalReferenceCode");
 			}
 
 			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingCommentERC = "ercComment",
-				blogPostingERC = "${blogPostingERC}",
+				blogPostingCommentErc = "ercComment",
+				blogPostingErc = "${blogPostingErc}",
 				fieldName = "text");
 		}
 
@@ -255,14 +255,16 @@ definition {
 			task ("Get Blog Posting ID") {
 				var getBlogPostings = BlogPostingAPI.getBlogPostings();
 
-				var blogPostingERC = JSONUtil.getWithJSONPath("${getBlogPostings}", "$..externalReferenceCode");
+				var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
+				response = "${getBlogPostings}",
+				fieldName = "externalReferenceCode");
 			}
 
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
 			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingCommentERC = "${commentId}",
-				blogPostingERC = "${blogPostingERC}",
+				blogPostingCommentErc = "${commentId}",
+				blogPostingErc = "${blogPostingErc}",
 				fieldName = "status");
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeErcFromAssetLibraryForComments.testcase
@@ -9,7 +9,7 @@ definition {
 		TestCase.setUpPortalInstanceNoSelenium();
 
 		task ("Given a blog post is created") {
-			BlogPostingAPI.getIdOfCreatedBlogPosting(
+			BlogPostingAPI.setUpGlobalIdOfCreatedBlogPosting(
 				articleBody = "Blogs Entry Content",
 				headline = "Blogs Title");
 		}
@@ -25,10 +25,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
 			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
@@ -36,13 +34,21 @@ definition {
 		task ("When create a child comment with a custom external reference code") {
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
-			CommentAPI.createCommentInBlogPosting(
+			var response = CommentAPI.createCommentInBlogPosting(
 				commentId = "${commentId}",
 				commentText = "ChildComment",
 				externalReferenceCode = "ERC_ChildComment");
 		}
 
-		task ("Then a child comment is being created") {
+		task ("Then can see the custom external reference code in the body response") {
+			var externalReferenceCode = JSONUtil.getWithJSONPath("${response}", "$.externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = "${externalReferenceCode}",
+				expected = "ERC_ChildComment");
+		}
+
+		task ("And Then a child comment is being created") {
 			var childCommentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
 				commentId = "${commentId}",
 				fieldName = "totalCount");
@@ -50,16 +56,6 @@ definition {
 			TestUtils.assertEquals(
 				actual = "${childCommentsTotalCount}",
 				expected = "1");
-		}
-
-		task ("And Then can see the custom external reference code in the body response") {
-			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
-				commentId = "${commentId}",
-				fieldName = "externalReferenceCode");
-
-			TestUtils.assertEquals(
-				actual = "${externalReferenceCodes}",
-				expected = "ERC_ChildComment");
 		}
 	}
 
@@ -69,17 +65,15 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("When with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
 			CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
 
 		task ("Then I can see the custom external reference code in the body response") {
 			var commentErc = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				fieldName = "externalReferenceCode");
 
 			TestUtils.assertEquals(
@@ -94,10 +88,8 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given with POST request I create a comment without a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
 			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne");
 		}
 
@@ -105,14 +97,14 @@ definition {
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
 			CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentTwo",
 				externalReferenceCode = "${commentId}");
 		}
 
 		task ("Then a new comment is created") {
 			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				fieldName = "totalCount");
 
 			TestUtils.assertEquals(
@@ -127,41 +119,37 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
 			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
 
 		task ("When with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment") {
-			var idComment = JSONUtil.getWithJSONPath("${response}", "$.id");
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
-			var response2 = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentTwo",
-				externalReferenceCode = "${idComment}");
+				externalReferenceCode = "${commentId}");
 		}
 
-		task ("Then another comment with the same external reference code is being created") {
+		task ("Then can see the custom external reference code in the body response") {
+			var externalReferenceCode = JSONUtil.getWithJSONPath("${response}", "$.externalReferenceCode");
+
+			TestUtils.assertEquals(
+				actual = "${externalReferenceCode}",
+				expected = "${commentId}");
+		}
+
+		task ("And Then another comment with different external reference codes is being created") {
 			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				fieldName = "totalCount");
 
 			TestUtils.assertEquals(
 				actual = "${commentsTotalCount}",
 				expected = "2");
-		}
-
-		task ("And Then can see the custom external reference code in the body response") {
-			var externalReferenceCodes = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
-				fieldName = "externalReferenceCode");
-
-			TestUtils.assertEquals(
-				actual = "${externalReferenceCodes}",
-				expected = "ercComment,${idComment}");
 		}
 	}
 
@@ -171,18 +159,16 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("And Given with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
 			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
 
-		task ("When create a child comment with a custom external reference code") {
+		task ("And Given create a child comment with a custom external reference code") {
 			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
 
-			var response2 = CommentAPI.createCommentInBlogPosting(
+			CommentAPI.createCommentInBlogPosting(
 				commentId = "${commentId}",
 				commentText = "ChildComment",
 				externalReferenceCode = "ERC_ChildComment");
@@ -207,23 +193,19 @@ definition {
 	test CanGetCommentByExternalReferenceCode {
 		property portal.acceptance = "true";
 
-		task ("When with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
+		task ("And Given with POST request I create a comment with a custom external reference code") {
 			CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
 
 		task ("When I make a GET request by external reference code") {
-			task ("Get Blog Posting ID") {
-				var blogPostingId = BlogPostingAPI.getBlogPostings();
+			var response = BlogPostingAPI.getBlogPostings();
 
-				var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
-					fieldName = "externalReferenceCode",
-					response = "${blogPostingId}");
-			}
+			var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
+				fieldName = "externalReferenceCode",
+				responseToParse = "${response}");
 
 			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
 				blogPostingCommentErc = "ercComment",
@@ -240,63 +222,24 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = "4"
-	test CanGetCommentByExternalReferenceCodeWithCommentID {
+	test CannotCreateTwoCommentsWithSameCustomExternalReferenceCode {
 		property portal.acceptance = "true";
 
-		task ("When with POST request I create a comment without a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
-			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
-				commentText = "CommentOne");
-		}
-
-		task ("When I make a GET request by external reference code using comment ID as external reference code") {
-			task ("Get Blog Posting ID") {
-				var getBlogPostings = BlogPostingAPI.getBlogPostings();
-
-				var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
-					fieldName = "externalReferenceCode",
-					response = "${getBlogPostings}");
-			}
-
-			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
-
-			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingCommentErc = "${commentId}",
-				blogPostingErc = "${blogPostingErc}",
-				fieldName = "status");
-		}
-
-		task ("Then I receive an error about GET request by external reference code using comment ID as external reference code") {
-			TestUtils.assertPartialEquals(
-				actual = "${commentText}",
-				expected = "NOT_FOUND");
-		}
-	}
-
-	@disable-webdriver = "true"
-	@priority = "4"
-	test CannotCreateTwoCommentsWithCustomExternalReferenceCode {
-		property portal.acceptance = "true";
-
-		task ("When with POST request I create a comment with a custom external reference code") {
-			var blogPostingId = BlogPostingAPI.getBlogPostingsIdList();
-
+		task ("And Given with POST request I create a comment with a custom external reference code") {
 			CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentOne",
 				externalReferenceCode = "ercComment");
 		}
 
 		task ("When with POST request I create a comment with an already existing custom external reference code") {
 			var response = CommentAPI.createCommentInBlogPosting(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				commentText = "CommentTwo",
 				externalReferenceCode = "ercComment");
 		}
 
-		task ("Then I receive an error code response about duplicate folder erc") {
+		task ("Then I receive an error code response about duplicate erc") {
 			TestUtils.assertPartialEquals(
 				actual = "${response}",
 				expected = "Duplicate message external reference code");
@@ -304,12 +247,53 @@ definition {
 
 		task ("And Then another comment with the same external reference code is not being created") {
 			var commentsTotalCount = CommentAPI.getFieldValueOfBlogPostingComments(
-				blogPostingId = "${blogPostingId}",
+				blogPostingId = "${staticBlogPostingId}",
 				fieldName = "totalCount");
 
 			TestUtils.assertEquals(
 				actual = "${commentsTotalCount}",
 				expected = "1");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CannotGetCommentByExternalReferenceCodeWithCommentID {
+		property portal.acceptance = "true";
+
+		task ("And Given with POST request I create a comment without a custom external reference code") {
+			var response = CommentAPI.createCommentInBlogPosting(
+				blogPostingId = "${staticBlogPostingId}",
+				commentText = "CommentOne");
+		}
+
+		task ("When I make a GET request by external reference code using comment ID as external reference code") {
+			var repsonse = BlogPostingAPI.getBlogPostings();
+
+			var blogPostingErc = CommentAPI.getFieldValueOfBlogPostingComments(
+				fieldName = "externalReferenceCode",
+				responseToParse = "${repsonse}");
+			var commentId = JSONUtil.getWithJSONPath("${response}", "$.id");
+		}
+
+		task ("Then I receive an error about GET request by external reference code using comment ID as external reference code") {
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingCommentErc = "${commentId}",
+				blogPostingErc = "${blogPostingErc}",
+				fieldName = "status");
+
+			TestUtils.assertPartialEquals(
+				actual = "${commentText}",
+				expected = "NOT_FOUND");
+
+			var commentText = CommentAPI.getFieldValueOfBlogPostingComments(
+				blogPostingCommentErc = "${commentId}",
+				blogPostingErc = "${blogPostingErc}",
+				fieldName = "title");
+
+			TestUtils.assertPartialEquals(
+				actual = "${commentText}",
+				expected = "No MBMessage exists with the key");
 		}
 	}
 


### PR DESCRIPTION
Background:
Creates automated tests about comments and child comments in blog posting

Test Plan:
1. [ ExposeErcFromAssetLibraryForBlog#CanCreateChildCommentWithCustomExternalReferenceCode](https://issues.liferay.com/browse/LPS-158488)
**Given** blog post is created
**And Given** comment with a custom external reference code is created with a POST request
**When** I create a child comment with a custom external reference code
**Then** a child comment is being created
**And Then** I can see the custom external reference code in the body response

2. [ExposeErcFromAssetLibraryForBlog#CanCreateCommentWithoutCustomExternalReferenceCodePreviouslyCreated](https://issues.liferay.com/browse/LPS-158487)
**Given** blog post is created
**And Given** comment with no custom external reference code is created
**When** with POST request I create a comment with a custom external reference code with a value of the internal id of the previously created comment
**Then** a new comment is created

3. [ ExposeErcFromAssetLibraryForBlog#CanGetCommentByExternalReferenceCode](https://issues.liferay.com/browse/LPS-158492)
**Given** blog post is created
**And Given** comment with a custom external reference code is created with a POST request
**When** I make a GET request by external reference code
**Then** I receive a correct body response

4. [ExposeErcFromAssetLibraryForBlog#CanGetCommentByExternalReferenceCodeWithCommentID](https://issues.liferay.com/browse/LPS-161547)
**Given** blog post is created
**And Given** comment is created with no external reference code set
**When** I make a GET request by external reference code using comment ID as external reference code
**Then** I receive a correct body response

5. [ExposeErcFromAssetLibraryForBlog#CanGetChildCommentByExternalReferenceCode](https://issues.liferay.com/browse/LPS-161548)
**Given** blog post is created
**And Given** comment with a custom external reference code is created with a POST request
**And Given** a child comment with a custom external reference code is created with a POST request
**When** I make a GET request by external reference code of the child comment
**Then** I receive a correct body response