### PR TITLE
LPS-161760 | Support for ERC in taxonomy category

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyCategoryAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyCategoryAPI.macro
@@ -18,7 +18,9 @@ definition {
 		return "${curl}";
 	}
 
-	macro _curlTaxonomyCategory {
+	macro _curlTaxonomyCategoryByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId}");
+
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
@@ -63,9 +65,7 @@ definition {
 	}
 
 	macro deleteTaxonomyCategoryByErc {
-		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId}");
-
-		var curl = TaxonomyCategoryAPI._curlTaxonomyCategory(
+		var curl = TaxonomyCategoryAPI._curlTaxonomyCategoryByErc(
 			externalReferenceCode = "${externalReferenceCode}",
 			taxonomyVocabularyId = "${taxonomyVocabularyId}");
 
@@ -89,9 +89,7 @@ definition {
 	}
 
 	macro getTaxonomyCategoryByErc {
-		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId}");
-
-		var curl = TaxonomyCategoryAPI._curlTaxonomyCategory(
+		var curl = TaxonomyCategoryAPI._curlTaxonomyCategoryByErc(
 			externalReferenceCode = "${externalReferenceCode}",
 			taxonomyVocabularyId = "${taxonomyVocabularyId}");
 
@@ -113,14 +111,10 @@ definition {
 	}
 
 	macro updateTaxonomyCategoryByErc {
-		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId},${name}");
-
-		var curl = TaxonomyCategoryAPI._curlTaxonomyCategory(
+		var curl = TaxonomyCategoryAPI._curlTaxonomyCategoryByErc(
 			externalReferenceCode = "${externalReferenceCode}",
 			taxonomyVocabularyId = "${taxonomyVocabularyId}");
-		var body = '''-d {
-				"name": "${name}"
-			}''';
+		var body = '''-d {"name": "${name}"}''';
 
 		var curl = StringUtil.add("${curl}", "${body}", " ");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyCategoryAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyCategoryAPI.macro
@@ -13,7 +13,20 @@ definition {
 			}
 		''';
 
-		var curl = JSONCurlUtil.post("${curl}", "$.id");
+		var curl = JSONCurlUtil.post("${curl}");
+
+		return "${curl}";
+	}
+
+	macro _curlTaxonomyCategory {
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-admin-taxonomy/v1.0/taxonomy-vocabularies/${taxonomyVocabularyId}/taxonomy-categories/by-external-reference-code/${externalReferenceCode} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json \
+			-H accept: application/json \
+		''';
 
 		return "${curl}";
 	}
@@ -41,18 +54,79 @@ definition {
 			var externalReferenceCode = "";
 		}
 
-		var taxonomyCategoryId = TaxonomyCategoryAPI._createTaxonomyCategory(
+		var response = TaxonomyCategoryAPI._createTaxonomyCategory(
 			externalReferenceCode = "${externalReferenceCode}",
 			name = "${name}",
 			taxonomyVocabularyId = "${taxonomyVocabularyId}");
 
-		return "${taxonomyCategoryId}";
+		return "${response}";
+	}
+
+	macro deleteTaxonomyCategoryByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId}");
+
+		var curl = TaxonomyCategoryAPI._curlTaxonomyCategory(
+			externalReferenceCode = "${externalReferenceCode}",
+			taxonomyVocabularyId = "${taxonomyVocabularyId}");
+
+		var response = JSONCurlUtil.delete("${curl}");
+
+		return "${response}";
+	}
+
+	macro getElementOfCreatedCategory {
+		Variables.assertDefined(parameterList = "${responseToParse},${element}");
+
+		var elementValue = JSONUtil.getWithJSONPath("${responseToParse}", "${element}");
+
+		return "${elementValue}";
 	}
 
 	macro getTaxonomyCategory {
 		var getTaxonomyCategoryDetails = TaxonomyCategoryAPI._getTaxonomyCategory(taxonomyCategoryId = "${taxonomyCategoryId}");
 
 		return "${getTaxonomyCategoryDetails}";
+	}
+
+	macro getTaxonomyCategoryByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId}");
+
+		var curl = TaxonomyCategoryAPI._curlTaxonomyCategory(
+			externalReferenceCode = "${externalReferenceCode}",
+			taxonomyVocabularyId = "${taxonomyVocabularyId}");
+
+		var response = JSONCurlUtil.get("${curl}");
+
+		return "${response}";
+	}
+
+	macro setUpGlobalResponse {
+		var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+		var response = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
+			assetLibraryId = "${assetLibraryId}",
+			name = "Vocabulary Name");
+
+		static var responseOfCreated = "${response}";
+
+		return "${responseOfCreated}";
+	}
+
+	macro updateTaxonomyCategoryByErc {
+		Variables.assertDefined(parameterList = "${externalReferenceCode},${taxonomyVocabularyId},${name}");
+
+		var curl = TaxonomyCategoryAPI._curlTaxonomyCategory(
+			externalReferenceCode = "${externalReferenceCode}",
+			taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		var body = '''-d {
+				"name": "${name}"
+			}''';
+
+		var curl = StringUtil.add("${curl}", "${body}", " ");
+
+		var response = JSONCurlUtil.put("${curl}");
+
+		return "${response}";
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcForCategories.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcForCategories.testcase
@@ -8,7 +8,9 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstance();
 
-		JSONDepot.addDepot(depotName = "Test Depot Name");
+		task ("Given an asset library is created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+		}
 
 		TaxonomyCategoryAPI.setUpGlobalResponse();
 	}
@@ -28,7 +30,7 @@ definition {
 	test CanDeleteCategoryByErc {
 		property portal.acceptance = "true";
 
-		task ("Given a TaxonomyCategory with custom external reference code") {
+		task ("And Given a TaxonomyCategory with custom external reference code") {
 			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
 				element = "$.id",
 				responseToParse = "${responseOfCreated}");
@@ -43,7 +45,7 @@ definition {
 				responseToParse = "${responseOfCategory}");
 		}
 
-		task ("When using a GET request deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc") {
+		task ("When using a DELETE request deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc") {
 			TaxonomyCategoryAPI.deleteTaxonomyCategoryByErc(
 				externalReferenceCode = "erc",
 				taxonomyVocabularyId = "${taxonomyVocabularyId}");
@@ -66,7 +68,7 @@ definition {
 	test CanRecieveCorrectCategoryIdByErc {
 		property portal.acceptance = "true";
 
-		task ("Given a TaxonomyCategory with custom external reference code") {
+		task ("And Given a TaxonomyCategory with custom external reference code") {
 			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
 				element = "$.id",
 				responseToParse = "${responseOfCreated}");
@@ -99,7 +101,7 @@ definition {
 	test CanRecieveCorrectErcValueInCategory {
 		property portal.acceptance = "true";
 
-		task ("Given a TaxonomyCategory with custom external reference code") {
+		task ("And Given a TaxonomyCategory with custom external reference code") {
 			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
 				element = "$.id",
 				responseToParse = "${responseOfCreated}");
@@ -131,7 +133,7 @@ definition {
 	test CanRecieveErrorMessageByNotExistErcInCategory {
 		property portal.acceptance = "true";
 
-		task ("Given a TaxonomyCategory with custom external reference code") {
+		task ("And Given a TaxonomyCategory with custom external reference code") {
 			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
 				element = "$.id",
 				responseToParse = "${responseOfCreated}");
@@ -164,7 +166,7 @@ definition {
 	test CanUpdateCategoryByErc {
 		property portal.acceptance = "true";
 
-		task ("Given a TaxonomyCategory with custom external reference code") {
+		task ("And Given a TaxonomyCategory with custom external reference code") {
 			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
 				element = "$.id",
 				responseToParse = "${responseOfCreated}");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcForCategories.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/ExposeErcForCategories.testcase
@@ -8,11 +8,9 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstance();
 
-		User.firstLoginPG();
+		JSONDepot.addDepot(depotName = "Test Depot Name");
 
-		task ("Given an asset library is created") {
-			JSONDepot.addDepot(depotName = "Test Depot Name");
-		}
+		TaxonomyCategoryAPI.setUpGlobalResponse();
 	}
 
 	tearDown {
@@ -27,29 +25,96 @@ definition {
 	}
 
 	@priority = "4"
-	test CanRecieveCorrectErcValueInCategory {
+	test CanDeleteCategoryByErc {
 		property portal.acceptance = "true";
 
-		task ("Given a vocabulary with assetLibrary") {
-			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
-
-			var responseOfCreated = TaxonomyVocabularyAPI.createTaxonomyVocabulary(
-				assetLibraryId = "${assetLibraryId}",
-				name = "Vocabulary Name");
-		}
-
-		task ("And Given a TaxonomyCategory with custom external reference code") {
+		task ("Given a TaxonomyCategory with custom external reference code") {
 			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
 				element = "$.id",
 				responseToParse = "${responseOfCreated}");
 
-			var taxonomyCategoryId = TaxonomyCategoryAPI.createTaxonomyCategory(
+			var responseOfCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
+				externalReferenceCode = "erc",
+				name = "Category Name",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+
+			var siteId = TaxonomyCategoryAPI.getElementOfCreatedCategory(
+				element = "$.siteId",
+				responseToParse = "${responseOfCategory}");
+		}
+
+		task ("When using a GET request deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc") {
+			TaxonomyCategoryAPI.deleteTaxonomyCategoryByErc(
+				externalReferenceCode = "erc",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("Then I can delete the category") {
+			var response = TaxonomyCategoryAPI.getTaxonomyCategoryByErc(
+				externalReferenceCode = "erc",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.title");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "No AssetCategory exists with the key {groupId=${siteId}, externalReferenceCode=erc}");
+		}
+	}
+
+	@priority = "4"
+	test CanRecieveCorrectCategoryIdByErc {
+		property portal.acceptance = "true";
+
+		task ("Given a TaxonomyCategory with custom external reference code") {
+			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$.id",
+				responseToParse = "${responseOfCreated}");
+
+			var responseOfCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
+				externalReferenceCode = "erc",
+				name = "Category Name",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("When using a GET request getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc") {
+			var response = TaxonomyCategoryAPI.getTaxonomyCategoryByErc(
+				externalReferenceCode = "erc",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("Then I can receive the correct id in the response") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.id");
+			var taxonomyCategoryId = TaxonomyCategoryAPI.getElementOfCreatedCategory(
+				element = "$.id",
+				responseToParse = "${responseOfCategory}");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "${taxonomyCategoryId}");
+		}
+	}
+
+	@priority = "4"
+	test CanRecieveCorrectErcValueInCategory {
+		property portal.acceptance = "true";
+
+		task ("Given a TaxonomyCategory with custom external reference code") {
+			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$.id",
+				responseToParse = "${responseOfCreated}");
+
+			var responseOfCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
 				externalReferenceCode = "erc",
 				name = "Category Name",
 				taxonomyVocabularyId = "${taxonomyVocabularyId}");
 		}
 
 		task ("When with GET request getTaxonomyCategory") {
+			var taxonomyCategoryId = TaxonomyCategoryAPI.getElementOfCreatedCategory(
+				element = "$.id",
+				responseToParse = "${responseOfCategory}");
+
 			var response = TaxonomyCategoryAPI.getTaxonomyCategory(taxonomyCategoryId = "${taxonomyCategoryId}");
 		}
 
@@ -59,6 +124,70 @@ definition {
 			TestUtils.assertEquals(
 				actual = "${actualValue}",
 				expected = "erc");
+		}
+	}
+
+	@priority = "4"
+	test CanRecieveErrorMessageByNotExistErcInCategory {
+		property portal.acceptance = "true";
+
+		task ("Given a TaxonomyCategory with custom external reference code") {
+			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$.id",
+				responseToParse = "${responseOfCreated}");
+
+			var responseOfCategory = TaxonomyCategoryAPI.createTaxonomyCategory(
+				externalReferenceCode = "erc",
+				name = "Category Name",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("When using a GET request getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with not exist erc value") {
+			var response = TaxonomyCategoryAPI.getTaxonomyCategoryByErc(
+				externalReferenceCode = "liferay",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("Then I can receive the error message in the response") {
+			var siteId = TaxonomyCategoryAPI.getElementOfCreatedCategory(
+				element = "$.siteId",
+				responseToParse = "${responseOfCategory}");
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.title");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "No AssetCategory exists with the key {groupId=${siteId}, externalReferenceCode=liferay}");
+		}
+	}
+
+	@priority = "4"
+	test CanUpdateCategoryByErc {
+		property portal.acceptance = "true";
+
+		task ("Given a TaxonomyCategory with custom external reference code") {
+			var taxonomyVocabularyId = TaxonomyVocabularyAPI.getElementOfCreatedVocabulary(
+				element = "$.id",
+				responseToParse = "${responseOfCreated}");
+
+			TaxonomyCategoryAPI.createTaxonomyCategory(
+				externalReferenceCode = "erc",
+				name = "Category Name",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("When updating the category name value with a PUT request putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc") {
+			var response = TaxonomyCategoryAPI.updateTaxonomyCategoryByErc(
+				externalReferenceCode = "erc",
+				name = "New Category Name",
+				taxonomyVocabularyId = "${taxonomyVocabularyId}");
+		}
+
+		task ("Then I can receive the updated name value in the response") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.name");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "New Category Name");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Support for ERC in TaxonomyCategory

**Test Plan**
Given a vocabulary with assetLibrary 
And Given a TaxonomyCategory with custom external reference code
When updating the category name value with a PUT request
putTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc
Then I can receive the updated name value in the response

Given a vocabulary with assetLibrary 
And Given a TaxonomyCategory with custom external reference code
When using a GET request
getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc
Then I can receive the correct id in the response

Given a vocabulary with assetLibrary 
And Given a TaxonomyCategory with custom external reference code
When using a DELETE request
deleteTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with custom erc
Then I can delete the category

Given a vocabulary with assetLibrary 
And Given a TaxonomyCategory with custom external reference code
When using a GET request
getTaxonomyVocabularyTaxonomyCategoryByExternalReferenceCode with not exist erc value
Then I can receive the error message in the response

**JIRA Link:**
https://issues.liferay.com/browse/LPS-161444