### PR TITLE
[TS] LPS-162394

### DIFF
--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/UpdateCertificateMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/UpdateCertificateMVCActionCommand.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -104,7 +105,7 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 			_importCertificate(actionRequest, themeDisplay.getUser());
 		}
 		else if (cmd.equals("replace")) {
-			_replaceCertificate(actionRequest);
+			_replaceCertificate(actionRequest, actionResponse);
 		}
 	}
 
@@ -283,8 +284,11 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 			SamlWebKeys.SAML_X509_CERTIFICATE, x509Certificate);
 	}
 
-	private void _replaceCertificate(ActionRequest actionRequest)
+	private void _replaceCertificate(
+			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
+
+		hideDefaultSuccessMessage(actionRequest);
 
 		UnicodeProperties unicodeProperties = PropertiesParamUtil.getProperties(
 			actionRequest, "settings--");
@@ -351,6 +355,8 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 
 		actionRequest.setAttribute(
 			SamlWebKeys.SAML_X509_CERTIFICATE, x509Certificate);
+
+		actionResponse.setWindowState(LiferayWindowState.EXCLUSIVE);
 	}
 
 	private static final String _SHA256_PREFIX = "SHA256with";

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/update_certificate.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/update_certificate.jsp
@@ -24,14 +24,14 @@ LocalEntityManager.CertificateUsage certificateUsage = LocalEntityManager.Certif
 X509Certificate x509Certificate = (X509Certificate)request.getAttribute(SamlWebKeys.SAML_X509_CERTIFICATE);
 %>
 
-<aui:script>
+<script>
 	window['<portlet:namespace />requestCloseDialog'] = function (stateChange) {
-		Liferay.Util.getOpener().<portlet:namespace />closeDialog(
+		parent.window.<portlet:namespace />closeDialog(
 			'<portlet:namespace />certificateDialog',
 			stateChange
 		);
 	};
-</aui:script>
+</script>
 
 <c:if test='<%= cmd.equals("replace") || cmd.equals("import") %>'>
 	<clay:navigation-bar


### PR DESCRIPTION
Update to previous pull request https://github.com/liferay-frontend/liferay-portal/pull/2700 which should only affect the "replace" certificate command.

Also switched to `parent.window` instead of `Liferay.Util.getOpener()` due to a new React error that occurs in `frontend-js-state-web` that occurs when `aui:script` is present.

## Steps to reproduce

1. Go to [Control Panel -> SAML Admin]
1. Add any Entity ID
1. Create Certificate
1. Add Common Name
1. Add Key Password
1. Save

## Solution notes

https://liferay.slack.com/archives/CNBG06JS3/p1649760991802989

Based on testing, the issue was introduced when we switched to the v4 loader.

* 7.0 - not reproducible
* 7.1 - reproducible if loader v4 is enabled in system settings
* 7.2 - reproducible
* 7.3 - reproducible
* 7.4 - reproducible