### PR TITLE
LPS-161530 Fix tests in Remote Apps

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RemoteApps.macro
@@ -219,6 +219,13 @@ definition {
 		return "${externalReferenceCodeValue}";
 	}
 
+	macro getRemoteAppEntryId {
+		var companyId = JSONCompany.getCompanyId();
+		var externalReferenceCodeValue = RemoteApps.getExternalReferenceCodeValue();
+
+		return "${companyId}_${externalReferenceCodeValue}";
+	}
+
 	macro getRemoteAppEntryName {
 		WaitForSPARefresh();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/RemoteApps.testcase
@@ -401,12 +401,12 @@ definition {
 		}
 
 		task ("Obtain Vanilla Counter's remoteAppEntryId") {
-			var externalReferenceCodeValue = RemoteApps.getExternalReferenceCodeValue();
+			var remoteAppEntryId = RemoteApps.getRemoteAppEntryId();
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Guest",
 				layoutName = "Test Page",
-				remoteAppEntryId = "${externalReferenceCodeValue}",
+				remoteAppEntryId = "${remoteAppEntryId}",
 				widgetName = "Vanilla Counter");
 		}
 
@@ -473,12 +473,12 @@ definition {
 		}
 
 		task ("Add Vanilla Counter to Test Page") {
-			var externalReferenceCodeValue = RemoteApps.getExternalReferenceCodeValue();
+			var remoteAppEntryId = RemoteApps.getRemoteAppEntryId();
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Guest",
 				layoutName = "Test Page",
-				remoteAppEntryId = "${externalReferenceCodeValue}",
+				remoteAppEntryId = "${remoteAppEntryId}",
 				widgetName = "Vanilla Counter");
 		}
 


### PR DESCRIPTION
**Background**
Company ID is added to ClientExtensionEntry in https://github.com/liferay-frontend/liferay-portal/pull/2650. Fix tests to include this change. 

Before the portlet id would be something like
```
id="portlet_com_liferay_client_extension_web_internal_portlet_ClientExtensionEntryPortlet_ercValue"
```

Now it appends company id before erc, so the portlet wasn't locatable 
```
id="portlet_com_liferay_client_extension_web_internal_portlet_ClientExtensionEntryPortlet_companyId_ercValue"
```

**Test Plan:**
- RemoteApps#CustomElementCanConfigurePortletName passes
- RemoteApps#CustomElementCanInjectHTMLProperties passes

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-161530