### PR TITLE
LPS-162510 Move sr-only to portal

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_accessibility.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_accessibility.scss
@@ -1,0 +1,23 @@
+.sr-only {
+	border: 0;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
+.sr-only-focusable {
+	&:active,
+	&:focus {
+		clip: auto;
+		height: auto;
+		overflow: visible;
+		position: static;
+		white-space: normal;
+		width: auto;
+	}
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-162510

In order to prevent issues with screen reader classes like `sr-only` when uses of new versions of Bootstrap we move the `sr-only` to portal.

**How to test it:**

1º Use CSS extensions to remplace Clay CSS by attached CSS from the LPS-162510 issue or by an empty CSS.
2º Create a page with custom title
3º Go to the site and see how skip to content is hidden