### PR TITLE
LPS-159837 | Add tests CanBeEnabled and WillNotDisplayWhenNotDefinedForSite

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -1,5 +1,29 @@
 definition {
 
+	macro _editWalkthroughJSON {
+		var jsonSnippet = Walkthrough.getWalkthroughSteps(fileName = "${fileName}");
+
+		SystemSettings.editTextAreaSetting(
+			settingName = "Steps",
+			settingValue = "${jsonSnippet}");
+	}
+
+	macro _enableWalkthrough {
+		SystemSettings.configureSystemSetting(
+			enableSetting = "true",
+			settingFieldName = "Enable Walkthrough");
+	}
+
+	macro addWalkthrough {
+		Walkthrough.gotoSiteConfigWalkthrough();
+
+		Walkthrough._enableWalkthrough();
+
+		Walkthrough._editWalkthroughJSON(fileName = "${fileName}");
+
+		SystemSettings.saveConfiguration();
+	}
+
 	macro enablePopoverMode {
 		if (IsElementNotPresent(locator1 = "Walkthrough#POPOVER")) {
 			if (IsElementPresent(key_portletName = "JS Walkthrough Sample", locator1 = "Portlet#TITLE")) {
@@ -9,29 +33,6 @@ definition {
 				Click(locator1 = "Walkthrough#SAMPLE_PORTLET_HOTSPOT");
 			}
 		}
-	}
-
-	macro enableWalkthrough {
-		var jsonSnippet = Walkthrough.getWalkthroughSteps(fileName = "${fileName}");
-
-		ProductMenu.gotoPortlet(
-			category = "Configuration",
-			portlet = "Site Settings");
-
-		SystemSettings.gotoConfiguration(
-			configurationCategory = "Walkthrough",
-			configurationName = "Walkthrough",
-			configurationScope = "Site Scope");
-
-		SystemSettings.configureSystemSetting(
-			enableSetting = "true",
-			settingFieldName = "Enable Walkthrough");
-
-		SystemSettings.editTextAreaSetting(
-			settingName = "Steps",
-			settingValue = "${jsonSnippet}");
-
-		SystemSettings.saveConfiguration();
 	}
 
 	macro getWalkthroughSteps {
@@ -56,6 +57,17 @@ definition {
 		VerifyElementPresent(
 			key_title = "Step ${key_step}",
 			locator1 = "Walkthrough#POPOVER_TITLE");
+	}
+
+	macro gotoSiteConfigWalkthrough {
+		ProductMenu.gotoPortlet(
+			category = "Configuration",
+			portlet = "Site Settings");
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Walkthrough",
+			configurationName = "Walkthrough",
+			configurationScope = "Site Scope");
 	}
 
 	macro goToSpecificStep {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughMultiplePages.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughMultiplePages.testcase
@@ -17,7 +17,7 @@ definition {
 
 			ApplicationsMenu.gotoSite(site = "Site Name");
 
-			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
+			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration.json");
 		}
 
 		task ("And Given mutiple pages defined") {

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
@@ -33,7 +33,7 @@ definition {
 		}
 
 		task ("When walkthrough is enabled") {
-			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
+			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration.json");
 		}
 
 		task ("Then success message appears") {
@@ -53,7 +53,7 @@ definition {
 
 			ApplicationsMenu.gotoSite(site = "Site Name");
 
-			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
+			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration.json");
 
 			JSONLayout.addPublicLayout(
 				groupName = "Site Name",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
@@ -19,6 +19,28 @@ definition {
 		PortalInstances.tearDownCP();
 	}
 
+	@description = "LPS-159838. Can enable walkthrough in System Settings."
+	@priority = "5"
+	test CanBeEnabled {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given Walkthrough in System Settings") {
+			JSONGroup.addGroup(groupName = "Site Name");
+
+			ApplicationsMenu.gotoSite(site = "Site Name");
+		}
+
+		task ("When walkthrough is enabled") {
+			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
+		}
+
+		task ("TThen success message appears") {
+			Alert.viewSuccessMessage();
+		}
+	}
+
 	@description = "LPS-159836. Walkthrough displays when defined for a site."
 	@priority = "5"
 	test WillDisplayWhenDefinedForSite {
@@ -55,6 +77,39 @@ definition {
 			AssertElementPresent(
 				key_title = "Step 1 of 2: Click the Button",
 				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
+	@description = "LPS-159837. Walkthrough will not display when not defined for a site."
+	@priority = "5"
+	test WillNotDisplayWhenNotDefinedForSite {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given there is no site-level JSON defined for current site") {
+			JSONGroup.addGroup(groupName = "Site Name");
+
+			ApplicationsMenu.gotoSite(site = "Site Name");
+
+			JSONLayout.addPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1",
+				widgetName = "JS Walkthrough Sample");
+		}
+
+		task ("When instantiate the walkthrough") {
+			Navigator.openSitePage(
+				pageName = "Walkthrough Page 1",
+				siteName = "Site Name");
+		}
+
+		task ("Then walkthrough is not instantiated on the site") {
+			AssertElementNotPresent(locator1 = "Walkthrough#POPOVER");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
@@ -36,7 +36,7 @@ definition {
 			Walkthrough.enableWalkthrough(fileName = "walkthrough_configuration.json");
 		}
 
-		task ("TThen success message appears") {
+		task ("Then success message appears") {
 			Alert.viewSuccessMessage();
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevelConfiguration.testcase
@@ -11,12 +11,23 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Given a new Site") {
+			JSONGroup.addGroup(groupName = "Site Name");
+
+			ApplicationsMenu.gotoSite(site = "Site Name");
+		}
 	}
 
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		PortalInstances.tearDownCP();
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONGroup.deleteGroupByName(groupName = "Site Name");
+		}
 	}
 
 	@description = "LPS-159838. Can enable walkthrough in System Settings."
@@ -27,13 +38,11 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("Given Walkthrough in System Settings") {
-			JSONGroup.addGroup(groupName = "Site Name");
-
-			ApplicationsMenu.gotoSite(site = "Site Name");
+			Walkthrough.gotoSiteConfigWalkthrough();
 		}
 
 		task ("When walkthrough is enabled") {
-			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration.json");
+			Walkthrough._enableWalkthrough();
 		}
 
 		task ("Then success message appears") {
@@ -49,10 +58,6 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("Given there is a site-level JSON defined for current site") {
-			JSONGroup.addGroup(groupName = "Site Name");
-
-			ApplicationsMenu.gotoSite(site = "Site Name");
-
 			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration.json");
 
 			JSONLayout.addPublicLayout(
@@ -88,10 +93,6 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("Given there is no site-level JSON defined for current site") {
-			JSONGroup.addGroup(groupName = "Site Name");
-
-			ApplicationsMenu.gotoSite(site = "Site Name");
-
 			JSONLayout.addPublicLayout(
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 1");


### PR DESCRIPTION
**Test plan**
_WillNotDisplayWhenNotDefinedForSite_
Given there is no site-level JSON defined for current site
When instantiate the walkthrough
Then walkthrough is not instantiated on the site

_CanBeEnabled_
Given Walkthrough in System Settings
When walkthrough is enabled
Then success message appears

https://issues.liferay.com/browse/LPS-159837
https://issues.liferay.com/browse/LPS-159838