### PR TITLE
LPS-160293 Add type definition to FrontendDataSet component in frontend-data-set-web module

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -16,7 +16,6 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
 import {useIsMounted, useThunk} from '@liferay/frontend-js-react-web';
 import {fetch, openToast} from 'frontend-js-web';
-import PropTypes from 'prop-types';
 import React, {
 	useCallback,
 	useEffect,
@@ -764,77 +763,6 @@ const FrontendDataSet = ({
 			</ViewsContext.Provider>
 		</FrontendDataSetContext.Provider>
 	);
-};
-
-FrontendDataSet.propTypes = {
-	activeViewSettings: PropTypes.string,
-	apiURL: PropTypes.string,
-	appURL: PropTypes.string,
-	bulkActions: PropTypes.array,
-	creationMenu: PropTypes.shape({
-		primaryItems: PropTypes.array,
-		secondaryItems: PropTypes.array,
-	}),
-	currentURL: PropTypes.string,
-	enableInlineAddModeSetting: PropTypes.shape({
-		defaultBodyContent: PropTypes.object,
-	}),
-	filters: PropTypes.array,
-	formId: PropTypes.string,
-	formName: PropTypes.string,
-	id: PropTypes.string.isRequired,
-	initialSelectedItemsValues: PropTypes.array,
-	inlineAddingSettings: PropTypes.shape({
-		apiURL: PropTypes.string.isRequired,
-		defaultBodyContent: PropTypes.object,
-	}),
-	inlineEditingSettings: PropTypes.oneOfType([
-		PropTypes.bool,
-		PropTypes.shape({
-			alwaysOn: PropTypes.bool,
-			defaultBodyContent: PropTypes.object,
-		}),
-	]),
-	items: PropTypes.array,
-	itemsActions: PropTypes.array,
-	namespace: PropTypes.string,
-	nestedItemsKey: PropTypes.string,
-	nestedItemsReferenceKey: PropTypes.string,
-	overrideEmptyResultView: PropTypes.bool,
-	pagination: PropTypes.shape({
-		deltas: PropTypes.arrayOf(
-			PropTypes.shape({
-				href: PropTypes.string,
-				label: PropTypes.number.isRequired,
-			}).isRequired
-		),
-		initialDelta: PropTypes.number.isRequired,
-	}),
-	portletId: PropTypes.string,
-	selectedItemsKey: PropTypes.string,
-	selectionType: PropTypes.oneOf(['single', 'multiple']),
-	showManagementBar: PropTypes.bool,
-	showPagination: PropTypes.bool,
-	showSearch: PropTypes.bool,
-	sidePanelId: PropTypes.string,
-	sorting: PropTypes.arrayOf(
-		PropTypes.shape({
-			direction: PropTypes.oneOf(['asc', 'desc']),
-			key: PropTypes.string,
-		})
-	),
-	style: PropTypes.oneOf(['default', 'fluid', 'stacked']),
-	views: PropTypes.arrayOf(
-		PropTypes.shape({
-			component: PropTypes.any,
-			contentRenderer: PropTypes.string,
-			contentRendererModuleURL: PropTypes.string,
-			label: PropTypes.string,
-			name: PropTypes.string,
-			schema: PropTypes.object,
-			thumbnail: PropTypes.string,
-		})
-	).isRequired,
 };
 
 FrontendDataSet.defaultProps = {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export function FrontendDataSet({
+	actionParameterName,
+	activeViewSettings,
+	apiURL,
+	appURL,
+	bulkActions,
+	creationMenu,
+	currentURL,
+	customDataRenderers,
+	customViewsEnabled,
+	filters,
+	formId,
+	formName,
+	id,
+	initialSelectedItemsValues,
+	inlineAddingSettings,
+	inlineEditingSettings,
+	items,
+	itemsActions,
+	namespace,
+	nestedItemsKey,
+	nestedItemsReferenceKey,
+	onActionDropdownItemClick,
+	onBulkActionItemClick,
+	overrideEmptyResultView,
+	pagination,
+	portletId,
+	selectedItemsKey,
+	selectionType,
+	showManagementBar,
+	showPagination,
+	showSearch,
+	sidePanelId,
+	sorting,
+	style,
+	views,
+}: IFrontendDataSetProps): JSX.Element;
+
+interface IFrontendDataSetProps {
+	actionParameterName?: string;
+	activeViewSettings?: string;
+	apiURL?: string;
+	appURL?: string;
+	bulkActions?: any[];
+	creationMenu?: {
+		primaryItems?: any[];
+		secondaryItems?: any[];
+	};
+	currentURL?: string;
+	customDataRenderers?: any;
+	customViewsEnabled?: boolean;
+	enableInlineAddModeSetting?: {
+		defaultBodyContent?: object;
+	};
+	filters?: any;
+	formId?: string;
+	formName?: string;
+	id: string;
+	initialSelectedItemsValues?: any[];
+	inlineAddingSettings?: {
+		apiURL: string;
+		defaultBodyContent: object;
+	};
+	inlineEditingSettings?: [
+		boolean,
+		{
+			alwaysOn: boolean;
+			defaultBodyContent: object;
+		}
+	];
+	items?: any[];
+	itemsActions?: TItemsActions[];
+	namespace?: string;
+	nestedItemsKey?: string;
+	nestedItemsReferenceKey?: string;
+	onActionDropdownItemClick?: any;
+	onBulkActionItemClick?: any;
+	overrideEmptyResultView?: boolean;
+	pagination?: {
+		deltas?: [
+			{
+				href?: string;
+				label: number;
+			}
+		];
+		initialDelta: number;
+	};
+	portletId?: string;
+	selectedItemsKey?: string;
+	selectionType?: ['single', 'multiple'];
+	showManagementBar?: boolean;
+	showPagination?: boolean;
+	showSearch?: boolean;
+	sidePanelId?: string;
+	sorting?: [
+		{
+			direction?: ['asc', 'desc'];
+			key?: string;
+		}
+	];
+	style?: ['default', 'fluid', 'stacked'];
+	views: [
+		{
+			component?: any;
+			contentRenderer?: string;
+			contentRendererModuleURL?: string;
+			label?: string;
+			name?: string;
+			schema?: object;
+			thumbnail?: string;
+		}
+	];
+}
+
+type TItemsActions = {
+	data?: {
+		confirmationMessage?: string;
+		id?: string;
+		method?: 'delete' | 'get';
+		permissionKey?: string;
+	};
+	href?: string;
+	icon?: string;
+	id?: string;
+	label?: string;
+	target?: 'async' | 'headless' | 'link' | 'modal' | 'sidePanel' | 'event';
+};

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
@@ -25,72 +25,6 @@ import React, {useEffect, useMemo, useState} from 'react';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
-const getDataSetProps = (items: Item[]) => {
-	return {
-		id: 'DefinitionOfTermsTable',
-		items,
-		itemsActions: [
-			{
-				href: 'copyObjectFieldTerm',
-				id: 'copyObjectFieldTerm',
-				label: Liferay.Language.get('copy'),
-				target: 'event',
-			},
-		],
-		namespace: '',
-		onActionDropdownItemClick,
-		pageSize: 5,
-		pagination: {
-			deltas: [
-				{
-					label: 5,
-				},
-				{
-					label: 10,
-				},
-				{
-					label: 20,
-				},
-				{
-					label: 30,
-				},
-				{
-					label: 50,
-				},
-				{
-					href: '',
-					label: 75,
-				},
-			],
-			initialDelta: 10,
-		},
-		selectedItemsKey: 'id',
-		showManagementBar: false,
-		showPagination: true,
-		showSearch: false,
-		views: [
-			{
-				contentRenderer: 'table',
-				label: 'Table',
-				name: 'table',
-				schema: {
-					fields: [
-						{
-							fieldName: 'name',
-							label: Liferay.Language.get('name'),
-						},
-						{
-							fieldName: 'term',
-							label: Liferay.Language.get('term'),
-						},
-					],
-				},
-				thumbnail: 'table',
-			},
-		],
-	};
-};
-
 export function DefinitionOfTerms({baseResourceURL}: IProps) {
 	const [objectDefinitions, setObjectDefinitions] = useState<
 		ObjectDefinition[]
@@ -99,10 +33,6 @@ export function DefinitionOfTerms({baseResourceURL}: IProps) {
 	const [query, setQuery] = useState<string>('');
 
 	const [entityFields, setEntityFields] = useState<Item[]>([]);
-
-	const props = useMemo(() => {
-		return getDataSetProps(entityFields);
-	}, [entityFields]);
 
 	const filteredObjectDefinitions = useMemo(() => {
 		return objectDefinitions?.filter(({label}) =>
@@ -182,7 +112,43 @@ export function DefinitionOfTerms({baseResourceURL}: IProps) {
 				</AutoComplete>
 
 				<div id="lfr-notification-web__definition-of-terms-table">
-					<FrontendDataSet {...props} />
+					<FrontendDataSet
+						id="DefinitionOfTermsTable"
+						items={entityFields}
+						itemsActions={[
+							{
+								href: 'copyObjectFieldTerm',
+								id: 'copyObjectFieldTerm',
+								label: Liferay.Language.get('copy'),
+								target: 'event',
+							},
+						]}
+						onActionDropdownItemClick={onActionDropdownItemClick}
+						selectedItemsKey="id"
+						showManagementBar={false}
+						showPagination={false}
+						showSearch={false}
+						views={[
+							{
+								contentRenderer: 'table',
+								label: 'Table',
+								name: 'table',
+								schema: {
+									fields: [
+										{
+											fieldName: 'name',
+											label: Liferay.Language.get('name'),
+										},
+										{
+											fieldName: 'term',
+											label: Liferay.Language.get('term'),
+										},
+									],
+								},
+								thumbnail: 'table',
+							},
+						]}
+					/>
 				</div>
 			</ClayPanel.Body>
 		</ClayPanel>

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/js/components/DefinitionOfTerms.tsx
@@ -13,9 +13,6 @@
  */
 
 import ClayPanel from '@clayui/panel';
-
-// @ts-ignore
-
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import {
 	API,

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/frontend-data-set-web.d.ts
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/frontend-data-set-web.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+declare module '@liferay/frontend-data-set-web' {
+	export * from '@liferay/frontend-data-set-web/src/main/resources/META-INF/resources/index';
+}


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-160293

Motivation
Hey Reviewer, This PR follows the same idea as https://github.com/liferay-frontend/liferay-portal/pull/2608, but in this case I created the type definitions for the FrontendDataSet component.

I'm working on a technical debt to remove some @ts-ignore annotations from the Objects and Notification code. For this I have to create some type declarations for components that were not developed in Typescript, I can declare these types in the notification-web module, but I think it will be restricted just for our case, so I decided to declare the types in the frontend-data-set-web which is the root of the FrontendDataSet component I had to remove the @ts-ignore, so anyone who wants to use this component with typescript in the future doesn't need to declare the same types in their own module, avoiding code repetition. What do you think?