### PR TITLE
LPS-161431 Create unit tests for Walkthrough and fix some cases

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/SampleWalkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/SampleWalkthrough.js
@@ -19,8 +19,7 @@ const WALKTHROUGH_CONFIG = {
 	closeOnClickOutside: false,
 	closeable: true,
 	pages: {
-		[themeDisplay.getPathContext() +
-		location.pathname +
+		[themeDisplay.getLayoutRelativeURL() +
 		location.search +
 		location.hash]: ['step-1', 'step-2', 'step-3', 'step-4', 'step-5'],
 	},

--- a/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TestSampleWalkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-components-sample-web/src/main/resources/META-INF/resources/js/TestSampleWalkthrough.js
@@ -19,8 +19,7 @@ const TEST_WALKTHROUGH_CONFIG = {
 	closeOnClickOutside: false,
 	closeable: true,
 	pages: {
-		[themeDisplay.getPathContext() +
-		location.pathname +
+		[themeDisplay.getLayoutRelativeURL() +
 		location.search +
 		location.hash]: ['teststep1', 'teststep2'],
 	},

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/jest-setup.config.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/jest-setup.config.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/* eslint-env jest */
+
+window.themeDisplay = {
+	...window.themeDisplay,
+	getLayoutRelativeURL: jest.fn(() => '/home'),
+	getSiteGroupId: jest.fn(() => 11311),
+	getUserId: jest.fn(() => 42),
+};

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/package.json
@@ -7,7 +7,8 @@
 	"scripts": {
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
-		"format": "liferay-npm-scripts fix"
+		"format": "liferay-npm-scripts fix",
+		"test": "liferay-npm-scripts test"
 	},
 	"version": "1.0.8"
 }

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/package.json
@@ -2,6 +2,11 @@
 	"dependencies": {
 		"dom-align": "1.12.2"
 	},
+	"jest": {
+		"setupFiles": [
+			"<rootDir>/jest-setup.config.js"
+		]
+	},
 	"main": "index.js",
 	"name": "@liferay/frontend-js-walkthrough-web",
 	"scripts": {

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Hotspot.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Hotspot.js
@@ -36,6 +36,7 @@ export const Hotspot = forwardRef(({onHotspotClick, trigger}, ref) => {
 
 	return (
 		<div
+			aria-label={Liferay.Language.get('start-the-walkthrough')}
 			className="lfr-walkthrough-hotspot"
 			onClick={onHotspotClick}
 			ref={ref}

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -434,21 +434,13 @@ const Step = ({
 											onClick={() => {
 												onPrevious(previous);
 
-												if (previous) {
-													if (
-														SITE_PREFIX_PATH === '/'
-													) {
-														return navigate(
-															previous
-														);
-													}
-
-													return navigate(
-														SITE_PREFIX_PATH.concat(
-															previous
-														)
-													);
-												}
+												navigate(
+													SITE_PREFIX_PATH === '/'
+														? previous
+														: SITE_PREFIX_PATH.concat(
+																previous
+														  )
+												);
 											}}
 											small
 										>
@@ -461,19 +453,13 @@ const Step = ({
 											onClick={() => {
 												onNext(next);
 
-												if (next) {
-													if (
-														SITE_PREFIX_PATH === '/'
-													) {
-														return navigate(next);
-													}
-
-													return navigate(
-														SITE_PREFIX_PATH.concat(
-															next
-														)
-													);
-												}
+												navigate(
+													SITE_PREFIX_PATH === '/'
+														? next
+														: SITE_PREFIX_PATH.concat(
+																next
+														  )
+												);
 											}}
 											small
 										>

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -159,10 +159,6 @@ function removeStartingSlash(path) {
  * @returns {String} a string containg the path without the page URL
  */
 function getSitePrefix(currentPage) {
-	if (!currentPage) {
-		return currentPage;
-	}
-
 	const currentDXPLayoutRelativeURL = removeStartingSlash(
 		themeDisplay.getLayoutRelativeURL()
 	).split('/');

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -434,13 +434,15 @@ const Step = ({
 											onClick={() => {
 												onPrevious(previous);
 
-												navigate(
-													SITE_PREFIX_PATH === '/'
-														? previous
-														: SITE_PREFIX_PATH.concat(
-																previous
-														  )
-												);
+												if (previous) {
+													navigate(
+														SITE_PREFIX_PATH === '/'
+															? previous
+															: SITE_PREFIX_PATH.concat(
+																	previous
+															  )
+													);
+												}
 											}}
 											small
 										>
@@ -453,13 +455,15 @@ const Step = ({
 											onClick={() => {
 												onNext(next);
 
-												navigate(
-													SITE_PREFIX_PATH === '/'
-														? next
-														: SITE_PREFIX_PATH.concat(
-																next
-														  )
-												);
+												if (next) {
+													navigate(
+														SITE_PREFIX_PATH === '/'
+															? next
+															: SITE_PREFIX_PATH.concat(
+																	next
+															  )
+													);
+												}
 											}}
 											small
 										>

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -488,10 +488,10 @@ const Step = ({
 
 const Walkthrough = ({
 	closeOnClickOutside,
-	closeable,
-	pages,
-	skippable,
-	steps,
+	closeable = true,
+	pages = {},
+	skippable = true,
+	steps = [],
 }) => {
 	const [
 		currentStepIndex,

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
@@ -20,14 +20,6 @@ import {LOCAL_STORAGE_KEYS} from './localStorageKeys';
 
 const DEFAULT_CONTAINER_ID = 'walkthroughContainer';
 
-const DEFAULT_PROPS = {
-	closeOnClickOutside: false,
-	closeable: true,
-	pages: {},
-	skippable: true,
-	steps: [],
-};
-
 const getDefaultContainer = () => {
 	let container = document.getElementById(DEFAULT_CONTAINER_ID);
 
@@ -42,7 +34,7 @@ const getDefaultContainer = () => {
 
 function Root(props) {
 	if (!localStorage.getItem(LOCAL_STORAGE_KEYS.SKIPPABLE)) {
-		return <Walkthrough {...DEFAULT_PROPS} {...props} />;
+		return <Walkthrough {...props} />;
 	}
 
 	return null;

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/Walkthrough.test.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/Walkthrough.test.js
@@ -1,0 +1,251 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {cleanup, render, screen} from '@testing-library/react';
+import userEvents from '@testing-library/user-event';
+import {navigate} from 'frontend-js-web';
+import React from 'react';
+
+import Walkthrough from '../../src/main/resources/META-INF/resources/Walkthrough';
+import {
+	BOX_SHADOW_ELEMENT_MOCK,
+	DOM_STRUCTURE_FOR_PLACING_STEPS,
+	INVALID_NODE_SELECTOR_MOCK,
+	MULTI_PAGES_MOCK,
+	PAGE_MOCK,
+} from './__fixtures__/walkthroughMock';
+
+function setupDocument() {
+	const domStructureReference = document.createElement('div');
+
+	domStructureReference.innerHTML = DOM_STRUCTURE_FOR_PLACING_STEPS;
+
+	domStructureReference.id = 'test-structure';
+
+	document.body.appendChild(domStructureReference);
+
+	return () => {
+		window.localStorage.clear();
+
+		const nodeToBeRemoved = document.getElementById('test-structure');
+
+		document.body.removeChild(nodeToBeRemoved);
+
+		nodeToBeRemoved.remove();
+	};
+}
+
+function renderWalkthrough(props) {
+	return render(<Walkthrough {...props} />, {
+		baseElement: document.getElementById('app_root'),
+	});
+}
+
+jest.mock('frontend-js-web', () => ({
+	navigate: jest.fn((url) => url),
+}));
+
+const USER_ID = 42;
+
+describe('Walkthrough', () => {
+	window.themeDisplay = {
+		getLayoutRelativeURL: jest.fn(() => '/home'),
+		getUserId: jest.fn(() => USER_ID),
+	};
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	beforeEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	it('renders', () => {
+		const cleanUp = setupDocument();
+
+		const {container} = renderWalkthrough(PAGE_MOCK);
+
+		expect(container).toBeInTheDocument();
+
+		cleanUp();
+	});
+
+	it(`when clicking on Next, it navigates to the given URL of 'next'`, () => {
+		const cleanUp = setupDocument();
+
+		const {getByLabelText} = renderWalkthrough(MULTI_PAGES_MOCK);
+
+		const hotspot = getByLabelText('start-the-walkthrough');
+
+		userEvents.click(hotspot);
+
+		userEvents.click(screen.getByText('ok'));
+
+		expect(navigate).toBeCalledWith(MULTI_PAGES_MOCK.steps[0].next);
+
+		cleanUp();
+	});
+
+	xit(`when clicking on Previous, it navigates to the given url of 'previous'`, () => {
+		const cleanUp = setupDocument();
+
+		const {getByLabelText} = renderWalkthrough(MULTI_PAGES_MOCK);
+
+		const hotspot = getByLabelText('start-the-walkthrough');
+
+		userEvents.click(hotspot);
+
+		userEvents.click(screen.getByText('ok'));
+
+		// Change the location to '/home-2' and then make the Walkthrough render on this new page :/
+		// I consider this inviable. Maybe we should force the step 2 to be on the current page but IDK
+		// yet how to do it
+
+		// userEvents.click(screen.getByText('previous'));
+		// expect(navigate).toBeCalledWith(MULTI_PAGES_MOCK.steps[1].previous);
+
+		cleanUp();
+	});
+
+	it(`when clicking on Next, without passing 'next', it shows the next Walkthrough without navigating`, () => {
+		const cleanUp = setupDocument();
+
+		const {getByLabelText} = renderWalkthrough(PAGE_MOCK);
+
+		const hotspot = getByLabelText('start-the-walkthrough');
+
+		userEvents.click(hotspot);
+
+		const okButton = screen.getByText('ok');
+
+		userEvents.click(okButton);
+
+		expect(screen.queryByText('Hello2')).toBeInTheDocument();
+
+		cleanUp();
+	});
+
+	it(`when clicking on Previous, without passing 'previous', it shows the previous Walkthrough without navigating`, () => {
+		const cleanUp = setupDocument();
+
+		const {getByLabelText} = renderWalkthrough(PAGE_MOCK);
+
+		const hotspot = getByLabelText('start-the-walkthrough');
+
+		userEvents.click(hotspot);
+
+		const okButton = screen.getByText('ok');
+
+		userEvents.click(okButton);
+
+		expect(screen.queryByText('Hello2')).toBeInTheDocument();
+
+		userEvents.click(screen.getByText('previous'));
+
+		expect(screen.queryByText('Hello1')).toBeInTheDocument();
+
+		cleanUp();
+	});
+
+	it('throws an error when the provided selector is not defined', () => {
+		const cleanUp = setupDocument();
+
+		const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+		renderWalkthrough(INVALID_NODE_SELECTOR_MOCK);
+
+		expect(errorSpy).toHaveBeenCalled();
+		expect(errorSpy).toHaveBeenCalledTimes(1);
+
+		cleanUp();
+	});
+
+	it(`when 'darkbg' is set to false adds a 'lfr-walkthrough-element-shadow' to the nodeToHighlight'`, () => {
+		const cleanUp = setupDocument();
+
+		const {getByLabelText} = renderWalkthrough(BOX_SHADOW_ELEMENT_MOCK);
+
+		const hotspot = getByLabelText('start-the-walkthrough');
+
+		userEvents.click(hotspot);
+
+		const elementToBeHighlighted = screen.getByTestId(
+			'external-react-tree-button'
+		);
+
+		expect(elementToBeHighlighted).toHaveClass(
+			'lfr-walkthrough-element-shadow'
+		);
+
+		cleanUp();
+	});
+
+	it(`given the following layoutRelativeURLs and the value of '/home' the component needs to be rendered`, () => {
+		const POSSIBLE_LAYOUT_RELATIVE_URLS = [
+			'/undefined',
+			'/es/web/home/undefined',
+			'/es/web/home?redirectURL=/es/web/guest/home/abc',
+			'/home',
+			'/es/home',
+			'/es/web/guest/home',
+			'/home/abc',
+			'/es/home/abc',
+			'/es/web/guest/home/abc',
+			'/home/abc/home',
+			'/es/home/abc/home',
+			'/es/web/guest/home/abc/home',
+		];
+
+		POSSIBLE_LAYOUT_RELATIVE_URLS.forEach((url) => {
+			const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+			window.themeDisplay.getLayoutRelativeURL = jest.fn(() => url);
+
+			const cleanUp = setupDocument();
+
+			const {container} = renderWalkthrough(PAGE_MOCK);
+
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(container).toBeInTheDocument();
+
+			cleanUp();
+		});
+	});
+
+	it('persists the current step of a determined page on localStorage', () => {
+		const cleanUp = setupDocument();
+
+		const {getByLabelText} = renderWalkthrough(PAGE_MOCK);
+
+		const hotspot = getByLabelText('start-the-walkthrough');
+
+		userEvents.click(hotspot);
+
+		const okButton = screen.getByText('ok');
+
+		userEvents.click(okButton);
+
+		expect(
+			localStorage.getItem(`${USER_ID}-walkthrough-popover-visible`)
+		).toBe('true');
+
+		expect(
+			localStorage.getItem(`${USER_ID}-walkthrough-current-step`)
+		).toBe('1');
+
+		cleanUp();
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/Walkthrough.test.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/Walkthrough.test.js
@@ -25,6 +25,7 @@ import {
 	INVALID_NODE_SELECTOR_MOCK,
 	MULTI_PAGES_MOCK,
 	PAGE_MOCK,
+	PAGE_WITH_PREVIOUS_MOCK,
 } from './__fixtures__/walkthroughMock';
 
 function setupDocument() {
@@ -99,10 +100,10 @@ describe('Walkthrough', () => {
 		cleanUp();
 	});
 
-	xit(`when clicking on Previous, it navigates to the given url of 'previous'`, () => {
+	it(`when clicking on Previous, it navigates to the given URL of 'previous'`, () => {
 		const cleanUp = setupDocument();
 
-		const {getByLabelText} = renderWalkthrough(MULTI_PAGES_MOCK);
+		const {getByLabelText} = renderWalkthrough(PAGE_WITH_PREVIOUS_MOCK);
 
 		const hotspot = getByLabelText('start-the-walkthrough');
 
@@ -110,12 +111,11 @@ describe('Walkthrough', () => {
 
 		userEvents.click(screen.getByText('ok'));
 
-		// Change the location to '/home-2' and then make the Walkthrough render on this new page :/
-		// I consider this inviable. Maybe we should force the step 2 to be on the current page but IDK
-		// yet how to do it
+		userEvents.click(screen.getByText('previous'));
 
-		// userEvents.click(screen.getByText('previous'));
-		// expect(navigate).toBeCalledWith(MULTI_PAGES_MOCK.steps[1].previous);
+		expect(navigate).toBeCalledWith(
+			PAGE_WITH_PREVIOUS_MOCK.steps[1].previous
+		);
 
 		cleanUp();
 	});

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/__fixtures__/walkthroughMock.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/__fixtures__/walkthroughMock.js
@@ -42,6 +42,30 @@ export const PAGE_MOCK = {
 	],
 };
 
+export const PAGE_WITH_PREVIOUS_MOCK = {
+	pages: {
+		'/home': ['step-1', 'step-2'],
+	},
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'step-1',
+			nodeToHighlight: '.logo',
+			title: 'Title 1',
+		},
+		{
+			content: '<span>Content 2</span><br/><code>Hello2</code>',
+			darkbg: true,
+			id: 'step-2',
+			nodeToHighlight: '#footer',
+			positioning: 'top',
+			previous: '/fiona',
+			title: 'Title 2',
+		},
+	],
+};
+
 export const INVALID_NODE_SELECTOR_MOCK = {
 	pages: {
 		'/home': ['step-1', 'step-2'],

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/__fixtures__/walkthroughMock.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/__fixtures__/walkthroughMock.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const DOM_STRUCTURE_FOR_PLACING_STEPS = `
+	<div class="logo" />
+	<div id="footer" />	
+	<button class="btn" data-testid="external-react-tree-button" />
+	<div id="app_root" />
+`.trim();
+
+export const PAGE_MOCK = {
+	pages: {
+		'/home': ['step-1', 'step-2'],
+	},
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'step-1',
+			nodeToHighlight: '.logo',
+			title: 'Title 1',
+		},
+		{
+			content: '<span>Content 2</span><br/><code>Hello2</code>',
+			darkbg: true,
+			id: 'step-2',
+			nodeToHighlight: '#footer',
+			positioning: 'top',
+			title: 'Title 2',
+		},
+	],
+};
+
+export const INVALID_NODE_SELECTOR_MOCK = {
+	pages: {
+		'/home': ['step-1', 'step-2'],
+	},
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'step-1',
+			nodeToHighlight: '.fiona',
+			title: 'Title 1',
+		},
+		{
+			content: '<span>Content 2</span><br/><code>Hello2</code>',
+			darkbg: true,
+			id: 'step-2',
+			nodeToHighlight: '#footer',
+			positioning: 'top',
+			title: 'Title 2',
+		},
+	],
+};
+
+export const BOX_SHADOW_ELEMENT_MOCK = {
+	pages: {
+		'/home': ['step-1', 'step-2'],
+	},
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: false,
+			id: 'step-1',
+			nodeToHighlight: '.btn',
+			title: 'Title 1',
+		},
+		{
+			content: '<span>Content 2</span><br/><code>Hello2</code>',
+			darkbg: false,
+			id: 'step-2',
+			nodeToHighlight: '#footer',
+			positioning: 'top',
+			title: 'Title 2',
+		},
+	],
+};
+
+export const MULTI_PAGES_MOCK = {
+	pages: {
+		'/home': ['step-1'],
+		'/home-2': ['step-2', 'step-3'],
+	},
+	steps: [
+		{
+			content: '<span>Content 1</span><br/><code>Hello1</code>',
+			darkbg: true,
+			id: 'step-1',
+			next: '/home-2',
+			nodeToHighlight: '.logo',
+			title: 'Title 1',
+		},
+		{
+			content: '<span>Content 2</span><br/><code>Hello2</code>',
+			darkbg: true,
+			id: 'step-2',
+			nodeToHighlight: '#footer',
+			positioning: 'top',
+			previous: '/home',
+			title: 'Title 2',
+		},
+		{
+			content: '<span>Content 3</span><br/><code>Hello3</code>',
+			darkbg: true,
+			id: 'step-3',
+			nodeToHighlight: '.btn',
+			title: 'Title 3',
+		},
+	],
+};

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/__fixtures__/walkthroughMock.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/__fixtures__/walkthroughMock.js
@@ -22,6 +22,7 @@ export const DOM_STRUCTURE_FOR_PLACING_STEPS = `
 export const PAGE_MOCK = {
 	pages: {
 		'/home': ['step-1', 'step-2'],
+		'/home/abc': ['step-1'],
 	},
 	steps: [
 		{

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -14990,6 +14990,7 @@ status-date=Status Date
 status-summary=Status Summary
 status.callback.name=Status Callback
 stay=Stay
+start-the-walkthrough=Start the Walkthrough.
 step-name=Step Name
 step-x-of-x=Step {0} of {1}
 steps-walkthrough=Steps


### PR DESCRIPTION
# What it does

* Refactor the Walkthrough component and lift up some states from Step to Walkthrough component
* Fix element-shadow behavior on the first render. Before, we are just adding the element shadow when clicking Ok
* We were navigating to URLs using double slashes, like navigate('//page-1'); now, we are navigating like navigate('/page-1')

/cc @susanchen3 @mateusralv :)