### PR TITLE
LPS-161442 | Expose language from assetLibrary and site

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/LanguageAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/LanguageAPI.macro
@@ -1,0 +1,36 @@
+definition {
+
+	macro _getLanguages {
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(assetLibraryId)) {
+			var api = "asset-libraries/${assetLibraryId}";
+		}
+		else {
+			var api = "sites/${siteId}";
+		}
+
+		var curl = '''
+            ${portalURL}/o/headless-delivery/v1.0/${api}/languages \
+		    -u test@liferay.com:test \
+		    -H accept: application/json \
+	    ''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
+	macro getAssetLibraryLanguages {
+		Variables.assertDefined(parameterList = "${assetLibraryId}");
+
+		LanguageAPI._getLanguages(assetLibraryId = "${assetLibraryId}");
+	}
+
+	macro getSiteLanguages {
+		Variables.assertDefined(parameterList = "${siteId}");
+
+		LanguageAPI._getLanguages(siteId = "${siteId}");
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeLanguagesFromAssetLibraryAndSite.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/ExposeLanguagesFromAssetLibraryAndSite.testcase
@@ -1,0 +1,91 @@
+@component-name = "portal-headless-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Frontend Infrastructure";
+
+	setUp {
+		TestCase.setUpPortalInstanceNoSelenium();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			DepotNavigator.openDepotAdmin();
+
+			JSONDepot.deleteDepot(depotName = "Test Depot Name");
+
+			Site.tearDownCP();
+		}
+	}
+
+	@priority = "4"
+	test CanRecieveCurrentConfiguredLanguagesFromAssetLibrary {
+		property portal.acceptance = "true";
+
+		task ("Given an AssetLibrary with a list of languages configured") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			DepotNavigator.openDepotAdmin();
+
+			DepotNavigator.gotoDefineCustomLanguages(depotName = "Test Depot Name");
+
+			Button.click(button = "Edit");
+
+			Depot.configureCurrentLanguages(
+				currentLanguages = "English (United States),Chinese (China),French (France),Spanish (Spain)",
+				defaultDepotLanguage = "English (United States)");
+
+			Button.click(button = "Save");
+		}
+
+		task ("When a user makes a query to getAssetLibraryLanguagesPage") {
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var response = LanguageAPI.getAssetLibraryLanguages(assetLibraryId = "${assetLibraryId}");
+		}
+
+		task ("Then the response returns the configured languages for the AssetLibrary") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.items..name");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "English,Chinese,French,Spanish");
+		}
+	}
+
+	@priority = "4"
+	test CanRecieveCurrentConfiguredLanguagesFromSite {
+		property portal.acceptance = "true";
+
+		task ("Given a site with a language configured") {
+			Site.openSiteSettingsAdmin(siteURLKey = "guest");
+
+			Site.configureCurrentLanguagesCP(
+				currentSiteLanguages = "English (United States)",
+				defaultSiteLanguage = "English (United States)");
+		}
+
+		task ("When a user makes a query to getSiteLanguagesPage") {
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Guest");
+
+			var response = LanguageAPI.getSiteLanguages(siteId = "${siteId}");
+		}
+
+		task ("Then the response returns the configured languages for the site") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$.items..name");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "English");
+		}
+	}
+
+}


### PR DESCRIPTION
**Background**
Expose language from assetLibrary and site

**Test Plan**
Given a site with a language configured
When a user makes a query to getSiteLanguagesPage
Then the response returns the configured languages for the site

Given an AssetLibrary with a list of languages configured
When a user makes a query to
getAssetLibraryLanguagesPage
Then the response returns the configured languages for the AssetLibrary

**JIRA Link:**
https://issues.liferay.com/browse/LPS-161442