### PR TITLE
LPS-159786 500 status error with FDS data

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FDSSamplePortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/portlet/FDSSamplePortlet.java
@@ -30,8 +30,10 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -46,7 +48,6 @@ import javax.portlet.RenderResponse;
 
 import javax.servlet.ServletContext;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -81,22 +82,22 @@ public class FDSSamplePortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		try {
+			_generate(themeDisplay.getCompanyId());
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
 		renderRequest.setAttribute(
 			FDSSampleWebKeys.FDS_SAMPLE_DISPLAY_CONTEXT,
 			new FDSSampleDisplayContext(
 				_portal.getHttpServletRequest(renderRequest)));
 
 		super.doDispatch(renderRequest, renderResponse);
-	}
-
-	@Activate
-	protected void activate() {
-		try {
-			_generate(_portal.getDefaultCompanyId());
-		}
-		catch (Exception exception) {
-			_log.error(exception);
-		}
 	}
 
 	private synchronized void _generate(long companyId) throws Exception {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -68,6 +68,12 @@ definition {
 		}
 	}
 
+	macro removeAllFilters {
+		while (IsElementPresent(key_filter = "", locator1 = "FrontendDataSet#REMOVE_FILTER")) {
+			FDSFilters.removeFilter(key_filter = "");
+		}
+	}
+
 	macro removeFilter {
 		Click(
 			locator1 = "FrontendDataSet#REMOVE_FILTER",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -282,6 +282,10 @@ definition {
 	@description = "LPS-155312. Assert results can be correctly filtered when using the status filter."
 	@priority = "5"
 	test StatusFilterCanBeAdded {
+		task ("Given no filters applied") {
+			FDSFilters.removeAllFilters();
+		}
+
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -289,14 +293,12 @@ definition {
 		task ("And When adding an option from the status list filter") {
 			FDSFilters.enableStatusFilters(key_status = "Pending");
 
-			FDSFilters.disableStatusFilters(key_status = "Approved");
-
 			Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 		}
 
 		task ("Then the filter will be added to the Filters Summary") {
 			AssertElementPresent(
-				key_filter = "Status: Draft, Pending",
+				key_filter = "Status: Pending",
 				locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "upgrade.database.auto.run=false";
 	property osgi.modules.includes = "frontend-data-set-sample-web";
 	property portal.acceptance = "true";
 	property portal.release = "true";
@@ -49,8 +48,6 @@ definition {
 	@description = "LPS-155309. Assert all filters can be removed."
 	@priority = "4"
 	test AllFiltersCanBeRemoved {
-		property custom.properties = "upgrade.database.auto.run=false";
-
 		task ("When there is a filter already established") {
 			AssertElementPresent(
 				key_filter = "Color: Blue, Green, Yellow",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -79,9 +79,6 @@ definition {
 	@priority = "5"
 	test AvailableFiltersCanBeApplied {
 		property custom.properties = "upgrade.database.auto.run=false";
-		property portal.acceptance = "false";
-		property portal.release = "false";
-		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FDSFilters#AvailableFiltersCanBeApplied";
 
 		task ("When click on the filter button") {
@@ -111,9 +108,6 @@ definition {
 	@priority = "5"
 	test ExcludeCanBeEnabled {
 		property custom.properties = "upgrade.database.auto.run=false";
-		property portal.acceptance = "false";
-		property portal.release = "false";
-		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FDSFilters#ExcludeCanBeEnabled";
 
 		task ("When click on the filter button") {
@@ -309,9 +303,6 @@ definition {
 	@description = "LPS-155312. Assert results can be correctly filtered when using the status filter."
 	@priority = "5"
 	test StatusFilterCanBeAdded {
-		property portal.acceptance = "false";
-		property portal.release = "false";
-		property portal.upstream = "quarantine";
 		property test.name.skip.portal.instance = "FDSFilters#StatusFilterCanBeAdded";
 
 		task ("When click on the filter button") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -50,7 +50,6 @@ definition {
 	@priority = "4"
 	test AllFiltersCanBeRemoved {
 		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FDSFilters#AllFiltersCanBeRemoved";
 
 		task ("When there is a filter already established") {
 			AssertElementPresent(
@@ -78,9 +77,6 @@ definition {
 	@description = "LPS-155305. Assert results can be correctly filtered when selecting available filters."
 	@priority = "5"
 	test AvailableFiltersCanBeApplied {
-		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FDSFilters#AvailableFiltersCanBeApplied";
-
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -107,9 +103,6 @@ definition {
 	@description = "LPS-155313. Assert results can be correctly filtered when exclude is enabled."
 	@priority = "5"
 	test ExcludeCanBeEnabled {
-		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FDSFilters#ExcludeCanBeEnabled";
-
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -138,9 +131,6 @@ definition {
 	@description = "LPS-155306. Assert results can be correctly filtered by editing the filter summary boxes."
 	@priority = "5"
 	test FilterCanBeEdited {
-		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FDSFilters#FilterCanBeEdited";
-
 		task ("When there is a filter already established") {
 			AssertElementPresent(
 				key_filter = "Color: Blue, Green, Yellow",
@@ -189,8 +179,6 @@ definition {
 	@description = "LPS-155310. Assert results can be correctly filtered when searching for a filter."
 	@priority = "5"
 	test FilterCanBeSearched {
-		property test.name.skip.portal.instance = "FDSFilters#FilterCanBeSearched";
-
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -221,8 +209,6 @@ definition {
 	@description = "LPS-155311. Assert the filter cannot be filtered by searching."
 	@priority = "3"
 	test FilterNotFound {
-		property test.name.skip.portal.instance = "FDSFilters#FilterNotFound";
-
 		task ("When clicking on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -245,8 +231,6 @@ definition {
 	@description = "LPS-155303. Assert management bar will render."
 	@priority = "3"
 	test ManagementBarWillRender {
-		property test.name.skip.portal.instance = "FDSFilters#ManagementBarWillRender";
-
 		task ("Then the Management Bar will be displayed correctly") {
 			AssertElementPresent(locator1 = "FrontendDataSet#MANAGEMENT_BAR");
 
@@ -257,8 +241,6 @@ definition {
 	@description = "LPS-155308. Assert one filter can be removed."
 	@priority = "4"
 	test OneFilterCanBeRemoved {
-		property test.name.skip.portal.instance = "FDSFilters#OneFilterCanBeRemoved";
-
 		task ("When there are several filters already established") {
 			FDSFilters.openFilters();
 
@@ -303,8 +285,6 @@ definition {
 	@description = "LPS-155312. Assert results can be correctly filtered when using the status filter."
 	@priority = "5"
 	test StatusFilterCanBeAdded {
-		property test.name.skip.portal.instance = "FDSFilters#StatusFilterCanBeAdded";
-
 		task ("When click on the filter button") {
 			FDSFilters.openFilters();
 		}
@@ -331,8 +311,6 @@ definition {
 	@description = "LPS-155304. Assert filter is preloaded when entering on a FDS page for first time."
 	@priority = "5"
 	test WillRenderAsInitialState {
-		property test.name.skip.portal.instance = "FDSFilters#WillRenderAsInitialState";
-
 		task ("And When viewing FDS Sample portlet dataset") {
 			Click(
 				key_sampleTab = "Customized",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "upgrade.database.auto.run=false";
 	property osgi.modules.includes = "frontend-data-set-sample-web";
 	property portal.acceptance = "true";
 	property portal.release = "true";
@@ -57,8 +56,6 @@ definition {
 	@description = "LPS-155465. Assert that clicking quick action is equivalent to clicking the ellipsis dropdown menu."
 	@priority = "5"
 	test BehaviorIsEqualToEllipsisDropdownEquivalentAction {
-		property custom.properties = "upgrade.database.auto.run=false";
-
 		var portalURL = PropsUtil.get("portal.url");
 
 		task ("When click on Pencil Icon") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSQuickActions.testcase
@@ -58,7 +58,6 @@ definition {
 	@priority = "5"
 	test BehaviorIsEqualToEllipsisDropdownEquivalentAction {
 		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FDSQuickActions#BehaviorIsEqualToEllipsisDropdownEquivalentAction";
 
 		var portalURL = PropsUtil.get("portal.url");
 
@@ -90,8 +89,6 @@ definition {
 	@description = "LPS-155457. Assert that hover over mouse off of the table body quick action menu is not visible."
 	@priority = "5"
 	test CanDisappearWhenNotHovered {
-		property test.name.skip.portal.instance = "FDSQuickActions#CanDisappearWhenNotHovered";
-
 		task ("When hover mouse off of the table body") {
 			MouseOver(locator1 = "FrontendDataSet#TABLE_BODY");
 		}
@@ -104,9 +101,6 @@ definition {
 	@description = "LPS-155455: When hovering over the first line item and the quick action menu is displayed on the 1st line"
 	@priority = "5"
 	test CanDisplayOnHover {
-		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayOnHover";
-
 		task ("Then the quick action menu is displayed on the 1st line") {
 			FDSQuickActions.viewQuickActionMenuPresent(title = "Sample1");
 		}
@@ -116,8 +110,6 @@ definition {
 	@ignore = "true"
 	@priority = "3"
 	test CanDisplayOnMultipleActiveRows {
-		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayOnMultipleActiveRows";
-
 		task ("When click on ellipsis button 2nd row item") {
 			Click(
 				key_title = "Sample2",
@@ -148,8 +140,6 @@ definition {
 	@description = "LPS-155458. Assert can be displayed on one an active row."
 	@priority = "4"
 	test CanDisplayOnOneActiveRow {
-		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayOnOneActiveRow";
-
 		task ("When hover over 3rd row item") {
 			MouseOver(
 				key_itemName = "Sample3",
@@ -168,8 +158,6 @@ definition {
 	@description = "LPS-155463. Assert that Quick actions icons list should be limited to three actions."
 	@priority = "4"
 	test CanDisplayUpToThreeIcons {
-		property test.name.skip.portal.instance = "FDSQuickActions#CanDisplayUpToThreeIcons";
-
 		task ("Then quick action menu only has 3 actions icons available") {
 			AssertElementPresent(
 				key_index = "1",
@@ -196,8 +184,6 @@ definition {
 	@description = "LPS-155466. Assert that test-pencil is appended to browser URL after clicking."
 	@priority = "5"
 	test CanExecuteAnAction {
-		property test.name.skip.portal.instance = "FDSQuickActions#CanExecuteAnAction";
-
 		task ("When click on Pencil Icon ") {
 			ClickNoError(
 				key_title = "Sample1",
@@ -212,8 +198,6 @@ definition {
 	@description = "LPS-155467. Assert the quick action is not visible when the row checkbox is checked."
 	@priority = "3"
 	test IsNotVisibleOnCheckedRow {
-		property test.name.skip.portal.instance = "FDSQuickActions#IsNotVisibleOnCheckedRow";
-
 		task ("When mark a row checkbox as checked") {
 			Check.checkToggleSwitch(
 				key_title = "Sample1",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -52,7 +52,6 @@ definition {
 	@priority = "4"
 	test ActionsCanBeCustomized {
 		property custom.properties = "upgrade.database.auto.run=false";
-		property test.name.skip.portal.instance = "FrontendDataSet#ActionsCanBeCustomized";
 
 		task ("When Click on 1st action button in FDS sample") {
 			MouseOver(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSet.testcase
@@ -1,7 +1,6 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "upgrade.database.auto.run=false";
 	property osgi.modules.includes = "frontend-data-set-sample-web";
 	property portal.acceptance = "true";
 	property portal.release = "true";
@@ -51,8 +50,6 @@ definition {
 	@description = "LPS-147914: Verify alert message is present when action button is clicked"
 	@priority = "4"
 	test ActionsCanBeCustomized {
-		property custom.properties = "upgrade.database.auto.run=false";
-
 		task ("When Click on 1st action button in FDS sample") {
 			MouseOver(
 				key_itemName = "Sample1",


### PR DESCRIPTION
### References

- [LPS-159786 500 status error with FDS data](https://issues.liferay.com/browse/LPS-159786)

### What is the goal of this PR?

In this PR, we are enabling FDS sample module to work in the CI environment. To achieve this, we are:
- reverting FDS data generation to execute on the first rendering, instead of module activation
- setting `companyId` to reflect currently used virtual instance, instead of the default virtual instance 
- enabling and fixing all previously disabled FDS tests.

In the current code, we are generating FDS sample data in the module activation phase, to the default virtual instance. Note that Objects data is tied to a virtual instance. This does not create sample data available in CI environment. CI creates a custom virtual instance, based on rather complex criteria. When the sample module is deployed, it is deployed on a page on the custom virtual instance. At the time of module activation, custom virtual instances don't exist, so there is no way to generate data in that phase. Having data generated on first render will always work, even if new virtual instance is created between each test.