### PR TITLE
LPS-165426 Make sure to always close the modal if the user press the done button

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -443,6 +443,9 @@ const openSelectionModal = ({
 					}
 				);
 			}
+			else {
+				processCloseFn();
+			}
 		}
 		else {
 			onSelect(selectedItem);


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-165426

This PR make sure that the modal is closed when the done button is clicked by the user. Otherwise we may end up in a situation where the button is enabled and doesn't do anything

Let me know what do you think 🤔  It may be other ways to fix this like disabling the button if the user hasn't selected any option, but that may be hard since there are a lot of implementations of the selectors