### PR TITLE
LPS-159826 | Add autom. tests for walkthrough

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -24,6 +24,19 @@ definition {
 		SystemSettings.saveConfiguration();
 	}
 
+	macro assertHighlightedSpecificObject {
+		AssertAttributeValue.assertAttributeNotPresent(
+			attribute1 = "fill-opacity",
+			key_stepId = "${key_stepId}",
+			locator1 = "Walkthrough#STEP_ID",
+			value1 = "0.8");
+
+		AssertAttributeValue(
+			attribute1 = "fill",
+			locator1 = "Walkthrough#POPOVER_OVERLAY",
+			value1 = "#393a4a");
+	}
+
 	macro enablePopoverMode {
 		if (IsElementNotPresent(locator1 = "Walkthrough#POPOVER")) {
 			if (IsElementPresent(key_portletName = "JS Walkthrough Sample", locator1 = "Portlet#TITLE")) {
@@ -78,26 +91,33 @@ definition {
 
 	macro setupWalkthroughPage {
 		task ("Given there is a site-level JSON defined for current site") {
-			JSONGroup.addGroup(groupName = "Site Name");
-
-			ApplicationsMenu.gotoSite(site = "Site Name");
-
 			Walkthrough.addWalkthrough(fileName = "${filename}");
 
 			JSONLayout.addPublicLayout(
-				groupName = "Site Name",
-				layoutName = "Walkthrough Page");
+				groupName = "${siteName}",
+				layoutName = "Walkthrough Page 1");
 
 			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Site Name",
-				layoutName = "Walkthrough Page",
+				groupName = "${siteName}",
+				layoutName = "Walkthrough Page 1",
 				widgetName = "JS Walkthrough Sample");
+			
+			if ("${filename}" == "walkthrough_configuration_multiple_page.json") {
+				JSONLayout.addPublicLayout(
+					groupName = "${siteName}",
+					layoutName = "Walkthrough Page 2");
+
+				JSONLayout.addWidgetToPublicLayout(
+					groupName = "${siteName}",
+					layoutName = "Walkthrough Page 2",
+					widgetName = "JS Walkthrough Sample");
+			}
 		}
 
 		task ("When instantiate the walkthrough") {
 			Navigator.openSitePage(
-				pageName = "Walkthrough Page",
-				siteName = "Site Name");
+				pageName = "Walkthrough Page 1",
+				siteName = "${siteName}");
 
 			Walkthrough.enablePopoverMode();
 		}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/macros/Walkthrough.macro
@@ -101,7 +101,7 @@ definition {
 				groupName = "${siteName}",
 				layoutName = "Walkthrough Page 1",
 				widgetName = "JS Walkthrough Sample");
-			
+
 			if ("${filename}" == "walkthrough_configuration_multiple_page.json") {
 				JSONLayout.addPublicLayout(
 					groupName = "${siteName}",

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/Walkthrough.path
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/paths/Walkthrough.path
@@ -31,6 +31,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>STEP_ID</td>
+	<td>//div[not(contains(@class,'hide'))]//div[contains(@id,'${key_stepId}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>POPOVER</td>
 	<td>//*[contains(@class,'popover') and contains(@class,'show')]</td>
 	<td></td>

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevel.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevel.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property osgi.modules.includes = "frontend-js-walkthrough-sample-web";
+	property osgi.modules.includes = "frontend-js-walkthrough-sample-web,frontend-editor-ckeditor-sample-web";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.component.names = "Walkthrough";
@@ -34,7 +34,9 @@ definition {
 		property portal.acceptance = "true";
 
 		task ("Given walkthrough enabled site-level") {
-			Walkthrough.setupWalkthroughPage(filename = "walkthrough_configuration_single_page.json");
+			Walkthrough.setupWalkthroughPage(
+				filename = "walkthrough_configuration_single_page.json",
+				siteName = "Site Name");
 		}
 
 		task ("And When navigate to second step") {
@@ -71,9 +73,7 @@ definition {
 
 		task ("Given walkthrough enabled site-level") {
 			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration_multiple_page.json");
-		}
 
-		task ("Given a page width larger than the preview window.") {
 			JSONLayout.addPublicLayout(
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 1");
@@ -82,7 +82,9 @@ definition {
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 1",
 				widgetName = "JS Walkthrough Sample");
+		}
 
+		task ("Given a page width larger than the preview window.") {
 			JSONLayout.addPublicLayout(
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 2");
@@ -90,7 +92,7 @@ definition {
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 2",
-				widgetName = "Documents and Media");
+				widgetName = "CKEditor Sample");
 
 			JSONLayout.addWidgetToPublicLayout(
 				groupName = "Site Name",
@@ -111,7 +113,7 @@ definition {
 		}
 
 		task ("Then popover element is visible when rendered") {
-			AssertElementPresent(
+			AssertVisible(
 				key_title = "Step 2 of 2: Enter Your Name",
 				locator1 = "Walkthrough#POPOVER_TITLE");
 		}

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevel.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevel.testcase
@@ -11,6 +11,10 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		JSONGroup.addGroup(groupName = "Site Name");
+
+		ApplicationsMenu.gotoSite(site = "Site Name");
 	}
 
 	tearDown {
@@ -57,6 +61,90 @@ definition {
 			AssertElementNotPresent(
 				key_title = "",
 				locator1 = "Walkthrough#HOTSPOT");
+		}
+	}
+
+	@description = "LPS-159826. Checked that each step corresponds to the expected Step Id."
+	@priority = "5"
+	test StepCanCorrespondToCorrectStepId {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given walkthrough enabled site-level") {
+			Walkthrough.setupWalkthroughPage(
+				filename = "walkthrough_configuration_multiple_page.json",
+				siteName = "Site Name");
+		}
+
+		task ("When on step 1") {
+			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-1");
+		}
+
+		task ("Then correspond to the correct step ID on correct page"){
+			Walkthrough.assertHighlightedSpecificObject(key_stepId = "step-1");
+
+		}
+
+		task ("When on step 2 correspond to the correct step ID on correct page") {
+			Walkthrough.goToNextStep(key_step = "2");
+
+			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-2");
+
+			Walkthrough.assertHighlightedSpecificObject(key_stepId = "step-2");
+		}
+	}
+
+	@description = "LPS-159844. When a walkthrough step is defined and a step is below the fold, user can see popover is."
+	@priority = "3"
+	test CanRenderWhenStepIsBelowFold {
+		property portal.acceptance = "true";
+
+		task ("Given walkthrough enabled site-level") {
+			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration_multiple_page.json");
+		}
+
+		task ("Given a page width larger than the preview window."){
+			JSONLayout.addPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 1",
+				widgetName = "JS Walkthrough Sample");
+				
+			JSONLayout.addPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 2");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 2",
+				widgetName = "Documents and Media");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Site Name",
+				layoutName = "Walkthrough Page 2",
+				widgetName = "JS Walkthrough Sample");
+		}
+
+		task ("When enable popover mode") {
+			Navigator.openSitePage(
+				pageName = "Walkthrough Page 1",
+				siteName = "Site Name");
+
+			Walkthrough.enablePopoverMode();
+		}
+
+		task ("And When navigate to step that is below the fold") {
+			Walkthrough.goToNextStep(key_step = "2");
+		}
+
+		task ("Then popover element is visible when rendered") {
+			AssertElementPresent(
+				key_title = "Step 2 of 2: Enter Your Name",
+				locator1 = "Walkthrough#POPOVER_TITLE");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevel.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughSiteLevel.testcase
@@ -64,37 +64,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-159826. Checked that each step corresponds to the expected Step Id."
-	@priority = "5"
-	test StepCanCorrespondToCorrectStepId {
-		property portal.acceptance = "true";
-
-		var portalURL = PropsUtil.get("portal.url");
-
-		task ("Given walkthrough enabled site-level") {
-			Walkthrough.setupWalkthroughPage(
-				filename = "walkthrough_configuration_multiple_page.json",
-				siteName = "Site Name");
-		}
-
-		task ("When on step 1") {
-			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-1");
-		}
-
-		task ("Then correspond to the correct step ID on correct page"){
-			Walkthrough.assertHighlightedSpecificObject(key_stepId = "step-1");
-
-		}
-
-		task ("When on step 2 correspond to the correct step ID on correct page") {
-			Walkthrough.goToNextStep(key_step = "2");
-
-			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-2");
-
-			Walkthrough.assertHighlightedSpecificObject(key_stepId = "step-2");
-		}
-	}
-
 	@description = "LPS-159844. When a walkthrough step is defined and a step is below the fold, user can see popover is."
 	@priority = "3"
 	test CanRenderWhenStepIsBelowFold {
@@ -104,7 +73,7 @@ definition {
 			Walkthrough.addWalkthrough(fileName = "walkthrough_configuration_multiple_page.json");
 		}
 
-		task ("Given a page width larger than the preview window."){
+		task ("Given a page width larger than the preview window.") {
 			JSONLayout.addPublicLayout(
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 1");
@@ -113,7 +82,7 @@ definition {
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 1",
 				widgetName = "JS Walkthrough Sample");
-				
+
 			JSONLayout.addPublicLayout(
 				groupName = "Site Name",
 				layoutName = "Walkthrough Page 2");
@@ -145,6 +114,36 @@ definition {
 			AssertElementPresent(
 				key_title = "Step 2 of 2: Enter Your Name",
 				locator1 = "Walkthrough#POPOVER_TITLE");
+		}
+	}
+
+	@description = "LPS-159826. Checked that each step corresponds to the expected Step Id."
+	@priority = "5"
+	test StepCanCorrespondToCorrectStepId {
+		property portal.acceptance = "true";
+
+		var portalURL = PropsUtil.get("portal.url");
+
+		task ("Given walkthrough enabled site-level") {
+			Walkthrough.setupWalkthroughPage(
+				filename = "walkthrough_configuration_multiple_page.json",
+				siteName = "Site Name");
+		}
+
+		task ("When on step 1") {
+			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-1");
+		}
+
+		task ("Then correspond to the correct step ID on correct page") {
+			Walkthrough.assertHighlightedSpecificObject(key_stepId = "step-1");
+		}
+
+		task ("When on step 2 correspond to the correct step ID on correct page") {
+			Walkthrough.goToNextStep(key_step = "2");
+
+			AssertLocation(value1 = "${portalURL}/web/site-name/walkthrough-page-2");
+
+			Walkthrough.assertHighlightedSpecificObject(key_stepId = "step-2");
 		}
 	}
 

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/dependencies/walkthrough_configuration_single_page.json
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/dependencies/walkthrough_configuration_single_page.json
@@ -2,7 +2,7 @@
 	"closeOnClickOutside": true,
 	"closeable": true,
 	"pages": {
-		"/walkthrough-page": [
+		"/walkthrough-page-1": [
 			"step-1",
 			"step-2",
 			"step-3"

--- a/portal-web/test/functional/com/liferay/portalweb/functions/AssertAttributeValue.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/AssertAttributeValue.function
@@ -25,4 +25,16 @@ definition {
 		selenium.assertLiferayErrors();
 	}
 
+	function assertAttributeNotPresent {
+		WaitForSPARefresh();
+
+		selenium.waitForElementPresent();
+
+		selenium.assertAttributeNotPresent("${attribute1}", "${locator1}", "${value1}");
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/functions/AssertAttributeValue.function
+++ b/portal-web/test/functional/com/liferay/portalweb/functions/AssertAttributeValue.function
@@ -1,6 +1,18 @@
 @default = "assertAttributeValue"
 definition {
 
+	function assertAttributeNotPresent {
+		WaitForSPARefresh();
+
+		selenium.waitForElementPresent();
+
+		selenium.assertAttributeNotPresent("${attribute1}", "${locator1}", "${value1}");
+
+		selenium.assertJavaScriptErrors();
+
+		selenium.assertLiferayErrors();
+	}
+
 	function assertAttributeValue {
 		WaitForSPARefresh();
 
@@ -19,18 +31,6 @@ definition {
 		selenium.waitForElementPresent();
 
 		selenium.assertAttributeValue("${attribute1}", "${locator1}", "${value1}");
-
-		selenium.assertJavaScriptErrors();
-
-		selenium.assertLiferayErrors();
-	}
-
-	function assertAttributeNotPresent {
-		WaitForSPARefresh();
-
-		selenium.waitForElementPresent();
-
-		selenium.assertAttributeNotPresent("${attribute1}", "${locator1}", "${value1}");
 
 		selenium.assertJavaScriptErrors();
 


### PR DESCRIPTION
Background:
Add StepCanCorrespondToCorrectStepId and CanRenderWhenStepIsBelowFold autom. tests

Test Plan:
WalkthroughSiteLevel#StepCanCorrespondToCorrectStepId
Given walkthrough enabled site-level
When step IDs are defined in the pages property
and when walkthrough steps correspond to the correct step ID on correct page
Then complete walkthrough process

WalkthroughSiteLevel#CanRenderWhenStepIsBelowFold
Given walkthrough enabled site-level
And Given a page width larger than the preview window
When enable popover mode
And When navigate to step that is below the fold
Then popover element is visible when rendered

JIRA Link:
https://issues.liferay.com/browse/LPS-159826
https://issues.liferay.com/browse/LPS-159844