### PR TITLE
LPS-160159 | Add test CanBeSelected

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -102,6 +102,55 @@ definition {
 		}
 	}
 
+	@description = "LPS-160159. Assert that it's possible to select a new custom view and selected the default view"
+	@priority = "4"
+	test CanBeSelected {
+		task ("Given FDS sample portlet deployed and given customized tab active") {
+			AssertElementPresent(
+				key_tabName = "Customized",
+				locator1 = "StagingPublishToLive#ACTIVE_TAB_NAME");
+		}
+
+		task ("When open menu to select created custom view") {
+			FDSFilters.editFilters(
+				key_disableFilters = "Blue,Green,Yellow",
+				key_enableFilters = "Red",
+				key_filter = "Color");
+
+			FDSCustomView.createNewView(key_nameView = "Custom Test");
+
+			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+			Click(
+				key_itemName = "Save View",
+				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+		}
+
+		task ("Then option to select default view is available") {
+			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+			Click(
+				key_itemName = "Default View",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+
+			AssertElementPresent(
+				key_wikiNodeName = "Default View",
+				locator1 = "Wiki#NODE_NAME");
+		}
+
+		task ("And Then option to select created custom view is available") {
+			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+			Click(
+				key_itemName = "Custom Test",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+
+			AssertElementPresent(
+				key_wikiNodeName = "Custom Test",
+				locator1 = "Wiki#NODE_NAME");
+		}
+	}
+
 	@description = "LPS-164618. Assert that it's possible can edit a new instance was previously created"
 	@priority = "4"
 	test CanCreateMultiple {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -105,49 +105,35 @@ definition {
 	@description = "LPS-160159. Assert that it's possible to select a new custom view and selected the default view"
 	@priority = "4"
 	test CanBeSelected {
-		task ("Given FDS sample portlet deployed and given customized tab active") {
+		task ("And Given FDS sample portlet deployed and given customized tab active") {
 			AssertElementPresent(
 				key_tabName = "Customized",
 				locator1 = "StagingPublishToLive#ACTIVE_TAB_NAME");
 		}
 
-		task ("When open menu to select created custom view") {
+		task ("And Given a created customized view") {
 			FDSFilters.editFilters(
 				key_disableFilters = "Blue,Green,Yellow",
 				key_enableFilters = "Red",
 				key_filter = "Color");
 
-			FDSCustomView.createNewView(key_nameView = "Custom Test");
+			FDSCustomView.createNewView(key_nameView = "Custom View Name");
+		}
 
+		task ("When open menu to select created custom view") {
 			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-			Click(
-				key_itemName = "Save View",
-				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 		}
 
 		task ("Then option to select default view is available") {
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-			Click(
-				key_itemName = "Default View",
-				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
-
-			AssertElementPresent(
-				key_wikiNodeName = "Default View",
-				locator1 = "Wiki#NODE_NAME");
+			AssertTextPresent(
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+				value1 = "Default View");
 		}
 
 		task ("And Then option to select created custom view is available") {
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-
-			Click(
-				key_itemName = "Custom Test",
-				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
-
-			AssertElementPresent(
-				key_wikiNodeName = "Custom Test",
-				locator1 = "Wiki#NODE_NAME");
+			AssertTextPresent(
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
+				value1 = "Custom View Name");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -85,6 +85,16 @@
 	<td>//*[contains(@class,'pagination-results')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>COLUMN_NAME</td>
+	<td>//div[contains(text(),'${columnName}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>TABLE_CELL</td>
+	<td>xpath=(//div[@class='dnd-td' and position()='${key_columnIndex}'])[${key_valueIndex}]</td>
+	<td></td>
+</tr>
 
 <!--FILTERS-->
 
@@ -188,6 +198,9 @@
 	<td>//button[contains(@aria-label, "Open Fields Menu")]</td>
 	<td></td>
 </tr>
+
+<!--CUSTOM VIEWS-->
+
 <tr>
 	<td>SELECT_CUSTOM_VIEW</td>
 	<td>//div[contains(@class,'custom-views-selection')]</td>
@@ -201,16 +214,6 @@
 <tr>
 	<td>INPUT_CUSTOM_VIEW_NAME</td>
 	<td>//input[contains(@id,'customViewLabelInput')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>COLUMN_NAME</td>
-	<td>//div[contains(text(),'${columnName}')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>TABLE_CELL</td>
-	<td>xpath=(//div[@class='dnd-td' and position()='${key_columnIndex}'])[${key_valueIndex}]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
**Background**
Make test that asserts that it's possible to select a new custom view and selected the default view

**Test Scenario**
_CanBeSelected_
Given FDS sample portlet deployed
//Frontend Data Set sample portlet
And Given customized tab active
//verify that customize tab is active
And Given a created customized view
When open menu to select created custom view
// click the name of current view to show dropdown
Then
option to select default view is available
//assert default view is present on the dropdown menu
And Then
option to select created custom view is available
//assert created custom view is present on the dropdown menu

https://issues.liferay.com/browse/LPS-160159


cc/ @bronsonsoda