### PR TITLE
LPS-163160 Remove `Liferay.Util.getGeolocation` usage

### DIFF
--- a/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.js
+++ b/modules/apps/map/map-common/src/main/resources/META-INF/resources/js/MapBase.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {EventEmitter, buildFragment} from 'frontend-js-web';
+import {EventEmitter, buildFragment, getGeolocation} from 'frontend-js-web';
 
 import GeoJSONBase from './GeoJSONBase';
 import MarkerBase from './MarkerBase';
@@ -180,7 +180,7 @@ class MapBase extends EventEmitter {
 				: {};
 
 		if (!currentGeolocation.lat && !currentGeolocation.lng) {
-			Liferay.Util.getGeolocation(
+			getGeolocation(
 				(lat, lng) => {
 					this._initializeLocation({lat, lng});
 				},

--- a/modules/apps/map/map-common/test/liferay/MapBase.js
+++ b/modules/apps/map/map-common/test/liferay/MapBase.js
@@ -67,12 +67,6 @@ describe('MapBase', () => {
 	const GeoJSONImpl = jest.fn().mockImplementation(() => geoJSONImpl);
 
 	beforeEach(() => {
-		window.Liferay = {
-			Util: {
-				getGeolocation: jest.fn(),
-			},
-		};
-
 		MapImpl.MarkerImpl = MarkerImpl;
 		MapImpl.DialogImpl = DialogImpl;
 		MapImpl.GeocoderImpl = GeocoderImpl;
@@ -127,12 +121,6 @@ describe('MapBase', () => {
 
 	describe('constructor()', () => {
 		it('calls _initializeMap as a fallback', () => {
-			window.Liferay = {
-				Util: {
-					getGeolocation: jest.fn((success, fallback) => fallback()),
-				},
-			};
-
 			jest.spyOn(MapImpl.prototype, '_initializeMap');
 
 			const mapImpl = new MapImpl();
@@ -161,6 +149,8 @@ describe('MapBase', () => {
 
 		it('disposes existing search custom control', () => {
 			const control = {dispose: jest.fn()};
+
+			mapImpl._geoJSONLayer = {dispose: jest.fn()};
 
 			mapImpl._customControls = {[MapImpl.CONTROLS.SEARCH]: control};
 
@@ -288,6 +278,8 @@ describe('MapBase', () => {
 	describe('_getGeoCoder()', () => {
 		it('does nothing if there is no MapBase.GeocoderImpl', () => {
 			MapImpl.GeocoderImpl = null;
+
+			mapImpl = new MapImpl();
 
 			expect(mapImpl._getGeocoder()).toBe(null);
 		});


### PR DESCRIPTION
I had to update 2 tests here, not 100% sure why, as `Liferay.Util.getGeolocation === getGeolocation`, but both fixes make sense to me.  I've added inline comments for those 2 changes with my reasoning for them.