### PR TITLE
LPS-159837 | Add tests CanBeEnabled and WillNotDisplayWhenNotDefinedForSite

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -1,5 +1,16 @@
 definition {
 
+	macro assertEnablePopoverModeNotPresent {
+		if (IsElementNotPresent(locator1 = "Walkthrough#POPOVER")) {
+			if (IsElementNotPresent(key_portletName = "JS Walkthrough Sample", locator1 = "Portlet#TITLE")) {
+				IsElementNotPresent(locator1 = "Walkthrough#HOTSPOT");
+			}
+			else {
+				IsElementNotPresent(locator1 = "Walkthrough#SAMPLE_PORTLET_HOTSPOT");
+			}
+		}
+	}
+
 	macro enablePopoverMode {
 		if (IsElementNotPresent(locator1 = "Walkthrough#POPOVER")) {
 			if (IsElementPresent(key_portletName = "JS Walkthrough Sample", locator1 = "Portlet#TITLE")) {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
@@ -1,0 +1,61 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-js-walkthrough-sample-web";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Walkthrough";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		PortalInstances.tearDownCP();
+	}
+
+	@description = "LPS-159836. Walkthrough displays when defined for a site."
+	@priority = "5"
+	test WillDisplayWhenDefinedForSite {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given there is a site-level JSON defined for current site") {
+			JSONGroup.addGroup(groupName = "Site Name");
+
+			ApplicationsMenu.gotoSite(site = "Site Name");
+
+			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
+
+			JSONLayout.addPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1",
+				widgetName = "JS Walkthrough Sample");
+		}
+
+		task ("When instantiate the walkthrough") {
+			Navigator.openSitePage(
+				pageName = "Walkthrough Page 1",
+				siteName = "Site Name");
+
+			Walkthrough.enablePopoverMode();
+		}
+
+		task ("Then walkthrough is instantiated on the site") {
+			AssertElementPresent(
+				key_title = "Step 1 of 2: Click the Button",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
+}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
@@ -19,6 +19,45 @@ definition {
 		PortalInstances.tearDownCP();
 	}
 
+	@description = "LPS-159837. Walkthrough will not display when not defined for a site."
+	@priority = "5"
+	test CanBeEnabled {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given Walkthrough in System Settings") {
+			JSONGroup.addGroup(groupName = "Site Name");
+
+			ApplicationsMenu.gotoSite(site = "Site Name");
+
+			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
+
+			JSONLayout.addPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1",
+				widgetName = "JS Walkthrough Sample");
+		}
+
+		task ("When walkthrough is enabled") {
+			Navigator.openSitePage(
+				pageName = "Walkthrough Page 1",
+				siteName = "Site Name");
+
+			Walkthrough.enablePopoverMode();
+		}
+
+		task ("Then walkthrough is not instantiated on the site") {
+			AssertElementPresent(
+				key_title = "Step 1 of 2: Click the Button",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
 	@description = "LPS-159836. Walkthrough displays when defined for a site."
 	@priority = "5"
 	test WillDisplayWhenDefinedForSite {
@@ -53,6 +92,43 @@ definition {
 
 		task ("Then walkthrough is instantiated on the site") {
 			AssertElementPresent(
+				key_title = "Step 1 of 2: Click the Button",
+				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
+	@description = "LPS-159837. Walkthrough will not display when not defined for a site."
+	@priority = "5"
+	test WillNotDisplayWhenNotDefinedForSite {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given there is no site-level JSON defined for current site") {
+			JSONGroup.addGroup(groupName = "Site Name");
+
+			ApplicationsMenu.gotoSite(site = "Site Name");
+
+			JSONLayout.addPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1",
+				widgetName = "JS Walkthrough Sample");
+		}
+
+		task ("When instantiate the walkthrough") {
+			Navigator.openSitePage(
+				pageName = "Walkthrough Page 1",
+				siteName = "Site Name");
+
+			Walkthrough.assertEnablePopoverModeNotPresent();
+		}
+
+		task ("Then walkthrough is not instantiated on the site") {
+			AssertElementNotPresent(
 				key_title = "Step 1 of 2: Click the Button",
 				locator1 = "Walkthrough#POPOVER_TITLE");
 		}


### PR DESCRIPTION
**Background**
Create walkthrough tests that use a site-level setting and system settings

**Test plan**
_WillNotDisplayWhenNotDefinedForSite_
Given there is no site-level JSON defined for current site
When instantiate the walkthrough
Then walkthrough is not instantiated on the site

_CanBeEnabled_
Given Walkthrough in System Settings
When walkthrough is enabled
Then success message appears

https://issues.liferay.com/browse/LPS-159837
https://issues.liferay.com/browse/LPS-159838

Hey @john-co could you take a look 🤔