### PR TITLE
LPS-161237 Adds `skippable` functionallity

### DIFF
--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -359,13 +359,15 @@ const Step = ({
 
 	return (
 		<>
-			{!popoverVisible && (
-				<Hotspot
-					onHotspotClick={() => setPopoverVisible(true)}
-					ref={hotspotRef}
-					trigger={memoizedTrigger}
-				/>
-			)}
+			{!popoverVisible &&
+				currentStep !== steps.length &&
+				!localStorage.getItem(LOCAL_STORAGE_KEYS.SKIPPABLE) && (
+					<Hotspot
+						onHotspotClick={() => setPopoverVisible(true)}
+						ref={hotspotRef}
+						trigger={memoizedTrigger}
+					/>
+				)}
 
 			{darkbg && (
 				<Overlay

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/Walkthrough.js
@@ -26,6 +26,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Hotspot} from './Hotspot';
 import {Overlay} from './Overlay';
 import {doAlign} from './doAlign';
+import {LOCAL_STORAGE_KEYS} from './localStorageKeys';
 import {useLocalStorage} from './useLocalStorage';
 import {useObserveRect} from './useObserveRect';
 
@@ -188,7 +189,7 @@ const Step = ({
 	const hotspotRef = useRef(null);
 
 	const [popoverVisible, setPopoverVisible] = useLocalStorage(
-		`${themeDisplay.getUserId()}-walkthrough-popover-visible`,
+		LOCAL_STORAGE_KEYS.POPOVER_VISIBILITY,
 		false
 	);
 
@@ -205,6 +206,8 @@ const Step = ({
 	const [currentAlignment, setCurrentAlignment] = useState(
 		defaultPositioning
 	);
+
+	const [checkboxValue, setCheckboxValue] = useState(false);
 
 	const memoizedTrigger = useMemo(() => {
 		const currentNode = steps[currentStep].nodeToHighlight;
@@ -421,9 +424,18 @@ const Step = ({
 							{skippable && (
 								<ClayLayout.ContentCol expand>
 									<ClayCheckbox
+										checked={checkboxValue}
 										label={Liferay.Language.get(
 											'do-not-show-me-this-again'
 										)}
+										onChange={() => {
+											setCheckboxValue(!checkboxValue);
+
+											localStorage.setItem(
+												LOCAL_STORAGE_KEYS.SKIPPABLE,
+												!checkboxValue
+											);
+										}}
 									/>
 								</ClayLayout.ContentCol>
 							)}
@@ -498,9 +510,8 @@ const Walkthrough = ({
 	const [
 		currentStepIndex,
 		setCurrentStepIndex,
-	] = useLocalStorage(
-		`${themeDisplay.getUserId()}-walkthrough-current-step`,
-		() => (!steps.length ? null : 0)
+	] = useLocalStorage(LOCAL_STORAGE_KEYS.CURRENT_STEP, () =>
+		!steps.length ? null : 0
 	);
 
 	if (currentStepIndex === null) {

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
@@ -16,6 +16,7 @@ import {render} from '@liferay/frontend-js-react-web';
 import React from 'react';
 
 import Walkthrough from './Walkthrough';
+import {LOCAL_STORAGE_KEYS} from './localStorageKeys';
 
 const DEFAULT_CONTAINER_ID = 'walkthroughContainer';
 
@@ -40,7 +41,11 @@ const getDefaultContainer = () => {
 };
 
 function Root(props) {
-	return <Walkthrough {...DEFAULT_PROPS} {...props} />;
+	if (!localStorage.getItem(LOCAL_STORAGE_KEYS.SKIPPABLE)) {
+		return <Walkthrough {...DEFAULT_PROPS} {...props} />;
+	}
+
+	return null;
 }
 
 export default function main(props = {}) {

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/localStorageKeys.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/localStorageKeys.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const LOCAL_STORAGE_KEYS = {
+	CURRENT_STEP: `${themeDisplay.getUserId()}-walkthrough-current-step`,
+	POPOVER_VISIBILITY: `${themeDisplay.getUserId()}-walkthrough-popover-visible`,
+	SKIPPABLE: `${themeDisplay.getUserId()}-${themeDisplay.getSiteGroupId()}-walkthrough-dismissed`,
+};


### PR DESCRIPTION
# How to use it?

1. Go to Site Settings -> Walkthrough and place this JSON snippet:

```js
{
	pages: {
		'/home' : ['step-1', 'step-2'],
	},
	steps: [
		{
			content: '<span>Content 1</span><br/><code>Hello1</code>',
			darkbg: false,
			id: 'step-1',
			nodeToHighlight: '.logo',
			title: 'Title 1',
		},
		{
			content: '<span>Content 2</span><br/><code>Hello2</code>',
			darkbg: false,
			id: 'step-2',
			nodeToHighlight: '[aria-label="Open menu"]',
			positioning: 'left',
			title: 'Title 2',
		}
	],
        skippable: true,
}
```
_See `skippable: true`_
 
2. Enable Walkthrough and then Save
3. Go to your home page
4. Navigate using Next/Previous
5. Check the `Don't show me again` checkbox if you want

# Considerations

There are lots of possible UX interactions here. I considered this one:

When checking the checkbox, it will save on localStorage a key containing the `siteGroupId` and the `userId` representing this user X on this website Y doesn't want to see these steps again.

It will take effect just when accessing the page again. Requires a page refresh.

## Other possibilities:

1. We can check, and by the end of the tour/walkthrough, once the user clicks on Close, it will not show the Walkthrough again, even on refresh
2. We can check, and if the user closes the Walkthrough, it will not show it again

Hey @drakonux, what do you think is the best? The current implemented one or 1 or 2? 🤔 
