### PR TITLE
LPS-165414 EditorTag is not working on fragments

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/FragmentPortlet.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/FragmentPortlet.java
@@ -73,7 +73,8 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=" + FragmentPortletKeys.FRAGMENT,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.security-role-ref=administrator"
+		"javax.portlet.security-role-ref=administrator",
+		"javax.portlet.version=3.0"
 	},
 	service = Portlet.class
 )

--- a/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
+++ b/modules/apps/frontend-editor/frontend-editor-taglib/src/main/java/com/liferay/frontend/editor/taglib/servlet/taglib/EditorTag.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.servlet.PortalWebResourcesUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -439,12 +440,8 @@ public class EditorTag extends BaseValidatorTagSupport {
 	private Map<String, Object> _getData() {
 		HttpServletRequest httpServletRequest = getRequest();
 
-		String portletId = (String)httpServletRequest.getAttribute(
-			WebKeys.PORTLET_ID);
-
-		if (portletId == null) {
-			return _data;
-		}
+		String portletId = GetterUtil.getString(
+			(String)httpServletRequest.getAttribute(WebKeys.PORTLET_ID));
 
 		Map<String, Object> attributes = new HashMap<>();
 

--- a/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputEditorTag.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.servlet.PortalWebResourcesUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -351,12 +352,8 @@ public class InputEditorTag extends BaseValidatorTagSupport {
 	protected Map<String, Object> getData() {
 		HttpServletRequest httpServletRequest = getRequest();
 
-		String portletId = (String)httpServletRequest.getAttribute(
-			WebKeys.PORTLET_ID);
-
-		if (portletId == null) {
-			return _data;
-		}
+		String portletId = GetterUtil.getString(
+			(String)httpServletRequest.getAttribute(WebKeys.PORTLET_ID));
 
 		Map<String, Object> attributes = new HashMap<>();
 


### PR DESCRIPTION
Motivation
----
In order to support comments taglibs on freemarker code, we should update the Editor taglibs.

[Link to the issue](https://issues.liferay.com/browse/LPS-165414)

Proposed Solution
----
Removes check for **portletId** and use an empty string to get the **EditorConfiguration**.

Steps to verify
----
 * Go to Control Panel > Configuration > System Settings > Template Engines: Freemaker Engine and delete Restricted Variables: "serviceLocator" and "staticUtil"
 * Go to default site
 * Go to Content > Web Content
 * Add a web content with the following settings

```java
Title: test content
Content: test content
Friendly URL: test_content
```

 * Go to Site Builder > Page Fragments
 * Add a Fragment Sets named "CUSTOMIZE"
 * Add a fragment named "test_frament"
 * Copy into the HTML field
```freemarker
[#assign 
  articleLocalService = serviceLocator.findService("com.liferay.journal.service.JournalArticleLocalService")
  entryLocalService = serviceLocator.findService("com.liferay.asset.kernel.service.AssetEntryLocalService")
  groupId = themeDisplay.getSiteGroupId()
  urlTitle = "test_content"
/]

[#assign article =articleLocalService.fetchLatestArticleByUrlTitle(groupId,urlTitle,0)!'' ]
[#if article?has_content ]
[#assign
  resourcePrimKey = article.getResourcePrimKey()?number
  entry=entryLocalService.fetchEntry("com.liferay.journal.model.JournalArticle",resourcePrimKey)
  userId = entry.getUserId()
/]

[@liferay_comment["discussion"] 
  className=entry.className 
	classPK=entry.classPK
	formName="fm" 
	ratingsEnabled=true
	userId=themeDisplay.userId
/]
[/#if] 
```
 * Go to Site Builder > Pages and add a content page
 * Add a "test_frament" to page and publish
→Note the comments section is displayed properly, including the input field
 * Access to the content page
