### PR TITLE
LPS-165964 - set opacity to 1 for editable portlets to address accessibility problems

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_topper.scss
@@ -95,7 +95,7 @@ html#{$cadmin-selector} {
 			}
 
 			.portlet-content-editable {
-				opacity: 0.5;
+				opacity: 1;
 			}
 		}
 	}


### PR DESCRIPTION
Hi @liferay-frontend,

https://issues.liferay.com/browse/LPS-165964

The client has reported that due to the lowered opacity on certain editable portlets, the colors shown on web content displays and  asset publishers that do not have content yet are not ADA accessible. The colors in these portlets have a contrast rating of ~2, below the 4.5 limit for WCAG AA compliance. I've therefore set the opacity of these specific portlets to full opacity which brings us back to a contrast ratio of 4.57. While this technically removes the visual cue that these portlets may not be active since they are 'grayed out' in essence, this does mean we are back in ADA compliance. Please let me know if you have any questions or concerns. Thanks!