### PR TITLE
LPS-156893 Escape the_title at render time

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -69,7 +69,7 @@
 		</#if>
 
 		<section class="${portal_content_css_class} flex-fill" id="content">
-			<h2 class="sr-only" role="heading" aria-level="1">${the_title}</h2>
+			<h2 class="sr-only" role="heading" aria-level="1">${htmlUtil.escape(the_title)}</h2>
 
 			<#if selectable>
 				<@liferay_util["include"] page=content_include />

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
@@ -46,7 +46,7 @@
 	</header>
 
 	<section id="content">
-		<h2 class="hide-accessible sr-only" role="heading" aria-level="1">${the_title}</h2>
+		<h2 class="hide-accessible sr-only" role="heading" aria-level="1">${htmlUtil.escape(the_title)}</h2>
 
 		<#if selectable>
 			<@liferay_util["include"] page=content_include />


### PR DESCRIPTION
### References

- https://issues.liferay.com/browse/LPS-156893

### What is the goal of this PR?

We want to fix a security vulnerability (please see the private LPS for details)

Notes:

- I preferred this approach over escaping [when computing the value](https://github.com/liferay/liferay-portal/blob/f79d0732d64007ef88e86ae56c728d2289957a1b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl#L263) because
  - That value gets calculated in [different ways](https://github.com/liferay/liferay-portal/blob/f79d0732d64007ef88e86ae56c728d2289957a1b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/init.ftl#L230-L269), so we'd cover all of them. 
  - Also, the value goes to many different places such as the portlet display object which is later encoded before boing outputted to the frontend, so here we're basically honoring that pattern too.