### PR TITLE
LPS-165319 Use setData instead of setHTML to avoid CKEditor content duplications during resizing

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -581,7 +581,9 @@ name = HtmlUtil.escapeJS(name);
 
 										window['<%= name %>'].create();
 
-										window['<%= name %>'].setHTML(ckEditorContent);
+										CKEDITOR.instances['<%= name %>'].setData(
+											ckEditorContent
+										);
 
 										initialEditor =
 											CKEDITOR.instances['<%= name %>'].id;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -566,7 +566,7 @@ name = HtmlUtil.escapeJS(name);
 									}
 								}
 							}
-						}, 250)
+						}, 1000)
 					)
 				);
 			</c:if>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -287,30 +287,6 @@ name = HtmlUtil.escapeJS(name);
 				);
 			},
 		</c:if>
-
-		setHTML: function (value) {
-			var ckEditorInstance = CKEDITOR.instances['<%= name %>'];
-
-			var win = window['<%= name %>'];
-
-			var setHTML = function (data) {
-				if (instanceDataReady) {
-					ckEditorInstance.setData(data);
-				}
-				else {
-					instancePendingData = data;
-				}
-
-				win._setStyles();
-			};
-
-			if (win.instanceReady) {
-				setHTML(value);
-			}
-			else {
-				instancePendingData = value;
-			}
-		},
 	};
 
 	var addAUIClass = function (iframe) {


### PR DESCRIPTION
Hello,

**Reproductions steps and discussion:**
https://issues.liferay.com/browse/LPS-165319
https://issues.liferay.com/browse/PTR-3373

**Issue**
Drag to move handler multiplies in CKEditor, when an image is added to the editor body and we toggle between mobile and desktop view. The editor is recreated during resizing and the ckEditorContent is wrongly set.
The issue can be reproduced in Chrome, but not in Firefox.

**Solution**
Replacing _setHTML_ to _setData_ CKEditor method.

Please review it. 
Thank you.

cc. @georgel-pop-lr