### PR TITLE
LPS-163171 Status filter is not working on FDS sample module

### DIFF
--- a/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/frontend/data/set/filter/CommerceOrderStatusFDSFilter.java
+++ b/modules/apps/commerce/commerce-order-web/src/main/java/com/liferay/commerce/order/web/internal/frontend/data/set/filter/CommerceOrderStatusFDSFilter.java
@@ -17,6 +17,7 @@ package com.liferay.commerce.order.web.internal.frontend.data.set.filter;
 import com.liferay.commerce.order.status.CommerceOrderStatus;
 import com.liferay.commerce.order.status.CommerceOrderStatusRegistry;
 import com.liferay.commerce.order.web.internal.constants.CommerceOrderFDSNames;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
@@ -40,7 +41,7 @@ public class CommerceOrderStatusFDSFilter extends BaseSelectionFDSFilter {
 
 	@Override
 	public String getEntityFieldType() {
-		return "collection";
+		return FDSEntityFieldTypes.COLLECTION;
 	}
 
 	@Override

--- a/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/ChangesetPortlet.java
+++ b/modules/apps/export-import/export-import-changeset-web/src/main/java/com/liferay/exportimport/changeset/web/internal/portlet/ChangesetPortlet.java
@@ -33,7 +33,8 @@ import org.osgi.service.component.annotations.Component;
 		"javax.portlet.display-name=Changeset",
 		"javax.portlet.name=" + ChangesetPortletKeys.CHANGESET,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=power-user,user"
+		"javax.portlet.security-role-ref=power-user,user",
+		"javax.portlet.version=3.0"
 	},
 	service = Portlet.class
 )

--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 11.1.2
+Bundle-Version: 11.2.0
 Export-Package:\
 	com.liferay.frontend.data.set.constants,\
 	com.liferay.frontend.data.set.filter,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.constants;
+
+/**
+ * @author Marko Cikos
+ */
+public class FDSEntityFieldTypes {
+
+	public static final String COLLECTION = "collection";
+
+	public static final String DATE = "date";
+
+	public static final String STRING = "string";
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseAutocompleteFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseAutocompleteFDSFilter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Locale;
@@ -28,7 +29,7 @@ public abstract class BaseAutocompleteFDSFilter implements FDSFilter {
 
 	@Override
 	public String getEntityFieldType() {
-		return "collection";
+		return FDSEntityFieldTypes.COLLECTION;
 	}
 
 	public abstract String getItemKey();

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/constants/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedDateRangeFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/CustomizedDateRangeFDSFilter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.data.set.sample.web.internal.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseDateRangeFDSFilter;
 import com.liferay.frontend.data.set.filter.DateFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
@@ -34,7 +35,7 @@ public class CustomizedDateRangeFDSFilter extends BaseDateRangeFDSFilter {
 
 	@Override
 	public String getEntityFieldType() {
-		return "date";
+		return FDSEntityFieldTypes.DATE;
 	}
 
 	@Override

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/StatusSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/StatusSelectionFDSFilter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.frontend.data.set.sample.web.internal.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
@@ -34,6 +35,11 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class StatusSelectionFDSFilter extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.COLLECTION;
+	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 41.5.1
+Bundle-Version: 41.6.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageCollectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageCollectionDefinition.java
@@ -283,6 +283,35 @@ public class PageCollectionDefinition implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected FragmentViewport[] fragmentViewports;
 
+	@Schema(description = "the page section's layout.")
+	@Valid
+	public Layout getLayout() {
+		return layout;
+	}
+
+	public void setLayout(Layout layout) {
+		this.layout = layout;
+	}
+
+	@JsonIgnore
+	public void setLayout(
+		UnsafeSupplier<Layout, Exception> layoutUnsafeSupplier) {
+
+		try {
+			layout = layoutUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "the page section's layout.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Layout layout;
+
 	@Schema(
 		description = "The style of a list of items in the page collection."
 	)
@@ -710,6 +739,16 @@ public class PageCollectionDefinition implements Serializable {
 			}
 
 			sb.append("]");
+		}
+
+		if (layout != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"layout\": ");
+
+			sb.append(String.valueOf(layout));
 		}
 
 		if (listItemStyle != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 26.5.0
+version 26.6.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageCollectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageCollectionDefinition.java
@@ -189,6 +189,27 @@ public class PageCollectionDefinition implements Cloneable, Serializable {
 
 	protected FragmentViewport[] fragmentViewports;
 
+	public Layout getLayout() {
+		return layout;
+	}
+
+	public void setLayout(Layout layout) {
+		this.layout = layout;
+	}
+
+	public void setLayout(
+		UnsafeSupplier<Layout, Exception> layoutUnsafeSupplier) {
+
+		try {
+			layout = layoutUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Layout layout;
+
 	public String getListItemStyle() {
 		return listItemStyle;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageCollectionDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageCollectionDefinitionSerDes.java
@@ -170,6 +170,16 @@ public class PageCollectionDefinitionSerDes {
 			sb.append("]");
 		}
 
+		if (pageCollectionDefinition.getLayout() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"layout\": ");
+
+			sb.append(String.valueOf(pageCollectionDefinition.getLayout()));
+		}
+
 		if (pageCollectionDefinition.getListItemStyle() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -377,6 +387,14 @@ public class PageCollectionDefinitionSerDes {
 					pageCollectionDefinition.getFragmentViewports()));
 		}
 
+		if (pageCollectionDefinition.getLayout() == null) {
+			map.put("layout", null);
+		}
+		else {
+			map.put(
+				"layout", String.valueOf(pageCollectionDefinition.getLayout()));
+		}
+
 		if (pageCollectionDefinition.getListItemStyle() == null) {
 			map.put("listItemStyle", null);
 		}
@@ -548,6 +566,12 @@ public class PageCollectionDefinitionSerDes {
 						).toArray(
 							size -> new FragmentViewport[size]
 						));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "layout")) {
+				if (jsonParserFieldValue != null) {
+					pageCollectionDefinition.setLayout(
+						LayoutSerDes.toDTO((String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "listItemStyle")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -3304,6 +3304,21 @@ components:
                     items:
                         $ref: "#/components/schemas/FragmentViewport"
                     type: array
+                layout:
+                    # @review
+                    description:
+                        the page section's layout.
+                    properties:
+                        align:
+                            enum: [Baseline, Center, End, None, Start, Stretch]
+                            type: string
+                        flexWrap:
+                            enum: [NoWrap, Wrap, WrapReverse]
+                            type: string
+                        justify:
+                            enum: [Center, End, None, SpaceAround, SpaceBetween, Start]
+                            type: string
+                    type: object
                 listItemStyle:
                     # @review
                     description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/CollectionLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/CollectionLayoutStructureItemMapper.java
@@ -20,10 +20,14 @@ import com.liferay.headless.delivery.dto.v1_0.CollectionConfig;
 import com.liferay.headless.delivery.dto.v1_0.CollectionViewport;
 import com.liferay.headless.delivery.dto.v1_0.CollectionViewportDefinition;
 import com.liferay.headless.delivery.dto.v1_0.EmptyCollectionConfig;
+import com.liferay.headless.delivery.dto.v1_0.Layout;
 import com.liferay.headless.delivery.dto.v1_0.PageCollectionDefinition;
 import com.liferay.headless.delivery.dto.v1_0.PageElement;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoListItemSelectorReturnType;
+import com.liferay.layout.page.template.util.AlignConverter;
+import com.liferay.layout.page.template.util.FlexWrapConverter;
+import com.liferay.layout.page.template.util.JustifyConverter;
 import com.liferay.layout.responsive.ViewportSize;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
@@ -74,6 +78,7 @@ public class CollectionLayoutStructureItemMapper
 								isDisplayAllPages();
 						emptyCollectionConfig = _getEmptyCollectionConfig(
 							collectionStyledLayoutStructureItem);
+						layout = _toLayout(collectionStyledLayoutStructureItem);
 						listItemStyle =
 							collectionStyledLayoutStructureItem.
 								getListItemStyle();
@@ -281,6 +286,52 @@ public class CollectionLayoutStructureItemMapper
 						}
 
 						return jsonObject.getInt("numberOfColumns");
+					});
+			}
+		};
+	}
+
+	private Layout _toLayout(
+		CollectionStyledLayoutStructureItem
+			collectionStyledLayoutStructureItem) {
+
+		return new Layout() {
+			{
+				setAlign(
+					() -> {
+						String align =
+							collectionStyledLayoutStructureItem.getAlign();
+
+						if (Validator.isNull(align)) {
+							return null;
+						}
+
+						return Align.create(
+							AlignConverter.convertToExternalValue(align));
+					});
+				setFlexWrap(
+					() -> {
+						String flexWrap =
+							collectionStyledLayoutStructureItem.getFlexWrap();
+
+						if (Validator.isNull(flexWrap)) {
+							return null;
+						}
+
+						return FlexWrap.create(
+							FlexWrapConverter.convertToExternalValue(flexWrap));
+					});
+				setJustify(
+					() -> {
+						String justify =
+							collectionStyledLayoutStructureItem.getJustify();
+
+						if (Validator.isNull(justify)) {
+							return null;
+						}
+
+						return Justify.create(
+							JustifyConverter.convertToExternalValue(justify));
 					});
 			}
 		};

--- a/modules/apps/layout/layout-api/bnd.bnd
+++ b/modules/apps/layout/layout-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout API
 Bundle-SymbolicName: com.liferay.layout.api
-Bundle-Version: 19.2.1
+Bundle-Version: 19.3.0
 Export-Package:\
 	com.liferay.layout.adaptive.media,\
 	com.liferay.layout.configuration,\

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CollectionStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CollectionStyledLayoutStructureItem.java
@@ -94,6 +94,10 @@ public class CollectionStyledLayoutStructureItem
 		return super.equals(object);
 	}
 
+	public String getAlign() {
+		return _align;
+	}
+
 	public JSONObject getCollectionJSONObject() {
 		return _collectionJSONObject;
 	}
@@ -102,11 +106,17 @@ public class CollectionStyledLayoutStructureItem
 		return _emptyCollectionOptions;
 	}
 
+	public String getFlexWrap() {
+		return _flexWrap;
+	}
+
 	@Override
 	public JSONObject getItemConfigJSONObject() {
 		JSONObject jsonObject = super.getItemConfigJSONObject();
 
 		jsonObject = jsonObject.put(
+			"align", _align
+		).put(
 			"collection", _collectionJSONObject
 		).put(
 			"displayAllItems", _displayAllItems
@@ -122,7 +132,11 @@ public class CollectionStyledLayoutStructureItem
 				return _emptyCollectionOptions.toJSONObject();
 			}
 		).put(
+			"flexWrap", _flexWrap
+		).put(
 			"gutters", _gutters
+		).put(
+			"justify", _justify
 		).put(
 			"listItemStyle", _listItemStyle
 		).put(
@@ -178,6 +192,10 @@ public class CollectionStyledLayoutStructureItem
 	@Override
 	public String getItemType() {
 		return LayoutDataItemTypeConstants.TYPE_COLLECTION;
+	}
+
+	public String getJustify() {
+		return _justify;
 	}
 
 	public String getListItemStyle() {
@@ -246,6 +264,10 @@ public class CollectionStyledLayoutStructureItem
 		return _showAllItems;
 	}
 
+	public void setAlign(String align) {
+		_align = align;
+	}
+
 	public void setCollectionJSONObject(JSONObject collectionJSONObject) {
 		_collectionJSONObject = collectionJSONObject;
 	}
@@ -274,8 +296,16 @@ public class CollectionStyledLayoutStructureItem
 		_emptyCollectionOptions = emptyCollectionOptions;
 	}
 
+	public void setFlexWrap(String flexWrap) {
+		_flexWrap = flexWrap;
+	}
+
 	public void setGutters(boolean gutters) {
 		_gutters = gutters;
+	}
+
+	public void setJustify(String justify) {
+		_justify = justify;
 	}
 
 	public void setListItemStyle(String listItemStyle) {
@@ -352,6 +382,10 @@ public class CollectionStyledLayoutStructureItem
 	public void updateItemConfig(JSONObject itemConfigJSONObject) {
 		super.updateItemConfig(itemConfigJSONObject);
 
+		if (itemConfigJSONObject.has("align")) {
+			setAlign(itemConfigJSONObject.getString("align"));
+		}
+
 		if (itemConfigJSONObject.has("collection")) {
 			setCollectionJSONObject(
 				itemConfigJSONObject.getJSONObject("collection"));
@@ -374,8 +408,16 @@ public class CollectionStyledLayoutStructureItem
 						"emptyCollectionOptions")));
 		}
 
