### PR TITLE
LPS-163858 Do not run all acceptance tests in Clay module's ci:test:relevant

### DIFF
--- a/modules/apps/frontend-taglib/test.properties
+++ b/modules/apps/frontend-taglib/test.properties
@@ -16,7 +16,8 @@
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (\
             (environment.acceptance == true) OR \
-            (portal.acceptance == true) OR \
+            (test.class.method.name == "ClayIcons#FlagIconsCanRender") OR \
+            (test.class.method.name == "ClaySmoke#CanRenderUI") OR \
             (testray.component.names == "Clay")\
         ) AND \
         (\


### PR DESCRIPTION
**Description**
Currently we're running all acceptance functional tests which is probably overkill (we're running headless tests which are definitely unrelated) and is taking up a lot of time to wait for the results and analyze the tests. Most of which are not related to Clay changes.

[Propose]
Remove running all portal.acceptance from clay-taglib's `ci:test:relevant` test.properties and limit it down to acceptance tests that are either environment.acceptance or Clay component tests.

**Test Plan**
- [x] Base level relevant tests are run
- [x] environment acceptance tests are run
- [x] clay smoke test is run

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-163858