### PR TITLE
LPS-162923 CKEditor required asterisk

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -54,6 +54,7 @@ if (Validator.isNotNull(onInitMethod)) {
 }
 
 String placeholder = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":placeholder"));
+String required = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":required"));
 
 boolean skipEditorLoading = GetterUtil.getBoolean((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":skipEditorLoading"));
 String toolbarSet = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":toolbarSet");
@@ -107,6 +108,10 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 	<c:if test="<%= Validator.isNotNull(placeholder) %>">
 		<label class="control-label" for="<%= HtmlUtil.escapeAttribute(name) %>">
 			<liferay-ui:message key="<%= placeholder %>" />
+
+			<c:if test="<%= Boolean.parseBoolean(required) %>">
+				<span class="text-warning">*</span>
+			</c:if>
 		</label>
 	</c:if>
 


### PR DESCRIPTION
Issue [The asterisk is missing for the KB content field](https://issues.liferay.com/browse/LPS-162923)

I added the asterisk just as it is done for [AlloyEditor](https://github.com/liferay/liferay-portal/blame/master/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp#L93-L93). 

**Before:** 
<img width="600" alt="CKEditor required BEFORE" src="https://user-images.githubusercontent.com/8373764/189873955-b1d72c51-056a-436d-bfe1-73896de5a5b0.png">


**After:** 

<img width="1095" alt="CKEditor required AFTER" src="https://user-images.githubusercontent.com/8373764/189873976-a87e1bb5-0146-4ed9-910c-a972e0dec4ae.png">