+		if (itemConfigJSONObject.has("flexWrap")) {
+			setFlexWrap(itemConfigJSONObject.getString("flexWrap"));
+		}
+
 		if (itemConfigJSONObject.has("gutters")) {
 			setGutters(itemConfigJSONObject.getBoolean("gutters"));
+		}
+
+		if (itemConfigJSONObject.has("justify")) {
+			setJustify(itemConfigJSONObject.getString("justify"));
 		}
 
 		if (itemConfigJSONObject.has("showAllItems")) {
@@ -436,11 +478,14 @@ public class CollectionStyledLayoutStructureItem
 
 	private static final ViewportSize[] _viewportSizes = ViewportSize.values();
 
+	private String _align = "";
 	private JSONObject _collectionJSONObject;
 	private boolean _displayAllItems;
 	private boolean _displayAllPages = true;
 	private EmptyCollectionOptions _emptyCollectionOptions;
+	private String _flexWrap = "";
 	private boolean _gutters = true;
+	private String _justify = "";
 	private String _listItemStyle;
 	private String _listStyle;
 	private int _numberOfColumns = 1;

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/structure/packageinfo
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/structure/packageinfo
@@ -1,1 +1,1 @@
-version 9.1.0
+version 9.2.0

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ManageAllowedFragmentModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ManageAllowedFragmentModal.js
@@ -17,7 +17,6 @@ import ClayModal from '@clayui/modal';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
-import {config} from '../config/index';
 import {useDispatch} from '../contexts/StoreContext';
 import updateItemConfig from '../thunks/updateItemConfig';
 import AllowedFragmentSelectorTree from './AllowedFragmentSelectorTree';
@@ -41,7 +40,6 @@ const ManageAllowedFragmentModal = ({item, observer, onClose}) => {
 					fragmentEntryKeys: [...selectedFragments],
 				},
 				itemId: item.itemId,
-				segmentsExperienceId: config.defaultSegmentsExperienceId,
 			})
 		).then(() => {
 			setLoading(false);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/SaveFragmentCompositionModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/SaveFragmentCompositionModal.js
@@ -29,12 +29,10 @@ import {openImageSelector} from '../../core/openImageSelector';
 import {config} from '../config/index';
 import {useActiveItemId} from '../contexts/ControlsContext';
 import {useDispatch, useSelector} from '../contexts/StoreContext';
-import selectSegmentsExperienceId from '../selectors/selectSegmentsExperienceId';
 import addFragmentComposition from '../thunks/addFragmentComposition';
 
 const SaveFragmentCompositionModal = ({onCloseModal}) => {
 	const dispatch = useDispatch();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const activeItemId = useActiveItemId();
 	const isMounted = useIsMounted();
@@ -81,7 +79,6 @@ const SaveFragmentCompositionModal = ({onCloseModal}) => {
 					previewImageURL: thumbnail.url,
 					saveInlineContent,
 					saveMappingConfiguration,
-					segmentsExperienceId,
 				})
 			)
 				.then(() => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -85,7 +85,7 @@ export default function ShortcutManager() {
 	const sidebarHidden = state.sidebar.hidden;
 	const {widgets} = state;
 
-	const {fragmentEntryLinks, layoutData, segmentsExperienceId} = state;
+	const {fragmentEntryLinks, layoutData} = state;
 
 	const activeLayoutDataItem =
 		activeItemType === ITEM_TYPES.layoutDataItem
@@ -96,7 +96,6 @@ export default function ShortcutManager() {
 		dispatch(
 			duplicateItem({
 				itemId: activeItemId,
-				segmentsExperienceId,
 				selectItem,
 			})
 		);
@@ -143,7 +142,6 @@ export default function ShortcutManager() {
 				itemId,
 				parentItemId: parentId,
 				position,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -14,7 +14,7 @@
 
 import React, {useEffect, useRef, useState} from 'react';
 
-import {CONTAINER_DISPLAY_OPTIONS} from '../config/constants/containerDisplayOptions';
+import {CONTENT_DISPLAY_OPTIONS} from '../config/constants/contentDisplayOptions';
 import {ITEM_ACTIVATION_ORIGINS} from '../config/constants/itemActivationOrigins';
 import {ITEM_TYPES} from '../config/constants/itemTypes';
 import {
@@ -255,7 +255,7 @@ export default function ShortcutManager() {
 
 				if (
 					parentItem.config.contentDisplay ===
-					CONTAINER_DISPLAY_OPTIONS.flexRow
+					CONTENT_DISPLAY_OPTIONS.flexRow
 				) {
 					return (
 						event.keyCode === ARROW_RIGHT_KEYCODE ||

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/HideFromSearchField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/HideFromSearchField.js
@@ -19,7 +19,6 @@ import React from 'react';
 import {VIEWPORT_SIZES} from '../../config/constants/viewportSizes';
 import {useSelectItem} from '../../contexts/ControlsContext';
 import {useDispatch, useSelector} from '../../contexts/StoreContext';
-import selectSegmentsExperienceId from '../../selectors/selectSegmentsExperienceId';
 import updateItemConfig from '../../thunks/updateItemConfig';
 import {CheckboxField} from './CheckboxField';
 
@@ -37,7 +36,6 @@ function getHiddenAncestorId(layoutData, item) {
 
 export function HideFromSearchField({item}) {
 	const dispatch = useDispatch();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -67,7 +65,6 @@ export function HideFromSearchField({item}) {
 						updateItemConfig({
 							itemConfig,
 							itemId: item.itemId,
-							segmentsExperienceId,
 						})
 					);
 				}}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContentProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContentProcessor.js
@@ -27,7 +27,6 @@ import {
 	useSelectorCallback,
 } from '../../contexts/StoreContext';
 import selectLanguageId from '../../selectors/selectLanguageId';
-import selectSegmentsExperienceId from '../../selectors/selectSegmentsExperienceId';
 import updateEditableValues from '../../thunks/updateEditableValues';
 
 export default function FragmentContentProcessor({
@@ -38,7 +37,6 @@ export default function FragmentContentProcessor({
 	const editableProcessorClickPosition = useEditableProcessorClickPosition();
 	const editableProcessorUniqueId = useEditableProcessorUniqueId();
 	const languageId = useSelector(selectLanguageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const setEditableProcessorUniqueId = useSetEditableProcessorUniqueId();
 	const toControlsId = useToControlsId();
 
@@ -108,7 +106,6 @@ export default function FragmentContentProcessor({
 							},
 						},
 						fragmentEntryLinkId,
-						segmentsExperienceId,
 					})
 				);
 			},
@@ -133,7 +130,6 @@ export default function FragmentContentProcessor({
 		editableValues,
 		fragmentEntryLinkId,
 		languageId,
-		segmentsExperienceId,
 		setEditableProcessorUniqueId,
 	]);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContentProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContentProcessor.js
@@ -108,7 +108,6 @@ export default function FragmentContentProcessor({
 							},
 						},
 						fragmentEntryLinkId,
-						languageId,
 						segmentsExperienceId,
 					})
 				);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
@@ -139,7 +139,7 @@ const FlexContainer = ({
 			})}
 		>
 			{Array.from({length: numberOfItemsToDisplay}).map((_, index) => (
-				<ColumnContext
+				<ItemContext
 					collectionConfig={collectionConfig}
 					collectionId={collectionId}
 					collectionItem={collection.items[index] ?? {}}
@@ -150,7 +150,7 @@ const FlexContainer = ({
 					key={index}
 				>
 					{child}
-				</ColumnContext>
+				</ItemContext>
 			))}
 		</div>
 	);
@@ -207,7 +207,7 @@ const Grid = ({
 									}
 								>
 									{index < numberOfItemsToDisplay && (
-										<ColumnContext
+										<ItemContext
 											collectionConfig={collectionConfig}
 											collectionId={collectionId}
 											collectionItem={
@@ -219,7 +219,7 @@ const Grid = ({
 											index={index}
 										>
 											{child}
-										</ColumnContext>
+										</ItemContext>
 									)}
 								</ClayLayout.Col>
 							);
@@ -234,7 +234,7 @@ const Grid = ({
 	);
 };
 
-const ColumnContext = ({
+const ItemContext = ({
 	children,
 	collectionConfig,
 	collectionId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
@@ -28,7 +28,6 @@ import {
 import {useDisplayPagePreviewItem} from '../../contexts/DisplayPagePreviewItemContext';
 import {useDispatch, useSelector} from '../../contexts/StoreContext';
 import selectLanguageId from '../../selectors/selectLanguageId';
-import selectSegmentsExperienceId from '../../selectors/selectSegmentsExperienceId';
 import CollectionService from '../../services/CollectionService';
 import updateItemConfig from '../../thunks/updateItemConfig';
 import {collectionIsMapped} from '../../utils/collectionIsMapped';
@@ -287,7 +286,6 @@ const Collection = React.memo(
 
 		const dispatch = useDispatch();
 		const languageId = useSelector(selectLanguageId);
-		const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 		const [activePage, setActivePage] = useState(1);
 		const [collection, setCollection] = useState(emptyCollection);
@@ -389,7 +387,6 @@ const Collection = React.memo(
 										},
 									},
 									itemId: item.itemId,
-									segmentsExperienceId,
 								})
 							);
 						}
@@ -412,7 +409,6 @@ const Collection = React.memo(
 			itemClassNameId,
 			itemClassPK,
 			languageId,
-			segmentsExperienceId,
 		]);
 
 		const selectedViewportSize = useSelector(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/CollectionItemWithControls.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/CollectionItemWithControls.js
@@ -28,7 +28,8 @@ const CollectionItemWithControls = React.forwardRef(({children, item}, ref) => {
 	return (
 		<div
 			className={classNames('page-editor__collection__block', {
-				empty: !title,
+				'empty': !title,
+				'flex-grow-1': !children.length,
 			})}
 		>
 			<TopperEmpty item={item}>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/ColumnWithControls.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/ColumnWithControls.js
@@ -29,7 +29,6 @@ import {
 import {useDispatch, useSelector} from '../../contexts/StoreContext';
 import selectCanUpdateItemConfiguration from '../../selectors/selectCanUpdateItemConfiguration';
 import selectCanUpdatePageStructure from '../../selectors/selectCanUpdatePageStructure';
-import selectSegmentsExperienceId from '../../selectors/selectSegmentsExperienceId';
 import resizeColumns from '../../thunks/resizeColumns';
 import {
 	NotDraggableArea,
@@ -80,7 +79,6 @@ const ColumnWithControls = React.forwardRef(({children, item}, ref) => {
 	const globalContext = useGlobalContext();
 	const isActive = useIsActive();
 	const resizing = useResizing();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const setCanDrag = useSetCanDrag();
 	const setResizing = useSetResizing();
 	const setNextColumnSizes = useSetNextColumnSizes();
@@ -168,7 +166,6 @@ const ColumnWithControls = React.forwardRef(({children, item}, ref) => {
 					resizeColumns({
 						layoutData: nextLayoutData,
 						rowItemId: parentItem.itemId,
-						segmentsExperienceId,
 					})
 				).then(() => {
 					setNextColumnSizes(null);
@@ -182,7 +179,6 @@ const ColumnWithControls = React.forwardRef(({children, item}, ref) => {
 			dispatch,
 			layoutData,
 			parentItem,
-			segmentsExperienceId,
 			selectedViewportSize,
 			setCanDrag,
 			setNextColumnSizes,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Container.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Container.js
@@ -18,8 +18,8 @@ import React, {useEffect, useState} from 'react';
 
 import {useId} from '../../../core/hooks/useId';
 import {getLayoutDataItemPropTypes} from '../../../prop-types/index';
-import {CONTAINER_DISPLAY_OPTIONS} from '../../config/constants/containerDisplayOptions';
 import {CONTAINER_WIDTH_TYPES} from '../../config/constants/containerWidthTypes';
+import {CONTENT_DISPLAY_OPTIONS} from '../../config/constants/contentDisplayOptions';
 import {useGetFieldValue} from '../../contexts/CollectionItemContext';
 import {useSelector} from '../../contexts/StoreContext';
 import selectLanguageId from '../../selectors/selectLanguageId';
@@ -120,10 +120,9 @@ const Container = React.memo(
 							widthType === CONTAINER_WIDTH_TYPES.fixed,
 						'd-flex flex-column':
 							contentDisplay ===
-							CONTAINER_DISPLAY_OPTIONS.flexColumn,
+							CONTENT_DISPLAY_OPTIONS.flexColumn,
 						'd-flex flex-row':
-							contentDisplay ===
-							CONTAINER_DISPLAY_OPTIONS.flexRow,
+							contentDisplay === CONTENT_DISPLAY_OPTIONS.flexRow,
 						'empty': !item.children.length && !height,
 						[flexWrap]: Boolean(flexWrap),
 						[justify]: Boolean(justify),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/Topper.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/Topper.js
@@ -38,7 +38,6 @@ import {
 import selectCanUpdateItemConfiguration from '../../selectors/selectCanUpdateItemConfiguration';
 import selectCanUpdatePageStructure from '../../selectors/selectCanUpdatePageStructure';
 import selectLayoutDataItemLabel from '../../selectors/selectLayoutDataItemLabel';
-import selectSegmentsExperienceId from '../../selectors/selectSegmentsExperienceId';
 import moveItem from '../../thunks/moveItem';
 import switchSidebarPanel from '../../thunks/switchSidebarPanel';
 import {TARGET_POSITIONS} from '../../utils/drag-and-drop/constants/targetPositions';
@@ -91,7 +90,6 @@ function TopperContent({
 	const editableProcessorUniqueId = useEditableProcessorUniqueId();
 	const hoverItem = useHoverItem();
 	const {isOverTarget, targetPosition, targetRef} = useDropTarget(item);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectItem = useSelectItem();
 	const topperLabelId = useId();
 
@@ -134,7 +132,6 @@ function TopperContent({
 				itemId: item.itemId,
 				parentItemId,
 				position,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
@@ -45,12 +45,9 @@ export default function TopperItemActions({item}) {
 	const selectItem = useSelectItem();
 	const widgets = useSelector((state) => state.widgets);
 
-	const {
-		fragmentEntryLinks,
-		layoutData,
-		segmentsExperienceId,
-		selectedViewportSize,
-	} = useSelector((state) => state);
+	const {fragmentEntryLinks, layoutData, selectedViewportSize} = useSelector(
+		(state) => state
+	);
 
 	const [openSaveModal, setOpenSaveModal] = useState(false);
 
@@ -72,7 +69,6 @@ export default function TopperItemActions({item}) {
 					hideFragment({
 						dispatch,
 						itemId: item.itemId,
-						segmentsExperienceId,
 						selectedViewportSize,
 					});
 
@@ -112,7 +108,6 @@ export default function TopperItemActions({item}) {
 					dispatch(
 						duplicateItem({
 							itemId: item.itemId,
-							segmentsExperienceId,
 							selectItem,
 						})
 					),
@@ -147,7 +142,6 @@ export default function TopperItemActions({item}) {
 		isInputFragment,
 		item,
 		layoutData,
-		segmentsExperienceId,
 		selectedViewportSize,
 		selectItem,
 		widgets,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoMoveItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoMoveItem.js
@@ -14,11 +14,10 @@
 
 import moveItem from '../../thunks/moveItem';
 
-function undoAction({action, store}) {
+function undoAction({action}) {
 	const {itemId, parentItemId, position} = action;
-	const {segmentsExperienceId} = store;
 
-	return moveItem({itemId, parentItemId, position, segmentsExperienceId});
+	return moveItem({itemId, parentItemId, position});
 }
 
 function getDerivedStateForUndo({action, state}) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoUpdateEditableValuesAction.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoUpdateEditableValuesAction.js
@@ -17,7 +17,6 @@ import updateEditableValues from '../../thunks/updateEditableValues';
 function undoAction({action, store}) {
 	return updateEditableValues({
 		...action,
-		languageId: store.languageId,
 		segmentsExperienceId: store.segmentsExperienceId,
 	});
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoUpdateEditableValuesAction.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoUpdateEditableValuesAction.js
@@ -14,10 +14,9 @@
 
 import updateEditableValues from '../../thunks/updateEditableValues';
 
-function undoAction({action, store}) {
+function undoAction({action}) {
 	return updateEditableValues({
 		...action,
-		segmentsExperienceId: store.segmentsExperienceId,
 	});
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoUpdateRowColumns.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/undo/undoUpdateRowColumns.js
@@ -15,12 +15,11 @@
 import updateRowColumns from '../../thunks/updateRowColumns';
 
 function undoAction({action}) {
-	const {itemId, numberOfColumns, segmentsExperienceId} = action;
+	const {itemId, numberOfColumns} = action;
 
 	return updateRowColumns({
 		itemId,
 		numberOfColumns,
-		segmentsExperienceId,
 	});
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/contentDisplayOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/contentDisplayOptions.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const CONTENT_DISPLAY_OPTIONS = {
+	block: 'block',
+	flexColumn: 'flex-column',
+	flexRow: 'flex-row',
+};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/flexDisplayOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/flexDisplayOptions.js
@@ -11,9 +11,3 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
-
-export const CONTAINER_DISPLAY_OPTIONS = {
-	block: 'block',
-	flexColumn: 'flex-column',
-	flexRow: 'flex-row',
-};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragment.js
@@ -22,19 +22,16 @@ export default function addFragment({
 	parentItemId,
 	position,
 	selectItem = () => {},
-	store,
 	type,
 }) {
-	return (dispatch) => {
-		const {segmentsExperienceId} = store;
-
+	return (dispatch, getState) => {
 		const params = {
 			fragmentEntryKey,
 			groupId,
 			onNetworkStatus: dispatch,
 			parentItemId,
 			position,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 			type,
 		};
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragmentComposition.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragmentComposition.js
@@ -23,9 +23,8 @@ export default function addFragment({
 	previewImageURL,
 	saveInlineContent,
 	saveMappingConfiguration,
-	segmentsExperienceId,
 }) {
-	return (dispatch) => {
+	return (dispatch, getState) => {
 		return FragmentService.addFragmentComposition({
 			description,
 			fragmentCollectionId,
@@ -35,7 +34,7 @@ export default function addFragment({
 			previewImageURL,
 			saveInlineContent,
 			saveMappingConfiguration,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then((fragmentComposition) => {
 			dispatch(
 				addFragmentComposition({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addItem.js
@@ -20,17 +20,14 @@ export default function addItem({
 	parentItemId,
 	position,
 	selectItem = () => {},
-	store,
 }) {
-	return (dispatch) => {
-		const {segmentsExperienceId} = store;
-
+	return (dispatch, getState) => {
 		return LayoutService.addItem({
 			itemType,
 			onNetworkStatus: dispatch,
 			parentItemId,
 			position,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then(({addedItemId, layoutData}) => {
 			dispatch(addItemAction({itemId: addedItemId, layoutData}));
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addWidget.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addWidget.js
@@ -20,18 +20,15 @@ export default function addWidget({
 	portletId,
 	portletItemId,
 	position,
-	store,
 }) {
-	return (dispatch) => {
-		const {segmentsExperienceId} = store;
-
+	return (dispatch, getState) => {
 		WidgetService.addPortlet({
 			onNetworkStatus: dispatch,
 			parentItemId,
 			portletId,
 			portletItemId,
 			position,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then(({addedItemId, fragmentEntryLink, layoutData}) => {
 			dispatch(
 				addFragmentEntryLinks({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/duplicateItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/duplicateItem.js
@@ -15,16 +15,12 @@
 import duplicateItemAction from '../actions/duplicateItem';
 import FragmentService from '../services/FragmentService';
 
-export default function duplicateItem({
-	itemId,
-	segmentsExperienceId,
-	selectItem = () => {},
-}) {
-	return (dispatch) => {
+export default function duplicateItem({itemId, selectItem = () => {}}) {
+	return (dispatch, getState) => {
 		FragmentService.duplicateItem({
 			itemId,
 			onNetworkStatus: dispatch,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then(
 			({duplicatedFragmentEntryLinks, duplicatedItemId, layoutData}) => {
 				dispatch(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/moveItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/moveItem.js
@@ -15,19 +15,14 @@
 import moveItemAction from '../actions/moveItem';
 import LayoutService from '../services/LayoutService';
 
-export default function moveItem({
-	itemId,
-	parentItemId,
-	position,
-	segmentsExperienceId,
-}) {
-	return (dispatch) => {
+export default function moveItem({itemId, parentItemId, position}) {
+	return (dispatch, getState) => {
 		return LayoutService.moveItem({
 			itemId,
 			onNetworkStatus: dispatch,
 			parentItemId,
 			position,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then((layoutData) => {
 			dispatch(moveItemAction({itemId, layoutData}));
 		});

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/resizeColumns.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/resizeColumns.js
@@ -15,16 +15,12 @@
 import updateColSize from '../actions/updateColSize';
 import LayoutService from '../services/LayoutService';
 
-export default function resizeColumns({
-	layoutData,
-	rowItemId,
-	segmentsExperienceId,
-}) {
-	return (dispatch) => {
+export default function resizeColumns({layoutData, rowItemId}) {
+	return (dispatch, getState) => {
 		return LayoutService.updateLayoutData({
 			layoutData,
 			onNetworkStatus: dispatch,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then(() => {
 			dispatch(updateColSize({layoutData, rowItemId}));
 		});

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues.js
@@ -20,14 +20,13 @@ import InfoItemService from '../services/InfoItemService';
 export default function updateEditableValues({
 	editableValues,
 	fragmentEntryLinkId,
-	languageId,
 	segmentsExperienceId,
 }) {
-	return (dispatch) =>
+	return (dispatch, getState) =>
 		FragmentService.updateEditableValues({
 			editableValues,
 			fragmentEntryLinkId,
-			languageId,
+			languageId: getState().languageId,
 			onNetworkStatus: dispatch,
 		})
 			.then((fragmentEntryLink) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateEditableValues.js
@@ -20,13 +20,14 @@ import InfoItemService from '../services/InfoItemService';
 export default function updateEditableValues({
 	editableValues,
 	fragmentEntryLinkId,
-	segmentsExperienceId,
 }) {
-	return (dispatch, getState) =>
-		FragmentService.updateEditableValues({
+	return (dispatch, getState) => {
+		const {languageId, segmentsExperienceId} = getState();
+
+		return FragmentService.updateEditableValues({
 			editableValues,
 			fragmentEntryLinkId,
-			languageId: getState().languageId,
+			languageId,
 			onNetworkStatus: dispatch,
 		})
 			.then((fragmentEntryLink) => {
@@ -51,4 +52,5 @@ export default function updateEditableValues({
 					);
 				});
 			});
+	};
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig.js
@@ -17,13 +17,11 @@ import updatePageContents from '../actions/updatePageContents';
 import InfoItemService from '../services/InfoItemService';
 import LayoutService from '../services/LayoutService';
 
-export default function updateItemConfig({
-	itemConfig,
-	itemId,
-	segmentsExperienceId,
-}) {
-	return (dispatch) =>
-		LayoutService.updateItemConfig({
+export default function updateItemConfig({itemConfig, itemId}) {
+	return (dispatch, getState) => {
+		const {segmentsExperienceId} = getState();
+
+		return LayoutService.updateItemConfig({
 			itemConfig,
 			itemId,
 			onNetworkStatus: dispatch,
@@ -44,4 +42,5 @@ export default function updateItemConfig({
 					);
 				});
 			});
+	};
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateRowColumns.js
@@ -15,17 +15,13 @@
 import updateRowColumnsAction from '../actions/updateRowColumns';
 import LayoutService from '../services/LayoutService';
 
-export default function updateRowColumns({
-	itemId,
-	numberOfColumns,
-	segmentsExperienceId,
-}) {
-	return (dispatch) =>
+export default function updateRowColumns({itemId, numberOfColumns}) {
+	return (dispatch, getState) =>
 		LayoutService.updateRowColumns({
 			itemId,
 			numberOfColumns,
 			onNetworkStatus: dispatch,
-			segmentsExperienceId,
+			segmentsExperienceId: getState().segmentsExperienceId,
 		}).then(({layoutData}) => {
 			dispatch(
 				updateRowColumnsAction({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/drag-and-drop/defaultComputeHover.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/drag-and-drop/defaultComputeHover.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {CONTAINER_DISPLAY_OPTIONS} from '../../config/constants/containerDisplayOptions';
+import {CONTENT_DISPLAY_OPTIONS} from '../../config/constants/contentDisplayOptions';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../config/constants/layoutDataItemTypes';
 import {collectionIsMapped} from '../collectionIsMapped';
 import {formIsMapped} from '../formIsMapped';
@@ -326,7 +326,7 @@ function shouldBeIgnoredInElevation(item) {
 function itemIsContainerFlex(item) {
 	return (
 		item.type === LAYOUT_DATA_ITEM_TYPES.container &&
-		item.config.contentDisplay === CONTAINER_DISPLAY_OPTIONS.flexRow
+		item.config.contentDisplay === CONTENT_DISPLAY_OPTIONS.flexRow
 	);
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/hideFragment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/hideFragment.js
@@ -14,16 +14,10 @@
 
 import updateItemStyle from './updateItemStyle';
 
-export default function hideFragment({
-	dispatch,
-	itemId,
-	segmentsExperienceId,
-	selectedViewportSize,
-}) {
+export default function hideFragment({dispatch, itemId, selectedViewportSize}) {
 	updateItemStyle({
 		dispatch,
 		itemId,
-		segmentsExperienceId,
 		selectedViewportSize,
 		styleName: 'display',
 		styleValue: 'none',

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/updateItemStyle.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/updateItemStyle.js
@@ -18,7 +18,6 @@ import updateItemConfig from '../thunks/updateItemConfig';
 export default function updateItemStyle({
 	dispatch,
 	itemId,
-	segmentsExperienceId,
 	selectedViewportSize,
 	styleName,
 	styleValue,
@@ -43,7 +42,6 @@ export default function updateItemStyle({
 		updateItemConfig({
 			itemConfig,
 			itemId,
-			segmentsExperienceId,
 		})
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNode.js
@@ -38,7 +38,6 @@ import {
 	useSelectorRef,
 } from '../../../../../app/contexts/StoreContext';
 import selectCanUpdatePageStructure from '../../../../../app/selectors/selectCanUpdatePageStructure';
-import selectSegmentsExperienceId from '../../../../../app/selectors/selectSegmentsExperienceId';
 import CollectionService from '../../../../../app/services/CollectionService';
 import moveItem from '../../../../../app/thunks/moveItem';
 import updateItemConfig from '../../../../../app/thunks/updateItemConfig';
@@ -188,7 +187,6 @@ function StructureTreeNodeContent({
 	const dispatch = useDispatch();
 	const hoverItem = useHoverItem();
 	const nodeRef = useRef();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -240,7 +238,6 @@ function StructureTreeNodeContent({
 					itemId: node.id,
 					parentItemId,
 					position,
-					segmentsExperienceId,
 				})
 			)
 	);
@@ -257,7 +254,6 @@ function StructureTreeNodeContent({
 				updateItemConfig({
 					itemConfig: {name: trimmedName},
 					itemId: node.id,
-					segmentsExperienceId,
 				})
 			);
 		}
@@ -389,7 +385,6 @@ function StructureTreeNodeContent({
 						<VisibilityButton
 							dispatch={dispatch}
 							node={node}
-							segmentsExperienceId={segmentsExperienceId}
 							selectedViewportSize={selectedViewportSize}
 							visible={node.hidden || isHovered || isSelected}
 						/>
@@ -490,13 +485,7 @@ const NameLabel = React.forwardRef(
 	}
 );
 
-const VisibilityButton = ({
-	dispatch,
-	node,
-	segmentsExperienceId,
-	selectedViewportSize,
-	visible,
-}) => {
+const VisibilityButton = ({dispatch, node, selectedViewportSize, visible}) => {
 	const hasRequiredChild = useHasRequiredChild(node.id);
 
 	return (
@@ -519,7 +508,6 @@ const VisibilityButton = ({
 				updateItemStyle({
 					dispatch,
 					itemId: node.id,
-					segmentsExperienceId,
 					selectedViewportSize,
 					styleName: 'display',
 					styleValue: node.hidden ? 'block' : 'none',

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNodeActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNodeActions.js
@@ -107,12 +107,9 @@ const ActionList = ({item, setActive, setEditingName, setOpenSaveModal}) => {
 	const selectItem = useSelectItem();
 	const widgets = useSelector((state) => state.widgets);
 
-	const {
-		fragmentEntryLinks,
-		layoutData,
-		segmentsExperienceId,
-		selectedViewportSize,
-	} = useSelector((state) => state);
+	const {fragmentEntryLinks, layoutData, selectedViewportSize} = useSelector(
+		(state) => state
+	);
 
 	const isInputFragment =
 		item.type === LAYOUT_DATA_ITEM_TYPES.fragment &&
@@ -134,7 +131,6 @@ const ActionList = ({item, setActive, setEditingName, setOpenSaveModal}) => {
 					updateItemStyle({
 						dispatch,
 						itemId: item.itemId,
-						segmentsExperienceId,
 						selectedViewportSize,
 						styleName: 'display',
 						styleValue: isHidden ? 'block' : 'none',
@@ -178,7 +174,6 @@ const ActionList = ({item, setActive, setEditingName, setOpenSaveModal}) => {
 					dispatch(
 						duplicateItem({
 							itemId: item.itemId,
-							segmentsExperienceId,
 							selectItem,
 						})
 					),
@@ -222,7 +217,6 @@ const ActionList = ({item, setActive, setEditingName, setOpenSaveModal}) => {
 		isInputFragment,
 		item,
 		layoutData,
-		segmentsExperienceId,
 		selectedViewportSize,
 		selectItem,
 		widgets,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/CSSFieldSet.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/CSSFieldSet.js
@@ -21,7 +21,6 @@ import {
 	useSelector,
 } from '../../../../../../app/contexts/StoreContext';
 import selectCanUpdateCSSAdvancedOptions from '../../../../../../app/selectors/selectCanUpdateCSSAdvancedOptions';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateItemConfig from '../../../../../../app/thunks/updateItemConfig';
 import {getResponsiveConfig} from '../../../../../../app/utils/getResponsiveConfig';
 import {FieldSet} from './FieldSet';
@@ -47,7 +46,6 @@ export default function CSSFieldSet({item}) {
 		selectCanUpdateCSSAdvancedOptions
 	);
 	const languageId = useSelector((state) => state.languageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -69,7 +67,6 @@ export default function CSSFieldSet({item}) {
 			updateItemConfig({
 				itemConfig: nextConfig,
 				itemId: item.itemId,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.js
@@ -23,7 +23,6 @@ import {
 	useDispatch,
 	useSelector,
 } from '../../../../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateItemStyle from '../../../../../../app/utils/updateItemStyle';
 import {FieldSet, fieldIsDisabled} from './FieldSet';
 
@@ -34,7 +33,6 @@ export function CommonStyles({
 	item,
 }) {
 	const dispatch = useDispatch();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -52,7 +50,6 @@ export function CommonStyles({
 		updateItemStyle({
 			dispatch,
 			itemId: item.itemId,
-			segmentsExperienceId,
 			selectedViewportSize,
 			styleName: name,
 			styleValue: value,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerAdvancedPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerAdvancedPanel.js
@@ -22,7 +22,6 @@ import {
 	useDispatch,
 	useSelector,
 } from '../../../../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateItemConfig from '../../../../../../app/thunks/updateItemConfig';
 import {getLayoutDataItemPropTypes} from '../../../../../../prop-types/index';
 import CSSFieldSet from './CSSFieldSet';
@@ -40,7 +39,6 @@ const HTML_TAGS = [
 
 export default function ContainerAdvancedPanel({item}) {
 	const dispatch = useDispatch();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -70,7 +68,6 @@ export default function ContainerAdvancedPanel({item}) {
 								updateItemConfig({
 									itemConfig,
 									itemId: item.itemId,
-									segmentsExperienceId,
 								})
 							);
 						}}
@@ -104,7 +101,6 @@ export default function ContainerAdvancedPanel({item}) {
 										[name]: value,
 									},
 									itemId: item.itemId,
-									segmentsExperienceId,
 								})
 							);
 						}}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerDisplayOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerDisplayOptions.js
@@ -16,8 +16,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {SelectField} from '../../../../../../app/components/fragment-configuration-fields/SelectField';
-import {CONTAINER_DISPLAY_OPTIONS} from '../../../../../../app/config/constants/containerDisplayOptions';
 import {CONTAINER_WIDTH_TYPES} from '../../../../../../app/config/constants/containerWidthTypes';
+import {CONTENT_DISPLAY_OPTIONS} from '../../../../../../app/config/constants/contentDisplayOptions';
 import {
 	useDispatch,
 	useSelector,
@@ -30,18 +30,18 @@ const ALIGN_ITEMS_STRETCH = 'align-items-stretch';
 const FLEX_WRAP_NOWRAP = 'flex-nowrap';
 const JUSTIFY_CONTENT_START = 'justify-content-start';
 
-const CONTENT_DISPLAY_OPTIONS = [
+const DISPLAY_OPTIONS = [
 	{
 		label: Liferay.Language.get('block'),
-		value: CONTAINER_DISPLAY_OPTIONS.block,
+		value: CONTENT_DISPLAY_OPTIONS.block,
 	},
 	{
 		label: Liferay.Language.get('flex-row'),
-		value: CONTAINER_DISPLAY_OPTIONS.flexRow,
+		value: CONTENT_DISPLAY_OPTIONS.flexRow,
 	},
 	{
 		label: Liferay.Language.get('flex-column'),
-		value: CONTAINER_DISPLAY_OPTIONS.flexColumn,
+		value: CONTENT_DISPLAY_OPTIONS.flexColumn,
 	},
 ];
 
@@ -122,8 +122,8 @@ export default function ContainerDisplayOptions({item}) {
 	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const flexOptionsVisible =
-		item.config.contentDisplay === CONTAINER_DISPLAY_OPTIONS.flexColumn ||
-		item.config.contentDisplay === CONTAINER_DISPLAY_OPTIONS.flexRow;
+		item.config.contentDisplay === CONTENT_DISPLAY_OPTIONS.flexColumn ||
+		item.config.contentDisplay === CONTENT_DISPLAY_OPTIONS.flexRow;
 
 	return (
 		<>
@@ -132,12 +132,12 @@ export default function ContainerDisplayOptions({item}) {
 					label: Liferay.Language.get('content-display'),
 					name: 'contentDisplay',
 					typeOptions: {
-						validValues: CONTENT_DISPLAY_OPTIONS,
+						validValues: DISPLAY_OPTIONS,
 					},
 				}}
 				onValueSelect={(name, value) => {
 					const itemConfig =
-						value === CONTAINER_DISPLAY_OPTIONS.block
+						value === CONTENT_DISPLAY_OPTIONS.block
 							? {
 									align: '',
 									flexWrap: '',

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerDisplayOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerDisplayOptions.js
@@ -25,10 +25,7 @@ import {
 import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateItemConfig from '../../../../../../app/thunks/updateItemConfig';
 import {getLayoutDataItemPropTypes} from '../../../../../../prop-types/index';
-
-const ALIGN_ITEMS_STRETCH = 'align-items-stretch';
-const FLEX_WRAP_NOWRAP = 'flex-nowrap';
-const JUSTIFY_CONTENT_START = 'justify-content-start';
+import {FlexOptions} from './FlexOptions';
 
 const DISPLAY_OPTIONS = [
 	{
@@ -42,67 +39,6 @@ const DISPLAY_OPTIONS = [
 	{
 		label: Liferay.Language.get('flex-column'),
 		value: CONTENT_DISPLAY_OPTIONS.flexColumn,
-	},
-];
-
-const ALIGN_OPTIONS = [
-	{
-		label: Liferay.Language.get('start'),
-		value: 'align-items-start',
-	},
-	{
-		label: Liferay.Language.get('center'),
-		value: 'align-items-center',
-	},
-	{
-		label: Liferay.Language.get('end'),
-		value: 'align-items-end',
-	},
-	{
-		label: Liferay.Language.get('stretch'),
-		value: ALIGN_ITEMS_STRETCH,
-	},
-	{
-		label: Liferay.Language.get('baseline'),
-		value: 'align-items-baseline',
-	},
-];
-
-const FLEX_WRAP_OPTIONS = [
-	{
-		label: Liferay.Language.get('nowrap'),
-		value: FLEX_WRAP_NOWRAP,
-	},
-	{
-		label: Liferay.Language.get('wrap'),
-		value: 'flex-wrap',
-	},
-	{
-		label: Liferay.Language.get('wrap-reverse'),
-		value: 'flex-wrap-reverse',
-	},
-];
-
-const JUSTIFY_OPTIONS = [
-	{
-		label: Liferay.Language.get('start'),
-		value: JUSTIFY_CONTENT_START,
-	},
-	{
-		label: Liferay.Language.get('center'),
-		value: 'justify-content-center',
-	},
-	{
-		label: Liferay.Language.get('end'),
-		value: 'justify-content-end',
-	},
-	{
-		label: Liferay.Language.get('between'),
-		value: 'justify-content-between',
-	},
-	{
-		label: Liferay.Language.get('around'),
-		value: 'justify-content-around',
 	},
 ];
 
@@ -158,86 +94,20 @@ export default function ContainerDisplayOptions({item}) {
 			/>
 
 			{flexOptionsVisible && (
-				<>
-					<SelectField
-						field={{
-							label: Liferay.Language.get('flex-wrap'),
-							name: 'flexWrap',
-							typeOptions: {
-								validValues: FLEX_WRAP_OPTIONS,
-							},
-						}}
-						onValueSelect={(name, value) => {
-							dispatch(
-								updateItemConfig({
-									itemConfig: {
-										[name]:
-											value === FLEX_WRAP_NOWRAP
-												? ''
-												: value,
-									},
-									itemId: item.itemId,
-									segmentsExperienceId,
-								})
-							);
-						}}
-						value={item.config.flexWrap || FLEX_WRAP_NOWRAP}
-					/>
-
-					<div className="d-flex justify-content-between">
-						<SelectField
-							className="page-editor__sidebar__fieldset__field-small"
-							field={{
-								label: Liferay.Language.get('align-items'),
-								name: 'align',
-								typeOptions: {
-									validValues: ALIGN_OPTIONS,
+				<FlexOptions
+					itemConfig={item.config}
+					onConfigChange={(name, value) => {
+						dispatch(
+							updateItemConfig({
+								itemConfig: {
+									[name]: value,
 								},
-							}}
-							onValueSelect={(name, value) => {
-								dispatch(
-									updateItemConfig({
-										itemConfig: {
-											[name]:
-												value === ALIGN_ITEMS_STRETCH
-													? ''
-													: value,
-										},
-										itemId: item.itemId,
-										segmentsExperienceId,
-									})
-								);
-							}}
-							value={item.config.align || ALIGN_ITEMS_STRETCH}
-						/>
-
-						<SelectField
-							className="page-editor__sidebar__fieldset__field-small"
-							field={{
-								label: Liferay.Language.get('justify-content'),
-								name: 'justify',
-								typeOptions: {
-									validValues: JUSTIFY_OPTIONS,
-								},
-							}}
-							onValueSelect={(name, value) => {
-								dispatch(
-									updateItemConfig({
-										itemConfig: {
-											[name]:
-												value === JUSTIFY_CONTENT_START
-													? ''
-													: value,
-										},
-										itemId: item.itemId,
-										segmentsExperienceId,
-									})
-								);
-							}}
-							value={item.config.justify || JUSTIFY_CONTENT_START}
-						/>
-					</div>
-				</>
+								itemId: item.itemId,
+								segmentsExperienceId,
+							})
+						);
+					}}
+				/>
 			)}
 
 			<SelectField

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerDisplayOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerDisplayOptions.js
@@ -18,11 +18,7 @@ import React from 'react';
 import {SelectField} from '../../../../../../app/components/fragment-configuration-fields/SelectField';
 import {CONTAINER_WIDTH_TYPES} from '../../../../../../app/config/constants/containerWidthTypes';
 import {CONTENT_DISPLAY_OPTIONS} from '../../../../../../app/config/constants/contentDisplayOptions';
-import {
-	useDispatch,
-	useSelector,
-} from '../../../../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
+import {useDispatch} from '../../../../../../app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../app/thunks/updateItemConfig';
 import {getLayoutDataItemPropTypes} from '../../../../../../prop-types/index';
 import {FlexOptions} from './FlexOptions';
@@ -55,7 +51,6 @@ const WIDTH_TYPE_OPTIONS = [
 
 export default function ContainerDisplayOptions({item}) {
 	const dispatch = useDispatch();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const flexOptionsVisible =
 		item.config.contentDisplay === CONTENT_DISPLAY_OPTIONS.flexColumn ||
@@ -86,7 +81,6 @@ export default function ContainerDisplayOptions({item}) {
 						updateItemConfig({
 							itemConfig,
 							itemId: item.itemId,
-							segmentsExperienceId,
 						})
 					);
 				}}
@@ -103,7 +97,6 @@ export default function ContainerDisplayOptions({item}) {
 									[name]: value,
 								},
 								itemId: item.itemId,
-								segmentsExperienceId,
 							})
 						);
 					}}
@@ -123,7 +116,6 @@ export default function ContainerDisplayOptions({item}) {
 						updateItemConfig({
 							itemConfig: {[name]: value},
 							itemId: item.itemId,
-							segmentsExperienceId,
 						})
 					);
 				}}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.js
@@ -22,7 +22,6 @@ import {
 	useDispatch,
 	useSelector,
 } from '../../../../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateItemConfig from '../../../../../../app/thunks/updateItemConfig';
 import isMapped from '../../../../../../app/utils/editable-value/isMapped';
 import {getEditableLinkValue} from '../../../../../../app/utils/getEditableLinkValue';
@@ -35,7 +34,6 @@ import ContainerDisplayOptions from './ContainerDisplayOptions';
 export default function ContainerGeneralPanel({item}) {
 	const dispatch = useDispatch();
 	const languageId = useSelector((state) => state.languageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const [linkConfig, setLinkConfig] = useState({});
 	const [linkValue, setLinkValue] = useState({});
@@ -82,7 +80,6 @@ export default function ContainerGeneralPanel({item}) {
 			updateItemConfig({
 				itemConfig: nextConfig,
 				itemId: item.itemId,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.js
@@ -24,7 +24,6 @@ import {
 } from '../../../../../../app/contexts/StoreContext';
 import selectEditableValue from '../../../../../../app/selectors/selectEditableValue';
 import selectEditableValues from '../../../../../../app/selectors/selectEditableValues';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateEditableValues from '../../../../../../app/thunks/updateEditableValues';
 import {deepEqual} from '../../../../../../app/utils/checkDeepEqual';
 import isMapped from '../../../../../../app/utils/editable-value/isMapped';
@@ -34,7 +33,6 @@ import {getEditableItemPropTypes} from '../../../../../../prop-types/index';
 export default function EditableLinkPanel({item}) {
 	const dispatch = useDispatch();
 	const languageId = useSelector((state) => state.languageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const editableValues = useSelectorCallback(
 		(state) => selectEditableValues(state, item.fragmentEntryLinkId),
@@ -122,7 +120,6 @@ export default function EditableLinkPanel({item}) {
 					},
 				},
 				fragmentEntryLinkId: item.fragmentEntryLinkId,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/EditableLinkPanel.js
@@ -122,7 +122,6 @@ export default function EditableLinkPanel({item}) {
 					},
 				},
 				fragmentEntryLinkId: item.fragmentEntryLinkId,
-				languageId,
 				segmentsExperienceId,
 			})
 		);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FlexOptions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FlexOptions.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {SelectField} from '../../../../../../app/components/fragment-configuration-fields/SelectField';
+
+const ALIGN_OPTIONS = [
+	{
+		label: Liferay.Language.get('start'),
+		value: 'align-items-start',
+	},
+	{
+		label: Liferay.Language.get('center'),
+		value: 'align-items-center',
+	},
+	{
+		label: Liferay.Language.get('end'),
+		value: 'align-items-end',
+	},
+	{
+		label: Liferay.Language.get('stretch'),
+		value: '',
+	},
+	{
+		label: Liferay.Language.get('baseline'),
+		value: 'align-items-baseline',
+	},
+];
+
+const FLEX_WRAP_OPTIONS = [
+	{
+		label: Liferay.Language.get('nowrap'),
+		value: '',
+	},
+	{
+		label: Liferay.Language.get('wrap'),
+		value: 'flex-wrap',
+	},
+	{
+		label: Liferay.Language.get('wrap-reverse'),
+		value: 'flex-wrap-reverse',
+	},
+];
+
+const JUSTIFY_OPTIONS = [
+	{
+		label: Liferay.Language.get('start'),
+		value: '',
+	},
+	{
+		label: Liferay.Language.get('center'),
+		value: 'justify-content-center',
+	},
+	{
+		label: Liferay.Language.get('end'),
+		value: 'justify-content-end',
+	},
+	{
+		label: Liferay.Language.get('between'),
+		value: 'justify-content-between',
+	},
+	{
+		label: Liferay.Language.get('around'),
+		value: 'justify-content-around',
+	},
+];
+
+export function FlexOptions({itemConfig, onConfigChange}) {
+	return (
+		<>
+			<SelectField
+				field={{
+					label: Liferay.Language.get('flex-wrap'),
+					name: 'flexWrap',
+					typeOptions: {
+						validValues: FLEX_WRAP_OPTIONS,
+					},
+				}}
+				onValueSelect={onConfigChange}
+				value={itemConfig.flexWrap || ''}
+			/>
+
+			<div className="d-flex justify-content-between">
+				<SelectField
+					className="page-editor__sidebar__fieldset__field-small"
+					field={{
+						label: Liferay.Language.get('align-items'),
+						name: 'align',
+						typeOptions: {
+							validValues: ALIGN_OPTIONS,
+						},
+					}}
+					onValueSelect={onConfigChange}
+					value={itemConfig.align || ''}
+				/>
+
+				<SelectField
+					className="page-editor__sidebar__fieldset__field-small"
+					field={{
+						label: Liferay.Language.get('justify-content'),
+						name: 'justify',
+						typeOptions: {
+							validValues: JUSTIFY_OPTIONS,
+						},
+					}}
+					onValueSelect={onConfigChange}
+					value={itemConfig.justify || ''}
+				/>
+			</div>
+		</>
+	);
+}
+
+FlexOptions.propTypes = {
+	itemConfig: PropTypes.object.isRequired,
+	onConfigChange: PropTypes.func.isRequired,
+};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.js
@@ -30,7 +30,6 @@ import {
 import selectFormConfiguration from '../../../../../../app/selectors/selectFormConfiguration';
 import selectFragmentEntryLink from '../../../../../../app/selectors/selectFragmentEntryLink';
 import selectLanguageId from '../../../../../../app/selectors/selectLanguageId';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import FormService from '../../../../../../app/services/FormService';
 import updateEditableValues from '../../../../../../app/thunks/updateEditableValues';
 import {CACHE_KEYS} from '../../../../../../app/utils/cache';
@@ -128,7 +127,6 @@ function getTypeLabels(classNameId, classTypeId) {
 export function FormInputGeneralPanel({item}) {
 	const dispatch = useDispatch();
 	const languageId = useSelector(selectLanguageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const fragmentEntryLinkRef = useSelectorRef((state) =>
 		selectFragmentEntryLink(state, item)
@@ -296,7 +294,6 @@ export function FormInputGeneralPanel({item}) {
 				editableValues: setIn(editableValues, keyPath, value),
 				fragmentEntryLinkId:
 					fragmentEntryLinkRef.current.fragmentEntryLinkId,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FormInputGeneralPanel.js
@@ -296,7 +296,6 @@ export function FormInputGeneralPanel({item}) {
 				editableValues: setIn(editableValues, keyPath, value),
 				fragmentEntryLinkId:
 					fragmentEntryLinkRef.current.fragmentEntryLinkId,
-				languageId,
 				segmentsExperienceId,
 			})
 		);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ImageSourcePanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ImageSourcePanel.js
@@ -28,7 +28,6 @@ import {
 } from '../../../../../../app/contexts/StoreContext';
 import selectEditableValueContent from '../../../../../../app/selectors/selectEditableValueContent';
 import selectLanguageId from '../../../../../../app/selectors/selectLanguageId';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateEditableValuesThunk from '../../../../../../app/thunks/updateEditableValues';
 import isMapped from '../../../../../../app/utils/editable-value/isMapped';
 import isMappedToCollection from '../../../../../../app/utils/editable-value/isMappedToCollection';
@@ -57,7 +56,6 @@ const SOURCE_OPTIONS = {
 export default function ImageSourcePanel({item}) {
 	const dispatch = useDispatch();
 	const fragmentEntryLinks = useSelector((state) => state.fragmentEntryLinks);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const sourceSelectionInputId = useId();
 
 	const selectedViewportSize = useSelector(
@@ -94,7 +92,6 @@ export default function ImageSourcePanel({item}) {
 						}
 					),
 					fragmentEntryLinkId: item.fragmentEntryLinkId,
-					segmentsExperienceId,
 				})
 			);
 		}
@@ -149,7 +146,6 @@ export default function ImageSourcePanel({item}) {
 									value
 								),
 								fragmentEntryLinkId: item.fragmentEntryLinkId,
-								segmentsExperienceId,
 							})
 						);
 					}}
@@ -170,7 +166,6 @@ function DirectImagePanel({item}) {
 	const dispatch = useDispatch();
 	const fragmentEntryLinks = useSelector((state) => state.fragmentEntryLinks);
 	const languageId = useSelector(selectLanguageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -248,7 +243,6 @@ function DirectImagePanel({item}) {
 					nextEditableValue
 				),
 				fragmentEntryLinkId,
-				segmentsExperienceId,
 			})
 		);
 	};
@@ -279,7 +273,6 @@ function DirectImagePanel({item}) {
 					{}
 				),
 				fragmentEntryLinkId,
-				segmentsExperienceId,
 			})
 		);
 	};
@@ -341,7 +334,6 @@ function ImagePanelSizeSelector({item}) {
 	const fragmentEntryLinks = useSelector((state) => state.fragmentEntryLinks);
 	const globalContext = useGlobalContext();
 	const languageId = useSelector(selectLanguageId);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -401,7 +393,6 @@ function ImagePanelSizeSelector({item}) {
 					imageSizeId
 				),
 				fragmentEntryLinkId,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ImageSourcePanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/ImageSourcePanel.js
@@ -57,7 +57,6 @@ const SOURCE_OPTIONS = {
 export default function ImageSourcePanel({item}) {
 	const dispatch = useDispatch();
 	const fragmentEntryLinks = useSelector((state) => state.fragmentEntryLinks);
-	const languageId = useSelector(selectLanguageId);
 	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const sourceSelectionInputId = useId();
 
@@ -95,7 +94,6 @@ export default function ImageSourcePanel({item}) {
 						}
 					),
 					fragmentEntryLinkId: item.fragmentEntryLinkId,
-					languageId,
 					segmentsExperienceId,
 				})
 			);
@@ -151,7 +149,6 @@ export default function ImageSourcePanel({item}) {
 									value
 								),
 								fragmentEntryLinkId: item.fragmentEntryLinkId,
-								languageId,
 								segmentsExperienceId,
 							})
 						);
@@ -251,7 +248,6 @@ function DirectImagePanel({item}) {
 					nextEditableValue
 				),
 				fragmentEntryLinkId,
-				languageId,
 				segmentsExperienceId,
 			})
 		);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/MappingPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/MappingPanel.js
@@ -69,7 +69,6 @@ export function MappingPanel({item}) {
 			updateEditableValues({
 				editableValues: nextEditableValues,
 				fragmentEntryLinkId,
-				segmentsExperienceId: state.segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/MappingPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/MappingPanel.js
@@ -69,7 +69,6 @@ export function MappingPanel({item}) {
 			updateEditableValues({
 				editableValues: nextEditableValues,
 				fragmentEntryLinkId,
-				languageId: state.languageId,
 				segmentsExperienceId: state.segmentsExperienceId,
 			})
 		);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.js
@@ -23,7 +23,6 @@ import {
 	useDispatch,
 	useSelector,
 } from '../../../../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../../../../app/selectors/selectSegmentsExperienceId';
 import updateItemConfig from '../../../../../../app/thunks/updateItemConfig';
 import updateRowColumns from '../../../../../../app/thunks/updateRowColumns';
 import {deepEqual} from '../../../../../../app/utils/checkDeepEqual';
@@ -71,7 +70,6 @@ const ROW_STYLE_IDENTIFIERS = {
 export function RowGeneralPanel({item}) {
 	const dispatch = useDispatch();
 	const layoutData = useSelector((state) => state.layoutData);
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -105,7 +103,6 @@ export function RowGeneralPanel({item}) {
 					updateRowColumns({
 						itemId: item.itemId,
 						numberOfColumns: newNumberOfColumns,
-						segmentsExperienceId,
 						viewportSizeId: selectedViewportSize,
 					})
 				);
@@ -118,7 +115,6 @@ export function RowGeneralPanel({item}) {
 			updateItemConfig({
 				itemConfig,
 				itemId: item.itemId,
-				segmentsExperienceId,
 			})
 		);
 	};
@@ -150,7 +146,6 @@ export function RowGeneralPanel({item}) {
 					updateRowColumns({
 						itemId: item.itemId,
 						numberOfColumns: newNumberOfColumns,
-						segmentsExperienceId,
 						viewportSizeId: selectedViewportSize,
 					})
 				);
@@ -163,7 +158,6 @@ export function RowGeneralPanel({item}) {
 			updateItemConfig({
 				itemConfig: itemStyles,
 				itemId: item.itemId,
-				segmentsExperienceId,
 			})
 		);
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
@@ -30,7 +30,6 @@ import {
 	useGetState,
 	useSelector,
 } from '../../../../../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../../../../../app/selectors/selectSegmentsExperienceId';
 import CollectionService from '../../../../../../../app/services/CollectionService';
 import InfoItemService from '../../../../../../../app/services/InfoItemService';
 import updateCollectionDisplayCollection from '../../../../../../../app/thunks/updateCollectionDisplayCollection';
@@ -84,7 +83,6 @@ export function CollectionGeneralPanel({item}) {
 	const collectionVerticalAlignmentId = useId();
 	const dispatch = useDispatch();
 	const getState = useGetState();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const {
 		observer: filterConfigurationObserver,
@@ -190,11 +188,10 @@ export function CollectionGeneralPanel({item}) {
 				updateItemConfig({
 					itemConfig,
 					itemId: item.itemId,
-					segmentsExperienceId,
 				})
 			);
 		},
-		[item.itemId, dispatch, segmentsExperienceId, selectedViewportSize]
+		[item.itemId, dispatch, selectedViewportSize]
 	);
 
 	useEffect(() => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
@@ -20,6 +20,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {COLLECTION_APPLIED_FILTERS_FRAGMENT_ENTRY_KEY} from '../../../../../../../app/config/constants/collectionAppliedFiltersFragmentKey';
 import {COLLECTION_FILTER_FRAGMENT_ENTRY_KEY} from '../../../../../../../app/config/constants/collectionFilterFragmentEntryKey';
 import {COMMON_STYLES_ROLES} from '../../../../../../../app/config/constants/commonStylesRoles';
+import {CONTENT_DISPLAY_OPTIONS} from '../../../../../../../app/config/constants/contentDisplayOptions';
 import {FREEMARKER_FRAGMENT_ENTRY_PROCESSOR} from '../../../../../../../app/config/constants/freemarkerFragmentEntryProcessor';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../../../app/config/constants/layoutDataItemTypes';
 import {VIEWPORT_SIZES} from '../../../../../../../app/config/constants/viewportSizes';
@@ -40,6 +41,7 @@ import CollectionSelector from '../../../../../../../common/components/Collectio
 import {useId} from '../../../../../../../core/hooks/useId';
 import CollectionFilterConfigurationModal from '../../CollectionFilterConfigurationModal';
 import {CommonStyles} from '../CommonStyles';
+import {FlexOptions} from '../FlexOptions';
 import {EmptyCollectionOptions} from './EmptyCollectionOptions';
 import {LayoutSelector} from './LayoutSelector';
 import {ListItemStyleSelector} from './ListItemStyleSelector';
@@ -50,7 +52,11 @@ import {ShowGutterSelector} from './ShowGutterSelector';
 import {StyleDisplaySelector} from './StyleDisplaySelector';
 import {VerticalAlignmentSelector} from './VerticalAlignmentSelector';
 
-const LIST_STYLE_GRID = '';
+const LIST_STYLES = {
+	flexColumn: CONTENT_DISPLAY_OPTIONS.flexColumn,
+	flexRow: CONTENT_DISPLAY_OPTIONS.flexRow,
+	grid: '',
+};
 
 export function CollectionGeneralPanel({item}) {
 	const {
@@ -118,7 +124,7 @@ export function CollectionGeneralPanel({item}) {
 			updateCollectionDisplayCollection({
 				collection: Object.keys(collection).length ? collection : null,
 				itemId: item.itemId,
-				listStyle: LIST_STYLE_GRID,
+				listStyle: LIST_STYLES.grid,
 			})
 		);
 	};
@@ -192,7 +198,7 @@ export function CollectionGeneralPanel({item}) {
 	);
 
 	useEffect(() => {
-		if (collection && listStyle && listStyle !== LIST_STYLE_GRID) {
+		if (collection && listStyle && listStyle !== LIST_STYLES.grid) {
 			InfoItemService.getAvailableListItemRenderers({
 				itemSubtype: collection.itemSubtype,
 				itemType: collection.itemType,
@@ -229,6 +235,10 @@ export function CollectionGeneralPanel({item}) {
 		}
 	}, [collection]);
 
+	const flexEnabled =
+		listStyle === LIST_STYLES.flexColumn ||
+		listStyle === LIST_STYLES.flexRow;
+
 	return (
 		<>
 			<div className="mb-3">
@@ -262,7 +272,18 @@ export function CollectionGeneralPanel({item}) {
 								/>
 							)}
 
-							{listStyle === LIST_STYLE_GRID && (
+							{flexEnabled && (
+								<FlexOptions
+									itemConfig={collectionConfig}
+									onConfigChange={(name, value) => {
+										handleConfigurationChanged({
+											[name]: value,
+										});
+									}}
+								/>
+							)}
+
+							{listStyle === LIST_STYLES.grid && (
 								<>
 									<LayoutSelector
 										collectionConfig={collectionConfig}
@@ -302,10 +323,11 @@ export function CollectionGeneralPanel({item}) {
 									)}
 								</>
 							)}
+
 							{selectedViewportSize ===
 								VIEWPORT_SIZES.desktop && (
 								<>
-									{listStyle !== LIST_STYLE_GRID &&
+									{listStyle !== LIST_STYLES.grid &&
 										!!availableListItemStyles.length && (
 											<ListItemStyleSelector
 												availableListItemStyles={

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.js
@@ -355,17 +355,31 @@ export function CollectionGeneralPanel({item}) {
 										}
 									/>
 
-									<PaginationSelector
-										collectionPaginationTypeId={
-											collectionPaginationTypeId
-										}
-										handleConfigurationChanged={
-											handleConfigurationChanged
-										}
-										value={paginationType || 'none'}
-									/>
+									{!flexEnabled && (
+										<PaginationSelector
+											collectionPaginationTypeId={
+												collectionPaginationTypeId
+											}
+											handleConfigurationChanged={
+												handleConfigurationChanged
+											}
+											value={paginationType || 'none'}
+										/>
+									)}
 
-									{paginationType !== 'none' ? (
+									{paginationType === 'none' ||
+									flexEnabled ? (
+										<NoPaginationOptions
+											collection={collection}
+											displayAllItems={displayAllItems}
+											handleConfigurationChanged={
+												handleConfigurationChanged
+											}
+											initialNumberOfItems={
+												initialNumberOfItems
+											}
+										/>
+									) : (
 										<PaginationOptions
 											displayAllPages={displayAllPages}
 											handleConfigurationChanged={
@@ -376,17 +390,6 @@ export function CollectionGeneralPanel({item}) {
 											}
 											initialNumberOfPages={
 												initialNumberOfPages
-											}
-										/>
-									) : (
-										<NoPaginationOptions
-											collection={collection}
-											displayAllItems={displayAllItems}
-											handleConfigurationChanged={
-												handleConfigurationChanged
-											}
-											initialNumberOfItems={
-												initialNumberOfItems
 											}
 										/>
 									)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/StyleDisplaySelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/StyleDisplaySelector.js
@@ -16,24 +16,33 @@ import ClayForm, {ClaySelectWithOption} from '@clayui/form';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
+import {CONTENT_DISPLAY_OPTIONS} from '../../../../../../../app/config/constants/contentDisplayOptions';
 import InfoItemService from '../../../../../../../app/services/InfoItemService';
 import {useId} from '../../../../../../../core/hooks/useId';
 
-const LIST_STYLE_GRID = '';
-
-const DEFAULT_LIST_STYLE = {
-	label: Liferay.Language.get('grid'),
-	value: LIST_STYLE_GRID,
-};
+const DEFAULT_LIST_STYLES = [
+	{
+		label: Liferay.Language.get('grid'),
+		value: '',
+	},
+	{
+		label: Liferay.Language.get('flex-row'),
+		value: CONTENT_DISPLAY_OPTIONS.flexRow,
+	},
+	{
+		label: Liferay.Language.get('flex-column'),
+		value: CONTENT_DISPLAY_OPTIONS.flexColumn,
+	},
+];
 
 export function StyleDisplaySelector({
 	collectionItemType,
 	handleConfigurationChanged,
 	listStyle,
 }) {
-	const [availableListStyles, setAvailableListStyles] = useState([
-		DEFAULT_LIST_STYLE,
-	]);
+	const [availableListStyles, setAvailableListStyles] = useState(
+		DEFAULT_LIST_STYLES
+	);
 
 	const listStyleId = useId();
 
@@ -44,7 +53,7 @@ export function StyleDisplaySelector({
 			})
 				.then((response) => {
 					setAvailableListStyles([
-						DEFAULT_LIST_STYLE,
+						...DEFAULT_LIST_STYLES,
 						{
 							label: Liferay.Language.get('templates'),
 							options: response,
@@ -53,7 +62,7 @@ export function StyleDisplaySelector({
 					]);
 				})
 				.catch(() => {
-					setAvailableListStyles([DEFAULT_LIST_STYLE]);
+					setAvailableListStyles(DEFAULT_LIST_STYLES);
 				});
 		}
 	}, [collectionItemType]);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/StyleDisplaySelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/StyleDisplaySelector.js
@@ -79,6 +79,12 @@ export function StyleDisplaySelector({
 				onChange={(event) =>
 					handleConfigurationChanged({
 						listStyle: event.target.value,
+						...(event.target.value ===
+							CONTENT_DISPLAY_OPTIONS.flexColumn ||
+							(event.target.value ===
+								CONTENT_DISPLAY_OPTIONS.flexRow && {
+								paginationType: 'none',
+							})),
 					})
 				}
 				options={availableListStyles}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments-widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments-widgets/components/TabItem.js
@@ -21,8 +21,7 @@ import React from 'react';
 
 import {FRAGMENTS_DISPLAY_STYLES} from '../../../app/config/constants/fragmentsDisplayStyles';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../app/config/constants/layoutDataItemTypes';
-import {useDispatch, useSelector} from '../../../app/contexts/StoreContext';
-import selectSegmentsExperienceId from '../../../app/selectors/selectSegmentsExperienceId';
+import {useDispatch} from '../../../app/contexts/StoreContext';
 import addFragment from '../../../app/thunks/addFragment';
 import addItem from '../../../app/thunks/addItem';
 import addWidget from '../../../app/thunks/addWidget';
@@ -41,7 +40,6 @@ const ITEM_PROPTYPES_SHAPE = PropTypes.shape({
 
 export default function TabItem({displayStyle, item}) {
 	const dispatch = useDispatch();
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
 
 	const onToggleHighlighted = () => {
 		if (item.data.portletId) {
@@ -93,7 +91,6 @@ export default function TabItem({displayStyle, item}) {
 					itemType: item.type,
 					parentItemId: parentId,
 					position,
-					store: {segmentsExperienceId},
 				})
 			);
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/CommonStyles.test.js
@@ -186,7 +186,6 @@ describe('CommonStyles', () => {
 				},
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.test.js
@@ -94,7 +94,6 @@ describe('ContainerGeneralPanel', () => {
 				},
 			},
 			itemId: 'some-container-id',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -114,7 +113,6 @@ describe('ContainerGeneralPanel', () => {
 				},
 			},
 			itemId: 'some-container-id',
-			segmentsExperienceId: '0',
 		});
 	});
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.test.js
@@ -185,8 +185,8 @@ describe('ContainerGeneralPanel', () => {
 		const alignInput = screen.getByLabelText('align-items');
 		const justifyInput = screen.getByLabelText('justify-content');
 
-		expect(flexWrapInput).toHaveValue('flex-nowrap');
-		expect(alignInput).toHaveValue('align-items-stretch');
-		expect(justifyInput).toHaveValue('justify-content-start');
+		expect(flexWrapInput).toHaveValue('');
+		expect(alignInput).toHaveValue('');
+		expect(justifyInput).toHaveValue('');
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/ContainerGeneralPanel.test.js
@@ -17,7 +17,7 @@ import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import {CONTAINER_DISPLAY_OPTIONS} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/containerDisplayOptions';
+import {CONTENT_DISPLAY_OPTIONS} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/contentDisplayOptions';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/layoutDataItemTypes';
 import {StoreAPIContextProvider} from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/StoreContext';
 import updateItemConfig from '../../../../../../../../../src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig';
@@ -156,7 +156,7 @@ describe('ContainerGeneralPanel', () => {
 
 	it('does not show Flex Wrap, Align and Justify selects when item is not flex container', async () => {
 		renderComponent({
-			contentDisplay: CONTAINER_DISPLAY_OPTIONS.block,
+			contentDisplay: CONTENT_DISPLAY_OPTIONS.block,
 		});
 
 		expect(screen.queryByLabelText('flex-wrap')).not.toBeInTheDocument();
@@ -168,7 +168,7 @@ describe('ContainerGeneralPanel', () => {
 
 	it('shows Flex Wrap, Align and Justify selects when item is flex container', async () => {
 		renderComponent({
-			contentDisplay: CONTAINER_DISPLAY_OPTIONS.flexRow,
+			contentDisplay: CONTENT_DISPLAY_OPTIONS.flexRow,
 		});
 
 		expect(screen.getByLabelText('flex-wrap')).toBeInTheDocument();
@@ -178,7 +178,7 @@ describe('ContainerGeneralPanel', () => {
 
 	it('sets correct default values for Flex Wrap, Align and Justify when flex is selected', async () => {
 		renderComponent({
-			contentDisplay: CONTAINER_DISPLAY_OPTIONS.flexRow,
+			contentDisplay: CONTENT_DISPLAY_OPTIONS.flexRow,
 		});
 
 		const flexWrapInput = screen.getByLabelText('flex-wrap');

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
@@ -229,7 +229,6 @@ describe('FragmentStylesPanel', () => {
 				},
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/RowGeneralPanel.test.js
@@ -112,7 +112,6 @@ describe('RowGeneralPanel', () => {
 		expect(updateRowColumns).toHaveBeenCalledWith({
 			itemId: '0',
 			numberOfColumns: 6,
-			segmentsExperienceId: '0',
 			viewportSizeId: 'desktop',
 		});
 	});
@@ -127,7 +126,6 @@ describe('RowGeneralPanel', () => {
 		expect(updateItemConfig).toHaveBeenCalledWith({
 			itemConfig: {gutters: false},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -145,7 +143,6 @@ describe('RowGeneralPanel', () => {
 				modulesPerRow: 2,
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -196,7 +193,6 @@ describe('RowGeneralPanel', () => {
 				verticalAlignment: 'middle',
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -232,7 +228,6 @@ describe('RowGeneralPanel', () => {
 				reverseOrder: true,
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -253,7 +248,6 @@ describe('RowGeneralPanel', () => {
 				tablet: {modulesPerRow: 1},
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page-structure/components/item-configuration-panels/collection-general-panel/CollectionGeneralPanel.test.js
@@ -130,7 +130,6 @@ describe('CollectionGeneralPanel', () => {
 		expect(updateItemConfig).toHaveBeenCalledWith({
 			itemConfig: {gutters: true},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -147,7 +146,6 @@ describe('CollectionGeneralPanel', () => {
 				verticalAlignment: 'center',
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -165,7 +163,6 @@ describe('CollectionGeneralPanel', () => {
 				},
 			}),
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -189,7 +186,6 @@ describe('CollectionGeneralPanel', () => {
 				},
 			}),
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -206,7 +202,6 @@ describe('CollectionGeneralPanel', () => {
 				paginationType: 'none',
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -224,7 +219,6 @@ describe('CollectionGeneralPanel', () => {
 				displayAllItems: true,
 			}),
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -255,7 +249,6 @@ describe('CollectionGeneralPanel', () => {
 				displayAllPages: true,
 			}),
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 
@@ -278,7 +271,6 @@ describe('CollectionGeneralPanel', () => {
 					numberOfItems: 3,
 				},
 				itemId: '0',
-				segmentsExperienceId: '0',
 			});
 		});
 
@@ -327,7 +319,6 @@ describe('CollectionGeneralPanel', () => {
 					numberOfPages: 3,
 				},
 				itemId: '0',
-				segmentsExperienceId: '0',
 			});
 		});
 	});
@@ -351,7 +342,6 @@ describe('CollectionGeneralPanel', () => {
 					numberOfItemsPerPage: 2,
 				},
 				itemId: '0',
-				segmentsExperienceId: '0',
 			});
 		});
 
@@ -450,7 +440,6 @@ describe('CollectionGeneralPanel', () => {
 				tablet: {numberOfColumns: '1'},
 			},
 			itemId: '0',
-			segmentsExperienceId: '0',
 		});
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/thunks/updateItemConfig.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/thunks/updateItemConfig.test.js
@@ -60,7 +60,10 @@ describe('updateItemConfig', () => {
 			itemConfig: {},
 			itemId: '0',
 			segmentsExperienceId: '0',
-		})(() => {});
+		})(
+			() => {},
+			() => ({})
+		);
 
 	it('calls LayoutService.updateItemConfig with the given information', () => {
 		LayoutService.updateItemConfig.mockImplementation(() =>

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/thunks/updateRowColumns.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/thunks/updateRowColumns.test.js
@@ -49,8 +49,10 @@ describe('updateRowColumns', () => {
 		updateRowColumnsThunk({
 			itemId: '0',
 			numberOfColumns: 6,
-			segmentsExperienceId: '0',
-		})(() => {});
+		})(
+			() => {},
+			() => ({})
+		);
 
 	it('calls LayoutService.updateRowColumns with the given information', () => {
 		runThunk();
@@ -59,7 +61,6 @@ describe('updateRowColumns', () => {
 			expect.objectContaining({
 				itemId: '0',
 				numberOfColumns: 6,
-				segmentsExperienceId: '0',
 			})
 		);
 	});

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/CollectionLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/CollectionLayoutStructureItemImporter.java
@@ -24,10 +24,14 @@ import com.liferay.info.collection.provider.RelatedInfoItemCollectionProvider;
 import com.liferay.info.collection.provider.SingleFormVariationInfoCollectionProvider;
 import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType;
 import com.liferay.item.selector.criteria.InfoListItemSelectorReturnType;
+import com.liferay.layout.page.template.util.AlignConverter;
+import com.liferay.layout.page.template.util.FlexWrapConverter;
+import com.liferay.layout.page.template.util.JustifyConverter;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.collection.EmptyCollectionOptions;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -168,6 +172,35 @@ public class CollectionLayoutStructureItemImporter
 
 				collectionStyledLayoutStructureItem.updateItemConfig(
 					jsonObject);
+			}
+		}
+
+		Map<String, Object> formLayout = (Map<String, Object>)definitionMap.get(
+			"layout");
+
+		if (formLayout != null) {
+			String align = String.valueOf(
+				formLayout.getOrDefault("align", StringPool.BLANK));
+
+			if (Validator.isNotNull(align)) {
+				collectionStyledLayoutStructureItem.setAlign(
+					AlignConverter.convertToInternalValue(align));
+			}
+
+			String flexWrap = String.valueOf(
+				formLayout.getOrDefault("flexWrap", StringPool.BLANK));
+
+			if (Validator.isNotNull(flexWrap)) {
+				collectionStyledLayoutStructureItem.setFlexWrap(
+					FlexWrapConverter.convertToInternalValue(flexWrap));
+			}
+
+			String justify = String.valueOf(
+				formLayout.getOrDefault("justify", StringPool.BLANK));
+
+			if (Validator.isNotNull(justify)) {
+				collectionStyledLayoutStructureItem.setJustify(
+					JustifyConverter.convertToInternalValue(justify));
 			}
 		}
 

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
@@ -949,6 +949,46 @@
 					"title": "The fragmentViewports Schema",
 					"type": "array"
 				},
+				"layout": {
+					"additionalProperties": false,
+					"properties": {
+						"align": {
+							"enum": [
+								"Baseline",
+								"Center",
+								"End",
+								"None",
+								"Start",
+								"Stretch"
+							],
+							"title": "The align Schema",
+							"type": "string"
+						},
+						"flexWrap": {
+							"enum": [
+								"NoWrap",
+								"Wrap",
+								"WrapReverse"
+							],
+							"title": "The flexWrap Schema",
+							"type": "string"
+						},
+						"justify": {
+							"enum": [
+								"Center",
+								"End",
+								"None",
+								"SpaceAround",
+								"SpaceBetween",
+								"Start"
+							],
+							"title": "The justify Schema",
+							"type": "string"
+						}
+					},
+					"title": "The layout Schema",
+					"type": "object"
+				},
 				"listItemStyle": {
 					"title": "The listItemStyle Schema",
 					"type": "string"

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -285,7 +285,46 @@ public class RenderLayoutStructureTag extends IncludeTag {
 
 				ContainerTag containerTag = new ContainerTag();
 
-				containerTag.setCssClass("overflow-hidden px-0");
+				StringBundler containerCSSClassSB = new StringBundler(
+					"overflow-hidden px-0");
+
+				if (Objects.equals(
+						collectionStyledLayoutStructureItem.getListStyle(),
+						"flex-column")) {
+
+					containerCSSClassSB.append(" d-flex flex-column");
+				}
+				else if (Objects.equals(
+							collectionStyledLayoutStructureItem.getListStyle(),
+							"flex-row")) {
+
+					containerCSSClassSB.append(" d-flex flex-row");
+				}
+
+				String align = collectionStyledLayoutStructureItem.getAlign();
+
+				if (Validator.isNotNull(align)) {
+					containerCSSClassSB.append(StringPool.SPACE);
+					containerCSSClassSB.append(align);
+				}
+
+				String flexWrap =
+					collectionStyledLayoutStructureItem.getFlexWrap();
+
+				if (Validator.isNotNull(flexWrap)) {
+					containerCSSClassSB.append(StringPool.SPACE);
+					containerCSSClassSB.append(flexWrap);
+				}
+
+				String justify =
+					collectionStyledLayoutStructureItem.getJustify();
+
+				if (Validator.isNotNull(justify)) {
+					containerCSSClassSB.append(StringPool.SPACE);
+					containerCSSClassSB.append(justify);
+				}
+
+				containerTag.setCssClass(containerCSSClassSB.toString());
 				containerTag.setFluid(true);
 				containerTag.setPageContext(pageContext);
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -325,6 +325,7 @@ public class RenderLayoutStructureTag extends IncludeTag {
 				}
 
 				containerTag.setCssClass(containerCSSClassSB.toString());
+
 				containerTag.setFluid(true);
 				containerTag.setPageContext(pageContext);
 
@@ -333,18 +334,18 @@ public class RenderLayoutStructureTag extends IncludeTag {
 				for (int i = 0; i < numberOfRows; i++) {
 					RowTag rowTag = new RowTag();
 
-					StringBundler cssClassSB = new StringBundler(3);
+					StringBundler rowCSSClassSB = new StringBundler(3);
 
-					cssClassSB.append("align-items-");
-					cssClassSB.append(
+					rowCSSClassSB.append("align-items-");
+					rowCSSClassSB.append(
 						collectionStyledLayoutStructureItem.
 							getVerticalAlignment());
 
 					if (!collectionStyledLayoutStructureItem.isGutters()) {
-						cssClassSB.append(" no-gutters");
+						rowCSSClassSB.append(" no-gutters");
 					}
 
-					rowTag.setCssClass(cssClassSB.toString());
+					rowTag.setCssClass(rowCSSClassSB.toString());
 
 					rowTag.setPageContext(pageContext);
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/item/selector/ObjectEntryItemSelectorView.java
@@ -286,7 +286,10 @@ public class ObjectEntryItemSelectorView
 					"no-entries-were-found");
 
 			try {
-				searchContainer.setResultsAndTotal(_getObjectEntries());
+				searchContainer.setResultsAndTotal(
+					_getObjectEntries(
+						ParamUtil.getLong(
+							_portletRequest, "objectDefinitionId")));
 			}
 			catch (Exception exception) {
 				_log.error(exception);
@@ -303,11 +306,10 @@ public class ObjectEntryItemSelectorView
 				_themeDisplay.getLocale(), null, _themeDisplay.getUser());
 		}
 
-		private List<ObjectEntry> _getObjectEntries() throws Exception {
-			long objectDefinitionId = ParamUtil.getLong(
-				_portletRequest, "objectDefinitionId");
+		private List<ObjectEntry> _getObjectEntries(long objectDefinitionId)
+			throws Exception {
 
-			if (objectDefinitionId > 0) {
+			if (objectDefinitionId == 0) {
 				Group scopeGroup = _themeDisplay.getScopeGroup();
 
 				Page<com.liferay.object.rest.dto.v1_0.ObjectEntry> page =

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/filter/ListTypeEntryAutocompleteFDSFilter.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/filter/ListTypeEntryAutocompleteFDSFilter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.web.internal.object.entries.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseAutocompleteFDSFilter;
 
 import java.util.Map;
@@ -42,7 +43,7 @@ public class ListTypeEntryAutocompleteFDSFilter
 
 	@Override
 	public String getEntityFieldType() {
-		return "string";
+		return FDSEntityFieldTypes.STRING;
 	}
 
 	@Override

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/filter/ObjectEntryStatusSelectionFDSFilter.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/frontend/data/set/filter/ObjectEntryStatusSelectionFDSFilter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.object.web.internal.object.entries.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -37,7 +38,7 @@ public class ObjectEntryStatusSelectionFDSFilter
 
 	@Override
 	public String getEntityFieldType() {
-		return "collection";
+		return FDSEntityFieldTypes.COLLECTION;
 	}
 
 	@Override

--- a/modules/dxp/apps/saml/saml-opensaml-integration/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/bnd.bnd
@@ -67,6 +67,7 @@ Import-Package:\
 	!sun.io,\
 	\
 	*
+-dsannotations-options: inherit
 -fixupmessages: Classes found in the wrong directory: ...;is:=ignore
 -includeresource:\
 	opensaml-core-*;lib:=true,\

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/KeyStoreCredentialResolver.java
@@ -224,20 +224,6 @@ public class KeyStoreCredentialResolver
 		}
 	}
 
-	@Reference(
-		name = "KeyStoreManager", target = "(default=true)", unbind = "-"
-	)
-	public void setKeyStoreManager(KeyStoreManager keyStoreManager) {
-		_keyStoreManager = keyStoreManager;
-	}
-
-	@Reference(unbind = "-")
-	public void setSamlProviderConfigurationHelper(
-		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
-
-		_samlProviderConfigurationHelper = samlProviderConfigurationHelper;
-	}
-
 	@Override
 	public void storeLocalEntityCertificate(
 			PrivateKey privateKey, String certificateKeyPassword,
@@ -362,7 +348,10 @@ public class KeyStoreCredentialResolver
 		return basicX509Credential;
 	}
 
+	@Reference(name = "KeyStoreManager", target = "(default=true)")
 	private KeyStoreManager _keyStoreManager;
+
+	@Reference
 	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
@@ -467,16 +467,6 @@ public class MetadataManagerImpl
 		return false;
 	}
 
-	@Reference(unbind = "-")
-	public void setCredentialResolver(CredentialResolver credentialResolver) {
-		_credentialResolver = credentialResolver;
-	}
-
-	@Reference(unbind = "-")
-	public void setLocalEntityManager(LocalEntityManager localEntityManager) {
-		_localEntityManager = localEntityManager;
-	}
-
 	@Reference(
 		cardinality = ReferenceCardinality.AT_LEAST_ONE,
 		policyOption = ReferencePolicyOption.GREEDY,
@@ -488,23 +478,6 @@ public class MetadataManagerImpl
 		}
 
 		_cachingChainingMetadataResolver.addMetadataResolver(metadataResolver);
-	}
-
-	@Reference(unbind = "-")
-	public void setParserPool(ParserPool parserPool) {
-		_parserPool = parserPool;
-	}
-
-	@Reference(unbind = "-")
-	public void setPortal(Portal portal) {
-		_portal = portal;
-	}
-
-	@Reference(unbind = "-")
-	public void setSamlProviderConfigurationHelper(
-		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
-
-		_samlProviderConfigurationHelper = samlProviderConfigurationHelper;
 	}
 
 	public void unsetMetadataResolver(MetadataResolver metadataResolver) {
@@ -594,11 +567,21 @@ public class MetadataManagerImpl
 		_cachingChainingMetadataResolver =
 			new CachingChainingMetadataResolver();
 	private ChainingSignatureTrustEngine _chainingSignatureTrustEngine;
+
+	@Reference
 	private CredentialResolver _credentialResolver;
+
+	@Reference
 	private LocalEntityManager _localEntityManager;
+
 	private MetadataCredentialResolver _metadataCredentialResolver;
+
+	@Reference
 	private ParserPool _parserPool;
+
+	@Reference
 	private Portal _portal;
+
 	private final PredicateRoleDescriptorResolver
 		_predicateRoleDescriptorResolver = new PredicateRoleDescriptorResolver(
 			_cachingChainingMetadataResolver);
@@ -606,6 +589,7 @@ public class MetadataManagerImpl
 	@Reference
 	private SamlIdpSpConnectionLocalService _samlIdpSpConnectionLocalService;
 
+	@Reference
 	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/AttributeResolverRegistry.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/AttributeResolverRegistry.java
@@ -55,16 +55,6 @@ public class AttributeResolverRegistry {
 		return attributeResolver;
 	}
 
-	@Reference(
-		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(!(companyId=*))", unbind = "-"
-	)
-	public void setDefaultAttributeResolver(
-		AttributeResolver defaultAttributeResolver) {
-
-		_defaultAttributeResolver = defaultAttributeResolver;
-	}
-
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_attributeResolvers = ServiceTrackerMapFactory.openSingleValueMap(
@@ -81,6 +71,10 @@ public class AttributeResolverRegistry {
 		AttributeResolverRegistry.class);
 
 	private ServiceTrackerMap<String, AttributeResolver> _attributeResolvers;
+
+	@Reference(
+		policyOption = ReferencePolicyOption.GREEDY, target = "(!(companyId=*))"
+	)
 	private AttributeResolver _defaultAttributeResolver;
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultAttributeResolver.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultAttributeResolver.java
@@ -132,35 +132,6 @@ public class DefaultAttributeResolver implements AttributeResolver {
 		}
 	}
 
-	@Reference(unbind = "-")
-	public void setGroupLocalService(GroupLocalService groupLocalService) {
-		_groupLocalService = groupLocalService;
-	}
-
-	@Reference(unbind = "-")
-	public void setMetadataManager(MetadataManager metadataManager) {
-		_metadataManager = metadataManager;
-	}
-
-	@Reference(unbind = "-")
-	public void setRoleLocalService(RoleLocalService roleLocalService) {
-		_roleLocalService = roleLocalService;
-	}
-
-	@Reference(unbind = "-")
-	public void setUserGroupGroupRoleLocalService(
-		UserGroupGroupRoleLocalService userGroupGroupRoleLocalService) {
-
-		_userGroupGroupRoleLocalService = userGroupGroupRoleLocalService;
-	}
-
-	@Reference(unbind = "-")
-	public void setUserGroupRoleLocalService(
-		UserGroupRoleLocalService userGroupRoleLocalService) {
-
-		_userGroupRoleLocalService = userGroupRoleLocalService;
-	}
-
 	protected String[] getAttributeNames(String entityId) {
 		return _metadataManager.getAttributeNames(entityId);
 	}
@@ -727,10 +698,19 @@ public class DefaultAttributeResolver implements AttributeResolver {
 	@Reference
 	private BeanProperties _beanProperties;
 
+	@Reference
 	private GroupLocalService _groupLocalService;
+
+	@Reference
 	private MetadataManager _metadataManager;
+
+	@Reference
 	private RoleLocalService _roleLocalService;
+
+	@Reference
 	private UserGroupGroupRoleLocalService _userGroupGroupRoleLocalService;
+
+	@Reference
 	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultNameIdResolver.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultNameIdResolver.java
@@ -43,11 +43,6 @@ public class DefaultNameIdResolver implements NameIdResolver {
 		return _getNameIdValue(user, entityId);
 	}
 
-	@Reference(unbind = "-")
-	public void setMetadataManager(MetadataManager metadataManager) {
-		_metadataManager = metadataManager;
-	}
-
 	private String _getNameIdAttributeName(String entityId) {
 		return _metadataManager.getNameIdAttribute(entityId);
 	}
@@ -85,6 +80,7 @@ public class DefaultNameIdResolver implements NameIdResolver {
 	@Reference
 	private BeanProperties _beanProperties;
 
+	@Reference
 	private MetadataManager _metadataManager;
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/NameIdResolverRegistry.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/resolver/NameIdResolverRegistry.java
@@ -55,14 +55,6 @@ public class NameIdResolverRegistry {
 		return nameIdResolver;
 	}
 
-	@Reference(
-		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(!(companyId=*))", unbind = "-"
-	)
-	public void setDefaultNameIdResolver(NameIdResolver defaultNameIdResolver) {
-		_defaultNameIdResolver = defaultNameIdResolver;
-	}
-
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_nameIdResolvers = ServiceTrackerMapFactory.openSingleValueMap(
@@ -78,7 +70,11 @@ public class NameIdResolverRegistry {
 	private static final Log _log = LogFactoryUtil.getLog(
 		NameIdResolverRegistry.class);
 
+	@Reference(
+		policyOption = ReferencePolicyOption.GREEDY, target = "(!(companyId=*))"
+	)
 	private NameIdResolver _defaultNameIdResolver;
+
 	private ServiceTrackerMap<String, NameIdResolver> _nameIdResolvers;
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -75,6 +75,8 @@ import org.opensaml.xmlsec.context.SecurityParametersContext;
 import org.opensaml.xmlsec.criterion.SignatureValidationConfigurationCriterion;
 import org.opensaml.xmlsec.impl.BasicSignatureValidationParametersResolver;
 
+import org.osgi.service.component.annotations.Reference;
+
 /**
  * @author Mika Koivisto
  */
@@ -591,8 +593,10 @@ public abstract class BaseProfile {
 		removeSamlBinding(samlBinding);
 	}
 
+	@Reference
 	protected IdentifierGenerationStrategyFactory
 		identifierGenerationStrategyFactory;
+
 	protected MetadataManager metadataManager;
 	protected Portal portal;
 	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -567,18 +567,8 @@ public abstract class BaseProfile {
 		_samlBindings.remove(samlBinding);
 	}
 
-	protected void setMetadataManager(MetadataManager metadataManager) {
-		this.metadataManager = metadataManager;
-	}
-
 	protected void setSamlBindings(List<SamlBinding> samlBindings) {
 		_samlBindings = samlBindings;
-	}
-
-	protected void setSamlProviderConfigurationHelper(
-		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
-
-		this.samlProviderConfigurationHelper = samlProviderConfigurationHelper;
 	}
 
 	protected void unsetSamlBinding(SamlBinding samlBinding) {
@@ -589,9 +579,14 @@ public abstract class BaseProfile {
 	protected IdentifierGenerationStrategyFactory
 		identifierGenerationStrategyFactory;
 
+	@Reference
 	protected MetadataManager metadataManager;
+
 	protected Portal portal;
+
+	@Reference
 	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;
+
 	protected SamlSpSessionLocalService samlSpSessionLocalService;
 
 	private static final Log _log = LogFactoryUtil.getLog(BaseProfile.class);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -588,6 +588,7 @@ public abstract class BaseProfile {
 	@Reference
 	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;
 
+	@Reference
 	protected SamlSpSessionLocalService samlSpSessionLocalService;
 
 	private static final Log _log = LogFactoryUtil.getLog(BaseProfile.class);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -582,6 +582,7 @@ public abstract class BaseProfile {
 	@Reference
 	protected MetadataManager metadataManager;
 
+	@Reference
 	protected Portal portal;
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -567,14 +567,6 @@ public abstract class BaseProfile {
 		_samlBindings.remove(samlBinding);
 	}
 
-	protected void setIdentifierGenerationStrategyFactory(
-		IdentifierGenerationStrategyFactory
-			identifierGenerationStrategyFactory) {
-
-		this.identifierGenerationStrategyFactory =
-			identifierGenerationStrategyFactory;
-	}
-
 	protected void setMetadataManager(MetadataManager metadataManager) {
 		this.metadataManager = metadataManager;
 	}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -223,7 +223,7 @@ public abstract class BaseProfile {
 	public IdentifierGenerationStrategyFactory
 		getIdentifierGenerationStrategyFactory() {
 
-		return _identifierGenerationStrategyFactory;
+		return identifierGenerationStrategyFactory;
 	}
 
 	public MessageContext<SAMLObject> getMessageContext(
@@ -569,7 +569,7 @@ public abstract class BaseProfile {
 		IdentifierGenerationStrategyFactory
 			identifierGenerationStrategyFactory) {
 
-		_identifierGenerationStrategyFactory =
+		this.identifierGenerationStrategyFactory =
 			identifierGenerationStrategyFactory;
 	}
 
@@ -591,6 +591,8 @@ public abstract class BaseProfile {
 		removeSamlBinding(samlBinding);
 	}
 
+	protected IdentifierGenerationStrategyFactory
+		identifierGenerationStrategyFactory;
 	protected MetadataManager metadataManager;
 	protected Portal portal;
 	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;
@@ -598,8 +600,6 @@ public abstract class BaseProfile {
 
 	private static final Log _log = LogFactoryUtil.getLog(BaseProfile.class);
 
-	private IdentifierGenerationStrategyFactory
-		_identifierGenerationStrategyFactory;
 	private List<SamlBinding> _samlBindings = new ArrayList<>();
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
-import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManager;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlIdpSpSession;
@@ -47,7 +46,6 @@ import com.liferay.saml.persistence.service.SamlIdpSsoSessionLocalService;
 import com.liferay.saml.persistence.service.SamlPeerBindingLocalService;
 import com.liferay.saml.persistence.service.SamlSpSessionLocalService;
 import com.liferay.saml.runtime.SamlException;
-import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.exception.UnsolicitedLogoutResponseException;
 import com.liferay.saml.runtime.exception.UnsupportedBindingException;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
@@ -321,27 +319,12 @@ public class SingleLogoutProfileImpl
 		}
 	}
 
-	@Override
-	@Reference(unbind = "-")
-	public void setMetadataManager(MetadataManager metadataManager) {
-		super.setMetadataManager(metadataManager);
-	}
-
 	@Reference(
 		cardinality = ReferenceCardinality.AT_LEAST_ONE,
 		policyOption = ReferencePolicyOption.GREEDY
 	)
 	public void setSamlBinding(SamlBinding samlBinding) {
 		addSamlBinding(samlBinding);
-	}
-
-	@Override
-	@Reference(unbind = "-")
-	public void setSamlProviderConfigurationHelper(
-		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
-
-		super.setSamlProviderConfigurationHelper(
-			samlProviderConfigurationHelper);
 	}
 
 	@Override

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -706,50 +706,10 @@ public class SingleLogoutProfileImpl
 	}
 
 	@Reference(unbind = "-")
-	protected void setSamlHttpRequestUtil(
-		SamlHttpRequestUtil samlHttpRequestUtil) {
-
-		_samlHttpRequestUtil = samlHttpRequestUtil;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlIdpSpConnectionLocalService(
-		SamlIdpSpConnectionLocalService samlIdpSpConnectionLocalService) {
-
-		_samlIdpSpConnectionLocalService = samlIdpSpConnectionLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlIdpSpSessionLocalService(
-		SamlIdpSpSessionLocalService samlIdpSpSessionLocalService) {
-
-		_samlIdpSpSessionLocalService = samlIdpSpSessionLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlIdpSsoSessionLocalService(
-		SamlIdpSsoSessionLocalService samlIdpSsoSessionLocalService) {
-
-		_samlIdpSsoSessionLocalService = samlIdpSsoSessionLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlPeerBindingLocalService(
-		SamlPeerBindingLocalService samlPeerBindingLocalService) {
-
-		_samlPeerBindingLocalService = samlPeerBindingLocalService;
-	}
-
-	@Reference(unbind = "-")
 	protected void setSamlSpSessionLocalService(
 		SamlSpSessionLocalService samlSpSessionLocalService) {
 
 		super.samlSpSessionLocalService = samlSpSessionLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setUserLocalService(UserLocalService userLocalService) {
-		_userLocalService = userLocalService;
 	}
 
 	private void _addSessionIndex(
@@ -1496,11 +1456,22 @@ public class SingleLogoutProfileImpl
 	@Reference
 	private HttpClient _httpClient;
 
+	@Reference
 	private SamlHttpRequestUtil _samlHttpRequestUtil;
+
+	@Reference
 	private SamlIdpSpConnectionLocalService _samlIdpSpConnectionLocalService;
+
+	@Reference
 	private SamlIdpSpSessionLocalService _samlIdpSpSessionLocalService;
+
+	@Reference
 	private SamlIdpSsoSessionLocalService _samlIdpSsoSessionLocalService;
+
+	@Reference
 	private SamlPeerBindingLocalService _samlPeerBindingLocalService;
+
+	@Reference
 	private UserLocalService _userLocalService;
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -323,16 +323,6 @@ public class SingleLogoutProfileImpl
 
 	@Override
 	@Reference(unbind = "-")
-	public void setIdentifierGenerationStrategyFactory(
-		IdentifierGenerationStrategyFactory
-			identifierGenerationStrategyFactory) {
-
-		super.setIdentifierGenerationStrategyFactory(
-			identifierGenerationStrategyFactory);
-	}
-
-	@Override
-	@Reference(unbind = "-")
 	public void setMetadataManager(MetadataManager metadataManager) {
 		super.setMetadataManager(metadataManager);
 	}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlWebKeys;
@@ -671,11 +670,6 @@ public class SingleLogoutProfileImpl
 		samlPeerEndpointSubcontext.setEndpoint(singleLogoutService);
 
 		sendSamlMessage(messageContext, httpServletResponse);
-	}
-
-	@Reference(unbind = "-")
-	protected void setPortal(Portal portal) {
-		super.portal = portal;
 	}
 
 	@Reference(unbind = "-")

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -43,7 +43,6 @@ import com.liferay.saml.persistence.service.SamlIdpSpConnectionLocalService;
 import com.liferay.saml.persistence.service.SamlIdpSpSessionLocalService;
 import com.liferay.saml.persistence.service.SamlIdpSsoSessionLocalService;
 import com.liferay.saml.persistence.service.SamlPeerBindingLocalService;
-import com.liferay.saml.persistence.service.SamlSpSessionLocalService;
 import com.liferay.saml.runtime.SamlException;
 import com.liferay.saml.runtime.exception.UnsolicitedLogoutResponseException;
 import com.liferay.saml.runtime.exception.UnsupportedBindingException;
@@ -670,13 +669,6 @@ public class SingleLogoutProfileImpl
 		samlPeerEndpointSubcontext.setEndpoint(singleLogoutService);
 
 		sendSamlMessage(messageContext, httpServletResponse);
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlSpSessionLocalService(
-		SamlSpSessionLocalService samlSpSessionLocalService) {
-
-		super.samlSpSessionLocalService = samlSpSessionLocalService;
 	}
 
 	private void _addSessionIndex(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -62,7 +62,6 @@ import com.liferay.saml.persistence.service.SamlIdpSsoSessionLocalService;
 import com.liferay.saml.persistence.service.SamlSpAuthRequestLocalService;
 import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
 import com.liferay.saml.persistence.service.SamlSpMessageLocalService;
-import com.liferay.saml.persistence.service.SamlSpSessionLocalService;
 import com.liferay.saml.runtime.SamlException;
 import com.liferay.saml.runtime.configuration.SamlConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
@@ -683,13 +682,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	)
 	protected void setSamlBinding(SamlBinding samlBinding) {
 		addSamlBinding(samlBinding);
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlSpSessionLocalService(
-		SamlSpSessionLocalService samlSpSessionLocalService) {
-
-		super.samlSpSessionLocalService = samlSpSessionLocalService;
 	}
 
 	@Override

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
-import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManager;
 import com.liferay.saml.opensaml.integration.internal.resolver.AttributePublisherImpl;
 import com.liferay.saml.opensaml.integration.internal.resolver.AttributeResolverRegistry;
 import com.liferay.saml.opensaml.integration.internal.resolver.AttributeResolverSAMLContextImpl;
@@ -68,7 +67,6 @@ import com.liferay.saml.persistence.service.SamlSpSessionLocalService;
 import com.liferay.saml.runtime.SamlException;
 import com.liferay.saml.runtime.configuration.SamlConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
-import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.exception.AssertionException;
 import com.liferay.saml.runtime.exception.AudienceException;
 import com.liferay.saml.runtime.exception.AuthnAgeException;
@@ -680,12 +678,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 		return subjectConfirmationData;
 	}
 
-	@Override
-	@Reference(unbind = "-")
-	protected void setMetadataManager(MetadataManager metadataManager) {
-		super.setMetadataManager(metadataManager);
-	}
-
 	@Reference(unbind = "-")
 	protected void setPortal(Portal portal) {
 		super.portal = portal;
@@ -697,15 +689,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	)
 	protected void setSamlBinding(SamlBinding samlBinding) {
 		addSamlBinding(samlBinding);
-	}
-
-	@Override
-	@Reference(unbind = "-")
-	protected void setSamlProviderConfigurationHelper(
-		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
-
-		super.setSamlProviderConfigurationHelper(
-			samlProviderConfigurationHelper);
 	}
 
 	@Reference(unbind = "-")

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -30,7 +30,6 @@ import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
@@ -676,11 +675,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 		subjectConfirmationData.setNotOnOrAfter(notOnOrAfterDateTime);
 
 		return subjectConfirmationData;
-	}
-
-	@Reference(unbind = "-")
-	protected void setPortal(Portal portal) {
-		super.portal = portal;
 	}
 
 	@Reference(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -680,13 +680,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 		return subjectConfirmationData;
 	}
 
-	@Reference(unbind = "-")
-	protected void setAttributeResolverRegistry(
-		AttributeResolverRegistry attributeResolverRegistry) {
-
-		_attributeResolverRegistry = attributeResolverRegistry;
-	}
-
 	@Override
 	@Reference(unbind = "-")
 	protected void setIdentifierGenerationStrategyFactory(
@@ -700,13 +693,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	@Reference(unbind = "-")
 	protected void setMetadataManager(MetadataManager metadataManager) {
 		super.setMetadataManager(metadataManager);
-	}
-
-	@Reference(unbind = "-")
-	protected void setNameIdResolverRegistry(
-		NameIdResolverRegistry nameIdResolverRegistry) {
-
-		_nameIdResolverRegistry = nameIdResolverRegistry;
 	}
 
 	@Reference(unbind = "-")
@@ -732,36 +718,10 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	}
 
 	@Reference(unbind = "-")
-	protected void setSamlSpAuthRequestLocalService(
-		SamlSpAuthRequestLocalService samlSpAuthRequestLocalService) {
-
-		_samlSpAuthRequestLocalService = samlSpAuthRequestLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlSpIdpConnectionLocalService(
-		SamlSpIdpConnectionLocalService samlSpIdpConnectionLocalService) {
-
-		_samlSpIdpConnectionLocalService = samlSpIdpConnectionLocalService;
-	}
-
-	@Reference(unbind = "-")
-	protected void setSamlSpMessageLocalService(
-		SamlSpMessageLocalService samlSpMessageLocalService) {
-
-		_samlSpMessageLocalService = samlSpMessageLocalService;
-	}
-
-	@Reference(unbind = "-")
 	protected void setSamlSpSessionLocalService(
 		SamlSpSessionLocalService samlSpSessionLocalService) {
 
 		super.samlSpSessionLocalService = samlSpSessionLocalService;
-	}
-
-	@Reference(policyOption = ReferencePolicyOption.GREEDY, unbind = "-")
-	protected void setUserResolver(UserResolver userResolver) {
-		_userResolver = userResolver;
 	}
 
 	@Override
@@ -2126,11 +2086,13 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	private static final SAMLSignatureProfileValidator
 		_samlSignatureProfileValidator = new SAMLSignatureProfileValidator();
 
+	@Reference
 	private AttributeResolverRegistry _attributeResolverRegistry;
 
 	@Reference(cardinality = ReferenceCardinality.OPTIONAL)
 	private Decrypter _decrypter;
 
+	@Reference
 	private NameIdResolverRegistry _nameIdResolverRegistry;
 
 	@Reference
@@ -2149,13 +2111,20 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 	private SAMLMetadataEncryptionParametersResolver
 		_samlMetadataEncryptionParametersResolver;
+
+	@Reference
 	private SamlSpAuthRequestLocalService _samlSpAuthRequestLocalService;
+
+	@Reference
 	private SamlSpIdpConnectionLocalService _samlSpIdpConnectionLocalService;
+
+	@Reference
 	private SamlSpMessageLocalService _samlSpMessageLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;
 
+	@Reference(policyOption = ReferencePolicyOption.GREEDY)
 	private UserResolver _userResolver;
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -2095,9 +2095,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	@Reference
 	private NameIdResolverRegistry _nameIdResolverRegistry;
 
-	@Reference
-	private Portal _portal;
-
 	private SamlConfiguration _samlConfiguration;
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -682,15 +682,6 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 	@Override
 	@Reference(unbind = "-")
-	protected void setIdentifierGenerationStrategyFactory(
-		IdentifierGenerationStrategyFactory identifierGenerationStrategy) {
-
-		super.setIdentifierGenerationStrategyFactory(
-			identifierGenerationStrategy);
-	}
-
-	@Override
-	@Reference(unbind = "-")
 	protected void setMetadataManager(MetadataManager metadataManager) {
 		super.setMetadataManager(metadataManager);
 	}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
@@ -627,12 +627,14 @@ public abstract class BaseSamlTestCase {
 					"/credential/dependencies/keystore.jks"
 			).build());
 
+		ReflectionTestUtil.invoke(
+			metadataManagerImpl, "activate", new Class<?>[0]);
+
 		credentialResolver = new KeyStoreCredentialResolver();
 
 		ReflectionTestUtil.setFieldValue(
 			credentialResolver, "_keyStoreManager",
 			fileSystemKeyStoreManagerImpl);
-
 		ReflectionTestUtil.setFieldValue(
 			credentialResolver, "_samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
@@ -641,22 +643,17 @@ public abstract class BaseSamlTestCase {
 			metadataManagerImpl, "_credentialResolver", credentialResolver);
 
 		ReflectionTestUtil.setFieldValue(
-			metadataManagerImpl, "_parserPool", parserPool);
+			metadataManagerImpl, "_localEntityManager", credentialResolver);
 
 		metadataManagerImpl.setMetadataResolver(new MockMetadataResolver());
 
 		ReflectionTestUtil.setFieldValue(
-			metadataManagerImpl, "_samlProviderConfigurationHelper",
-			samlProviderConfigurationHelper);
-
+			metadataManagerImpl, "_parserPool", parserPool);
 		ReflectionTestUtil.setFieldValue(
 			metadataManagerImpl, "_portal", portal);
-
 		ReflectionTestUtil.setFieldValue(
-			metadataManagerImpl, "_localEntityManager", credentialResolver);
-
-		ReflectionTestUtil.invoke(
-			metadataManagerImpl, "activate", new Class<?>[0]);
+			metadataManagerImpl, "_samlProviderConfigurationHelper",
+			samlProviderConfigurationHelper);
 	}
 
 	private void _setupParserPool() {

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
@@ -439,7 +439,8 @@ public abstract class BaseSamlTestCase {
 		KeyStoreCredentialResolver keyStoreCredentialResolver =
 			new KeyStoreCredentialResolver();
 
-		keyStoreCredentialResolver.setKeyStoreManager(
+		ReflectionTestUtil.setFieldValue(
+			keyStoreCredentialResolver, "_keyStoreManager",
 			fileSystemKeyStoreManagerImpl);
 
 		SamlProviderConfigurationHelper peerSamlProviderConfigurationHelper =
@@ -469,7 +470,8 @@ public abstract class BaseSamlTestCase {
 			peerSamlProviderConfiguration
 		);
 
-		keyStoreCredentialResolver.setSamlProviderConfigurationHelper(
+		ReflectionTestUtil.setFieldValue(
+			keyStoreCredentialResolver, "_samlProviderConfigurationHelper",
 			peerSamlProviderConfigurationHelper);
 
 		return keyStoreCredentialResolver;
@@ -627,23 +629,31 @@ public abstract class BaseSamlTestCase {
 
 		credentialResolver = new KeyStoreCredentialResolver();
 
-		credentialResolver.setKeyStoreManager(fileSystemKeyStoreManagerImpl);
+		ReflectionTestUtil.setFieldValue(
+			credentialResolver, "_keyStoreManager",
+			fileSystemKeyStoreManagerImpl);
 
-		credentialResolver.setSamlProviderConfigurationHelper(
+		ReflectionTestUtil.setFieldValue(
+			credentialResolver, "_samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 
-		metadataManagerImpl.setCredentialResolver(credentialResolver);
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_credentialResolver", credentialResolver);
 
-		metadataManagerImpl.setParserPool(parserPool);
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_parserPool", parserPool);
 
 		metadataManagerImpl.setMetadataResolver(new MockMetadataResolver());
 
-		metadataManagerImpl.setSamlProviderConfigurationHelper(
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 
-		metadataManagerImpl.setPortal(portal);
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_portal", portal);
 
-		metadataManagerImpl.setLocalEntityManager(credentialResolver);
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_localEntityManager", credentialResolver);
 
 		ReflectionTestUtil.invoke(
 			metadataManagerImpl, "activate", new Class<?>[0]);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultAttributeResolverTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultAttributeResolverTest.java
@@ -71,11 +71,13 @@ public class DefaultAttributeResolverTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_defaultAttributeResolver, "_beanProperties", _beanProperties);
 
-		_defaultAttributeResolver.setGroupLocalService(groupLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_defaultAttributeResolver, "_groupLocalService", groupLocalService);
 
 		_metadataManager = Mockito.mock(MetadataManager.class);
 
-		_defaultAttributeResolver.setMetadataManager(_metadataManager);
+		ReflectionTestUtil.setFieldValue(
+			_defaultAttributeResolver, "_metadataManager", _metadataManager);
 
 		Mockito.when(
 			_metadataManager.isAttributesEnabled(Mockito.eq(SP_ENTITY_ID))
@@ -95,7 +97,8 @@ public class DefaultAttributeResolverTest extends BaseSamlTestCase {
 
 		_roleLocalService = Mockito.mock(RoleLocalService.class);
 
-		_defaultAttributeResolver.setRoleLocalService(_roleLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_defaultAttributeResolver, "_roleLocalService", _roleLocalService);
 
 		_messageContext = new MessageContext<>();
 
@@ -107,13 +110,15 @@ public class DefaultAttributeResolverTest extends BaseSamlTestCase {
 		_userGroupGroupRoleLocalService = Mockito.mock(
 			UserGroupGroupRoleLocalService.class);
 
-		_defaultAttributeResolver.setUserGroupGroupRoleLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_defaultAttributeResolver, "_userGroupGroupRoleLocalService",
 			_userGroupGroupRoleLocalService);
 
 		_userGroupRoleLocalService = Mockito.mock(
 			UserGroupRoleLocalService.class);
 
-		_defaultAttributeResolver.setUserGroupRoleLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_defaultAttributeResolver, "_userGroupRoleLocalService",
 			_userGroupRoleLocalService);
 	}
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultAttributeResolverTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultAttributeResolverTest.java
@@ -70,7 +70,6 @@ public class DefaultAttributeResolverTest extends BaseSamlTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			_defaultAttributeResolver, "_beanProperties", _beanProperties);
-
 		ReflectionTestUtil.setFieldValue(
 			_defaultAttributeResolver, "_groupLocalService", groupLocalService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultNameIdResolverTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultNameIdResolverTest.java
@@ -56,7 +56,8 @@ public class DefaultNameIdResolverTest extends BaseSamlTestCase {
 
 		_metadataManager = Mockito.mock(MetadataManager.class);
 
-		_defaultNameIdResolver.setMetadataManager(_metadataManager);
+		ReflectionTestUtil.setFieldValue(
+			_defaultNameIdResolver, "_metadataManager", _metadataManager);
 
 		Mockito.when(
 			_metadataManager.getNameIdFormat(Mockito.eq(SP_ENTITY_ID))

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -94,10 +94,8 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
-
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "metadataManager", metadataManagerImpl);
-
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "portal", portal);
 
@@ -106,11 +104,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "_samlPeerBindingLocalService",
 			samlPeerBindingLocalService);
-
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
-
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "samlSpSessionLocalService",
 			_samlSpSessionLocalService);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -95,7 +95,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 			_singleLogoutProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
 
-		_singleLogoutProfileImpl.setMetadataManager(metadataManagerImpl);
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "metadataManager", metadataManagerImpl);
+
 		_singleLogoutProfileImpl.setPortal(portal);
 		_singleLogoutProfileImpl.setSamlBindings(samlBindings);
 
@@ -103,8 +105,10 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 			_singleLogoutProfileImpl, "_samlPeerBindingLocalService",
 			samlPeerBindingLocalService);
 
-		_singleLogoutProfileImpl.setSamlProviderConfigurationHelper(
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
+
 		_singleLogoutProfileImpl.setSamlSpSessionLocalService(
 			_samlSpSessionLocalService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -91,8 +91,10 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 
 		_singleLogoutProfileImpl = new SingleLogoutProfileImpl();
 
-		_singleLogoutProfileImpl.setIdentifierGenerationStrategyFactory(
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
+
 		_singleLogoutProfileImpl.setMetadataManager(metadataManagerImpl);
 		_singleLogoutProfileImpl.setPortal(portal);
 		_singleLogoutProfileImpl.setSamlBindings(samlBindings);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -98,7 +98,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "metadataManager", metadataManagerImpl);
 
-		_singleLogoutProfileImpl.setPortal(portal);
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "portal", portal);
+
 		_singleLogoutProfileImpl.setSamlBindings(samlBindings);
 
 		ReflectionTestUtil.setFieldValue(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -17,6 +17,7 @@ package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.struts.Definition;
 import com.liferay.portal.struts.TilesUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -95,8 +96,11 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		_singleLogoutProfileImpl.setMetadataManager(metadataManagerImpl);
 		_singleLogoutProfileImpl.setPortal(portal);
 		_singleLogoutProfileImpl.setSamlBindings(samlBindings);
-		_singleLogoutProfileImpl.setSamlPeerBindingLocalService(
+
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "_samlPeerBindingLocalService",
 			samlPeerBindingLocalService);
+
 		_singleLogoutProfileImpl.setSamlProviderConfigurationHelper(
 			samlProviderConfigurationHelper);
 		_singleLogoutProfileImpl.setSamlSpSessionLocalService(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -111,7 +111,8 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 			_singleLogoutProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 
-		_singleLogoutProfileImpl.setSamlSpSessionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "samlSpSessionLocalService",
 			_samlSpSessionLocalService);
 
 		prepareServiceProvider(SP_ENTITY_ID);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -129,10 +129,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
-
 		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
 
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
@@ -140,21 +138,17 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "_samlSpAuthRequestLocalService",
 			_samlSpAuthRequestLocalService);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlSpSessionLocalService",
 			_samlSpSessionLocalService);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "_samlSpMessageLocalService",
 			getMockPortletService(
 				SamlSpMessageLocalServiceUtil.class,
 				SamlSpMessageLocalService.class));
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			getMockPortletService(
@@ -603,9 +597,10 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		metadataManagerImpl = new MetadataManagerImpl();
 
+		ReflectionTestUtil.invoke(
+			metadataManagerImpl, "activate", new Class<?>[0]);
 		ReflectionTestUtil.setFieldValue(
 			metadataManagerImpl, "_credentialResolver", credentialResolver);
-
 		ReflectionTestUtil.setFieldValue(
 			metadataManagerImpl, "_localEntityManager", credentialResolver);
 
@@ -614,16 +609,11 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			metadataManagerImpl, "_parserPool", parserPool);
-
 		ReflectionTestUtil.setFieldValue(
 			metadataManagerImpl, "_portal", portal);
-
 		ReflectionTestUtil.setFieldValue(
 			metadataManagerImpl, "_samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
-
-		ReflectionTestUtil.invoke(
-			metadataManagerImpl, "activate", new Class<?>[0]);
 
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -134,18 +134,26 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		_webSsoProfileImpl.setSamlProviderConfigurationHelper(
 			samlProviderConfigurationHelper);
-		_webSsoProfileImpl.setSamlSpAuthRequestLocalService(
+
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpAuthRequestLocalService",
 			_samlSpAuthRequestLocalService);
+
 		_webSsoProfileImpl.setSamlSpSessionLocalService(
 			_samlSpSessionLocalService);
-		_webSsoProfileImpl.setSamlSpMessageLocalService(
+
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpMessageLocalService",
 			getMockPortletService(
 				SamlSpMessageLocalServiceUtil.class,
 				SamlSpMessageLocalService.class));
-		_webSsoProfileImpl.setSamlSpIdpConnectionLocalService(
+
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			getMockPortletService(
 				SamlSpIdpConnectionLocalServiceUtil.class,
 				SamlSpIdpConnectionLocalService.class));
+
 		_webSsoProfileImpl.activate(new HashMap<String, Object>());
 
 		prepareServiceProvider(SP_ENTITY_ID);
@@ -381,7 +389,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			samlSpIdpConnection
 		);
 
-		_webSsoProfileImpl.setSamlSpIdpConnectionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -494,7 +503,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			samlSpIdpConnection
 		);
 
-		_webSsoProfileImpl.setSamlSpIdpConnectionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -586,13 +596,23 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		metadataManagerImpl = new MetadataManagerImpl();
 
-		metadataManagerImpl.setCredentialResolver(credentialResolver);
-		metadataManagerImpl.setLocalEntityManager(credentialResolver);
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_credentialResolver", credentialResolver);
+
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_localEntityManager", credentialResolver);
+
 		metadataManagerImpl.setMetadataResolver(
 			new MockMetadataResolver(false));
-		metadataManagerImpl.setParserPool(parserPool);
-		metadataManagerImpl.setPortal(portal);
-		metadataManagerImpl.setSamlProviderConfigurationHelper(
+
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_parserPool", parserPool);
+
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_portal", portal);
+
+		ReflectionTestUtil.setFieldValue(
+			metadataManagerImpl, "_samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 
 		ReflectionTestUtil.invoke(
@@ -607,7 +627,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			samlSpIdpConnection
 		);
 
-		_webSsoProfileImpl.setSamlSpIdpConnectionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
 
 		MockHttpServletRequest mockHttpServletRequest =
@@ -660,7 +681,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			samlSpIdpConnection
 		);
 
-		_webSsoProfileImpl.setSamlSpIdpConnectionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
 
 		MockHttpServletRequest mockHttpServletRequest =

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -126,8 +126,10 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			SamlSpSessionLocalServiceUtil.class,
 			SamlSpSessionLocalService.class);
 
-		_webSsoProfileImpl.setIdentifierGenerationStrategyFactory(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
+
 		_webSsoProfileImpl.setMetadataManager(metadataManagerImpl);
 		_webSsoProfileImpl.setPortal(portal);
 		_webSsoProfileImpl.setSamlBindings(samlBindings);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -145,7 +145,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			_webSsoProfileImpl, "_samlSpAuthRequestLocalService",
 			_samlSpAuthRequestLocalService);
 
-		_webSsoProfileImpl.setSamlSpSessionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "samlSpSessionLocalService",
 			_samlSpSessionLocalService);
 
 		ReflectionTestUtil.setFieldValue(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -133,7 +133,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
 
-		_webSsoProfileImpl.setPortal(portal);
+		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
+
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
 
 		ReflectionTestUtil.setFieldValue(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -130,11 +130,14 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
 
-		_webSsoProfileImpl.setMetadataManager(metadataManagerImpl);
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
+
 		_webSsoProfileImpl.setPortal(portal);
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
 
-		_webSsoProfileImpl.setSamlProviderConfigurationHelper(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 
 		ReflectionTestUtil.setFieldValue(
@@ -620,7 +623,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.invoke(
 			metadataManagerImpl, "activate", new Class<?>[0]);
 
-		_webSsoProfileImpl.setMetadataManager(metadataManagerImpl);
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
 
 		Mockito.when(
 			samlSpIdpConnectionLocalService.getSamlSpIdpConnection(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileTest.java
@@ -17,6 +17,7 @@ package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
 
@@ -44,7 +45,8 @@ public class WebSsoProfileTest extends BaseSamlTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
-		_webSsoProfileImpl.setSamlProviderConfigurationHelper(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 	}
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -115,7 +115,8 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
 
-		_webSsoProfileImpl.setSamlSpSessionLocalService(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "samlSpSessionLocalService",
 			samlSpSessionLocalService);
 
 		prepareServiceProvider(SP_ENTITY_ID);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -99,7 +99,8 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
 
-		_webSsoProfileImpl.setPortal(portal);
+		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
+
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
 
 		ReflectionTestUtil.setFieldValue(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -95,10 +95,8 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
-
 		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
 
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
@@ -106,15 +104,12 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "_samlSpAuthRequestLocalService",
 			samlSpAuthRequestLocalService);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
-
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlSpSessionLocalService",
 			samlSpSessionLocalService);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -96,10 +96,14 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
 
-		_webSsoProfileImpl.setMetadataManager(metadataManagerImpl);
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
+
 		_webSsoProfileImpl.setPortal(portal);
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
-		_webSsoProfileImpl.setSamlProviderConfigurationHelper(
+
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "samlProviderConfigurationHelper",
 			samlProviderConfigurationHelper);
 
 		ReflectionTestUtil.setFieldValue(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -92,8 +92,10 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 			samlSpIdpConnection
 		);
 
-		_webSsoProfileImpl.setIdentifierGenerationStrategyFactory(
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
+
 		_webSsoProfileImpl.setMetadataManager(metadataManagerImpl);
 		_webSsoProfileImpl.setPortal(portal);
 		_webSsoProfileImpl.setSamlBindings(samlBindings);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -15,6 +15,7 @@
 package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
@@ -98,10 +99,15 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		_webSsoProfileImpl.setSamlBindings(samlBindings);
 		_webSsoProfileImpl.setSamlProviderConfigurationHelper(
 			samlProviderConfigurationHelper);
-		_webSsoProfileImpl.setSamlSpAuthRequestLocalService(
+
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpAuthRequestLocalService",
 			samlSpAuthRequestLocalService);
-		_webSsoProfileImpl.setSamlSpIdpConnectionLocalService(
+
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_samlSpIdpConnectionLocalService",
 			samlSpIdpConnectionLocalService);
+
 		_webSsoProfileImpl.setSamlSpSessionLocalService(
 			samlSpSessionLocalService);
 


### PR DESCRIPTION
### References

- [LPS-163171 Status filter is not working on FDS sample module](https://issues.liferay.com/browse/LPS-163171)
- related to [LPS-158738 A data request with status field filter breaks in URI parsing](https://issues.liferay.com/browse/LPS-158738)

### What is the goal of this PR?

A bugfix. Status filter in FDS sample stopped working after a change in Objects backend. LPS-158738 was a part of the fix, but we also need to explicitly declare entity field type of the status in FDS. In addition, we are introducing constants for entity types related to FDS.

/cc @john-co 

### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/190608189-dba643d8-5b22-49fb-9904-863e90d1a4c7.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/190608164-af7b1ea7-6894-466a-8c3d-8d8a66127ad4.gif)

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.