### PR TITLE
LPS-161506: Expose Navigation Menu type parameter as resource name

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/NavigationMenuResourceImpl.java
@@ -625,6 +625,21 @@ public class NavigationMenuResourceImpl extends BaseNavigationMenuResourceImpl {
 							"getSiteSitePage", contextUriInfo,
 							arguments.toArray(new Object[0]));
 					});
+
+				setType(
+					() -> {
+						DTOConverter<?, ?> dtoConverter =
+							_dtoConverterRegistry.getDTOConverter(type);
+
+						if (dtoConverter == null) {
+							return type;
+						}
+
+						String typeContent = dtoConverter.getContentType();
+
+						return Character.toLowerCase(typeContent.charAt(0)) +
+							typeContent.substring(1);
+					});
 			}
 		};
 	}


### PR DESCRIPTION
**What is new?**
- Update `type` parameter using resource name in Navigation Manu Item.

**Before PR**

```
"type": "com.liferay.blogs.model.BlogsEntry",
"type": "com.liferay.document.library.kernel.model.DLFileEntry"
"type": "com.liferay.journal.model.JournalArticle"
```
**After PR**

```
"type": "blogPosting",
"type": "document"
"type": "structuredContent"
```
**JIRA Ticket**
https://issues.liferay.com/browse/LPS-157380

cc/ @4lejandrito