### PR TITLE
LPS-138669 When an FDS column is unchecked, it leaves a large empty area making the UI ugly

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -177,6 +177,7 @@ const FrontendDataSet = ({
 				visibleFieldNames: initialVisibleFieldNames,
 			},
 			filters,
+			modifiedFields: {},
 			paginationDelta,
 			sorting: sortingProp,
 			views,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
@@ -19,12 +19,13 @@
 
 .dnd-td,
 .dnd-th {
-	border-right: 1px solid $table-list-border-color;
+	border-color: $table-list-border-color;
+	border-style: solid;
+	border-width: 0 1px 1px 0;
 	display: table-cell;
-	opacity: 0;
 	overflow: hidden;
 	padding: $table-cell-padding;
-	transition: opacity 0.1s ease-in;
+	vertical-align: middle;
 	white-space: normal;
 
 	&:last-child {
@@ -48,7 +49,6 @@
 }
 
 .dnd-tr {
-	border-bottom: 1px solid $table-list-border-color;
 	display: table-row;
 	min-width: 100%;
 	position: relative;
@@ -119,7 +119,6 @@
 		align-items: center;
 		display: flex;
 		min-width: auto;
-		opacity: 1;
 	}
 
 	.dnd-tr {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/ViewsContext.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/ViewsContext.js
@@ -20,6 +20,7 @@ export default React.createContext({
 	customViews: {},
 	customViewsEnabled: false,
 	filters: [],
+	modifiedFields: {},
 	paginationDelta: null,
 	sorting: [],
 	views: [],

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Row.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Row.js
@@ -16,23 +16,25 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useMemo} from 'react';
 
+import ViewsContext from '../../ViewsContext';
 import Cell from './Cell';
 import TableContext from './TableContext';
 
 function Row({children, className, paddingLeftCells}) {
-	const {columnDefinitions, columnNames, isFixed} = useContext(TableContext);
+	const [{modifiedFields}] = useContext(ViewsContext);
+	const {columnNames, isFixed} = useContext(TableContext);
 
 	const marginLeft = useMemo(() => {
 		let margin = 0;
 
 		if (isFixed) {
 			for (let i = 0; i < paddingLeftCells; i++) {
-				margin += columnDefinitions.get(columnNames[i]).width;
+				margin += modifiedFields[columnNames[i]].width;
 			}
 		}
 
 		return margin;
-	}, [columnDefinitions, columnNames, isFixed, paddingLeftCells]);
+	}, [columnNames, isFixed, modifiedFields, paddingLeftCells]);
 
 	const style = marginLeft
 		? {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
@@ -20,6 +20,7 @@ export const VIEWS_ACTION_TYPES = {
 	RESET_TO_DEFAULT_VIEW: 'RESET_TO_DEFAULT_VIEW',
 	UPDATE_ACTIVE_CUSTOM_VIEW: 'UPDATE_ACTIVE_CUSTOM_VIEW',
 	UPDATE_ACTIVE_VIEW: 'UPDATE_ACTIVE_VIEW',
+	UPDATE_FIELD: 'UPDATE_FIELD',
 	UPDATE_FILTERS: 'UPDATE_FILTERS',
 	UPDATE_PAGINATION_DELTA: 'UPDATE_PAGINATION_DELTA',
 	UPDATE_SORTING: 'UPDATE_SORTING',
@@ -28,7 +29,7 @@ export const VIEWS_ACTION_TYPES = {
 };
 
 export function viewsReducer(state, {type, value}) {
-	const {activeView, customViews, defaultView, views} = state;
+	const {activeView, customViews, defaultView, modifiedFields, views} = state;
 
 	if (type === VIEWS_ACTION_TYPES.ADD_OR_UPDATE_CUSTOM_VIEW) {
 		const {id, viewState} = value;
@@ -105,6 +106,19 @@ export function viewsReducer(state, {type, value}) {
 			viewUpdated: true,
 		};
 	}
+	else if (type === VIEWS_ACTION_TYPES.UPDATE_FIELD) {
+		const {name} = value;
+
+		const fieldAttributes = modifiedFields[name] ?? {};
+
+		return {
+			...state,
+			modifiedFields: {
+				...modifiedFields,
+				[name]: {...fieldAttributes, ...value},
+			},
+		};
+	}
 	else if (type === VIEWS_ACTION_TYPES.UPDATE_PAGINATION_DELTA) {
 		return {
 			...state,
@@ -142,8 +156,22 @@ export function viewsReducer(state, {type, value}) {
 		};
 	}
 	else if (type === VIEWS_ACTION_TYPES.UPDATE_VISIBLE_FIELD_NAMES) {
+		const fieldNames = Object.keys(value);
+
+		const fields = {};
+
+		fieldNames.forEach((fieldName) => {
+			const fieldAttributes = modifiedFields[fieldName] ?? {};
+
+			fieldAttributes.visible = value[fieldName];
+			fieldAttributes.width = null;
+
+			fields[fieldName] = fieldAttributes;
+		});
+
 		return {
 			...state,
+			modifiedFields: fields,
 			viewUpdated: true,
 			visibleFieldNames: value,
 		};


### PR DESCRIPTION
### References

- [LPS-138669 When a column is unchecked, it leaves a large empty area making the UI ugly](https://issues.liferay.com/browse/LPS-138669)
- This is a followup on #2750

### What is the goal of this PR?

In this PR, we are improving the solution from #2750. Instead of fixing width of the last column, we are resetting widths of all columns.

Technical notes:
- Column widths in FDS are calculated in a pretty complex way. We are taking browser default widths and solidify them in inline styles, combined with flex display. Widths are are defined in a state variable, `columnDefinitions`, and the process of setting widths is enabled and disabled with the `isFixed` flag. In this PR, we are resetting widths and the control flag, causing re-setting of widths.
- Much of the changes in PR is caused by moving of the `columnDefinitions` state to `viewsReducer`, and renaming it to `modifiedFields`. This is needed as we want to expose widths to visibility change dispatch.
- I considered merging `visibleFieldNames` into `modifiedFields`, as visibility definitely fits as a column attribute. The only reason I didn't is we persist `visibleFieldNames`, so changing state structure would introduce some complexity. We may do this later down the line, when we remove that explicit persistence.
- I considered adding updated field attributes to `view.schema.fields`. I didn't, to follow the pattern of other custom view specifics, where they are separate from base view definitions. Currently, widths are not a part of a custom view, but this will make it easier to add them later on.
- Style changes are to remove fade-in after widths calculation. Without this change there is a very clunky fade-out-fade-in on visibility change.
- `IntersectionObserver` logic seems very unnecessary, so I removed it. I am not even sure what the goal with it was for the original author.
 
### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/195127966-f36958e7-1c8d-44bd-9f80-fdeffd772223.gif)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/195127935-33cb0178-6575-4f9f-8f6a-56051fefb8b2.gif)

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.