### PR TITLE
LPS-162074 Replace rest of usages of `Liferay.Util.sub` with imported `sub`

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DocumentLibrary.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DocumentLibrary.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {buildFragment, openSelectionModal} from 'frontend-js-web';
+import {buildFragment, openSelectionModal, sub} from 'frontend-js-web';
 
 export default function DocumentLibrary({
 	editEntryUrl,
@@ -132,7 +132,7 @@ export default function DocumentLibrary({
 			},
 			selectEventName: `${namespace}selectFolder`,
 			size: 'lg',
-			title: Liferay.Util.sub(dialogTitle, [selectedItems]),
+			title: sub(dialogTitle, [selectedItems]),
 			url: selectFolderURL,
 		});
 	};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -24,7 +24,7 @@ import {
 	useConfig,
 	useFormState,
 } from 'data-engine-js-components-web';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal, sub} from 'frontend-js-web';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -376,7 +376,7 @@ const Main = ({
 			onClose: () => onBlur(event),
 			onSelect: handleFieldChanged,
 			selectEventName: `${portletNamespace}selectDocumentLibrary`,
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('document')
 			),
@@ -417,7 +417,7 @@ const Main = ({
 			return false;
 		}
 
-		const errorMessage = Liferay.Util.sub(
+		const errorMessage = sub(
 			Liferay.Language.get(
 				'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
 			),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -26,6 +26,7 @@ import {
 	useForm,
 	useFormState,
 } from 'data-engine-js-components-web';
+import {sub} from 'frontend-js-web';
 import moment from 'moment/min/moment-with-locales';
 import React, {useMemo, useState} from 'react';
 
@@ -272,7 +273,7 @@ export function FieldBase({
 				<div className="lfr-ddm-form-field-repeatable-toolbar">
 					{repeatedIndex > 0 && (
 						<ClayButton
-							aria-label={Liferay.Util.sub(
+							aria-label={sub(
 								Liferay.Language.get('remove-duplicate-field'),
 								label ? label : type
 							)}
@@ -293,7 +294,7 @@ export function FieldBase({
 					)}
 
 					<ClayButton
-						aria-label={Liferay.Util.sub(
+						aria-label={sub(
 							Liferay.Language.get('add-duplicate-field'),
 							label ? label : type
 						)}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayModal, {useModal} from '@clayui/modal';
-import {openSelectionModal} from 'frontend-js-web';
+import {openSelectionModal, sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -95,7 +95,7 @@ const ImagePicker = ({
 			onClose: () => onBlur(event),
 			onSelect: handleFieldChanged,
 			selectEventName: `${portletNamespace}selectDocumentLibrary`,
-			title: Liferay.Util.sub(
+			title: sub(
 				Liferay.Language.get('select-x'),
 				Liferay.Language.get('image')
 			),

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/Text/Text.es.js
@@ -17,6 +17,7 @@ import ClayDropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import {usePrevious} from '@liferay/frontend-js-react-web';
 import {normalizeFieldName} from 'data-engine-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {FieldBase} from '../FieldBase/ReactFieldBase.es';
@@ -39,7 +40,7 @@ const CounterContainer = ({
 		return null;
 	}
 
-	const message = Liferay.Util.sub(
+	const message = sub(
 		Liferay.Language.get('x-of-x-characters'),
 		counter,
 		maxLength

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openDeleteArticleModal.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/modals/openDeleteArticleModal.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 export default function openDeleteArticleModal({onDelete}) {
 	openModal({
@@ -35,7 +35,7 @@ export default function openDeleteArticleModal({onDelete}) {
 			},
 		],
 		status: 'danger',
-		title: Liferay.Util.sub(
+		title: sub(
 			Liferay.Language.get('delete-x'),
 			Liferay.Language.get('web-content')
 		),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
@@ -14,7 +14,12 @@
 
 import ClayPopover from '@clayui/popover';
 import {ReactPortal, useEventListener} from '@liferay/frontend-js-react-web';
-import {ALIGN_POSITIONS, align, suggestAlignBestRegion} from 'frontend-js-web';
+import {
+	ALIGN_POSITIONS,
+	align,
+	sub,
+	suggestAlignBestRegion,
+} from 'frontend-js-web';
 import React, {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
 import {useSelectItem} from '../contexts/ControlsContext';
@@ -172,7 +177,7 @@ const DisabledArea = () => {
 				>
 					<div
 						dangerouslySetInnerHTML={{
-							__html: Liferay.Util.sub(
+							__html: sub(
 								Liferay.Language.get(
 									'this-area-is-defined-by-the-theme.-you-can-change-the-theme-settings-by-clicking-x-in-the-x-panel-on-the-sidebar'
 								),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/FormValidationModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/FormValidationModal.js
@@ -16,6 +16,7 @@ import ClayAlert from '@clayui/alert';
 import {default as ClayButton} from '@clayui/button';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClayPanel from '@clayui/panel';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -73,7 +74,7 @@ export function FormValidationModal({onCloseModal, onPublish}) {
 							className="mb-0"
 							collapsable
 							defaultExpanded
-							displayTitle={Liferay.Util.sub(
+							displayTitle={sub(
 								Liferay.Language.get('x-form'),
 								typeLabel
 							)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/SelectField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/SelectField.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayCheckbox, ClaySelectWithOption} from '@clayui/form';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -135,10 +136,7 @@ const MultiSelect = ({
 			label;
 	}
 	else if (nextValue.length > 1) {
-		label = Liferay.Util.sub(
-			Liferay.Language.get('x-selected'),
-			nextValue.length
-		);
+		label = sub(Liferay.Language.get('x-selected'), nextValue.length);
 	}
 
 	const items = options.map((option) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
@@ -15,6 +15,7 @@
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {COLUMN_SIZE_MODULE_PER_ROW_SIZES} from '../../config/constants/columnSizes';
@@ -95,7 +96,7 @@ const EmptyCollectionGridMessage = () => (
 const EditModeMaxItemsAlert = () => (
 	<div className="alert alert-fluid alert-info">
 		<div className="container-fluid">
-			{Liferay.Util.sub(
+			{sub(
 				Liferay.Language.get(
 					'in-edit-mode,-the-number-of-elements-displayed-is-limited-to-x-due-to-performance'
 				),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/CollectionPagination.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/CollectionPagination.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import {ClayPaginationWithBasicItems} from '@clayui/pagination';
 import ClayPaginationBar from '@clayui/pagination-bar';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -66,7 +67,7 @@ export default function CollectionPagination({
 			{paginationType === 'numeric' ? (
 				<ClayPaginationBar className="flex-grow-1">
 					<ClayPaginationBar.Results>
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get('showing-x-to-x-of-x-entries'),
 							numericPaginationLabelValues
 						)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/getActionLabel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/getActionLabel.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 import {SELECT_SEGMENTS_EXPERIENCE} from '../../../plugins/experience/actions';
 import {
 	ADD_FRAGMENT_ENTRY_LINKS,
@@ -44,13 +46,10 @@ export default function getActionLabel(
 	switch (action.originalType || action.type) {
 		case ADD_FRAGMENT_ENTRY_LINKS:
 		case ADD_ITEM:
-			return Liferay.Util.sub(
-				Liferay.Language.get('add-x'),
-				action.itemName
-			);
+			return sub(Liferay.Language.get('add-x'), action.itemName);
 		case CHANGE_MASTER_LAYOUT:
 			return type === UNDO_TYPES.undo
-				? Liferay.Util.sub(
+				? sub(
 						Liferay.Language.get('select-x-master-layout'),
 						config.masterLayouts.find(
 							(masterLayout) =>
@@ -58,7 +57,7 @@ export default function getActionLabel(
 								action.nextMasterLayoutPlid
 						).name
 				  )
-				: Liferay.Util.sub(
+				: sub(
 						Liferay.Language.get('select-x-master-layout'),
 						config.masterLayouts.find(
 							(masterLayout) =>
@@ -68,30 +67,21 @@ export default function getActionLabel(
 				  );
 
 		case DELETE_ITEM:
-			return Liferay.Util.sub(
-				Liferay.Language.get('delete-x'),
-				action.itemName
-			);
+			return sub(Liferay.Language.get('delete-x'), action.itemName);
 		case DUPLICATE_ITEM:
-			return Liferay.Util.sub(
-				Liferay.Language.get('duplicate-x'),
-				action.itemName
-			);
+			return sub(Liferay.Language.get('duplicate-x'), action.itemName);
 		case MOVE_ITEM:
-			return Liferay.Util.sub(
-				Liferay.Language.get('move-x'),
-				action.itemName
-			);
+			return sub(Liferay.Language.get('move-x'), action.itemName);
 		case SELECT_SEGMENTS_EXPERIENCE:
 			return type === UNDO_TYPES.undo
-				? Liferay.Util.sub(
+				? sub(
 						Liferay.Language.get('select-x-experience'),
 						getSegmentsExperienceName(
 							action.nextSegmentsExperienceId,
 							availableSegmentsExperiences
 						)
 				  )
-				: Liferay.Util.sub(
+				: sub(
 						Liferay.Language.get('select-x-experience'),
 						getSegmentsExperienceName(
 							action.segmentsExperienceId,
@@ -100,11 +90,11 @@ export default function getActionLabel(
 				  );
 		case SWITCH_VIEWPORT_SIZE:
 			return type === UNDO_TYPES.undo
-				? Liferay.Util.sub(
+				? sub(
 						Liferay.Language.get('select-x-viewport'),
 						config.availableViewportSizes[action.nextSize].label
 				  )
-				: Liferay.Util.sub(
+				: sub(
 						Liferay.Language.get('select-x-viewport'),
 						config.availableViewportSizes[action.size].label
 				  );
@@ -126,22 +116,22 @@ export default function getActionLabel(
 		case UPDATE_FORM_ITEM_CONFIG:
 		case UPDATE_ITEM_CONFIG:
 		case UPDATE_ROW_COLUMNS:
-			return Liferay.Util.sub(
+			return sub(
 				Liferay.Language.get('update-x-configuration'),
 				action.itemName
 			);
 		case UPDATE_EDITABLE_VALUES:
-			return Liferay.Util.sub(
+			return sub(
 				Liferay.Language.get('update-x-editable-values'),
 				action.itemName
 			);
 		case UPDATE_LANGUAGE_ID:
 			return type === UNDO_TYPES.undo
-				? Liferay.Util.sub(
+				? sub(
 						Liferay.Language.get('select-x-language'),
 						action.nextLanguageId
 				  )
-				: Liferay.Util.sub(
+				: sub(
 						Liferay.Language.get('select-x-language'),
 						action.languageId
 				  );

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/selectors/selectPageContentDropdownItems.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/selectors/selectPageContentDropdownItems.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal, sub} from 'frontend-js-web';
 
 import {selectPageContents} from './selectPageContents';
 
@@ -41,7 +41,7 @@ export function selectPageContentDropdownItems(classPK, label = '') {
 			dropdownItems.push({
 				href: editURL,
 				label: label
-					? Liferay.Util.sub(Liferay.Language.get('edit-x'), label)
+					? sub(Liferay.Language.get('edit-x'), label)
 					: Liferay.Language.get('edit'),
 				symbolLeft: 'pencil',
 			});
@@ -86,15 +86,12 @@ export function selectPageContentDropdownItems(classPK, label = '') {
 
 			dropdownItems.push({
 				label: label
-					? Liferay.Util.sub(
-							Liferay.Language.get('edit-x-permissions'),
-							label
-					  )
+					? sub(Liferay.Language.get('edit-x-permissions'), label)
 					: Liferay.Language.get('permissions'),
 				onClick: () =>
 					openModal({
 						title: label
-							? Liferay.Util.sub(
+							? sub(
 									Liferay.Language.get('edit-x-permissions'),
 									label
 							  )
@@ -112,18 +109,12 @@ export function selectPageContentDropdownItems(classPK, label = '') {
 
 			dropdownItems.push({
 				label: label
-					? Liferay.Util.sub(
-							Liferay.Language.get('view-x-usages'),
-							label
-					  )
+					? sub(Liferay.Language.get('view-x-usages'), label)
 					: Liferay.Language.get('view-usages'),
 				onClick: () =>
 					openModal({
 						title: label
-							? Liferay.Util.sub(
-									Liferay.Language.get('view-x-usages'),
-									label
-							  )
+							? sub(Liferay.Language.get('view-x-usages'), label)
 							: Liferay.Language.get('view-usages'),
 						url: viewUsagesURL,
 					}),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getFormErrorDescription.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getFormErrorDescription.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 export const FORM_ERROR_TYPES = {
 	deletedFragment: 'deletedFragment',
 	hiddenFields: 'hiddenFields',
@@ -25,7 +27,7 @@ export function getFormErrorDescription({name = null, type}) {
 	switch (type) {
 		case FORM_ERROR_TYPES.deletedFragment:
 			return {
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'the-deleted-fragment-was-marked-as-required'
 					),
@@ -35,7 +37,7 @@ export function getFormErrorDescription({name = null, type}) {
 
 		case FORM_ERROR_TYPES.hiddenFields:
 			return {
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'x-form-contains-one-or-more-hidden-fragments-mapped-to-required-fields'
 					),
@@ -56,7 +58,7 @@ export function getFormErrorDescription({name = null, type}) {
 
 		case FORM_ERROR_TYPES.missingFields:
 			return {
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'x-form-has-one-or-more-required-fields-not-mapped-from-the-form'
 					),
@@ -70,7 +72,7 @@ export function getFormErrorDescription({name = null, type}) {
 
 		case FORM_ERROR_TYPES.missingFragments:
 			return {
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'x-form-has-some-fragments-not-mapped-to-object-fields'
 					),
@@ -84,7 +86,7 @@ export function getFormErrorDescription({name = null, type}) {
 
 		case FORM_ERROR_TYPES.missingSubmit:
 			return {
-				message: Liferay.Util.sub(
+				message: sub(
 					Liferay.Language.get(
 						'x-form-has-a-hidden-or-missing-submit-button'
 					),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getResetLabelByViewport.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getResetLabelByViewport.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
+
 import {VIEWPORT_SIZES} from '../config/constants/viewportSizes';
 import {config} from '../config/index';
 
@@ -34,8 +36,5 @@ export function getResetLabelByViewport(selectedViewportSize) {
 			].label;
 	}
 
-	return Liferay.Util.sub(
-		Liferay.Language.get('reset-to-x-value'),
-		previousViewport
-	);
+	return sub(Liferay.Language.get('reset-to-x-value'), previousViewport);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ImageSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ImageSelector.js
@@ -14,6 +14,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -76,7 +77,7 @@ export function ImageSelector({
 							}
 							small
 							symbol={hasImageTitle ? 'change' : 'plus'}
-							title={Liferay.Util.sub(
+							title={sub(
 								hasImageTitle
 									? Liferay.Language.get('change-x')
 									: Liferay.Language.get('select-x'),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ItemSelector.js
@@ -16,6 +16,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback} from 'react';
 
@@ -104,7 +105,7 @@ export default function ItemSelector({
 						type: 'divider',
 					},
 					{
-						label: `${Liferay.Util.sub(
+						label: `${sub(
 							Liferay.Language.get('select-x'),
 							label
 						)}...`,
@@ -146,10 +147,7 @@ export default function ItemSelector({
 			}
 
 			menuItems.push({
-				label: Liferay.Util.sub(
-					Liferay.Language.get('remove-x'),
-					label
-				),
+				label: sub(Liferay.Language.get('remove-x'), label),
 				onClick: () => onItemSelect({}),
 				symbolLeft:
 					label === Liferay.Language.get('collection')
@@ -186,7 +184,7 @@ export default function ItemSelector({
 
 	const selectContentButtonIcon = selectedItem?.title ? 'change' : 'plus';
 
-	const selectContentButtonLabel = Liferay.Util.sub(
+	const selectContentButtonLabel = sub(
 		selectedItem?.title
 			? Liferay.Language.get('change-x')
 			: Liferay.Language.get('select-x'),
@@ -210,7 +208,7 @@ export default function ItemSelector({
 								openModal();
 							}
 						}}
-						placeholder={Liferay.Util.sub(
+						placeholder={sub(
 							Liferay.Language.get('select-x'),
 							label
 						)}
@@ -266,14 +264,14 @@ export default function ItemSelector({
 							}}
 							trigger={
 								<ClayButtonWithIcon
-									aria-label={Liferay.Util.sub(
+									aria-label={sub(
 										Liferay.Language.get('view-x-options'),
 										label
 									)}
 									displayType="secondary"
 									small
 									symbol="ellipsis-v"
-									title={Liferay.Util.sub(
+									title={sub(
 										Liferay.Language.get('view-x-options'),
 										label
 									)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LengthField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LengthField.js
@@ -16,6 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
@@ -235,7 +236,7 @@ const LengthInput = ({field, id, initialValue, onValueSelect, value}) => {
 						<ClayButton
 							aria-expanded={active}
 							aria-haspopup="true"
-							aria-label={Liferay.Util.sub(
+							aria-label={sub(
 								Liferay.Language.get('select-a-unit'),
 								nextUnit
 							)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingFieldSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingFieldSelector.js
@@ -14,6 +14,7 @@
 
 import ClayForm, {ClaySelect} from '@clayui/form';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {EDITABLE_TYPES} from '../../app/config/constants/editableTypes';
@@ -92,7 +93,7 @@ export default function MappingFieldSelector({
 			{hasWarnings && (
 				<ClayForm.FeedbackGroup>
 					<ClayForm.FeedbackItem>
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get(
 								'no-fields-are-available-for-x-editable'
 							),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
@@ -14,6 +14,7 @@
 
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -391,7 +392,7 @@ function MappingSelector({fieldType, mappedItem, onMappingSelect}) {
 						}}
 						options={[
 							{
-								label: Liferay.Util.sub(
+								label: sub(
 									Liferay.Language.get('x-default'),
 									selectedMappingTypes.subtype
 										? selectedMappingTypes.subtype.label

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SpacingBox.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SpacingBox.js
@@ -15,6 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {useGlobalContext} from '../../app/contexts/GlobalContext';
@@ -235,7 +236,7 @@ function SpacingSelectorButton({field, onChange, position, type, value}) {
 					<ClayDropDown.Group header={field?.label}>
 						{field?.typeOptions?.validValues?.map((option) => (
 							<ClayDropDown.Item
-								aria-label={Liferay.Util.sub(
+								aria-label={sub(
 									Liferay.Language.get('set-x-to-x'),
 									[field.label, option.label]
 								)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/CollectionFilterConfigurationModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/CollectionFilterConfigurationModal.js
@@ -19,6 +19,7 @@ import ClayModal from '@clayui/modal';
 import ClayToolbar from '@clayui/toolbar';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {useSelector} from '../../../../../app/contexts/StoreContext';
@@ -256,13 +257,13 @@ const FilterInformationToolbar = ({
 								ref={filterInformationMessageElementRef}
 							>
 								{totalNumberOfItems === 1
-									? Liferay.Util.sub(
+									? sub(
 											Liferay.Language.get(
 												'there-is-1-result-for-x'
 											),
 											filterInformationMessage
 									  )
-									: Liferay.Util.sub(
+									: sub(
 											Liferay.Language.get(
 												'there-are-x-results-for-x'
 											),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNode.js
@@ -15,7 +15,7 @@
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
@@ -335,9 +335,7 @@ function StructureTreeNodeContent({
 			ref={targetRef}
 		>
 			<div
-				aria-label={Liferay.Util.sub(Liferay.Language.get('select-x'), [
-					node.name,
-				])}
+				aria-label={sub(Liferay.Language.get('select-x'), [node.name])}
 				className="lfr-portal-tooltip page-editor__page-structure__tree-node__mask"
 				data-title={node.tooltipTitle}
 				data-tooltip-align="left"
@@ -501,7 +499,7 @@ const VisibilityButton = ({
 
 	return (
 		<ClayButton
-			aria-label={Liferay.Util.sub(
+			aria-label={sub(
 				node.hidden || node.hiddenAncestor
 					? Liferay.Language.get('show-x')
 					: Liferay.Language.get('hide-x'),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.js
@@ -15,6 +15,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useMemo} from 'react';
 
 import {FRAGMENT_ENTRY_TYPES} from '../../../../../../app/config/constants/fragmentEntryTypes';
@@ -310,10 +311,7 @@ export function FormInputGeneralPanel({item}) {
 		<>
 			<div className="mb-3">
 				<Collapse
-					label={Liferay.Util.sub(
-						Liferay.Language.get('x-options'),
-						fragmentName
-					)}
+					label={sub(Liferay.Language.get('x-options'), fragmentName)}
 					open
 				>
 					{!isCaptchaInput && (
@@ -334,7 +332,7 @@ export function FormInputGeneralPanel({item}) {
 						isCaptchaInput) && (
 						<>
 							<span className="sr-only">
-								{Liferay.Util.sub(
+								{sub(
 									Liferay.Language.get('x-configuration'),
 									fragmentName
 								)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.js
@@ -13,6 +13,7 @@
  */
 
 import ClayForm, {ClayCheckbox, ClaySelectWithOption} from '@clayui/form';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useMemo} from 'react';
 
@@ -255,7 +256,7 @@ export function RowGeneralPanel({item}) {
 							label:
 								option === CUSTOM_ROW
 									? Liferay.Language.get('custom')
-									: Liferay.Util.sub(
+									: sub(
 											getModulesPerRowOptionLabel(option),
 											option
 									  ),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/LayoutSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/LayoutSelector.js
@@ -13,33 +13,34 @@
  */
 
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 const LAYOUT_OPTIONS = [
 	{label: Liferay.Language.get('full-width'), value: '1'},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-columns'), 2),
+		label: sub(Liferay.Language.get('x-columns'), 2),
 		value: '2',
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-columns'), 3),
+		label: sub(Liferay.Language.get('x-columns'), 3),
 		value: '3',
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-columns'), 4),
+		label: sub(Liferay.Language.get('x-columns'), 4),
 		value: '4',
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-columns'), 5),
+		label: sub(Liferay.Language.get('x-columns'), 5),
 		value: '5',
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-columns'), 6),
+		label: sub(Liferay.Language.get('x-columns'), 6),
 		value: '6',
 	},
 	{
-		label: Liferay.Util.sub(Liferay.Language.get('x-columns'), 12),
+		label: sub(Liferay.Language.get('x-columns'), 12),
 		value: '12',
 	},
 ];

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/NoPaginationOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/NoPaginationOptions.js
@@ -15,6 +15,7 @@
 import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -58,7 +59,7 @@ export function NoPaginationOptions({
 
 		if (totalNumberOfItems) {
 			if (initialNumberOfItems > totalNumberOfItems) {
-				errorMessage = Liferay.Util.sub(
+				errorMessage = sub(
 					PAGINATION_ERROR_MESSAGES.maximumItems,
 					totalNumberOfItems
 				);
@@ -102,7 +103,7 @@ export function NoPaginationOptions({
 
 			{displayAllItems && (
 				<p className="mt-1 small text-secondary">
-					{Liferay.Util.sub(
+					{sub(
 						Liferay.Language.get(
 							'this-setting-can-affect-page-performance-severely-if-the-number-of-collection-items-is-above-x.-we-strongly-recommend-using-pagination-instead'
 						),
@@ -136,7 +137,7 @@ export function NoPaginationOptions({
 					/>
 
 					<p className="mt-1 small text-secondary">
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get(
 								'setting-a-value-above-x-can-affect-page-performance-severely'
 							),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/PaginationOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/PaginationOptions.js
@@ -14,6 +14,7 @@
 
 import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -47,7 +48,7 @@ export function PaginationOptions({
 		let errorMessage = null;
 
 		if (isMaximumValuePerPageError) {
-			errorMessage = Liferay.Util.sub(
+			errorMessage = sub(
 				PAGINATION_ERROR_MESSAGES.maximumItemsPerPage,
 				config.searchContainerPageMaxDelta
 			);
@@ -159,7 +160,7 @@ export function PaginationOptions({
 							}
 						)}
 					>
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get('x-items-maximum'),
 							config.searchContainerPageMaxDelta
 						)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentComment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentComment.js
@@ -17,7 +17,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
@@ -154,7 +154,7 @@ export default function FragmentComment({
 						})}
 						data-title={
 							showModifiedDateTooltip &&
-							Liferay.Util.sub(
+							sub(
 								Liferay.Language.get('edited-x'),
 								modifiedDateDescription
 							)

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentEntryLinksWithComments.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentEntryLinksWithComments.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {sub} from 'frontend-js-web';
 import React from 'react';
 
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../app/config/constants/layoutDataItemTypes';
@@ -92,7 +93,7 @@ function FragmentEntryLinkWithComments({fragmentEntryLink, item}) {
 			</strong>
 
 			<span className="text-secondary">
-				{Liferay.Util.sub(
+				{sub(
 					fragmentEntryLink.comments.length === 1
 						? Liferay.Language.get('x-comment')
 						: Liferay.Language.get('x-comments'),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/create-layout-page-template-entry-modal/components/CreateLayoutPageTemplateEntryModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/create-layout-page-template-entry-modal/components/CreateLayoutPageTemplateEntryModal.js
@@ -16,7 +16,7 @@ import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
-import {openToast} from 'frontend-js-web';
+import {openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
@@ -100,7 +100,7 @@ const CreateLayoutPageTemplateEntryModal = ({observer, onClose}) => {
 			)
 				.then((response) => {
 					openToast({
-						message: Liferay.Util.sub(
+						message: sub(
 							Liferay.Language.get(
 								'the-page-template-was-created-successfully.-you-can-view-it-here-x'
 							),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments-widgets/components/FragmentsSidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments-widgets/components/FragmentsSidebar.js
@@ -13,6 +13,7 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
+import {sub} from 'frontend-js-web';
 import React, {useMemo, useState} from 'react';
 
 import {ReorderSetsModal} from '../../../app/components/ReorderSetsModal';
@@ -236,7 +237,7 @@ export default function FragmentsSidebar() {
 								? 'cards2'
 								: 'list'
 						}
-						title={Liferay.Util.sub(
+						title={sub(
 							Liferay.Language.get('switch-to-x-view'),
 							displayStyle === FRAGMENTS_DISPLAY_STYLES.LIST
 								? Liferay.Language.get('card')

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Collection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Collection.test.js
@@ -47,13 +47,16 @@ jest.mock(
 	})
 );
 
-function renderCollection(itemConfig = {}) {
-	Liferay.Util.sub.mockImplementation((langKey, args) => {
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => {
 		const nextArgs = Array.isArray(args) ? args : [args];
 
 		return [langKey, ...nextArgs].join('-');
-	});
+	}),
+}));
 
+function renderCollection(itemConfig = {}) {
 	const state = {
 		permissions: {
 			UPDATE: true,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/CollectionSelector.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/CollectionSelector.test.js
@@ -29,6 +29,11 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => [langKey, ...args].join('-')),
+}));
+
 describe('CollectionSelector', () => {
 	afterEach(() => {
 		openItemSelector.mockClear();
@@ -37,10 +42,6 @@ describe('CollectionSelector', () => {
 	it('uses custom item selector URL when present in the collection item context', () => {
 		const CUSTOM_COLLECTION_SELECTOR_URL = 'CUSTOM_COLLECTION_SELECTOR_URL';
 		const DEFAULT_ITEM_SELECTOR_URL = 'DEFAULT_ITEM_SELECTOR_URL';
-
-		Liferay.Util.sub.mockImplementation((langKey, args) =>
-			[langKey, ...args].join('-')
-		);
 
 		render(
 			<StoreAPIContextProvider dispatch={() => {}} getState={() => ({})}>
@@ -72,10 +73,6 @@ describe('CollectionSelector', () => {
 	it('uses passed item selector URL when not inside a collection item context', () => {
 		const DEFAULT_ITEM_SELECTOR_URL = 'DEFAULT_ITEM_SELECTOR_URL';
 
-		Liferay.Util.sub.mockImplementation((langKey, args) =>
-			[langKey, ...args].join('-')
-		);
-
 		render(
 			<StoreAPIContextProvider dispatch={() => {}} getState={() => ({})}>
 				<CollectionSelector
@@ -98,10 +95,6 @@ describe('CollectionSelector', () => {
 	});
 
 	it('does not show collection prefilter label when the filter is not configured', () => {
-		Liferay.Util.sub.mockImplementation((langKey, args) =>
-			[langKey, ...args].join('-')
-		);
-
 		render(
 			<StoreAPIContextProvider dispatch={() => {}} getState={() => ({})}>
 				<CollectionSelector label="" onCollectionSelect={() => {}} />
@@ -114,10 +107,6 @@ describe('CollectionSelector', () => {
 	});
 
 	it('shows collection prefilter label when the filter is not configured', () => {
-		Liferay.Util.sub.mockImplementation((langKey, args) =>
-			[langKey, ...args].join('-')
-		);
-
 		render(
 			<StoreAPIContextProvider dispatch={() => {}} getState={() => ({})}>
 				<CollectionSelector

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/fragment-configuration-fields/AdvancedSelectField.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/fragment-configuration-fields/AdvancedSelectField.test.js
@@ -124,6 +124,11 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
+}));
+
 describe('AdvancedSelectField', () => {
 	it('renders AdvancedSelectField', () => {
 		renderAdvancedSelectField();

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/CollectionFilterConfigurationModal.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/CollectionFilterConfigurationModal.test.js
@@ -30,6 +30,11 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, ...args) => [langKey, ...args].join('-')),
+}));
+
 const fakeObserver = {
 	dispatch: () => {},
 	mutation: [true, true],
@@ -68,10 +73,6 @@ const COLLECTION_KEY = 'COLLECTION_KEY';
 const handleConfigurationChanged = jest.fn();
 
 const renderComponent = () => {
-	Liferay.Util.sub.mockImplementation((langKey, ...args) =>
-		[langKey, ...args].join('-')
-	);
-
 	const result = render(
 		<StoreContextProvider
 			initialState={{

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/PageStructureSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/PageStructureSidebar.test.js
@@ -33,6 +33,15 @@ jest.mock(
 	() => jest.fn()
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => {
+		const nextArgs = Array.isArray(args) ? args : [args];
+
+		return [langKey, ...nextArgs].join('-');
+	}),
+}));
+
 const renderComponent = ({
 	activeItemId = null,
 	hasUpdatePermissions = true,
@@ -41,12 +50,6 @@ const renderComponent = ({
 	rootItemChildren = ['01-container'],
 	viewportSize = VIEWPORT_SIZES.desktop,
 } = {}) => {
-	Liferay.Util.sub.mockImplementation((langKey, args) => {
-		const nextArgs = Array.isArray(args) ? args : [args];
-
-		return [langKey, ...nextArgs].join('-');
-	});
-
 	const mockDispatch = jest.fn((a) => {
 		if (typeof a === 'function') {
 			return a(mockDispatch);

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
@@ -158,6 +158,13 @@ jest.mock(
 	() => jest.fn()
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((key, args) =>
+		args.reduce((key, arg) => key.replace('x', arg), key)
+	),
+}));
+
 describe('CommonStyles', () => {
 	afterEach(() => {
 		updateItemConfig.mockClear();
@@ -170,10 +177,6 @@ describe('CommonStyles', () => {
 	});
 
 	it('allows changing common styles for a given viewport', async () => {
-		Liferay.Util.sub.mockImplementation((key, args) =>
-			args.reduce((key, arg) => key.replace('x', arg), key)
-		);
-
 		const {getByLabelText} = renderComponent({
 			state: {selectedViewportSize: 'tablet'},
 		});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.test.js
@@ -120,6 +120,10 @@ jest.mock(
 		},
 	})
 );
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => [langKey, args].join('-')),
+}));
 
 const renderComponent = ({
 	fragmentEntryKey = 'textFragment',
@@ -229,10 +233,6 @@ describe('FormInputGeneralPanel', () => {
 	});
 
 	it('shows configuration fieldset when fragment is mapped', () => {
-		Liferay.Util.sub.mockImplementation((langKey, args) =>
-			[langKey, args].join('-')
-		);
-
 		renderComponent({mappedFieldId: 'requiredField'});
 
 		expect(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
@@ -193,6 +193,13 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((key, args) =>
+		args.reduce((key, arg) => key.replace('x', arg), key)
+	),
+}));
+
 describe('FragmentStylesPanel', () => {
 	afterEach(() => {
 		updateItemConfig.mockClear();
@@ -213,10 +220,6 @@ describe('FragmentStylesPanel', () => {
 	});
 
 	it('allows changing custom styles for a given viewport', async () => {
-		Liferay.Util.sub.mockImplementation((key, args) =>
-			args.reduce((key, arg) => key.replace('x', arg), key)
-		);
-
 		renderComponent({
 			selectedViewportSize: VIEWPORT_SIZES.tablet,
 		});

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.test.js
@@ -55,6 +55,11 @@ jest.mock(
 	() => jest.fn()
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => [langKey, args].join('-')),
+}));
+
 const DEFAULT_ITEM_CONFIG = {
 	collection: {
 		classNameId: '22101',
@@ -80,10 +85,6 @@ const renderComponent = ({
 	layoutData = {},
 	selectedViewportSize = 'desktop',
 } = {}) => {
-	Liferay.Util.sub.mockImplementation((langKey, args) =>
-		[langKey, args].join('-')
-	);
-
 	return render(
 		<StoreAPIContextProvider
 			dispatch={() => {}}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/comments/components/MappingSelector.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/comments/components/MappingSelector.test.js
@@ -131,6 +131,11 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => [langKey, args].join('-')),
+}));
+
 function renderMappingSelector({
 	mappedItem = {},
 	mappingFields = defaultMappingFields,
@@ -177,10 +182,6 @@ function renderMappingSelector({
 }
 
 describe('MappingSelector', () => {
-	Liferay.Util.sub.mockImplementation((langKey, args) =>
-		[langKey, args].join('-')
-	);
-
 	it('renders correct selects in content pages', async () => {
 		renderMappingSelector({});
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments-widgets/components/FragmentsSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/fragments-widgets/components/FragmentsSidebar.test.js
@@ -39,6 +39,11 @@ jest.mock(
 	}
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => langKey.replace('x', args)),
+}));
+
 const DEFAULT_WIDGETS = [
 	{
 		categories: [],
@@ -587,10 +592,6 @@ describe('FragmentsSidebar', () => {
 	});
 
 	describe('Button to switch the display style', () => {
-		Liferay.Util.sub.mockImplementation((langKey, args) =>
-			langKey.replace('x', args)
-		);
-
 		it('shows the card view when the display style is list', () => {
 			const {getByTitle} = renderComponent();
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/utils/getResetLabelByViewport.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/utils/getResetLabelByViewport.test.js
@@ -29,6 +29,11 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
+}));
+
 const getLabel = (viewport) => `reset-to-${viewport}-value`;
 
 describe('getResetLabelByViewport', () => {

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/components/ItemSelector.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/components/ItemSelector.test.js
@@ -37,6 +37,11 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, args) => langKey.replace('x', args)),
+}));
+
 function renderItemSelector({
 	pageContents = [],
 	selectedItemClassPK = '',
@@ -45,10 +50,6 @@ function renderItemSelector({
 	const state = {
 		pageContents,
 	};
-
-	Liferay.Util.sub.mockImplementation((langKey, args) =>
-		langKey.replace('x', args)
-	);
 
 	return render(
 		<StoreAPIContextProvider dispatch={() => {}} getState={() => state}>

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/components/SpacingBox.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/components/SpacingBox.test.js
@@ -39,6 +39,13 @@ jest.mock(
 	})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((key, args) =>
+		args.reduce((key, arg) => key.replace('x', arg), key)
+	),
+}));
+
 const SpacingBoxTest = ({onChange = () => {}, value = {}}) => (
 	<StyleBookContextProvider>
 		<SpacingBox
@@ -132,16 +139,13 @@ const SpacingBoxTest = ({onChange = () => {}, value = {}}) => (
 
 describe('SpacingBox', () => {
 	let _getComputedStyle;
-	let _liferayUtilSub;
 
 	beforeEach(() => {
 		_getComputedStyle = window.getComputedStyle;
-		_liferayUtilSub = window.Liferay.Util.sub;
 	});
 
 	afterEach(() => {
 		window.getComputedStyle = _getComputedStyle;
-		window.Liferay.Util.sub = _liferayUtilSub;
 	});
 
 	it('renders given spacing values from StyleBook', async () => {
@@ -169,9 +173,6 @@ describe('SpacingBox', () => {
 	});
 
 	it('can be used to update spacing', () => {
-		window.Liferay.Util.sub = (key, args) =>
-			args.reduce((key, arg) => key.replace('x', arg), key);
-
 		const onChange = jest.fn();
 		render(<SpacingBoxTest onChange={onChange} />);
 

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/IssuesList.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/IssuesList.js
@@ -19,6 +19,7 @@ import ClayLayout from '@clayui/layout';
 import ClayList from '@clayui/list';
 import ClayPanel from '@clayui/panel';
 import ClayProgressBar from '@clayui/progress-bar';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
@@ -59,7 +60,7 @@ export default function IssuesList() {
 		<>
 			{localizedIssues && !loading && (
 				<ClayAlert className="mb-4" displayType="info" variant="stripe">
-					{Liferay.Util.sub(
+					{sub(
 						Liferay.Language.get(
 							'showing-data-from-x-relaunch-to-update-data'
 						),
@@ -175,7 +176,7 @@ const Section = ({section}) => {
 			<ClayPanel.Body>
 				{sectionTotal === '0' ? (
 					<div className="text-secondary">
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get(
 								'there-are-no-x-related-issues'
 							),

--- a/modules/apps/layout/layout-reports-web/test/js/components/IssuesList.test.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/IssuesList.test.js
@@ -27,6 +27,11 @@ jest.mock(
 	() => jest.fn(() => () => {})
 );
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
+}));
+
 const mockLayoutReportsIssues = [
 	{
 		details: [

--- a/modules/apps/layout/layout-reports-web/test/js/components/LayoutReports.test.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/LayoutReports.test.js
@@ -21,6 +21,11 @@ import LayoutReports from '../../../src/main/resources/META-INF/resources/js/com
 import {StoreContextProvider} from '../../../src/main/resources/META-INF/resources/js/context/StoreContext';
 import {layoutReportsIssues, pageURLs, selectedIssue} from '../mocks';
 
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, arg) => langKey.replace('x', arg)),
+}));
+
 const getLayoutReportsComponent = ({
 	error = null,
 	layoutReportsIssues = null,

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SearchBarConfigurationSuggestions.js
@@ -19,7 +19,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useModal} from '@clayui/modal';
 import ClayMultiSelect from '@clayui/multi-select';
 import getCN from 'classnames';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import FieldList from './FieldList';
@@ -413,7 +413,7 @@ function Inputs({onChange, onReplace, contributorOptions, value = {}}) {
 					{value.size < 0 && touched.size && (
 						<div className="form-feedback-group">
 							<div className="form-feedback-item">
-								{Liferay.Util.sub(
+								{sub(
 									Liferay.Language.get(
 										'please-enter-a-value-greater-than-or-equal-to-x'
 									),

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SortConfigurationOptions.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/SortConfigurationOptions.js
@@ -15,6 +15,7 @@
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClaySelect, ClayToggle} from '@clayui/form';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import FieldList from './FieldList';
@@ -339,14 +340,11 @@ function SortConfigurationOptions({
 					onClick={_handleSwitchView}
 					small
 				>
-					{Liferay.Util.sub(
-						Liferay.Language.get('switch-to-x-view'),
-						[
-							view.value === VIEWS.NEW.value
-								? VIEWS.CLASSIC.label
-								: VIEWS.NEW.label,
-						]
-					)}
+					{sub(Liferay.Language.get('switch-to-x-view'), [
+						view.value === VIEWS.NEW.value
+							? VIEWS.CLASSIC.label
+							: VIEWS.NEW.label,
+					])}
 				</ClayButton>
 			</div>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/ManagementToolbar.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/ManagementToolbar.js
@@ -17,6 +17,7 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import {ManagementToolbar as FrontendManagementToolbar} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 const ManagementToolbar = ({
@@ -138,7 +139,7 @@ const ManagementToolbar = ({
 					<FrontendManagementToolbar.ResultsBarItem>
 						<span className="component-text text-truncate-inline">
 							<span className="text-truncate">
-								{Liferay.Util.sub(
+								{sub(
 									totalCount === 1
 										? Liferay.Language.get('x-result-for-x')
 										: Liferay.Language.get(

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/UndoHistory.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/UndoHistory.js
@@ -19,6 +19,7 @@ import {
 	useEventListener,
 	useIsMounted,
 } from '@liferay/frontend-js-react-web';
+import {sub} from 'frontend-js-web';
 import React, {useState} from 'react';
 
 import {UNDO_TYPES} from './constants/undoTypes';
@@ -158,7 +159,7 @@ const History = ({actions = [], type, onHistoryItemClick}) => {
 			}}
 			symbolRight={isSelectedAction(index) ? 'check' : ''}
 		>
-			{Liferay.Util.sub(Liferay.Language.get('update-x'), action.label)}
+			{sub(Liferay.Language.get('update-x'), action.label)}
 		</ClayDropDown.Item>
 	));
 };

--- a/modules/apps/style-book/style-book-web/test/style-book-editor/undoHistory.test.js
+++ b/modules/apps/style-book/style-book-web/test/style-book-editor/undoHistory.test.js
@@ -83,11 +83,12 @@ function renderUndoHistory() {
 	);
 }
 
-describe('UndoHistory', () => {
-	Liferay.Util.sub.mockImplementation((key, args) =>
-		key.replace('-x', ` ${args}`)
-	);
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((key, args) => key.replace('-x', ` ${args}`)),
+}));
 
+describe('UndoHistory', () => {
 	it('shows all redo and undo history items in the list', () => {
 		const {getByText} = renderUndoHistory();
 

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateFieldSetEntries.js
@@ -19,6 +19,7 @@ import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
 import {ClassicEditor} from 'frontend-editor-ckeditor-web';
+import {sub} from 'frontend-js-web';
 import React, {useEffect, useRef, useState} from 'react';
 
 import {FETCH_STATUS} from '../constants';
@@ -38,10 +39,7 @@ const TranslateAutoTranslateRow = ({
 	}
 
 	const isLoading = fieldStatus.status === FETCH_STATUS.LOADING;
-	const text = Liferay.Util.sub(
-		Liferay.Language.get('auto-translate-x-field'),
-		label
-	);
+	const text = sub(Liferay.Language.get('auto-translate-x-field'), label);
 
 	return (
 		<ClayLayout.Row>

--- a/modules/apps/translation/translation-web/test/js/translate/Translate.js
+++ b/modules/apps/translation/translation-web/test/js/translate/Translate.js
@@ -135,11 +135,12 @@ const baseProps = {
 
 const renderComponent = (props) => render(<Translate {...props} />);
 
-describe('Translate', () => {
-	Liferay.Util.sub.mockImplementation((langKey, ...args) =>
-		[langKey, ...args].join('-')
-	);
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	sub: jest.fn((langKey, ...args) => [langKey, ...args].join('-')),
+}));
 
+describe('Translate', () => {
 	Liferay.Util.unescapeHTML =
 		Liferay.Util.unescapeHTML ||
 		jest.fn((string) =>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/BasicInformation.js
@@ -13,6 +13,7 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
 import classnames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
@@ -36,7 +37,7 @@ function Author({author: {authorId, name, url}}) {
 				)}
 			</ClaySticker>
 
-			{Liferay.Util.sub(Liferay.Language.get('authored-by-x'), name)}
+			{sub(Liferay.Language.get('authored-by-x'), name)}
 		</div>
 	);
 }
@@ -103,7 +104,7 @@ function BasicInformation({
 			<ClayLayout.ContentRow className="mb-2">
 				<ClayLayout.ContentCol expand>
 					<span className="text-secondary">
-						{Liferay.Util.sub(
+						{sub(
 							Liferay.Language.get('published-on-x'),
 							formattedPublishDate
 						)}

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/Main.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useMemo} from 'react';
 
@@ -86,7 +87,7 @@ export default function Main({
 			<TotalCount
 				className="mb-2"
 				dataProvider={totalViewsDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('total-views'))}
+				label={sub(Liferay.Language.get('total-views'))}
 				popoverHeader={Liferay.Language.get('total-views')}
 				popoverMessage={Liferay.Language.get(
 					'this-number-refers-to-the-total-number-of-views-since-the-content-was-published'
@@ -97,9 +98,7 @@ export default function Main({
 				<TotalCount
 					className="mb-2"
 					dataProvider={totalReadsDataProvider}
-					label={Liferay.Util.sub(
-						Liferay.Language.get('total-reads')
-					)}
+					label={sub(Liferay.Language.get('total-reads'))}
 					popoverHeader={Liferay.Language.get('total-reads')}
 					popoverMessage={Liferay.Language.get(
 						'this-number-refers-to-the-total-number-of-reads-since-the-content-was-published'

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/CountriesDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/CountriesDetail.js
@@ -10,6 +10,7 @@
  */
 
 import className from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useMemo, useRef} from 'react';
 
@@ -134,7 +135,7 @@ export default function CountriesDetail({
 			<TotalCount
 				className="mb-2"
 				dataProvider={trafficVolumeDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
+				label={sub(Liferay.Language.get('traffic-volume'))}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
@@ -145,7 +146,7 @@ export default function CountriesDetail({
 			<TotalCount
 				className="mb-4"
 				dataProvider={trafficShareDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
+				label={sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/KeywordsDetail.js
@@ -9,6 +9,7 @@
  * distribution rights of the Software.
  */
 
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React from 'react';
 
@@ -25,7 +26,7 @@ export default function KeywordsDetail({
 			<TotalCount
 				className="mb-2"
 				dataProvider={trafficVolumeDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
+				label={sub(Liferay.Language.get('traffic-volume'))}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
@@ -36,7 +37,7 @@ export default function KeywordsDetail({
 			<TotalCount
 				className="mb-4"
 				dataProvider={trafficShareDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
+				label={sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/ReferralDetail.js
@@ -13,6 +13,7 @@ import ClayButton from '@clayui/button';
 import ClayList from '@clayui/list';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import className from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 
@@ -153,7 +154,7 @@ export default function ReferralDetail({
 			<TotalCount
 				className="c-mb-2"
 				dataProvider={trafficVolumeDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
+				label={sub(Liferay.Language.get('traffic-volume'))}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
@@ -164,7 +165,7 @@ export default function ReferralDetail({
 			<TotalCount
 				className="c-mb-3"
 				dataProvider={trafficShareDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
+				label={sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/components/detail/SocialDetail.js
@@ -12,6 +12,7 @@
 import ClayList from '@clayui/list';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import className from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 
@@ -175,7 +176,7 @@ export default function SocialDetail({
 			<TotalCount
 				className="c-mb-2"
 				dataProvider={trafficVolumeDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-volume'))}
+				label={sub(Liferay.Language.get('traffic-volume'))}
 				popoverHeader={Liferay.Language.get('traffic-volume')}
 				popoverMessage={Liferay.Language.get(
 					'traffic-volume-is-the-number-of-page-views-coming-from-one-channel'
@@ -186,7 +187,7 @@ export default function SocialDetail({
 			<TotalCount
 				className="c-mb-3"
 				dataProvider={trafficShareDataProvider}
-				label={Liferay.Util.sub(Liferay.Language.get('traffic-share'))}
+				label={sub(Liferay.Language.get('traffic-share'))}
 				percentage={true}
 				popoverHeader={Liferay.Language.get('traffic-share')}
 				popoverMessage={Liferay.Language.get(


### PR DESCRIPTION
There was a decent amount of usages of `Liferay.Util.sub` that we missed in an [earlier PR](https://github.com/liferay-frontend/liferay-portal/pull/2223). We should probably also work on some eslint rules that forbid further additions of utils from the global scope.