### PR TITLE
master Lps 161558 | | Add tests for allow developers to set properties added to system objects through the APIs

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadminuser/UserAccountAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadminuser/UserAccountAPI.macro
@@ -1,0 +1,60 @@
+definition {
+
+	macro _curlUserAccount {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(userAccountId)) {
+			var api = "user-accounts/${userAccountId}";
+		}
+		else {
+			var api = "user-accounts";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/${api} \
+			-H accept: application/json \
+			-H Content-Type: application/json \
+			-u test@liferay.com:test \
+		''';
+
+		return "${curl}";
+	}
+
+	macro createUserAccount {
+		Variables.assertDefined(parameterList = "${alternateName},${emailAddress},${familyName},${givenName}");
+
+		var curl = UserAccountAPI._curlUserAccount();
+		var body = '''"alternateName": "${alternateName}","emailAddress": "${emailAddress}","familyName": "${familyName}","givenName": "${givenName}"''';
+
+		if (isSet(fieldName) && isSet(fieldValue)) {
+			var body = StringUtil.add("${body},", "\"${fieldName}\":\"${fieldValue}\"", "");
+		}
+
+		var curl = StringUtil.add("${curl}", "-d {${body}}", " ");
+
+		var response = JSONCurlUtil.post("${curl}");
+
+		return "${response}";
+	}
+
+	macro deleteUserAccount {
+		var curl = UserAccountAPI._curlUserAccount(userAccountId = "${staticUserAccountId}");
+
+		JSONCurlUtil.delete("${curl}");
+	}
+
+	macro setUpGlobalUserAccountId {
+		var response = UserAccountAPI.createUserAccount(
+			alternateName = "${alternateName}",
+			emailAddress = "${emailAddress}",
+			familyName = "${familyName}",
+			fieldName = "${fieldName}",
+			fieldValue = "${fieldValue}",
+			givenName = "${givenName}");
+
+		static var staticUserAccountId = JSONUtil.getWithJSONPath("${response}", "$.id");
+
+		return "${response}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadminuser/UserAccountAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadminuser/UserAccountAPI.macro
@@ -43,6 +43,23 @@ definition {
 		JSONCurlUtil.delete("${curl}");
 	}
 
+	macro getUpdatedFieldOfUserAccountWithPatchRequest {
+		Variables.assertDefined(parameterList = "${fieldName},${updatedFieldValue}");
+
+		if (!(isSet(userAccountId))) {
+			var userAccountId = "${staticUserAccountId}";
+		}
+
+		var curl = UserAccountAPI._curlUserAccount(userAccountId = "${userAccountId}");
+		var body = '''-d {"${fieldName}":"${updatedFieldValue}"}''';
+
+		var curl = StringUtil.add("${curl}", "${body}", "");
+
+		var valueOfField = JSONCurlUtil.patch("${curl}", "$.${fieldName}");
+
+		return "${valueOfField}";
+	}
+
 	macro getUpdatedFieldOfUserAccountWithPutRequest {
 		Variables.assertDefined(parameterList = "${alternateName},${emailAddress},${familyName},${givenName},${fieldName},${updatedFieldValue}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadminuser/UserAccountAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadminuser/UserAccountAPI.macro
@@ -43,6 +43,31 @@ definition {
 		JSONCurlUtil.delete("${curl}");
 	}
 
+	macro getUpdatedFieldOfUserAccountWithPutRequest {
+		Variables.assertDefined(parameterList = "${alternateName},${emailAddress},${familyName},${givenName},${fieldName},${updatedFieldValue}");
+
+		if (!(isSet(userAccountId))) {
+			var userAccountId = "${staticUserAccountId}";
+		}
+
+		var curl = UserAccountAPI._curlUserAccount(userAccountId = "${userAccountId}");
+		var body = '''
+			-d {
+				"alternateName": "${alternateName}",
+				"emailAddress": "${emailAddress}",
+				"familyName": "${familyName}",
+				"givenName": "${givenName}",
+				"${fieldName}":"${updatedFieldValue}"
+			}
+		''';
+
+		var curl = StringUtil.add("${curl}", "${body}", "");
+
+		var valueOfField = JSONCurlUtil.put("${curl}", "$.${fieldName}");
+
+		return "${valueOfField}";
+	}
+
 	macro setUpGlobalUserAccountId {
 		var response = UserAccountAPI.createUserAccount(
 			alternateName = "${alternateName}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectDefinitionAPI.macro
@@ -632,6 +632,22 @@ definition {
 		ObjectDefinitionAPI._deleteRelationship(relationshipId = "${relationshipId}");
 	}
 
+	macro getObjectDefinitionIdByName {
+		Variables.assertDefined(parameterList = "${name}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/object-definitions?filter=name%20eq%20%27${name}%27 \
+			-H Content-Type: application/json \
+			-u test@liferay.com:test
+		''';
+
+		var objectDefinitionId = JSONCurlUtil.get("${curl}", "$.items[?(@['name'] == '${name}')]['id']");
+
+		return "${objectDefinitionId}";
+	}
+
 	macro getObjectEntryRelation {
 		var getObjectEntryRelation = ObjectDefinitionAPI._getObjectEntryRelation(
 			en_US_plural_label = "${en_US_plural_label}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectFieldAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectFieldAPI.macro
@@ -26,7 +26,7 @@ definition {
 		JSONCurlUtil.delete("${curl}");
 	}
 
-	macro getIdOfcreatedObjectField {
+	macro getIdOfCreatedObjectField {
 		Variables.assertDefined(parameterList = "${objectDefinitionId},${dbType},${name}");
 
 		var curl = ObjectFieldAPI._curlObjectField(objectDefinitionId = "${objectDefinitionId}");
@@ -55,7 +55,7 @@ definition {
 	}
 
 	macro setUpGlobalObjectFieldId {
-		var objectFieldId = ObjectFieldAPI.getIdOfcreatedObjectField(
+		var objectFieldId = ObjectFieldAPI.getIdOfCreatedObjectField(
 			dbType = "${dbType}",
 			name = "${name}",
 			objectDefinitionId = "${objectDefinitionId}");

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectFieldAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/objects/ObjectFieldAPI.macro
@@ -1,0 +1,68 @@
+definition {
+
+	macro _curlObjectField {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(objectDefinitionId)) {
+			var api = "object-definitions/${objectDefinitionId}/object-fields";
+		}
+		else {
+			var api = "/object-fields/${objectFieldId}";
+		}
+
+		var curl = '''
+			${portalURL}/o/object-admin/v1.0/${api} \
+			-H accept: application/json \
+			-H Content-Type: application/json \
+			-u test@liferay.com:test \
+		''';
+
+		return "${curl}";
+	}
+
+	macro deleteObjectField {
+		var curl = ObjectFieldAPI._curlObjectField(objectFieldId = "${staticObjectFieldId}");
+
+		JSONCurlUtil.delete("${curl}");
+	}
+
+	macro getIdOfcreatedObjectField {
+		Variables.assertDefined(parameterList = "${objectDefinitionId},${dbType},${name}");
+
+		var curl = ObjectFieldAPI._curlObjectField(objectDefinitionId = "${objectDefinitionId}");
+
+		if (!(isSet(label))) {
+			var label = "${name}";
+		}
+
+		var body = '''
+			-d {
+				"DBType": "${dbType}",
+				"indexed": true,
+				"indexedAsKeyword": false,
+				"label":{"en_US":"${label}"},
+				"listTypeDefinitionId": 0,
+				"name": "${name}",
+				"required": false
+			}
+		''';
+
+		var curl = StringUtil.add("${curl}", "${body}", " ");
+
+		var objectFieldId = JSONCurlUtil.post("${curl}", "$.id");
+
+		return "${objectFieldId}";
+	}
+
+	macro setUpGlobalObjectFieldId {
+		var objectFieldId = ObjectFieldAPI.getIdOfcreatedObjectField(
+			dbType = "${dbType}",
+			name = "${name}",
+			objectDefinitionId = "${objectDefinitionId}");
+
+		static var staticObjectFieldId = "${objectFieldId}";
+
+		return "${staticObjectFieldId}";
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExtendPropertiesForSystemObjects.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExtendPropertiesForSystemObjects.testcase
@@ -51,10 +51,38 @@ definition {
 
 	@disable-webdriver = "true"
 	@priority = "4"
+	test CanUpdateValueOfPropertyAddedToSystemObjectWithPatchRequest {
+		property portal.acceptance = "true";
+
+		task ("And Given with post request postUserAccount to create a user with the new field") {
+			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName = "userln",
+				emailAddress = "userln@liferay.com",
+				familyName = "userfn",
+				fieldName = "passportNumber",
+				fieldValue = "passportNum2022",
+				givenName = "usergn");
+		}
+
+		task ("When with PATCH request and existingUserAccountId I update the value of the new field") {
+			var actualValueOfPassportNumber = UserAccountAPI.getUpdatedFieldOfUserAccountWithPatchRequest(
+				fieldName = "passportNumber",
+				updatedFieldValue = "updateByPatch-passportNum2022");
+		}
+
+		task ("Then the value of the added filed is updated successfully") {
+			TestUtils.assertEquals(
+				actual = "${actualValueOfPassportNumber}",
+				expected = "updateByPatch-passportNum2022");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
 	test CanUpdateValueOfPropertyAddedToSystemObjectWithPutRequest {
 		property portal.acceptance = "true";
 
-		task ("Given with post request postUserAccount to create a user with the new field") {
+		task ("And Given with post request postUserAccount to create a user with the new field") {
 			UserAccountAPI.setUpGlobalUserAccountId(
 				alternateName = "userln",
 				emailAddress = "userln@liferay.com",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExtendPropertiesForSystemObjects.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExtendPropertiesForSystemObjects.testcase
@@ -1,0 +1,52 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property custom.properties = "feature.flag.LPS-135404=true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		task ("Given system User object with a new field added through the objects framework") {
+			var userObjectId = ObjectDefinitionAPI.getObjectDefinitionIdByName(name = "User");
+
+			ObjectFieldAPI.setUpGlobalObjectFieldId(
+				dbType = "String",
+				name = "passportNumber",
+				objectDefinitionId = "${userObjectId}");
+		}
+	}
+
+	tearDown {
+		UserAccountAPI.deleteUserAccount();
+
+		ObjectFieldAPI.deleteObjectField();
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanCreateUserAndSetValueOfPropertyAddedtoSystemObject {
+		property portal.acceptance = "true";
+
+		task ("When with post request postUserAccount to create a user with the new field") {
+			var response = UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName = "userln",
+				emailAddress = "userln@liferay.com",
+				familyName = "userfn",
+				fieldName = "passportNumber",
+				fieldValue = "passportNum2022",
+				givenName = "usergn");
+		}
+
+		task ("Then the value of the added field is set successfully in response") {
+			var passportNumberInResponse = JSONUtil.getWithJSONPath("${response}", "$.passportNumber");
+
+			TestUtils.assertEquals(
+				actual = "${passportNumberInResponse}",
+				expected = "passportNum2022");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExtendPropertiesForSystemObjects.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/AdvancedObjectAPI/ExtendPropertiesForSystemObjects.testcase
@@ -41,11 +41,43 @@ definition {
 		}
 
 		task ("Then the value of the added field is set successfully in response") {
-			var passportNumberInResponse = JSONUtil.getWithJSONPath("${response}", "$.passportNumber");
+			var actualValueOfPassportNumber = JSONUtil.getWithJSONPath("${response}", "$.passportNumber");
 
 			TestUtils.assertEquals(
-				actual = "${passportNumberInResponse}",
+				actual = "${actualValueOfPassportNumber}",
 				expected = "passportNum2022");
+		}
+	}
+
+	@disable-webdriver = "true"
+	@priority = "4"
+	test CanUpdateValueOfPropertyAddedToSystemObjectWithPutRequest {
+		property portal.acceptance = "true";
+
+		task ("Given with post request postUserAccount to create a user with the new field") {
+			UserAccountAPI.setUpGlobalUserAccountId(
+				alternateName = "userln",
+				emailAddress = "userln@liferay.com",
+				familyName = "userfn",
+				fieldName = "passportNumber",
+				fieldValue = "passportNum2022",
+				givenName = "usergn");
+		}
+
+		task ("When with PUT request and existingUserAccountId I update the value of the new field") {
+			var actualValueOfPassportNumber = UserAccountAPI.getUpdatedFieldOfUserAccountWithPutRequest(
+				alternateName = "userln",
+				emailAddress = "userln@liferay.com",
+				familyName = "userfn",
+				fieldName = "passportNumber",
+				givenName = "usergn",
+				updatedFieldValue = "updateByPut-passportNum2022");
+		}
+
+		task ("Then the value of the added filed is replaced successfully in response") {
+			TestUtils.assertEquals(
+				actual = "${actualValueOfPassportNumber}",
+				expected = "updateByPut-passportNum2022");
 		}
 	}
 


### PR DESCRIPTION
**Background**
- Add test to create a user with new added field of system user object
- Add test to update new added field of system user object with put request
- Add test to update new added field of system user object with patch request

**Test Plan**
- LPS-161558
Given system User object with a new field added through the objects framework
When with post request postUserAccount to create a user with the new field
Then the value of the added filed is set successfully in response
- LPS-161559
Given system User object with a new field added through the objects framework
When with PUT request and existingUserAccountId I update the value of the new field
Then the value of the added filed is replaced successfully in response
- LPS-161560
Given system User object with a new field added through the objects framework
When with PATCH request and existingUserAccountId I update the value of the new field
Then the value of the added filed is update successfully

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-161558
https://issues.liferay.com/browse/LPS-161559
https://issues.liferay.com/browse/LPS-161560
