### PR TITLE
LPS-148663 Migrate use cases of window.confirm on DXP Java files

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/util/PublicationsPortletURLUtil.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/util/PublicationsPortletURLUtil.java
@@ -41,16 +41,17 @@ public class PublicationsPortletURLUtil {
 		String backURL, long ctCollectionId, Language language) {
 
 		return StringBundler.concat(
-			"javascript: if (confirm('",
+			"javascript: Liferay.Util.openConfirmModal({message:'",
 			language.get(
 				httpServletRequest,
 				"are-you-sure-you-want-to-delete-this-publication"),
-			"')) { submitForm(document.hrefFm, '",
+			"', onConfirm: (isConfirmed) => {if (isConfirmed)".concat(
+				"{submitForm(document.hrefFm,'"),
 			getHref(
 				renderResponse.createActionURL(), ActionRequest.ACTION_NAME,
 				"/change_tracking/delete_ct_collection", "redirect", backURL,
 				"ctCollectionId", String.valueOf(ctCollectionId)),
-			"');} else {self.focus();}");
+			"');} else {self.focus();}}});");
 	}
 
 	public static String getHref(PortletURL portletURL, Object... parameters) {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilder.java
@@ -226,11 +226,11 @@ public class UIItemsBuilder {
 
 		StringBundler sb = new StringBundler(5);
 
-		sb.append("if (confirm('");
+		sb.append("Liferay.Util.openConfirmModal({message:'");
 		sb.append(
 			UnicodeLanguageUtil.get(
 				_resourceBundle, "are-you-sure-you-want-to-delete-this"));
-		sb.append("')) {");
+		sb.append("', onConfirm: (isConfirmed) => {if (isConfirmed) {");
 
 		LiferayPortletResponse liferayPortletResponse =
 			_getLiferayPortletResponse();
@@ -253,7 +253,7 @@ public class UIItemsBuilder {
 		sb.append(
 			_getSubmitFormJavaScript(Constants.DELETE, portletURL.toString()));
 
-		sb.append("}");
+		sb.append(" }}});");
 
 		_addJavaScriptUIItem(
 			new JavaScriptToolbarItem(), toolbarItems, DLUIItemKeys.DELETE,

--- a/util-taglib/src/com/liferay/taglib/ui/IconDeactivateTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeactivateTag.java
@@ -49,11 +49,12 @@ public class IconDeactivateTag extends IconTag {
 		setMessage("deactivate");
 		setUrl(
 			StringBundler.concat(
-				"javascript:if (confirm('",
+				"Liferay.Util.openConfirmModal({message:'",
 				UnicodeLanguageUtil.get(
 					TagResourceBundleUtil.getResourceBundle(pageContext),
 					"are-you-sure-you-want-to-deactivate-this"),
-				"')) { ", url, " } else { self.focus(); }"));
+				"', onConfirm: (isConfirmed) => {if (isConfirmed) {", url,
+				" } else { self.focus(); }}});"));
 
 		return super.getPage();
 	}

--- a/util-taglib/src/com/liferay/taglib/ui/IconDeactivateTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeactivateTag.java
@@ -49,7 +49,7 @@ public class IconDeactivateTag extends IconTag {
 		setMessage("deactivate");
 		setUrl(
 			StringBundler.concat(
-				"Liferay.Util.openConfirmModal({message:'",
+				"javascript:Liferay.Util.openConfirmModal({message:'",
 				UnicodeLanguageUtil.get(
 					TagResourceBundleUtil.getResourceBundle(pageContext),
 					"are-you-sure-you-want-to-deactivate-this"),

--- a/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconDeleteTag.java
@@ -99,7 +99,9 @@ public class IconDeleteTag extends IconTag {
 
 		String url = getUrl();
 
-		if (url.startsWith("javascript:if (confirm('")) {
+		if (url.startsWith(
+				"javascript: Liferay.Util.openConfirmModal({message:'")) {
+
 			return super.getPage();
 		}
 
@@ -117,7 +119,7 @@ public class IconDeleteTag extends IconTag {
 		if (!_trash) {
 			StringBundler sb = new StringBundler(5);
 
-			sb.append("javascript:if (confirm('");
+			sb.append("javascript: Liferay.Util.openConfirmModal({message:'");
 
 			if (Validator.isNotNull(_confirmation)) {
 				sb.append(
@@ -132,9 +134,9 @@ public class IconDeleteTag extends IconTag {
 						_getResourceBundle(), confirmation));
 			}
 
-			sb.append("')) { ");
+			sb.append("', onConfirm: (isConfirmed) => {if (isConfirmed) {");
 			sb.append(url);
-			sb.append(" } else { self.focus(); }");
+			sb.append(" } else { self.focus(); }}});");
 
 			url = sb.toString();
 		}


### PR DESCRIPTION
## How to test it:

### Publications

1. Global Menu -> Publications
2. Enable Publications and mark sandbox only to true
3. Add a new publication, name it 'fiona'
4. Go back to publications listings and try to delete 'fiona'

![image](https://user-images.githubusercontent.com/7663513/190511638-31678251-78de-4fa7-be03-c2f703072b34.png)

You should be able to open the confirm dialog and when clicking on Ok, it will delete, cancel will do nothing and close the dialog.

### Document Library

1. First, you need to disable the Recycle bin (the confirm only appears when there is no recycle bin). On the product menu, go to Configuration > Site Settings > Recycle bin and disable it.
2. Add the Documents and Media widget to a page, and on the configuration section, check the “show actions”  option
3. Select an entry and go to the detail of it. Here you will see at the top the toolbar items. Delete is the one you are looking for 

Same as publications, the dialog and the actions

## icon-delete (a.k.a IconDeleteTag)

1. Global Menu -> Roles
2. Create a new Role. I named it Cat Fan
3. Go to Roles listings
4. Click on the three-dot button on "Cat Fan" row, then, click on "Delete"

## icon-deactivate (a.k.a IconDeactivateTag)

1. Global Menu -> Accounts
2. Create a new Account. Name it "Refrigerantes Dolly"
3. See Account listings and click on three dot button and then "Deactivate"
