### PR TITLE
LPS-164246 KB preview article info button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_toggler_button/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/sidebar_toggler_button/page.jsp
@@ -16,13 +16,13 @@
 
 <%@ include file="/sidebar_toggler_button/init.jsp" %>
 
-<aui:a cssClass="<%= cssClass %>" href='<%= "#" + sidenavId %>' id="<%= StringUtil.randomId() %>">
-	<c:if test="<%= Validator.isNotNull(icon) %>">
-		<aui:icon cssClass="icon-monospaced" image="<%= icon %>" markupView="lexicon" />
-	</c:if>
-
-	<span><liferay-ui:message key="<%= label %>" /></span>
-</aui:a>
+<clay:link
+	cssClass="<%= cssClass %>"
+	href='<%= "#" + sidenavId %>'
+	icon="<%= icon %>"
+	label="<%= label %>"
+	type="button"
+/>
 
 <aui:script>
 	var sidenavToggle = document.querySelector('[href="#<%= sidenavId %>"]');

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/common/view_kb_article.jsp
@@ -61,9 +61,8 @@ if (portletTitleBasedNavigation) {
 				</li>
 				<li class="nav-item">
 					<liferay-frontend:sidebar-toggler-button
-						cssClass="btn-unstyled"
+						cssClass="btn btn-monospaced btn-sm btn-unstyled"
 						icon="info-circle-open"
-						label="info"
 					/>
 				</li>
 			</ul>


### PR DESCRIPTION
Hi team,

We need to use the `<liferay-frontend:sidebar-toggler-button` without text only button and fix the vertical alignment, at first we try to update the markup less as possible https://github.com/liferay-lima/liferay-portal/commit/4e5d2c98cffad96c47d9288ec98655794973d005 https://github.com/liferay-lima/liferay-portal/commit/df27fb0ae99a46fcc0fc1a390650feaeb7821d54 but later we take into account that feels better use directly a `clay:link` 682a556178bebdc65f6280435cb34c9b426596ec.

Previously reviewed: https://github.com/liferay-lima/liferay-portal/pull/3538

### Issue: https://issues.liferay.com/browse/LPS-164246

### How to test it

1. Go to the Product Menu > Content & Data > Knowledge base
2. Create a basic article 
3. Navigate to this new article

### Before the PR
![image](https://user-images.githubusercontent.com/67901/193002237-223ca513-c398-4612-9694-697bd20bf84c.png)

### After the PR:
![image](https://user-images.githubusercontent.com/67901/192851855-94ef401c-6331-40b1-acee-9559687e04f8.png)

![image](https://user-images.githubusercontent.com/67901/192851683-cd1b4050-eb22-4d00-afc9-e1fb3c701ecb.png)

![image](https://user-images.githubusercontent.com/67901/192851613-7c9962f7-3da3-46bc-afde-ff21a843f21c.png)


