### PR TITLE
Urgent Accessibility HR_56 | LPS-165503 set sidenav display to none for focus accessibility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -673,6 +673,7 @@ SideNavigation.prototype = {
 
 		if (closed) {
 			setStyles(menu, {
+				display: 'none',
 				width: px(width),
 			});
 
@@ -1229,6 +1230,10 @@ SideNavigation.prototype = {
 		}
 
 		this.setWidth();
+
+		setStyles(menu, {
+			display: 'block',
+		});
 	},
 
 	showSimpleSidenav() {
@@ -1359,6 +1364,10 @@ SideNavigation.prototype = {
 					'closed.lexicon.sidenav',
 					instance
 				);
+
+				setStyles(menu, {
+					display: 'none',
+				});
 			}
 			else {
 				setClasses(toggler, {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-165503

The issue is we are unable to `Tab` through the page since the focus would get stuck right before the right sidenav. This is due to the sidenav `visibility: hidden`.
I was able to resolve this by setting the `display: none` to the sidenav whenever it is hidden. This allows the focus to continue through the page. When it is open, I then set the `display: block`.

Please let me know if there are any questions or comments about this.
Thank you!