### PR TITLE
LPS-130190 Implement UI to select an FDS Custom View

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/BaseDisplayTag.java
@@ -15,12 +15,15 @@
 package com.liferay.frontend.data.set.taglib.servlet.taglib;
 
 import com.liferay.frontend.data.set.taglib.internal.js.loader.modules.extender.npm.NPMResolverProvider;
+import com.liferay.frontend.data.set.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.frontend.data.set.taglib.internal.util.ServicesProvider;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolvedPackageNameUtil;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.frontend.js.module.launcher.JSModuleResolver;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Validator;
@@ -175,6 +178,8 @@ public class BaseDisplayTag extends AttributesTagSupport {
 				return null;
 			}
 		).put(
+			"customViews", _getCustomViews()
+		).put(
 			"namespace", getNamespace()
 		).put(
 			"selectedItems", _selectedItems
@@ -236,6 +241,18 @@ public class BaseDisplayTag extends AttributesTagSupport {
 	}
 
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+	}
+
+	private String _getCustomViews() {
+		HttpServletRequest httpServletRequest = getRequest();
+
+		PortalPreferences portalPreferences =
+			PortletPreferencesFactoryUtil.getPortalPreferences(
+				httpServletRequest);
+
+		return portalPreferences.getValue(
+			ServletContextUtil.getFDSSettingsNamespace(httpServletRequest, _id),
+			"customViews", "{}");
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(BaseDisplayTag.class);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -142,6 +142,11 @@ const FrontendDataSet = ({
 			}
 		}
 
+		const activeView = {
+			component: getViewComponent(initialActiveView.contentRenderer),
+			...initialActiveView,
+		};
+
 		const filters = initialFilters.map((filter) => {
 			const preloadedData = filter.preloadedData;
 
@@ -156,17 +161,23 @@ const FrontendDataSet = ({
 			return filter;
 		});
 
+		const paginationDelta =
+			showPagination &&
+			(pagination?.initialDelta || DEFAULT_PAGINATION_DELTA);
+
 		return {
-			activeView: {
-				component: getViewComponent(initialActiveView.contentRenderer),
-				...initialActiveView,
-			},
-			customViews,
+			activeView,
+			customViews: JSON.parse(customViews),
 			customViewsEnabled,
+			defaultView: {
+				activeView,
+				filters,
+				paginationDelta,
+				sorting: sortingProp,
+				visibleFieldNames: initialVisibleFieldNames,
+			},
 			filters,
-			paginationDelta:
-				showPagination &&
-				(pagination?.initialDelta || DEFAULT_PAGINATION_DELTA),
+			paginationDelta,
 			sorting: sortingProp,
 			views,
 			visibleFieldNames: initialVisibleFieldNames,
@@ -782,7 +793,7 @@ const FrontendDataSet = ({
 
 FrontendDataSet.defaultProps = {
 	bulkActions: [],
-	customViews: {},
+	customViews: '{}',
 	filters: [],
 	inlineEditingSettings: null,
 	items: null,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -21,6 +21,7 @@ export function FrontendDataSet({
 	creationMenu,
 	currentURL,
 	customDataRenderers,
+	customViews,
 	customViewsEnabled,
 	filters,
 	formId,
@@ -62,6 +63,7 @@ interface IFrontendDataSetProps {
 	};
 	currentURL?: string;
 	customDataRenderers?: any;
+	customViews?: string;
 	customViewsEnabled?: boolean;
 	enableInlineAddModeSetting?: {
 		defaultBodyContent?: object;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
@@ -66,6 +66,34 @@ const CustomViewsControls = () => {
 		);
 	};
 
+	const ActionsItemList = () => {
+		return (
+			<ClayDropDown.ItemList>
+				{activeCustomViewId && (
+					<ClayDropDown.Item
+						onClick={() => {
+							saveCustomView({
+								id: activeCustomViewId,
+							});
+
+							setActionsDropdownActive(false);
+						}}
+						symbolLeft="disk"
+					>
+						{Liferay.Language.get('save-view')}
+					</ClayDropDown.Item>
+				)}
+
+				<ClayDropDown.Item
+					onClick={openSaveCustomViewModal}
+					symbolLeft="disk"
+				>
+					{Liferay.Language.get('save-view-as')}
+				</ClayDropDown.Item>
+			</ClayDropDown.ItemList>
+		);
+	};
+
 	const getNextCustomViewId = () => {
 		const ids = Object.keys(customViews);
 
@@ -84,7 +112,7 @@ const CustomViewsControls = () => {
 		url.searchParams.append('portletId', portletId);
 
 		const viewState = {
-			baseView: activeView,
+			activeView,
 			customViewLabel: label ?? customViews[id].customViewLabel,
 			filters,
 			paginationDelta,
@@ -173,6 +201,7 @@ const CustomViewsControls = () => {
 				<ClayDropDown
 					active={viewsDropdownActive}
 					className="custom-views-selection"
+					hasLeftSymbols
 					onActiveChange={setViewsDropdownActive}
 					trigger={
 						<ClayButton displayType="unstyled">
@@ -194,16 +223,44 @@ const CustomViewsControls = () => {
 					}
 				>
 					<ClayDropDown.ItemList>
-						<ClayDropDown.Item>
-							{Liferay.Language.get('default-view')}
-						</ClayDropDown.Item>
-
 						{Object.keys(customViews).map((id) => (
-							<ClayDropDown.Item key={id}>
+							<ClayDropDown.Item
+								key={id}
+								onClick={() => {
+									viewsDispatch({
+										type:
+											VIEWS_ACTION_TYPES.UPDATE_ACTIVE_CUSTOM_VIEW,
+										value: id,
+									});
+
+									setViewsDropdownActive(false);
+								}}
+								symbolLeft={
+									id === activeCustomViewId && 'check'
+								}
+							>
 								{customViews[id].customViewLabel}
 							</ClayDropDown.Item>
 						))}
+
+						<ClayDropDown.Item
+							onClick={() => {
+								viewsDispatch({
+									type:
+										VIEWS_ACTION_TYPES.RESET_TO_DEFAULT_VIEW,
+								});
+
+								setViewsDropdownActive(false);
+							}}
+							symbolLeft={!activeCustomViewId && 'check'}
+						>
+							{Liferay.Language.get('default-view')}
+						</ClayDropDown.Item>
 					</ClayDropDown.ItemList>
+
+					<ClayDropDown.Divider />
+
+					<ActionsItemList />
 				</ClayDropDown>
 			</ManagementToolbar.Item>
 
@@ -219,29 +276,7 @@ const CustomViewsControls = () => {
 						</ClayButton>
 					}
 				>
-					<ClayDropDown.ItemList>
-						{activeCustomViewId && (
-							<ClayDropDown.Item
-								onClick={() => {
-									saveCustomView({
-										id: activeCustomViewId,
-									});
-
-									setActionsDropdownActive(false);
-								}}
-								symbolLeft="disk"
-							>
-								{Liferay.Language.get('save-view')}
-							</ClayDropDown.Item>
-						)}
-
-						<ClayDropDown.Item
-							onClick={openSaveCustomViewModal}
-							symbolLeft="disk"
-						>
-							{Liferay.Language.get('save-view-as')}
-						</ClayDropDown.Item>
-					</ClayDropDown.ItemList>
+					<ActionsItemList />
 				</ClayDropDown>
 			</ManagementToolbar.Item>
 		</>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
@@ -47,52 +47,48 @@ const CustomViewsControls = () => {
 
 	const customViewLabelInputRef = useRef();
 
-	const SaveCustomViewModalBody = () => {
-		return (
-			<ClayForm.Group>
-				<label htmlFor={`${namespace}customViewLabelInput`}>
-					{Liferay.Language.get('name')}
+	const SaveCustomViewModalBody = () => (
+		<ClayForm.Group>
+			<label htmlFor={`${namespace}customViewLabelInput`}>
+				{Liferay.Language.get('name')}
 
-					<RequiredMark />
-				</label>
+				<RequiredMark />
+			</label>
 
-				<ClayInput
-					autoFocus={true}
-					id={`${namespace}customViewLabelInput`}
-					ref={customViewLabelInputRef}
-					type="text"
-				/>
-			</ClayForm.Group>
-		);
-	};
+			<ClayInput
+				autoFocus={true}
+				id={`${namespace}customViewLabelInput`}
+				ref={customViewLabelInputRef}
+				type="text"
+			/>
+		</ClayForm.Group>
+	);
 
-	const ActionsItemList = () => {
-		return (
-			<ClayDropDown.ItemList>
-				{activeCustomViewId && (
-					<ClayDropDown.Item
-						onClick={() => {
-							saveCustomView({
-								id: activeCustomViewId,
-							});
-
-							setActionsDropdownActive(false);
-						}}
-						symbolLeft="disk"
-					>
-						{Liferay.Language.get('save-view')}
-					</ClayDropDown.Item>
-				)}
-
+	const ActionsItemList = () => (
+		<ClayDropDown.ItemList>
+			{activeCustomViewId && (
 				<ClayDropDown.Item
-					onClick={openSaveCustomViewModal}
+					onClick={() => {
+						saveCustomView({
+							id: activeCustomViewId,
+						});
+
+						setActionsDropdownActive(false);
+					}}
 					symbolLeft="disk"
 				>
-					{Liferay.Language.get('save-view-as')}
+					{Liferay.Language.get('save-view')}
 				</ClayDropDown.Item>
-			</ClayDropDown.ItemList>
-		);
-	};
+			)}
+
+			<ClayDropDown.Item
+				onClick={openSaveCustomViewModal}
+				symbolLeft="disk"
+			>
+				{Liferay.Language.get('save-view-as')}
+			</ClayDropDown.Item>
+		</ClayDropDown.ItemList>
+	);
 
 	const getNextCustomViewId = () => {
 		const ids = Object.keys(customViews);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
@@ -16,6 +16,8 @@ import getViewComponent from './getViewComponent';
 
 export const VIEWS_ACTION_TYPES = {
 	ADD_OR_UPDATE_CUSTOM_VIEW: 'ADD_OR_UPDATE_CUSTOM_VIEW',
+	RESET_TO_DEFAULT_VIEW: 'RESET_TO_DEFAULT_VIEW',
+	UPDATE_ACTIVE_CUSTOM_VIEW: 'UPDATE_ACTIVE_CUSTOM_VIEW',
 	UPDATE_ACTIVE_VIEW: 'UPDATE_ACTIVE_VIEW',
 	UPDATE_FILTERS: 'UPDATE_FILTERS',
 	UPDATE_PAGINATION_DELTA: 'UPDATE_PAGINATION_DELTA',
@@ -25,7 +27,7 @@ export const VIEWS_ACTION_TYPES = {
 };
 
 export function viewsReducer(state, {type, value}) {
-	const {activeView, customViews, views} = state;
+	const {activeView, customViews, defaultView, views} = state;
 
 	if (type === VIEWS_ACTION_TYPES.ADD_OR_UPDATE_CUSTOM_VIEW) {
 		const {id, viewState} = value;
@@ -37,6 +39,36 @@ export function viewsReducer(state, {type, value}) {
 				...customViews,
 				[id]: viewState,
 			},
+			viewUpdated: false,
+		};
+	}
+	else if (type === VIEWS_ACTION_TYPES.RESET_TO_DEFAULT_VIEW) {
+		return {
+			...state,
+			...defaultView,
+			activeCustomViewId: null,
+			viewUpdated: false,
+		};
+	}
+	else if (type === VIEWS_ACTION_TYPES.UPDATE_ACTIVE_CUSTOM_VIEW) {
+		const activeCustomView = customViews[value];
+
+		if (!activeCustomView) {
+			return state;
+		}
+
+		if (!activeCustomView.activeView) {
+			activeCustomView.activeView = defaultView.activeView;
+		}
+
+		activeCustomView.activeView.component =
+			getViewComponent(activeCustomView.activeView.contentRenderer) ??
+			getViewComponent(defaultView.activeView.contentRenderer);
+
+		return {
+			...state,
+			...activeCustomView,
+			activeCustomViewId: value,
 			viewUpdated: false,
 		};
 	}


### PR DESCRIPTION
### References

- [LPS-130190 Implement UI to select an FDS Custom View](https://issues.liferay.com/browse/LPS-130190)
- Mockup: [View different custom views](https://www.figma.com/file/EqgsL82bX7GJfLdZA8iYFv/LPS-130101-allow-users-customize-and-manage-views-in-frontend-dataset?node-id=12%3A67293)
- Mockup: [Exit without saving the changes](https://www.figma.com/file/EqgsL82bX7GJfLdZA8iYFv/LPS-130101-allow-users-customize-and-manage-views-in-frontend-dataset?node-id=15%3A65409)

### What is the goal of this PR?

In this PR, we are:
- Reading custom views stored in portal preferences and passing them to FDS as `customViews` param. This is done internally in taglib. I don't see a need to extend tag API for this, but we can always add that in later on.
- Implementing UI that displays and allows selection of custom views.
- Applying custom view on selection.

Looking at the code, tickets and docs, different types of views might be confusing. We have several types:
- `contentRenderer`. This is `table`, `card`, or `list`. In docs, discussions and tickets, this it is sometimes referred as a view, or a base view. 
- `view`. This is combination of `contentRenderer` and its customizations based on specific FDS instance, for example definition of fields. It is equivalent of `*FDSView.java` in backend. When you select `table`, `card`, or `list` in UI, you select one of the `view`s specific to that FDS instance.
- `customView`. This is combination of `view` and its UI customizations (filters, sorting, pagination delta etc)
- `defaultView`. This is one of the `view`s, set by `default` attribute in a view.

@pablo-agulla @dsanz @john-co Please see [my comment in JIRA](https://issues.liferay.com/browse/LPS-158546?focusedCommentId=2760759&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2760759), related to story content and test scenarios.

Product sidenotes:
- We should add a feature to rename custom view.
- We should add a feature to set custom view as default.

### What does it look like?

![screenshot](https://user-images.githubusercontent.com/5435511/190648724-3b4fb079-d9b3-46f8-af03-76dd5e47ef23.gif)

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.