### PR TITLE
LPS - 166501 | Fix path used in OrderButtonAsAToggleCanDisplayTooltip test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -177,7 +177,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Message#TOOLTIP",
-				value1 = "Reverse Sort Direction");
+				value1 = "Reverse Order Direction");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/wysiwyg/ManagementToolbar.testcase
@@ -164,8 +164,8 @@ definition {
 
 		task ("And the button is changed to the other order direction") {
 			AssertElementPresent(
-				key_icon = "order-list-down",
-				locator1 = "ManagementBar#ORDER_TOGGLE_BUTTON");
+				key_text = "order-list-down",
+				locator1 = "ManagementBar#ANY_ICON");
 		}
 
 		task ("And a tooltip message will be displayed") {
@@ -177,7 +177,7 @@ definition {
 
 			AssertTextEquals(
 				locator1 = "Message#TOOLTIP",
-				value1 = "Reverse Order Direction");
+				value1 = "Reverse Sort Direction");
 		}
 	}
 


### PR DESCRIPTION
**Background**
Fix related to ManagementToolbar#OrderButtonAsAToggleCanDisplayTooltip test according to this [comment](https://github.com/liferay-frontend/liferay-portal/pull/2749#issuecomment-1284645658)

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-166501