### PR TITLE
LPS-165637 Remove actions from FDS custom views selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -161,15 +161,15 @@ export function handleAction(
 }
 function Actions({actions, itemData, itemId}) {
 	const context = useContext(FrontendDataSetContext);
-	const {inlineEditingSettings, onActionDropdownItemClick} = context;
-
-	const [loading, setLoading] = useState(false);
-
 	const [
 		{
 			activeView: {quickActionsEnabled},
 		},
 	] = useContext(ViewsContext);
+
+	const {inlineEditingSettings, onActionDropdownItemClick} = context;
+
+	const [loading, setLoading] = useState(false);
 
 	const inlineEditingAvailable =
 		inlineEditingSettings && itemData.actions?.update;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
@@ -71,6 +71,7 @@ function ActionsDropdown({
 	setLoading,
 }) {
 	const context = useContext(FrontendDataSetContext);
+
 	const [menuActive, setMenuActive] = useState(false);
 
 	const inlineEditingAvailable =

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/ActiveViewSelector.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/ActiveViewSelector.js
@@ -22,9 +22,10 @@ import persistActiveView from '../../thunks/persistActiveView';
 import ViewsContext from '../../views/ViewsContext';
 
 function ActiveViewSelector({views}) {
-	const [active, setActive] = useState(false);
-	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
 	const {appURL, id, portletId} = useContext(FrontendDataSetContext);
+	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
+
+	const [active, setActive] = useState(false);
 
 	return (
 		<ClayDropDown

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CreationMenu.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CreationMenu.js
@@ -21,8 +21,9 @@ import FrontendDataSetContext from '../../FrontendDataSetContext';
 import {triggerAction} from '../../utils/actionItems/index';
 
 function CreationMenu({primaryItems}) {
-	const [active, setActive] = useState(false);
 	const frontendDataSetContext = useContext(FrontendDataSetContext);
+
+	const [active, setActive] = useState(false);
 
 	return (
 		primaryItems?.length > 0 && (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
@@ -64,41 +64,6 @@ const CustomViewsControls = () => {
 		</ClayForm.Group>
 	);
 
-	const ActionsItemList = () => (
-		<ClayDropDown.ItemList>
-			{activeCustomViewId && (
-				<ClayDropDown.Item
-					onClick={() => {
-						saveCustomView({
-							id: activeCustomViewId,
-						});
-
-						setActionsDropdownActive(false);
-					}}
-					symbolLeft="disk"
-				>
-					{Liferay.Language.get('save-view')}
-				</ClayDropDown.Item>
-			)}
-
-			<ClayDropDown.Item
-				onClick={openSaveCustomViewModal}
-				symbolLeft="disk"
-			>
-				{Liferay.Language.get('save-view-as')}
-			</ClayDropDown.Item>
-
-			{activeCustomViewId && (
-				<ClayDropDown.Item
-					onClick={openDeleteCustomViewModal}
-					symbolLeft="trash"
-				>
-					{Liferay.Language.get('delete-view')}
-				</ClayDropDown.Item>
-			)}
-		</ClayDropDown.ItemList>
-	);
-
 	const getNextCustomViewId = () => {
 		const ids = Object.keys(customViews);
 
@@ -333,10 +298,6 @@ const CustomViewsControls = () => {
 							{Liferay.Language.get('default-view')}
 						</ClayDropDown.Item>
 					</ClayDropDown.ItemList>
-
-					<ClayDropDown.Divider />
-
-					<ActionsItemList />
 				</ClayDropDown>
 			</ManagementToolbar.Item>
 
@@ -352,7 +313,38 @@ const CustomViewsControls = () => {
 						</ClayButton>
 					}
 				>
-					<ActionsItemList />
+					<ClayDropDown.ItemList>
+						{activeCustomViewId && (
+							<ClayDropDown.Item
+								onClick={() => {
+									saveCustomView({
+										id: activeCustomViewId,
+									});
+
+									setActionsDropdownActive(false);
+								}}
+								symbolLeft="disk"
+							>
+								{Liferay.Language.get('save-view')}
+							</ClayDropDown.Item>
+						)}
+
+						<ClayDropDown.Item
+							onClick={openSaveCustomViewModal}
+							symbolLeft="disk"
+						>
+							{Liferay.Language.get('save-view-as')}
+						</ClayDropDown.Item>
+
+						{activeCustomViewId && (
+							<ClayDropDown.Item
+								onClick={openDeleteCustomViewModal}
+								symbolLeft="trash"
+							>
+								{Liferay.Language.get('delete-view')}
+							</ClayDropDown.Item>
+						)}
+					</ClayDropDown.ItemList>
 				</ClayDropDown>
 			</ManagementToolbar.Item>
 		</>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
@@ -25,9 +25,6 @@ import ViewsContext from '../../views/ViewsContext';
 import {VIEWS_ACTION_TYPES} from '../../views/viewsReducer';
 
 const CustomViewsControls = () => {
-	const [viewsDropdownActive, setViewsDropdownActive] = useState(false);
-	const [actionsDropdownActive, setActionsDropdownActive] = useState(false);
-
 	const {appURL, id: fdsName, namespace, portletId} = useContext(
 		FrontendDataSetContext
 	);
@@ -44,6 +41,9 @@ const CustomViewsControls = () => {
 		},
 		viewsDispatch,
 	] = useContext(ViewsContext);
+
+	const [viewsDropdownActive, setViewsDropdownActive] = useState(false);
+	const [actionsDropdownActive, setActionsDropdownActive] = useState(false);
 
 	const customViewLabelInputRef = useRef();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/selectable_table/SelectableTable.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/selectable_table/SelectableTable.js
@@ -22,8 +22,8 @@ import React, {useContext, useEffect, useState} from 'react';
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 
 function SelectableTable({dataLoading, items: itemsProp, schema, style}) {
-	const {namespace} = useContext(FrontendDataSetContext);
-	const {selectedItemsKey} = useContext(FrontendDataSetContext);
+	const {namespace, selectedItemsKey} = useContext(FrontendDataSetContext);
+
 	const [items, setItems] = useState(null);
 
 	useEffect(() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.js
@@ -32,10 +32,11 @@ function InlineEditInputRenderer({
 	valuePath,
 	...otherProps
 }) {
+	const {itemsChanges, updateItem} = useContext(FrontendDataSetContext);
+
 	const [InputRenderer, setInputRenderer] = useState(() =>
 		getInputRendererById(type)
 	);
-	const {itemsChanges, updateItem} = useContext(FrontendDataSetContext);
 
 	useEffect(() => {
 		setInputRenderer(() => getInputRendererById(type));

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableInlineAddingRow.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableInlineAddingRow.js
@@ -28,6 +28,7 @@ function TableInlineAddingRow({fields, selectable}) {
 		toggleItemInlineEdit,
 		updateItem,
 	} = useContext(FrontendDataSetContext);
+
 	const isMounted = useIsMounted();
 	const [loading, setLoading] = useState(false);
 	const itemHasChanged =

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
@@ -22,7 +22,6 @@ import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
 import Context from './TableContext';
 
 function Cell({children, className, columnName, expand, heading, resizable}) {
-	const [{modifiedFields}, viewsDispatch] = useContext(ViewsContext);
 	const {
 		draggingAllowed,
 		draggingColumnName,
@@ -31,6 +30,7 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 		updateDraggingAllowed,
 		updateDraggingColumnName,
 	} = useContext(Context);
+	const [{modifiedFields}, viewsDispatch] = useContext(ViewsContext);
 
 	const cellRef = useRef();
 	const clientXRef = useRef({current: null});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Row.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Row.js
@@ -21,8 +21,8 @@ import Cell from './Cell';
 import TableContext from './TableContext';
 
 function Row({children, className, paddingLeftCells}) {
-	const [{modifiedFields}] = useContext(ViewsContext);
 	const {columnNames, isFixed} = useContext(TableContext);
+	const [{modifiedFields}] = useContext(ViewsContext);
 
 	const marginLeft = useMemo(() => {
 		let margin = 0;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Table.js
@@ -21,6 +21,7 @@ function Table({children, className}) {
 	const {draggingColumnName, isFixed, updateTableWidth} = useContext(
 		TableContext
 	);
+
 	const dndTableRef = useRef(null);
 
 	useLayoutEffect(() => {


### PR DESCRIPTION
### References

- [LPS-165637 Remove actions from FDS custom views selection](https://issues.liferay.com/browse/LPS-165637)

### What is the goal of this PR?

It's pretty self-explanatory: we are removing actions from custom views selection.

In addition, I took the opportunity to add a bit of "unofficial" SF. I like context usages as first in the component, this change makes it consistent in FDS. This is in a a separate commit.

### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/195858602-2790cd58-ef33-4efd-9455-513afc45352a.png)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/195858572-8d611791-fd99-46e7-b152-e3495df78bf8.png)

### Steps to reproduce
