### PR TITLE
LPS-158667 Unquarantine Frontend Data Set tests

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -59,6 +59,7 @@ ci.test.available.suites=\
     friendly-url,\
     frontend,\
     frontend-clay,\
+    frontend-data-set,\
     gauntlet,\
     gauntlet-bucket,\
     gradle-plugins,\
@@ -218,6 +219,7 @@ ci.test.suite.description[license-cluster]=Compile a release bundle and execute 
 ci.test.suite.description[liferay-online]=Compile a release bundle and execute tests with liferay online properties.
 ci.test.suite.description[lima]=Test Lima tests.
 ci.test.suite.description[lima-acceptance]=Test Lima acceptance tests.
+ci.test.suite.description[frontend-data-set]=Test frontend data-set tests.
 ci.test.suite.description[lima-upgrade]=Test Lima upgrade tests.
 ci.test.suite.description[lpkg]=Test LPKG tests.
 ci.test.suite.description[mfa]=Test Multi Factor Authentication tests.

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -79,6 +79,9 @@ definition {
 	@priority = "5"
 	test AvailableFiltersCanBeApplied {
 		property custom.properties = "upgrade.database.auto.run=false";
+		property portal.acceptance = "false";
+		property portal.release = "false";
+		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FDSFilters#AvailableFiltersCanBeApplied";
 
 		task ("When click on the filter button") {
@@ -108,6 +111,9 @@ definition {
 	@priority = "5"
 	test ExcludeCanBeEnabled {
 		property custom.properties = "upgrade.database.auto.run=false";
+		property portal.acceptance = "false";
+		property portal.release = "false";
+		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FDSFilters#ExcludeCanBeEnabled";
 
 		task ("When click on the filter button") {
@@ -303,6 +309,9 @@ definition {
 	@description = "LPS-155312. Assert results can be correctly filtered when using the status filter."
 	@priority = "5"
 	test StatusFilterCanBeAdded {
+		property portal.acceptance = "false";
+		property portal.release = "false";
+		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FDSFilters#StatusFilterCanBeAdded";
 
 		task ("When click on the filter button") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -1,10 +1,11 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
+	property custom.properties = "upgrade.database.auto.run=false";
 	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "false";
-	property portal.release = "false";
-	property portal.upstream = "quarantine";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
 	property testray.component.names = "Frontend Dataset";
 	property testray.main.component.name = "Frontend Dataset";
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -49,9 +49,11 @@ definition {
 	@description = "LPS-155309. Assert all filters can be removed."
 	@priority = "4"
 	test AllFiltersCanBeRemoved {
+		property custom.properties = "upgrade.database.auto.run=false";
+
 		task ("When there is a filter already established") {
 			AssertElementPresent(
-				key_filter = "Status: Approved, Draft",
+				key_filter = "Color: Blue, Green, Yellow",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 
@@ -67,7 +69,7 @@ definition {
 
 		task ("And the Filters Summary boxes will be updated accordingly to it") {
 			AssertElementNotPresent(
-				key_filter = "Status: Approved, Draft",
+				key_filter = "Color: Blue, Green, Yellow",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 	}
@@ -84,7 +86,7 @@ definition {
 
 			FDSFilters.enableStatusFilters(key_status = "Pending");
 
-			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+			Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 		}
 
 		task ("Then the results will be displayed accordingly to the filter selected") {
@@ -112,7 +114,7 @@ definition {
 		task ("And When the exclude option is active") {
 			Check.checkToggleSwitch(locator1 = "FrontendDataSet#EXCLUDE_TOGGLE");
 
-			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+			Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 		}
 
 		task ("Then the filter will be added to the Filters Summary") {
@@ -131,31 +133,45 @@ definition {
 	test FilterCanBeEdited {
 		task ("When there is a filter already established") {
 			AssertElementPresent(
-				key_filter = "Status: Approved, Draft",
+				key_filter = "Color: Blue, Green, Yellow",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 
 		task ("And clicking on the Filters Summary") {
 			ClickNoError(
-				key_filter = "Status: Approved, Draft",
+				key_filter = "Color: Blue, Green, Yellow",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 
 		task ("And the filter is edited") {
-			FDSFilters.disableStatusFilters(key_status = "Approved,Draft");
+			FDSFilters.disableStatusFilters(key_status = "Blue,Green");
 
-			FDSFilters.enableStatusFilters(key_status = "Pending");
+			FDSFilters.enableStatusFilters(key_status = "Red");
 
 			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
 		}
 
 		task ("Then the results will be displayed updated accordingly to it") {
-			AssertElementPresent(locator1 = "FrontendDataSet#EMPTY_FDS_TABLE_MESSAGE");
+			AssertElementNotPresent(
+				key_itemName = "Green",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+
+			AssertElementNotPresent(
+				key_itemName = "Blue",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+
+			AssertElementPresent(
+				key_itemName = "Red",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
+
+			AssertElementPresent(
+				key_itemName = "Yellow",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
 		}
 
 		task ("And the Filters Summary boxes will be updated accordingly to it") {
 			AssertElementPresent(
-				key_filter = "Status: Pending",
+				key_filter = "Color: Yellow, Red",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 	}
@@ -180,12 +196,12 @@ definition {
 		task ("Then the results will be displayed updated accordingly to it") {
 			FDSFilters.enableStatusFilters(key_status = "Pending");
 
-			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+			Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 		}
 
 		task ("And Then the Filters Summary boxes will be updated accordingly to it") {
 			AssertElementPresent(
-				key_filter = "Status: Approved, Draft, Pending",
+				key_filter = "Status: Pending",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 	}
@@ -233,7 +249,7 @@ definition {
 				key_toDate = "02/02/2021");
 
 			VerifyElementPresent(
-				key_filter = "Status: Approved, Draft",
+				key_filter = "Color: Blue, Green, Yellow",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 
 			VerifyElementPresent(
@@ -244,7 +260,7 @@ definition {
 		task ("Then it can be removed one by one") {
 			FDSFilters.closeFilters();
 
-			FDSFilters.removeFilter(key_filter = "Status");
+			FDSFilters.removeFilter(key_filter = "Color");
 
 			FDSFilters.removeFilter(key_filter = "Date Range");
 		}
@@ -257,7 +273,7 @@ definition {
 
 		task ("And the Filters Summary boxes will be updated accordingly to it") {
 			AssertElementNotPresent(
-				key_filter = "Status",
+				key_filter = "Color",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 
 			AssertElementNotPresent(
@@ -278,7 +294,7 @@ definition {
 
 			FDSFilters.disableStatusFilters(key_status = "Approved");
 
-			Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+			Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 		}
 
 		task ("Then the filter will be added to the Filters Summary") {
@@ -318,12 +334,12 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "FrontendDataSet#PAGINATION_RESULTS",
-				value1 = "Showing 1 to 10 of 100");
+				value1 = "Showing 1 to 10 of 75");
 		}
 
 		task ("And Then the Filters Summary boxes will be displayed accordingly to it") {
 			AssertElementPresent(
-				key_filter = "Status: Approved, Draft",
+				key_filter = "Color: Blue, Green, Yellow",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -50,6 +50,7 @@ definition {
 	@priority = "4"
 	test AllFiltersCanBeRemoved {
 		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FDSFilters#AllFiltersCanBeRemoved";
 
 		task ("When there is a filter already established") {
 			AssertElementPresent(
@@ -77,6 +78,9 @@ definition {
 	@description = "LPS-155305. Assert results can be correctly filtered when selecting available filters."
 	@priority = "5"
 	test AvailableFiltersCanBeApplied {
+		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FDSFilters#AvailableFiltersCanBeApplied";
+
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -103,6 +107,9 @@ definition {
 	@description = "LPS-155313. Assert results can be correctly filtered when exclude is enabled."
 	@priority = "5"
 	test ExcludeCanBeEnabled {
+		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FDSFilters#ExcludeCanBeEnabled";
+
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -131,6 +138,9 @@ definition {
 	@description = "LPS-155306. Assert results can be correctly filtered by editing the filter summary boxes."
 	@priority = "5"
 	test FilterCanBeEdited {
+		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FDSFilters#FilterCanBeEdited";
+
 		task ("When there is a filter already established") {
 			AssertElementPresent(
 				key_filter = "Color: Blue, Green, Yellow",
@@ -179,6 +189,8 @@ definition {
 	@description = "LPS-155310. Assert results can be correctly filtered when searching for a filter."
 	@priority = "5"
 	test FilterCanBeSearched {
+		property test.name.skip.portal.instance = "FDSFilters#FilterCanBeSearched";
+
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -209,6 +221,8 @@ definition {
 	@description = "LPS-155311. Assert the filter cannot be filtered by searching."
 	@priority = "3"
 	test FilterNotFound {
+		property test.name.skip.portal.instance = "FDSFilters#FilterNotFound";
+
 		task ("When clicking on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -231,6 +245,8 @@ definition {
 	@description = "LPS-155303. Assert management bar will render."
 	@priority = "3"
 	test ManagementBarWillRender {
+		property test.name.skip.portal.instance = "FDSFilters#ManagementBarWillRender";
+
 		task ("Then the Management Bar will be displayed correctly") {
 			AssertElementPresent(locator1 = "FrontendDataSet#MANAGEMENT_BAR");
 
@@ -241,6 +257,8 @@ definition {
 	@description = "LPS-155308. Assert one filter can be removed."
 	@priority = "4"
 	test OneFilterCanBeRemoved {
+		property test.name.skip.portal.instance = "FDSFilters#OneFilterCanBeRemoved";
+
 		task ("When there are several filters already established") {
 			FDSFilters.openFilters();
 
@@ -285,6 +303,8 @@ definition {
 	@description = "LPS-155312. Assert results can be correctly filtered when using the status filter."
 	@priority = "5"
 	test StatusFilterCanBeAdded {
+		property test.name.skip.portal.instance = "FDSFilters#StatusFilterCanBeAdded";
+
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -311,6 +331,8 @@ definition {
 	@description = "LPS-155304. Assert filter is preloaded when entering on a FDS page for first time."
 	@priority = "5"
 	test WillRenderAsInitialState {
+		property test.name.skip.portal.instance = "FDSFilters#WillRenderAsInitialState";
+
 		task ("And When viewing FDS Sample portlet dataset") {
 			Click(
 				key_sampleTab = "Customized",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -59,6 +59,7 @@ definition {
 	test BehaviorIsEqualToEllipsisDropdownEquivalentAction {
 		property custom.properties = "upgrade.database.auto.run=false";
 		property test.name.skip.portal.instance = "FDSQuickActions#BehaviorIsEqualToEllipsisDropdownEquivalentAction";
+
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("When click on Pencil Icon") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -58,6 +58,7 @@ definition {
 	@priority = "5"
 	test BehaviorIsEqualToEllipsisDropdownEquivalentAction {
 		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FDSQuickActions#BehaviorIsEqualToEllipsisDropdownEquivalentAction";
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("When click on Pencil Icon") {
@@ -88,6 +89,8 @@ definition {
 	@description = "LPS-155457. Assert that hover over mouse off of the table body quick action menu is not visible."
 	@priority = "5"
 	test CanDisappearWhenNotHovered {
+		property test.name.skip.portal.instance = "FDSQuickActions#CanDisappearWhenNotHovered";
+
 		task ("When hover mouse off of the table body") {
 			MouseOver(locator1 = "FrontendDataSet#TABLE_BODY");
 		}
@@ -100,6 +103,9 @@ definition {
 	@description = "LPS-155455: When hovering over the first line item and the quick action menu is displayed on the 1st line"
 	@priority = "5"
 	test CanDisplayOnHover {
+		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayOnHover";
+
 		task ("Then the quick action menu is displayed on the 1st line") {
 			FDSQuickActions.viewQuickActionMenuPresent(title = "Sample1");
 		}
@@ -109,6 +115,8 @@ definition {
 	@ignore = "true"
 	@priority = "3"
 	test CanDisplayOnMultipleActiveRows {
+		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayOnMultipleActiveRows";
+
 		task ("When click on ellipsis button 2nd row item") {
 			Click(
 				key_title = "Sample2",
@@ -139,6 +147,8 @@ definition {
 	@description = "LPS-155458. Assert can be displayed on one an active row."
 	@priority = "4"
 	test CanDisplayOnOneActiveRow {
+		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayOnOneActiveRow";
+
 		task ("When hover over 3rd row item") {
 			MouseOver(
 				key_itemName = "Sample3",
@@ -157,6 +167,8 @@ definition {
 	@description = "LPS-155463. Assert that Quick actions icons list should be limited to three actions."
 	@priority = "4"
 	test CanDisplayUpToThreeIcons {
+		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayUpToThreeIcons";
+
 		task ("Then quick action menu only has 3 actions icons available") {
 			AssertElementPresent(
 				key_index = "1",
@@ -183,11 +195,7 @@ definition {
 	@description = "LPS-155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {
-<<<<<<< Updated upstream
-		var portalURL = PropsUtil.get("portal.url");
-=======
 		property test.name.skip.portal.instance = "FDSQuickActions#CanExecuteAnAction";
->>>>>>> Stashed changes
 
 		task ("When click on Pencil Icon ") {
 			ClickNoError(
@@ -203,6 +211,8 @@ definition {
 	@description = "LPS-155467. Assert the quick action is not visible when the row checkbox is checked."
 	@priority = "3"
 	test IsNotVisibleOnCheckedRow {
+		property test.name.skip.portal.instance = "FDSQuickActions#IsNotVisibleOnCheckedRow";
+
 		task ("When mark a row checkbox as checked") {
 			Check.checkToggleSwitch(
 				key_title = "Sample1",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -1,10 +1,11 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
+	property custom.properties = "upgrade.database.auto.run=false";
 	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "false";
-	property portal.release = "false";
-	property portal.upstream = "quarantine";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
 	property testray.component.names = "Frontend Dataset";
 	property testray.main.component.name = "Frontend Dataset";
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -57,6 +57,7 @@ definition {
 	@description = "LPS-155465. Assert that clicking quick action is equivalent to clicking the ellipsis dropdown menu."
 	@priority = "5"
 	test BehaviorIsEqualToEllipsisDropdownEquivalentAction {
+		property custom.properties = "upgrade.database.auto.run=false";
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("When click on Pencil Icon") {
@@ -66,7 +67,7 @@ definition {
 		}
 
 		task ("And when copy the browser URL (#test-pencil is appended)") {
-			AssertLocation(value1 = "${portalURL}/frontend-data-set-test-page#test-pencil");
+			var browserURL = selenium.getLocation();
 		}
 
 		task ("And when click on ellipsis of 1st row item in FDS table") {
@@ -80,7 +81,7 @@ definition {
 		}
 
 		task ("Then browser URL matches copied URL (#test-pencil)") {
-			AssertLocation(value1 = "${portalURL}/frontend-data-set-test-page#test-pencil");
+			AssertLocation(value1 = "${browserURL}");
 		}
 	}
 
@@ -138,14 +139,14 @@ definition {
 	@description = "LPS-155458. Assert can be displayed on one an active row."
 	@priority = "4"
 	test CanDisplayOnOneActiveRow {
-		task ("When hover over 2nd row item") {
+		task ("When hover over 3rd row item") {
 			MouseOver(
-				key_itemName = "Sample2",
+				key_itemName = "Sample3",
 				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
 		}
 
-		task ("Then quick action menu is displayed on the 2nd row") {
-			FDSQuickActions.viewQuickActionMenuPresent(title = "Sample2");
+		task ("Then quick action menu is displayed on the 3rd row") {
+			FDSQuickActions.viewQuickActionMenuPresent(title = "Sample3");
 		}
 
 		task ("Then quick action menu is not displayed on 1st row") {
@@ -182,7 +183,11 @@ definition {
 	@description = "LPS-155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {
+<<<<<<< Updated upstream
 		var portalURL = PropsUtil.get("portal.url");
+=======
+		property test.name.skip.portal.instance = "FDSQuickActions#CanExecuteAnAction";
+>>>>>>> Stashed changes
 
 		task ("When click on Pencil Icon ") {
 			ClickNoError(
@@ -191,7 +196,7 @@ definition {
 		}
 
 		task ("Then #test-pencil is appended to browser URL") {
-			AssertLocation(value1 = "${portalURL}/frontend-data-set-test-page#test-pencil");
+			AssertLocation.assertPartialLocation(value1 = "frontend-data-set-test-page#test-pencil");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -82,7 +82,7 @@
 </tr>
 <tr>
 	<td>PAGINATION_RESULTS</td>
-	<td>//div[contains(@class,'pagination-results') and contains(.,'Showing 1 to 10 of 100')]</td>
+	<td>//*[contains(@class,'pagination-results')]</td>
 	<td></td>
 </tr>
 
@@ -140,7 +140,7 @@
 </tr>
 <tr>
 	<td>MANAGEMENT_BAR</td>
-	<td>//div[contains(@class,'data-set-management-bar')]</td>
+	<td>//nav[contains(@class,'management-bar')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -1,10 +1,11 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
+	property custom.properties = "upgrade.database.auto.run=false";
 	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "false";
-	property portal.release = "false";
-	property portal.upstream = "quarantine";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
 	property testray.component.names = "Frontend Dataset";
 	property testray.main.component.name = "User Interface";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -52,6 +52,7 @@ definition {
 	@priority = "4"
 	test ActionsCanBeCustomized {
 		property custom.properties = "upgrade.database.auto.run=false";
+		property test.name.skip.portal.instance = "FrontendDataSet#ActionsCanBeCustomized";
 
 		task ("When Click on 1st action button in FDS sample") {
 			MouseOver(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -51,6 +51,8 @@ definition {
 	@description = "LPS-147914: Verify alert message is present when action button is clicked"
 	@priority = "4"
 	test ActionsCanBeCustomized {
+		property custom.properties = "upgrade.database.auto.run=false";
+
 		task ("When Click on 1st action button in FDS sample") {
 			MouseOver(
 				key_itemName = "Sample1",
@@ -65,18 +67,18 @@ definition {
 			AssertConfirm.assertConfirmationNoError(value1 = "Hello Sample1!");
 		}
 
-		task ("When Click on 2st action button in FDS sample") {
+		task ("When Click on 3rd action button in FDS sample") {
 			MouseOver(
-				key_itemName = "Sample2",
+				key_itemName = "Sample3",
 				locator1 = "FrontendDataSet#TABLE_ITEM_ROW");
 
 			ClickNoError(
-				key_title = "Sample2",
+				key_title = "Sample3",
 				locator1 = "FrontendDataSet#VIEW_ACTION_BUTTON");
 		}
 
-		task ("Then 2st alert message is present") {
-			AssertConfirm.assertConfirmationNoError(value1 = "Hello Sample2!");
+		task ("Then 3rd alert message is present") {
+			AssertConfirm.assertConfirmationNoError(value1 = "Hello Sample3!");
 		}
 	}
 

--- a/test.properties
+++ b/test.properties
@@ -4101,6 +4101,19 @@
         (testray.main.component.name ~ "Headless Frontend Infrastructure")
 
     #
+    # Frontend Data Set
+    #
+
+    test.batch.dist.app.servers[frontend-data-set]=tomcat
+
+    test.batch.names[frontend-data-set]=\
+        functional-tomcat90-mysql57-jdk8
+
+    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][frontend-data-set]=\
+        (portal.upstream != quarantine) AND \
+        (testray.main.component.name ~ "Frontend Dataset")
+
+    #
     # Frontend Infra
     #
 
@@ -4153,6 +4166,7 @@
         ) AND \
         (\
             (testray.main.component.name ~ "AMD Loader") OR \
+            (testray.main.component.name ~ "Frontend Dataset") OR \
             (testray.main.component.name ~ "Headless Frontend Infrastructure") OR \
             (testray.main.component.name ~ "Remote Apps") OR \
             (testray.main.component.name ~ "Theme") OR \


### PR DESCRIPTION
**Description**
Remove virtual instances from FDS tests as workaround to unblock the tests due to https://issues.liferay.com/browse/LPS-159786. Unquarantine passing tests in order to get back FDS test coverage.

**Test Plan**
- [x] Unquarantined FDS tests pass

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-158667