### PR TITLE
LPS-161440 Stabilize frontend test suite

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteAppsUpgrade.testcase
@@ -3,9 +3,6 @@ definition {
 
 	property app.server.types = "jboss,tcserver,tomcat,weblogic,websphere,wildfly";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver,sybase";
-	property portal.acceptance = "true";
-	property portal.release = "true";
-	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "true";
 	property testray.component.names = "Remote Apps";
 	property testray.main.component.name = "Upgrades Remote Apps";
@@ -59,6 +56,9 @@ definition {
 	@priority = "5"
 	test CanViewRemoteAppFieldsAfterUpgrade73101 {
 		property data.archive.type = "data-archive-remote-app";
+		property portal.acceptance = "false";
+		property portal.release = "false";
+		property portal.upstream = "quarantine";
 		property portal.version = "7.3.10.1";
 		property test.run.environment = "EE";
 

--- a/test.properties
+++ b/test.properties
@@ -4134,24 +4134,23 @@
         modules-unit-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend]=\
-        (portal.upstream == true) AND \
         (\
-            (testray.component.names ~ "Cadmin") OR \
-            (testray.component.names ~ "Frontend Dataset") OR \
-            (testray.component.names ~ "Remote Apps") OR \
-            (testray.component.names ~ "Theme") OR \
-            (testray.component.names ~ "Translation Manager") OR \
-            (testray.component.names ~ "WYSIWYG") OR \
-            (testray.component.names ~ "Walkthrough") OR \
+            (portal.acceptance != quarantine) AND \
+            (portal.upstream != quarantine)\
+        ) AND \
+        (\
             (testray.main.component.name ~ "AMD Loader") OR \
             (testray.main.component.name ~ "Headless Frontend Infrastructure") OR \
             (testray.main.component.name ~ "Remote Apps") OR \
             (testray.main.component.name ~ "Theme") OR \
-            (testray.main.component.name ~ "Upgrades Remote Apps") OR \
             (testray.main.component.name ~ "User Interface")\
         )
 
     test.batch.run.property.query[functional-upgrade-*][frontend]=\
+        (\
+            (portal.acceptance != quarantine) AND \
+            (portal.upstream != quarantine)\
+        ) AND \
         (testray.main.component.name == "Upgrades Remote Apps")
 
     #


### PR DESCRIPTION
**Description**
Only run stable FI tests in frontend test suite since we've been seeing too many false positives.

**Test Plan**
- [x] non-quarantined tests owned only by FI team are run in `ci:test:frontend`

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-161440