### PR TITLE
LPS-160082 | Add supported query params to Headless API Explorer for individual elements

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessadmintaxonomy/TaxonomyVocabularyAPI.macro
@@ -159,6 +159,7 @@ definition {
 	macro getAssetLibraryKeywordsWithDifferentParameters {
 		var curl = TaxonomyVocabularyAPI._curlTaxonomyKeywords(
 			assetLibraryId = "${assetLibraryId}",
+			keywordId = "${keywordId}",
 			parameter = "${parameter}",
 			parameterValue = "${parameterValue}");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/headlessdeliveryapi/DocumentAPI.macro
@@ -68,6 +68,29 @@ definition {
 		return "${curl}";
 	}
 
+	macro _getDocumentsByDifferentParameters {
+		Variables.assertDefined(parameterList = "${documentId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		if (isSet(parameter)) {
+			var api = "documents/${documentId}?${parameter}=${parameterValue}";
+		}
+		else {
+			var api = "documents/${documentId}";
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-delivery/v1.0/${api} \
+			-u test@liferay.com:test \
+			-H Content-Type: application/json
+		''';
+
+		var curl = JSONCurlUtil.get("${curl}");
+
+		return "${curl}";
+	}
+
 	macro _getDocumentsByErcInAssetLibrary {
 		Variables.assertDefined(parameterList = "${assetLibraryId},${externalReferenceCode}");
 
@@ -188,6 +211,15 @@ definition {
 		DocumentAPI._deleteDocumentsByErcInAssetLibrary(
 			assetLibraryId = "${assetLibraryId}",
 			externalReferenceCode = "${externalReferenceCode}");
+	}
+
+	macro getDocumentsByDifferentParameters {
+		var response = DocumentAPI._getDocumentsByDifferentParameters(
+			documentId = "${documentId}",
+			parameter = "${parameter}",
+			parameterValue = "${parameterValue}");
+
+		return "${response}";
 	}
 
 	macro getDocumentsByErcInAssetLibrary {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/headless/journal/HeadlessWebcontentAPI.macro
@@ -460,10 +460,17 @@ definition {
 			Variables.assertDefined(parameterList = "${versionvalue},${structuredContentId}");
 		}
 
+		if (isSet(parameter)) {
+			var api = "${structuredContentId}/by-version/${versionvalue}?${parameter}=${parameterValue}";
+		}
+		else {
+			var api = "${structuredContentId}/by-version/${versionvalue}";
+		}
+
 		var portalURL = JSONCompany.getPortalURL();
 
 		var curl = '''
-			${portalURL}/o/headless-admin-content/v1.0/structured-contents/${structuredContentId}/by-version/${versionvalue} \
+			${portalURL}/o/headless-admin-content/v1.0/structured-contents/${api} \
 			-u test@liferay.com:test \
 			-H accept: application/json
 		''';
@@ -767,6 +774,8 @@ definition {
 			Variables.assertDefined(parameterList = "${structuredContentId},${versionvalue}");
 
 			var response = HeadlessWebcontentAPI._versionStructureContent(
+				parameter = "${parameter}",
+				parameterValue = "${parameterValue}",
 				structuredContentId = "${structuredContentId}",
 				versionvalue = "${versionvalue}");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/HeadlessAdminContentSupprotDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminContentAPI/SupportContentVersioning/HeadlessAdminContentSupprotDifferentParameters.testcase
@@ -194,4 +194,104 @@ definition {
 		}
 	}
 
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("And Given web content created") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
+
+			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				siteId = "${siteId}",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with curl I request getStructuredContentByVersion with fields=id") {
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
+
+			var response = HeadlessWebcontentAPI.versionStructureContent(
+				parameter = "fields",
+				parameterValue = "id",
+				structuredContentId = "${structuredContentId}",
+				versionvalue = "1.0");
+		}
+
+		task ("Then in a response I received an id value only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{id=${structuredContentId}}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveTitleFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a content structure created") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+			NavItem.gotoStructures();
+
+			WebContentStructures.addCP(structureName = "content-structure");
+
+			FormViewBuilder.addFieldByDoubleClick(fieldType = "Text");
+
+			FormFields.editFieldReference(key_fieldReference = "Text");
+
+			Button.clickSave();
+		}
+
+		task ("And Given web content created") {
+			var ddmStructureId = WebContentStructures.getDdmStructureId(structureName = "content-structure");
+			var siteId = JSONGroupAPI._getSiteIdByGroupKey(groupName = "Test Site Name");
+
+			var responseFromCreate = HeadlessWebcontentAPI.createStructuredContent(
+				data = "<p>My content</p>",
+				ddmStructureId = "${ddmStructureId}",
+				label = "Text",
+				name = "Text",
+				siteId = "${siteId}",
+				title = "WC WebContent Title");
+		}
+
+		task ("When with curl I request getStructuredContentByVersion with restrictFields equal all fields except title field") {
+			var structuredContentId = HeadlessWebcontentAPI.getWebContentIdFromResponse(responseToParse = "${responseFromCreate}");
+
+			var response = HeadlessWebcontentAPI.versionStructureContent(
+				parameter = "restrictFields",
+				parameterValue = "actions,availableLanguages,contentFields,contentStructureId,creator,customFields,dateCreated,dateModified,datePublished,description,externalReferenceCode,friendlyUrlPath,id,key,keywords,numberOfComments,priority,relatedContents,renderedContents,siteId,subscribed,taxonomyCategoryBriefs,uuid,version",
+				structuredContentId = "${structuredContentId}",
+				versionvalue = "1.0");
+		}
+
+		task ("Then in a response I receive a body with title field values only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{title=WC WebContent Title}");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/HeadlessAdminTaxonomySupportDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessAdminTaxonomyAPI/HeadlessAdminTaxonomySupportDifferentParameters.testcase
@@ -86,6 +86,38 @@ definition {
 	}
 
 	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a AssetLibrary with keyword created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var responseFromCreate = TaxonomyVocabularyAPI.createAssetLibraryWithKeyWords(
+				assetLibraryId = "${assetLibraryId}",
+				name = "liferay");
+		}
+
+		task ("When with curl I request getKeyword with restrictFields equal all fields except id field") {
+			var keywordId = JSONUtil.getWithJSONPath("${responseFromCreate}", "$.id");
+
+			var response = TaxonomyVocabularyAPI.getAssetLibraryKeywordsWithDifferentParameters(
+				keywordId = "${keywordId}",
+				parameter = "restrictFields",
+				parameterValue = "actions,assetLibraryKey,creator,dateCreated,dateModified,name,keywordUsageCount,subscribed");
+		}
+
+		task ("Then in a response I receive a body with id field values only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{id=${keywordId}}");
+		}
+	}
+
+	@priority = "4"
 	test CanReceiveNameFieldValuesOnlyInResponse {
 		property portal.acceptance = "true";
 
@@ -115,6 +147,38 @@ definition {
 			TaxonomyVocabularyAPI.assertResponseHasNameFieldValueOnly(
 				expectedValue = "{name=${taxonomyVocabularyName}}",
 				responseToParse = "${response}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveNameFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a AssetLibrary with keyword created") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+
+			var responseFromCreate = TaxonomyVocabularyAPI.createAssetLibraryWithKeyWords(
+				assetLibraryId = "${assetLibraryId}",
+				name = "liferay");
+		}
+
+		task ("When with curl I request getKeyword with fields=name") {
+			var keywordId = JSONUtil.getWithJSONPath("${responseFromCreate}", "$.id");
+
+			var response = TaxonomyVocabularyAPI.getAssetLibraryKeywordsWithDifferentParameters(
+				keywordId = "${keywordId}",
+				parameter = "fields",
+				parameterValue = "name");
+		}
+
+		task ("Then in a response I receive a body with name values only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{name=liferay}");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliverySupportDifferentParameters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/headless/HeadlessDeliveryAPI/HeadlessDeliverySupportDifferentParameters.testcase
@@ -128,4 +128,68 @@ definition {
 		}
 	}
 
+	@priority = "4"
+	test CanReceiveIdFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a document of a site") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with curl I request getDocument with fields=id") {
+			var response = DocumentAPI.getDocumentsByDifferentParameters(
+				documentId = "${documentId}",
+				parameter = "fields",
+				parameterValue = "id");
+		}
+
+		task ("Then in a response I received an id value only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{id=${documentId}}");
+		}
+	}
+
+	@priority = "4"
+	test CanReceiveTitleFieldValuesOnlyInResponseForIndividualElement {
+		property portal.acceptance = "true";
+
+		task ("Given a document of a site") {
+			JSONDepot.addDepot(depotName = "Test Depot Name");
+
+			var assetLibraryId = JSONGroupAPI._getDepotIdByName(depotName = "Test Depot Name");
+			var filePath = TestCase.getDependenciesDirPath(fileName = "Document_1.txt");
+
+			var documentId = DocumentAPI.getIdOfCreatedDocument(
+				assetLibraryId = "${assetLibraryId}",
+				externalReferenceCode = "erc",
+				filePath = "${filePath}");
+		}
+
+		task ("When with curl I request getDocument with restrictFields equal all fields except title field") {
+			var response = DocumentAPI.getDocumentsByDifferentParameters(
+				documentId = "${documentId}",
+				parameter = "restrictFields",
+				parameterValue = "actions,adaptedImages,assetLibraryKey,contentUrl,creator,customFields,dateCreated,dateModified,description,documentFolderId,documentType,encodingFormat,externalReferenceCode,fileExtension,id,keywords,numberOfComments,relatedContents,renderedContents,siteId,sizeInBytes,taxonomyCategoryBriefs");
+		}
+
+		task ("Then in a response I receive a body with title field values only") {
+			var actualValue = JSONUtil.getWithJSONPath("${response}", "$");
+
+			TestUtils.assertEquals(
+				actual = "${actualValue}",
+				expected = "{title=Document_1.txt}");
+		}
+	}
+
 }


### PR DESCRIPTION
**Background**
Add supported query params to Headless API Explorer for individual elements

**Test Plan**
Given a document of a site
When with curl I request getDocument with fields=id
Then in a response I received an id value only 

Given a document of a site
When with curl I request getDocument with restrictFields equal all fields except title field
Then in a response I receive a body with title field values only

Given a content structure created
And Given web content created
When with curl I request getStructuredContentByVersion with fields=id
Then in a response I received an id value only

Given a content structure created
And Given web content created
When with curl I request getStructuredContentByVersion with restrictFields equal all fields except title field
Then in a response I receive a body with title field values only

Given an AssetLibrary with keyword created
When with curl I request getKeyword with fields=name
Then in a response I receive a body with name values only

Given an AssetLibrary with keyword created
When with curl I request getKeyword with restrictFields equal all fields except id field
Then in a response I receive a body with id field values only

**JIRA Link:**
https://issues.liferay.com/browse/LPS-160082