### PR TITLE
LPS-163254 Encode the hash on schema name

### DIFF
--- a/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/components/Scope.js
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/resources/META-INF/resources/js/components/Scope.js
@@ -25,7 +25,10 @@ function Scope({portletNamespace}) {
 		const handleSchemaUpdated = (event) => {
 			if (event.schemaName) {
 				fetch(
-					`${HEADLESS_BATCH_PLANNER_URL}/plans/${event.schemaName}/site-scopes?export=${event.isExport}`
+					`${HEADLESS_BATCH_PLANNER_URL}/plans/${event.schemaName.replace(
+						'#',
+						encodeURIComponent('#')
+					)}/site-scopes?export=${event.isExport}`
 				)
 					.then((response) => response.json())
 					.then((json) => {


### PR DESCRIPTION
This is the fix for the `java.lang.NumberFormatException: For input string: "com.liferay.object.rest.dto.v1_0.ObjectEntry"` of ticket [LPS-163254](https://issues.liferay.com/browse/LPS-163254) 

**Steps to reproduce:**

set `feature.flag.COMMERCE-8087=true` and start server
login into localhost:8080 and create a new object named "subject" then publish it
go to Applications > Import/Export Center
click New button > Export File
select C_Subject in the dropdown list of "Entity Type"
**Expect behavior:**

no error in server console
**Actual behavior:**

error occurs in server console, please refer to the attached log file for more details
javax.ws.rs.ClientErrorException: HTTP 404 Not Found
java.lang.NumberFormatException: For input string: "com.liferay.object.rest.dto.v1_0.ObjectEntry"