### PR TITLE
LPS-156881 Localize FDS field label by default

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
@@ -167,7 +167,7 @@ public class FDSTableSchemaField {
 	private boolean _expand;
 	private String _fieldName;
 	private String _label;
-	private boolean _localizeLabel;
+	private boolean _localizeLabel = true;
 	private boolean _sortable;
 	private SortingOrder _sortingOrder;
 


### PR DESCRIPTION
### References

- [LPS-156881 Using lowercase 'a' as object field name is displayed as '%A'](https://issues.liferay.com/browse/LPS-156881)
- This is a followup on #2637

### What is the goal of this PR?

A regression fix. Localization should be turned on by default.

/cc @TaiPhamLR

### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/189350668-cefbe5ef-8758-40a1-93b0-47143537b4c6.png)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/189350680-4b98e075-9247-4432-9557-91ff4ab14e31.png)

### Steps to reproduce

See JIRA ticket.