### PR TITLE
LPS-162900 Submit form manually instead of preventing the submit event

### DIFF
--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/certificate_info.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/certificate_info.jsp
@@ -25,7 +25,6 @@ GeneralTabDefaultViewDisplayContext.X509CertificateStatus x509CertificateStatus 
 
 X509Certificate x509Certificate = x509CertificateStatus.getX509Certificate();
 
-String deleteCertificatePrompt = UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this-certificate-from-the-keystore");
 String introKey = StringPool.BLANK;
 %>
 
@@ -68,29 +67,16 @@ String introKey = StringPool.BLANK;
 			<portlet:param name="certificateUsage" value="<%= certificateUsage.name() %>" />
 		</portlet:resourceURL>
 
-		<aui:form action="<%= deleteCertificateURL %>">
+		<aui:form action="<%= deleteCertificateURL %>" name="fm">
 			<aui:button-row>
 				<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "showCertificateDialog('" + replaceCertificateURL + "');" %>' value="replace-certificate" />
 				<aui:button href="<%= downloadCertificateURL %>" value="download-certificate" />
 
 				<c:if test="<%= certificateUsage == LocalEntityManager.CertificateUsage.ENCRYPTION %>">
-					<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "handleDeleteCertificatePrompt" %>' type="submit" value="delete-certificate" />
+					<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "handleDeleteCertificatePrompt(...arguments);" %>' type="submit" value="delete-certificate" />
 				</c:if>
 			</aui:button-row>
 		</aui:form>
-
-		<aui:script>
-			function <portlet:namespace />handleDeleteCertificatePrompt(event) {
-				Liferay.Util.openConfirmModal({
-					message: '<%= deleteCertificatePrompt %>',
-					onConfirm: (isConfirmed) => {
-						if (!isConfirmed) {
-							event.preventDefault();
-						}
-					},
-				});
-			}
-		</aui:script>
 	</c:when>
 	<c:when test="<%= (x509Certificate == null) && Validator.isNull(samlProviderConfiguration.entityId()) %>">
 		<div class="portlet-msg-info">
@@ -109,26 +95,13 @@ String introKey = StringPool.BLANK;
 			<liferay-ui:message key="certificate-needs-auth" />
 		</div>
 
-		<aui:form action="<%= deleteCertificateURL %>">
+		<aui:form action="<%= deleteCertificateURL %>" name="fm">
 			<aui:button-row>
 				<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "showCertificateDialog('" + authCertificateURL + "');" %>' value="auth-certificate" />
 				<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "showCertificateDialog('" + replaceCertificateURL + "');" %>' value="replace-certificate" />
 
 				<c:if test="<%= certificateUsage == LocalEntityManager.CertificateUsage.ENCRYPTION %>">
-					<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "handleDeleteCertificatePrompt" %>' type="submit" value="delete-certificate" />
-
-					<aui:script>
-						function <portlet:namespace />handleDeleteCertificatePrompt(event) {
-							Liferay.Util.openConfirmModal({
-								message: '<%= deleteCertificatePrompt %>',
-								onConfirm: (isConfirmed) => {
-									if (!isConfirmed) {
-										event.preventDefault();
-									}
-								},
-							});
-						}
-					</aui:script>
+					<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "handleDeleteCertificatePrompt(...arguments);" %>' type="submit" value="delete-certificate" />
 				</c:if>
 			</aui:button-row>
 		</aui:form>
@@ -143,3 +116,20 @@ String introKey = StringPool.BLANK;
 		</aui:button-row>
 	</c:otherwise>
 </c:choose>
+
+<aui:script>
+	window['<portlet:namespace />handleDeleteCertificatePrompt'] = function (event) {
+		event.preventDefault();
+
+		const form = event.target.closest('form');
+
+		Liferay.Util.openConfirmModal({
+			message: '<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this-certificate-from-the-keystore") %>',
+			onConfirm: (isConfirmed) => {
+				if (isConfirmed) {
+					form.submit();
+				}
+			},
+		});
+	}
+</aui:script>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/certificate_info.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/certificate_info.jsp
@@ -118,18 +118,21 @@ String introKey = StringPool.BLANK;
 </c:choose>
 
 <aui:script>
-	window['<portlet:namespace />handleDeleteCertificatePrompt'] = function (event) {
+	window['<portlet:namespace />handleDeleteCertificatePrompt'] = function (
+		event
+	) {
 		event.preventDefault();
 
 		const form = event.target.closest('form');
 
 		Liferay.Util.openConfirmModal({
-			message: '<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this-certificate-from-the-keystore") %>',
+			message:
+				'<%= UnicodeLanguageUtil.get(request, "are-you-sure-you-want-to-delete-this-certificate-from-the-keystore") %>',
 			onConfirm: (isConfirmed) => {
 				if (isConfirmed) {
 					form.submit();
 				}
 			},
 		});
-	}
+	};
 </aui:script>


### PR DESCRIPTION
# How to test it

1. Navigate to SAML Admin.
2. Select the Service Provider as SAML role.
3. Enter samlsp as entity ID, then click Save.
4. Click on Create Certificate under Encryption Certificate and Private Key section.
5. Enter the required information then click Save.
6. Click on Delete Certificate.

**Actual result:**

There's no confirmation message when deleting a certificate.

**Expected result:**

A confirmation message says, "Are you sure you want to delete this certificate from the keystore?" when deleting a certificate.

# How I fixed it

Instead of relying on automatic form event submission from HTML5, handle it on JS side
