### PR TITLE
LPS-165632 Make MT creation menu items navigable with arrow keys

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -25,6 +25,75 @@ import LinkOrButton from './LinkOrButton';
 
 import './CreationMenu.scss';
 
+const Item = ({item, onClick}) => {
+	return (
+		<ClayDropDown.Item
+			href={item.href}
+			onClick={(event) => {
+				onClick(event, {item});
+			}}
+			symbolLeft={item.icon}
+			{...getDataAttributes(item.data)}
+		>
+			{unescapeHTML(item.label)}
+		</ClayDropDown.Item>
+	);
+};
+
+const ItemList = ({
+	onItemClick,
+	primaryItems,
+	secondaryItems,
+	visibleItemsCount,
+}) => {
+	let currentItemCount = 0;
+
+	return (
+		<ClayDropDown.ItemList
+			className={classNames({
+				'dropdown-menu-indicator-start': primaryItems.some(
+					(item) => item.icon
+				),
+			})}
+		>
+			{primaryItems?.map((item, index) => {
+				currentItemCount++;
+
+				if (currentItemCount > visibleItemsCount) {
+					return false;
+				}
+
+				return <Item item={item} key={index} />;
+			})}
+
+			{secondaryItems?.map((secondaryItemsGroup, index) => (
+				<ClayDropDown.Group
+					header={secondaryItemsGroup.label}
+					key={index}
+				>
+					{secondaryItemsGroup.items.map((item, index) => {
+						currentItemCount++;
+
+						if (currentItemCount > visibleItemsCount) {
+							return false;
+						}
+
+						return (
+							<Item
+								item={item}
+								key={index}
+								onClick={onItemClick}
+							/>
+						);
+					})}
+
+					{secondaryItemsGroup.separator && <ClayDropDown.Divider />}
+				</ClayDropDown.Group>
+			))}
+		</ClayDropDown.ItemList>
+	);
+};
+
 const CreationMenu = ({
 	maxPrimaryItems,
 	maxSecondaryItems,
@@ -105,66 +174,6 @@ const CreationMenu = ({
 		getVisibleItemsCount()
 	);
 
-	const Item = ({item}) => {
-		return (
-			<ClayDropDown.Item
-				href={item.href}
-				onClick={(event) => {
-					onCreationMenuItemClick(event, {item});
-				}}
-				symbolLeft={item.icon}
-				{...getDataAttributes(item.data)}
-			>
-				{unescapeHTML(item.label)}
-			</ClayDropDown.Item>
-		);
-	};
-
-	const ItemList = () => {
-		let currentItemCount = 0;
-
-		return (
-			<ClayDropDown.ItemList
-				className={classNames({
-					'dropdown-menu-indicator-start': primaryItems.some(
-						(item) => item.icon
-					),
-				})}
-			>
-				{primaryItems?.map((item, index) => {
-					currentItemCount++;
-
-					if (currentItemCount > visibleItemsCount) {
-						return false;
-					}
-
-					return <Item item={item} key={index} />;
-				})}
-
-				{secondaryItems?.map((secondaryItemsGroup, index) => (
-					<ClayDropDown.Group
-						header={secondaryItemsGroup.label}
-						key={index}
-					>
-						{secondaryItemsGroup.items.map((item, index) => {
-							currentItemCount++;
-
-							if (currentItemCount > visibleItemsCount) {
-								return false;
-							}
-
-							return <Item item={item} key={index} />;
-						})}
-
-						{secondaryItemsGroup.separator && (
-							<ClayDropDown.Divider />
-						)}
-					</ClayDropDown.Group>
-				))}
-			</ClayDropDown.ItemList>
-		);
-	};
-
 	return (
 		<>
 			{totalItemsCountRef.current > 1 ? (
@@ -202,6 +211,7 @@ const CreationMenu = ({
 						<>
 							<div className="inline-scroller">
 								<ItemList
+									onItemClick={onCreationMenuItemClick}
 									primaryItems={primaryItems}
 									secondaryItems={secondaryItems}
 									visibleItemsCount={visibleItemsCount}
@@ -241,7 +251,7 @@ const CreationMenu = ({
 						</>
 					) : (
 						<ItemList
-							onCreationMenuItemClick={onCreationMenuItemClick}
+							onItemClick={onCreationMenuItemClick}
 							primaryItems={primaryItems}
 							secondaryItems={secondaryItems}
 							visibleItemsCount={totalItemsCountRef.current}


### PR DESCRIPTION
### References

- [LPS-165632](https://issues.liferay.com/browse/LPS-165632)

### What is the goal?

* Make MT creation menu accessible with arrow keys

### What does it look like?

https://user-images.githubusercontent.com/6642927/197020457-a2d38d21-e442-46e8-82cb-8ea0f18b9ba2.mov


### How to replicate
* Go to `Content & Data > Documents and Media` or `Content & Data > Web Content`
* Click on `+` or `New` button 
* See that if you click up/down arrow keys, the focus moves between the elements in the drop down menu


### Notes
I don't really know what is causing this bug. The only thing I've noticed is that, since the `Item` and `ItemList` components were defined inside the `CreationMenu` function, React cannot keep track of the changes, so the drop down menu's contents are re-mounted, resulting in different internal IDs when opening/closing the drop down:

https://user-images.githubusercontent.com/6642927/197145917-c9a7395c-16be-4f86-9607-5da2d7b159f4.mov

Why this would break the navigation I don't know, because the result is semantically correct regardless of when it's mounted. I even tried looking in React's source code because the only relevant subscription to the `keydown` event is there (this screencap is without the bugfix):

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/6642927/197146327-0b087b23-38f2-4531-8faa-dca40757fe9a.png">

Which I'm pretty sure corresponds to [this line in React's source code](https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/events/ReactDOMEventListener.js#L132-L148). But I found this when it was 8PM and I had a headache 😅.

Moving the child components outside the `CreationMenu` works, so 🤷‍♀️. I might go back down this rabbit hole to understand this behaviour once I've completed the tasks in this sprint.