### PR TITLE
LPS-165825 - Move focus to ResultsBar if it renders

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -16,7 +16,7 @@ import ClayLabel from '@clayui/label';
 import ClayLink from '@clayui/link';
 import {ManagementToolbar} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 
 const ResultsBar = ({
 	clearResultsURL,
@@ -24,13 +24,23 @@ const ResultsBar = ({
 	itemsTotal,
 	searchValue,
 }) => {
+	const resultsBarRef = useRef();
+
+	useEffect(() => {
+		resultsBarRef.current?.focus();
+	}, [searchValue]);
+
 	return (
 		<>
 			<ManagementToolbar.ResultsBar>
 				<ManagementToolbar.ResultsBarItem
 					expand={!(filterLabelItems?.length > 0)}
 				>
-					<span className="component-text text-truncate-inline">
+					<span
+						className="component-text text-truncate-inline"
+						ref={resultsBarRef}
+						tabIndex={0}
+					>
 						<span className="text-truncate">
 							{sub(
 								itemsTotal === 1


### PR DESCRIPTION
### References

- [LPS-165825](https://issues.liferay.com/browse/LPS-165825)

### What is the goal?

* Fix a11y issue in MT by moving focus to `ResultsBar` after searching

### What does it look like?

https://user-images.githubusercontent.com/6642927/197575149-2386fe9c-2711-401b-a499-b4697440c707.mov


### How to replicate
* Enable voiceover/JAWS
* Go to `Content & Data > Wen Content`
* Type something in the results bar and hit enter
* Check that the screen reader says `0 results for "something"`
* Check that if you tab, the focus doesn't start at the beginning of the page

### Notes
I'm not 100% sure this is the right element to make focusable, maybe it should be the results bar itself.