### PR TITLE
LPS-164618 | Add Autom. test FDSCustomView#CanCreateMultiple

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -1,57 +1,9 @@
 definition {
 
-	macro addRemoveColumn {
-		Click(
-			ariaLabel = "Open Fields Menu",
-			locator1 = "Button#ANY_WITH_ARIA_LABEL");
-
-		Click(
-			key_column = "${key_column}",
-			locator1 = "FrontendDataSet#OPEN_SELECT_FIELD");
-
-		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-	}
-
-	macro createNewView {
-		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-		Click(
-			key_itemName = "Save View As",
-			locator1 = "FrontendDataSet#SELECT_OPTION");
-
-		Type(
-			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
-			value1 = "${key_nameView}");
-
-		Click(
-			key_name = "Save",
-			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
-	}
-
-	macro selectView {
-		Click(
-			locator1 = "FrontendDataSet#SELECT_OPTION",
-			value1 = "${key_itemName}");
-	}
-
 	macro assertCustomView {
 		AssertTextEquals(
 			locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
 			value1 = "${key_nameCustomView}");
-	}
-
-	macro verifyFilterSummaryLabel {
-		VerifyElementPresent(
-			value1 = "${key_filter}",
-			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
-	}
-
-	macro changeCustomView {
-		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-		Click(
-			key_optionName = "${key_optionName}",
-			locator1 = "FrontendDataSet#SELECT_OPTION");
 	}
 
 	macro compareValue {
@@ -71,8 +23,8 @@ definition {
 		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
 		Click(
-			key_optionName = "Save View As",
-			locator1 = "FrontendDataSet#SELECT_OPTION");
+			key_itemName = "Save View As",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 
 		Type(
 			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
@@ -96,15 +48,15 @@ definition {
 
 		Click(
 			key_optionName = "Save View",
-			locator1 = "FrontendDataSet#SELECT_OPTION");
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 	}
 
 	macro saveViewAs {
 		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
 		Click(
-			key_optionName = "Save View As",
-			locator1 = "FrontendDataSet#SELECT_OPTION");
+			key_itemName = "Save View As",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 
 		Type(
 			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
@@ -121,8 +73,14 @@ definition {
 			locator1 = "Button#ANY_WITH_ARIA_LABEL");
 
 		Click(
-			key_optionName = "${key_optionName}",
-			locator1 = "FrontendDataSet#SELECT_OPTION");
+			key_itemName = "${key_itemName}",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+	}
+
+	macro selectView {
+		Click(
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
+			value1 = "${key_itemName}");
 	}
 
 	macro verifyCustomView {
@@ -148,5 +106,13 @@ definition {
 			key_field = "${key_field}",
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
 	}
+
+	 macro changeCustomView {
+        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+		Click(
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
+			key_optionName = "${key_itemName}");
+    }
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -6,6 +6,14 @@ definition {
 			value1 = "${key_nameCustomView}");
 	}
 
+	macro changeCustomView {
+		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+		Click(
+			key_optionName = "${key_itemName}",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+	}
+
 	macro compareValue {
 		var dataSetValue1 = FDSCustomView.getValueByPosition(
 			columnIndex = "${key_columnIndex}",
@@ -106,13 +114,5 @@ definition {
 			key_field = "${key_field}",
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
 	}
-
-	 macro changeCustomView {
-        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-		Click(
-			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
-			key_optionName = "${key_itemName}");
-    }
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -40,9 +40,9 @@ definition {
 			value1 = "${key_nameCustomView}");
 	}
 
-	macro assertFilterSummaryLabel {
-		AssertElementPresent(
-			key_filter = "${key_filter}",
+	macro verifyFilterSummaryLabel {
+		VerifyElementPresent(
+			value1 = "${key_filter}",
 			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
 	}
 
@@ -55,16 +55,16 @@ definition {
 	}
 
 	macro compareValue {
-		var dataSetId1 = FDSCustomView.getIdByPosition(
-			column = "${key_column}",
-			index = "${key_index1}");
-		var dataSetId2 = FDSCustomView.getIdByPosition(
-			column = "${key_column}",
-			index = "${key_index2}");
+		var dataSetValue1 = FDSCustomView.getValueByPosition(
+			columnIndex = "${key_columnIndex}",
+			valueIndex = "${key_valueIndex1}");
+		var dataSetValue2 = FDSCustomView.getValueByPosition(
+			columnIndex = "${key_columnIndex}",
+			valueIndex = "${key_valueIndex2}");
 
 		TestUtils.isGreaterThan(
-			actual = "${dataSetId1}",
-			expected = "${dataSetId2}");
+			actual = "${dataSetValue1}",
+			expected = "${dataSetValue2}");
 	}
 
 	macro createNewView {
@@ -83,12 +83,12 @@ definition {
 			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
 	}
 
-	macro getIdByPosition {
-		var key_column = "${column}";
-		var key_index = "${index}";
-		var dataSetId = selenium.getText("FrontendDataSet#TABLE_CELL");
+	macro getValueByPosition {
+		var key_columnIndex = "${columnIndex}";
+		var key_valueIndex = "${valueIndex}";
+		var dataSetValue = selenium.getText("FrontendDataSet#TABLE_CELL");
 
-		return "${dataSetId}";
+		return "${dataSetValue}";
 	}
 
 	macro saveCustomView {
@@ -126,7 +126,7 @@ definition {
 	}
 
 	macro viewColumn {
-		AssertElementPresent(
+		VerifyElementPresent(
 			key_field = "${key_field}",
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -125,6 +125,18 @@ definition {
 			locator1 = "FrontendDataSet#SELECT_OPTION");
 	}
 
+	macro verifyCustomView {
+		VerifyElementPresent(
+			locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+			value1 = "${key_nameCustomView}");
+	}
+
+	macro verifyFilterSummaryLabel {
+		VerifyElementPresent(
+			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL",
+			value1 = "${key_filter}");
+	}
+
 	macro viewColumn {
 		VerifyElementPresent(
 			key_field = "${key_field}",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -7,7 +7,7 @@ definition {
 
 		Click(
 			key_column = "${key_column}",
-			locator1 = "FrontendDataSet#SELECT_FIELD");
+			locator1 = "FrontendDataSet#OPEN_SELECT_FIELD");
 
 		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -34,106 +34,107 @@ definition {
 			value1 = "${key_itemName}");
 	}
 
+	macro assertCustomView {
+		AssertTextEquals(
+			locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+			value1 = "${key_nameCustomView}");
+	}
 
+	macro assertFilterSummaryLabel {
+		AssertElementPresent(
+			key_filter = "${key_filter}",
+			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+	}
 
-    macro createNewView {
-        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+	macro changeCustomView {
+		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
-        Click(
-            locator1 = "FrontendDataSet#SELECT_OPTION",
-            key_optionName = "Save View As");
-        
-        Type(
-            locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
-            value1 = "${key_nameView}");
+		Click(
+			key_optionName = "${key_optionName}",
+			locator1 = "FrontendDataSet#SELECT_OPTION");
+	}
 
-        Click(
-            key_name = "Save",
-            locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
-    }
+	macro compareValue {
+		var dataSetId1 = FDSCustomView.getIdByPosition(
+			column = "${key_column}",
+			index = "${key_index1}");
+		var dataSetId2 = FDSCustomView.getIdByPosition(
+			column = "${key_column}",
+			index = "${key_index2}");
 
-    macro selectColumn {
-        Click(
-            ariaLabel = "Open Fields Menu",
+		TestUtils.isGreaterThan(
+			actual = "${dataSetId1}",
+			expected = "${dataSetId2}");
+	}
+
+	macro createNewView {
+		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+		Click(
+			key_optionName = "Save View As",
+			locator1 = "FrontendDataSet#SELECT_OPTION");
+
+		Type(
+			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
+			value1 = "${key_nameView}");
+
+		Click(
+			key_name = "Save",
+			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
+	}
+
+	macro getIdByPosition {
+		var key_column = "${column}";
+		var key_index = "${index}";
+		var dataSetId = selenium.getText("FrontendDataSet#TABLE_CELL");
+
+		return "${dataSetId}";
+	}
+
+	macro saveCustomView {
+		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+		Click(
+			key_optionName = "Save View",
+			locator1 = "FrontendDataSet#SELECT_OPTION");
+	}
+
+	macro saveViewAs {
+		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+		Click(
+			key_optionName = "Save View As",
+			locator1 = "FrontendDataSet#SELECT_OPTION");
+
+		Type(
+			locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
+			value1 = "${key_nameView}");
+
+		Click(
+			key_name = "Save",
+			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
+	}
+
+	macro selectColumn {
+		Click(
+			ariaLabel = "Open Fields Menu",
 			locator1 = "Button#ANY_WITH_ARIA_LABEL");
 
 		Click(
-            locator1 = "FrontendDataSet#SELECT_OPTION",
-			key_optionName = "${key_optionName}");	
-    }
+			key_optionName = "${key_optionName}",
+			locator1 = "FrontendDataSet#SELECT_OPTION");
+	}
 
-    macro getIdByPosition {
-        var key_column = "${column}";
-        var key_index = "${index}";
-
-        var dataSetId = selenium.getText("FrontendDataSet#TABLE_CELL");
-
-        return "${dataSetId}";
-    }
-
-    macro compareValue {
-        var dataSetId1 = FDSCustomView.getIdByPosition(index = "${key_index1}", column = "${key_column}");
-
-		var dataSetId2 = FDSCustomView.getIdByPosition(index = "${key_index2}", column = "${key_column}");
-
-		TestUtils.isGreaterThan(
-            actual = "${dataSetId1}",
-            expected = "${dataSetId2}");
-    }
-
-    macro changeCustomView {
-        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-		Click(
-			locator1 = "FrontendDataSet#SELECT_OPTION",
-			key_optionName = "${key_optionName}");
-    }
-
-    macro saveViewAs {
-        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-        Click(
-            locator1 = "FrontendDataSet#SELECT_OPTION",
-            key_optionName = "Save View As");
-
-        Type(
-            locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
-            value1 = "${key_nameView}");
-
-        Click(
-            key_name = "Save",
-            locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
-    }
-
-    macro saveCustomView {
-        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-        Click(
-            locator1 = "FrontendDataSet#SELECT_OPTION",
-            key_optionName = "Save View");
-    }
-
-    macro assertCustomView {
-        AssertTextEquals(
-            locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-            value1 = "${key_nameCustomView}");
-    }
-
-    macro viewColumn {
-        AssertElementPresent(
+	macro viewColumn {
+		AssertElementPresent(
 			key_field = "${key_field}",
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
-    }
+	}
 
-    macro viewNoColumn {
-        AssertElementNotPresent(
+	macro viewNoColumn {
+		AssertElementNotPresent(
 			key_field = "${key_field}",
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
-    }
+	}
 
-    macro assertFilterSummaryLabel {
-        AssertElementPresent(
-			key_filter = "${key_filter}",
-			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
-    }
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -34,4 +34,106 @@ definition {
 			value1 = "${key_itemName}");
 	}
 
+
+
+    macro createNewView {
+        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+        Click(
+            locator1 = "FrontendDataSet#SELECT_OPTION",
+            key_optionName = "Save View As");
+        
+        Type(
+            locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
+            value1 = "${key_nameView}");
+
+        Click(
+            key_name = "Save",
+            locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
+    }
+
+    macro selectColumn {
+        Click(
+            ariaLabel = "Open Fields Menu",
+			locator1 = "Button#ANY_WITH_ARIA_LABEL");
+
+		Click(
+            locator1 = "FrontendDataSet#SELECT_OPTION",
+			key_optionName = "${key_optionName}");	
+    }
+
+    macro getIdByPosition {
+        var key_column = "${column}";
+        var key_index = "${index}";
+
+        var dataSetId = selenium.getText("FrontendDataSet#TABLE_CELL");
+
+        return "${dataSetId}";
+    }
+
+    macro compareValue {
+        var dataSetId1 = FDSCustomView.getIdByPosition(index = "${key_index1}", column = "${key_column}");
+
+		var dataSetId2 = FDSCustomView.getIdByPosition(index = "${key_index2}", column = "${key_column}");
+
+		TestUtils.isGreaterThan(
+            actual = "${dataSetId1}",
+            expected = "${dataSetId2}");
+    }
+
+    macro changeCustomView {
+        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+		Click(
+			locator1 = "FrontendDataSet#SELECT_OPTION",
+			key_optionName = "${key_optionName}");
+    }
+
+    macro saveViewAs {
+        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+        Click(
+            locator1 = "FrontendDataSet#SELECT_OPTION",
+            key_optionName = "Save View As");
+
+        Type(
+            locator1 = "FrontendDataSet#INPUT_CUSTOM_VIEW_NAME",
+            value1 = "${key_nameView}");
+
+        Click(
+            key_name = "Save",
+            locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
+    }
+
+    macro saveCustomView {
+        Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+        Click(
+            locator1 = "FrontendDataSet#SELECT_OPTION",
+            key_optionName = "Save View");
+    }
+
+    macro assertCustomView {
+        AssertTextEquals(
+            locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+            value1 = "${key_nameCustomView}");
+    }
+
+    macro viewColumn {
+        AssertElementPresent(
+			key_field = "${key_field}",
+			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
+    }
+
+    macro viewNoColumn {
+        AssertElementNotPresent(
+			key_field = "${key_field}",
+			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
+    }
+
+    macro assertFilterSummaryLabel {
+        AssertElementPresent(
+			key_filter = "${key_filter}",
+			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+    }
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -28,7 +28,7 @@ definition {
 	}
 
 	macro createNewView {
-		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 
 		Click(
 			key_itemName = "Save View As",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -71,7 +71,7 @@ definition {
 
 			Pagination.viewResults(results = "Showing 1 to 4 of 25");
 
-			Click(locator1 = "FrontendDataSet#SELECT_FIELD");
+			Click(locator1 = "FrontendDataSet#OPEN_SELECT_FIELD");
 
 			Click(
 				key_itemName = "Description",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -13,8 +13,6 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
-
-		task ("Given Frontend Dataset sample portlet") {
 			JSONLayout.addPublicLayout(
 				groupName = "Guest",
 				layoutName = "Frontend Data Set Test Page");
@@ -30,7 +28,7 @@ definition {
 				layoutTemplate = "1 Column");
 
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
-		}
+
 	}
 
 	tearDown {
@@ -49,9 +47,6 @@ definition {
 	@description = "LPS-164617. Assert that it's possible to make changes in the FDS "
 	@priority = "4"
 	test CanBeEditted {
-
-		// To-do CanBeEditted Autom. test
-
 	}
 
 	@description = "LPS-164616. Assert that it's possible to create A new custom view and selected as current view"
@@ -106,9 +101,48 @@ definition {
 	@description = "LPS-164618. Assert that it's possible can edit a new instance was previously created"
 	@priority = "4"
 	test CanCreateMultiple {
+		task ("And Given A custom view is created and selected") {
+			FDSCustomView.createNewView(key_nameView = "FrontendDataSet View");
+		}
 
-		// To-do CanCreateMultiple Autom. test
+		task ("When Make some changes to dataset display (filter, sorting, page size or visible columns if data display in table)") {
+			FDSFilters.editFilters(key_filter = "Color", key_disableFilters = "Blue,Green,Yellow", key_enableFilters = "Red");
 
+			Click(
+				locator1 = "Icon#ANY",
+				key_text = "order-arrow-down");
+
+			Click(
+				locator1 = "Icon#ANY",
+				key_text = "order-arrow-down");
+
+			FDSCustomView.selectColumn(key_optionName = "Description");
+
+			Pagination.changePagination(itemsPerPage = "4 items");
+		}
+
+		task ("And Click Save as button, provide a name") {
+			FDSCustomView.createNewView(key_nameView = "FrontendDataSet View 2");
+		}
+
+		task ("Then A new custom view is created, and selected as current view") {
+			FDSCustomView.assertCustomView(key_nameCustomView = "FrontendDataSet View 2");
+
+			FDSCustomView.changeCustomView(key_optionName = "FrontendDataSet View");
+
+			FDSCustomView.assertFilterSummaryLabel(key_filter = "Color: Blue, Green, Yellow");
+
+			FDSCustomView.viewColumn(key_field = "Description");
+
+			FDSCustomView.changeCustomView(key_optionName = "FrontendDataSet View 2");
+
+			Pagination.viewResults(results = "Showing 1 to 4 of 25");
+
+			FDSCustomView.assertFilterSummaryLabel(key_filter = "Color: Red");
+
+			FDSCustomView.viewNoColumn(key_field = "Description");
+
+			FDSCustomView.compareValue(key_index1 = "1", key_index2 = "2", key_column = "2");
+		}
 	}
-
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -13,22 +13,22 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
-			JSONLayout.addPublicLayout(
-				groupName = "Guest",
-				layoutName = "Frontend Data Set Test Page");
 
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Frontend Data Set Test Page",
-				widgetName = "Frontend Data Set Sample");
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "Frontend Data Set Test Page");
 
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Frontend Data Set Test Page",
-				layoutTemplate = "1 Column");
+		JSONLayout.addWidgetToPublicLayout(
+			groupName = "Guest",
+			layoutName = "Frontend Data Set Test Page",
+			widgetName = "Frontend Data Set Sample");
 
-			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		JSONLayout.updateLayoutTemplateOfPublicLayout(
+			groupName = "Guest",
+			layoutName = "Frontend Data Set Test Page",
+			layoutTemplate = "1 Column");
 
+		Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 	}
 
 	tearDown {
@@ -106,15 +106,18 @@ definition {
 		}
 
 		task ("When Make some changes to dataset display (filter, sorting, page size or visible columns if data display in table)") {
-			FDSFilters.editFilters(key_filter = "Color", key_disableFilters = "Blue,Green,Yellow", key_enableFilters = "Red");
+			FDSFilters.editFilters(
+				key_disableFilters = "Blue,Green,Yellow",
+				key_enableFilters = "Red",
+				key_filter = "Color");
 
 			Click(
-				locator1 = "Icon#ANY",
-				key_text = "order-arrow-down");
+				key_text = "order-arrow-down",
+				locator1 = "Icon#ANY");
 
 			Click(
-				locator1 = "Icon#ANY",
-				key_text = "order-arrow-down");
+				key_text = "order-arrow-down",
+				locator1 = "Icon#ANY");
 
 			FDSCustomView.selectColumn(key_optionName = "Description");
 
@@ -142,7 +145,11 @@ definition {
 
 			FDSCustomView.viewNoColumn(key_field = "Description");
 
-			FDSCustomView.compareValue(key_index1 = "1", key_index2 = "2", key_column = "2");
+			FDSCustomView.compareValue(
+				key_column = "2",
+				key_index1 = "1",
+				key_index2 = "2");
 		}
 	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -78,14 +78,16 @@ definition {
 		task ("And When Save As the custom view") {
 			FDSCustomView.createNewView(key_nameView = "TEST");
 
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 
 			Click(
 				key_itemName = "Save View",
-				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 		}
 
 		task ("Then A new custom view is created and selected as current view") {
+			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
 			FDSCustomView.selectView(key_itemName = "Default View");
 
 			AssertElementPresent(

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -12,23 +12,25 @@ definition {
 	setUp {
 		TestCase.setUpPortalInstance();
 
-		User.firstLoginPG();
+		task ("Given Custom view enabled for a dataset display instance") {
+			User.firstLoginPG();
 
-		JSONLayout.addPublicLayout(
-			groupName = "Guest",
-			layoutName = "Frontend Data Set Test Page");
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
 
-		JSONLayout.addWidgetToPublicLayout(
-			groupName = "Guest",
-			layoutName = "Frontend Data Set Test Page",
-			widgetName = "Frontend Data Set Sample");
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
 
-		JSONLayout.updateLayoutTemplateOfPublicLayout(
-			groupName = "Guest",
-			layoutName = "Frontend Data Set Test Page",
-			layoutTemplate = "1 Column");
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
 
-		Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
 	}
 
 	tearDown {
@@ -129,11 +131,11 @@ definition {
 		}
 
 		task ("Then A new custom view is created, and selected as current view") {
-			FDSCustomView.assertCustomView(key_nameCustomView = "FrontendDataSet View 2");
+			FDSCustomView.verifyCustomView(key_nameCustomView = "FrontendDataSet View 2");
 
 			FDSCustomView.changeCustomView(key_optionName = "FrontendDataSet View");
 
-			FDSCustomView.assertFilterSummaryLabel(key_filter = "Color: Blue, Green, Yellow");
+			FDSCustomView.verifyFilterSummaryLabel(key_filter = "Color: Blue, Green, Yellow");
 
 			FDSCustomView.viewColumn(key_field = "Description");
 
@@ -141,14 +143,14 @@ definition {
 
 			Pagination.viewResults(results = "Showing 1 to 4 of 25");
 
-			FDSCustomView.assertFilterSummaryLabel(key_filter = "Color: Red");
+			FDSCustomView.verifyFilterSummaryLabel(key_filter = "Color: Red");
 
 			FDSCustomView.viewNoColumn(key_field = "Description");
 
 			FDSCustomView.compareValue(
-				key_column = "2",
-				key_index1 = "1",
-				key_index2 = "2");
+				key_columnIndex = "2",
+				key_valueIndex1 = "1",
+				key_valueIndex2 = "2");
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -68,11 +68,11 @@ definition {
 
 			Pagination.viewResults(results = "Showing 1 to 4 of 25");
 
-			Click(locator1 = "FrontendDataSet#OPEN_SELECT_FIELD");
+			Click(locator1 = "FrontendDataSet#SELECT_FIELD");
 
 			Click(
 				key_itemName = "Description",
-				locator1 = "FrontendDataSet#SELECT_OPTION");
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 		}
 
 		task ("And When Save As the custom view") {
@@ -82,7 +82,7 @@ definition {
 
 			Click(
 				key_itemName = "Save View",
-				locator1 = "FrontendDataSet#SELECT_OPTION");
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 		}
 
 		task ("Then A new custom view is created and selected as current view") {
@@ -121,7 +121,7 @@ definition {
 				key_text = "order-arrow-down",
 				locator1 = "Icon#ANY");
 
-			FDSCustomView.selectColumn(key_optionName = "Description");
+			FDSCustomView.selectColumn(key_itemName = "Description");
 
 			Pagination.changePagination(itemsPerPage = "4 items");
 		}
@@ -133,13 +133,13 @@ definition {
 		task ("Then A new custom view is created, and selected as current view") {
 			FDSCustomView.verifyCustomView(key_nameCustomView = "FrontendDataSet View 2");
 
-			FDSCustomView.changeCustomView(key_optionName = "FrontendDataSet View");
+			FDSCustomView.changeCustomView(key_itemName = "FrontendDataSet View");
 
 			FDSCustomView.verifyFilterSummaryLabel(key_filter = "Color: Blue, Green, Yellow");
 
 			FDSCustomView.viewColumn(key_field = "Description");
 
-			FDSCustomView.changeCustomView(key_optionName = "FrontendDataSet View 2");
+			FDSCustomView.changeCustomView(key_itemName = "FrontendDataSet View 2");
 
 			Pagination.viewResults(results = "Showing 1 to 4 of 25");
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -213,6 +213,11 @@
 	<td>xpath=(//div[@class='dnd-td' and position()='${key_columnIndex}'])[${key_valueIndex}]</td>
 	<td></td>
 </tr>
+<tr>
+    <td>SELECT_OPTION_HEADER</td>
+    <td>//*[@class="dropdown custom-views-actions"]</td>
+    <td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -210,7 +210,7 @@
 </tr>
 <tr>
 	<td>TABLE_CELL</td>
-	<td>xpath=(//div[@class='dnd-td' and position()='${key_column}'])[${key_index}]</td>
+	<td>xpath=(//div[@class='dnd-td' and position()='${key_columnIndex}'])[${key_valueIndex}]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -169,12 +169,22 @@
 	<td></td>
 </tr>
 <tr>
+	<td>TABLE_ROW</td>
+	<td>//div[contains(@class, "dnd-tr")]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TABLE_ITEM_COLUMN</td>
+	<td>//div[(@class="dnd-tr")]/div[contains(@class,"dnd-th") and contains(string(), "${key_field}")]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>SORT_FIELD</td>
 	<td>//button[contains(@class, "btn-sorting") and contains(text(), "${key_field}")]</td>
 	<td></td>
 </tr>
 <tr>
-	<td>SELECT_FIELD</td>
+	<td>OPEN_SELECT_FIELD</td>
 	<td>//button[contains(@aria-label, "Open Fields Menu")]</td>
 	<td></td>
 </tr>
@@ -185,7 +195,7 @@
 </tr>
 <tr>
 	<td>SELECT_OPTION</td>
-	<td>//button[contains(@class,'dropdown-item') and contains(text(), '${key_itemName}')]</td>
+	<td>//button[contains(@class,'dropdown-item') and contains(text(), '${key_optionName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -196,6 +206,11 @@
 <tr>
 	<td>COLUMN_NAME</td>
 	<td>//div[contains(text(),${columnName})]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TABLE_CELL</td>
+	<td>xpath=(//div[@class='dnd-td' and position()='${key_column}'])[${key_index}]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -205,7 +205,7 @@
 </tr>
 <tr>
 	<td>COLUMN_NAME</td>
-	<td>//div[contains(text(),${columnName})]</td>
+	<td>//div[contains(text(),'${columnName}')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -214,9 +214,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>SELECT_OPTION_HEADER</td>
-    <td>//*[@class="dropdown custom-views-actions"]</td>
-    <td></td>
+	<td>SELECT_OPTION_HEADER</td>
+	<td>//*[@class="dropdown custom-views-actions"]</td>
+	<td></td>
 </tr>
 </tbody>
 </table>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -184,7 +184,7 @@
 	<td></td>
 </tr>
 <tr>
-	<td>OPEN_SELECT_FIELD</td>
+	<td>SELECT_FIELD</td>
 	<td>//button[contains(@aria-label, "Open Fields Menu")]</td>
 	<td></td>
 </tr>
@@ -194,8 +194,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>SELECT_OPTION</td>
-	<td>//button[contains(@class,'dropdown-item') and contains(text(), '${key_optionName}')]</td>
+	<td>SELECT_OPTION_CUSTOM_VIEW</td>
+	<td>//button[contains(@class,'dropdown-item') and contains(text(), '${key_itemName}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Test Plan**

- Given Custom view enabled for a dataset display instance
- And Given A custom view is created and selected
- When Make some changes to dataset display (filter, sorting, page size or visible columns if data display in table)
- And Click Save as button, provide a name
- Then A new custom view is created, and selected as current view

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-164618