### PR TITLE
LPS-164602 | Add Autom. test FDSCustomView#ManagementBarCanBeLocalized

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -1,82 +1,105 @@
 definition {
+
 	macro addDateRangeFilters {
 		var key_fromDate = StringUtil.extractDigits("${key_fromDate}");
 		var key_toDate = StringUtil.extractDigits("${key_toDate}");
+
 		if (IsElementPresent(key_filter = "Date Range", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(
 				key_filter = "Date Range",
 				locator1 = "FrontendDataSet#FILTER_OPTION");
 		}
+
 		Type.sendKeys(
 			key_dateId = "from-date",
 			locator1 = "FrontendDataSet#FILTER_DATE_RANGE",
 			value1 = "${key_fromDate}");
+
 		Type.sendKeys(
 			key_dateId = "to-date",
 			locator1 = "FrontendDataSet#FILTER_DATE_RANGE",
 			value1 = "${key_toDate}");
+
 		Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 	}
+
 	macro closeFilters {
 		if (IsElementNotPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
 			ClickNoError(locator1 = "FrontendDataSet#FILTER_BACK_NAVIGATION");
+
 			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
 		}
 		else if (IsElementPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
 			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
 		}
 	}
+
 	macro disableStatusFilters {
 		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(
 				key_filter = "Status",
 				locator1 = "FrontendDataSet#FILTER_OPTION");
 		}
+
 		for (var status : list "${key_status}") {
 			Uncheck.uncheckNotVisible(
 				key_status = "${status}",
 				locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
 		}
 	}
+
 	macro editFilters {
 		FDSFilters.openFilters();
+
 		FDSFilters.searchFilter(searchTerm = "${key_filter}");
+
 		Click(
 			key_filter = "${key_filter}",
 			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
+
 		FDSFilters.disableStatusFilters(key_status = "${key_disableFilters}");
+
 		FDSFilters.enableStatusFilters(key_status = "${key_enableFilters}");
+
 		Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
+
 		Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
+
 		FDSFilters.closeFilters();
 	}
+
 	macro enableStatusFilters {
 		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(
 				key_filter = "Status",
 				locator1 = "FrontendDataSet#FILTER_OPTION");
 		}
+
 		for (var status : list "${key_status}") {
 			Check.checkNotVisibleNoErrors(
 				key_status = "${status}",
 				locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
 		}
 	}
+
 	macro openFilters {
 		if (IsElementNotPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
 			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
 		}
 	}
+
 	macro removeAllFilters {
 		while (IsElementPresent(key_filter = "", locator1 = "FrontendDataSet#REMOVE_FILTER")) {
 			FDSFilters.removeFilter(key_filter = "");
 		}
 	}
+
 	macro removeFilter {
 		Click(
 			locator1 = "FrontendDataSet#REMOVE_FILTER",
 			value1 = "${key_filter}");
 	}
+
 	macro resetFilter {
 		if (!(isSet(reset_filter))) {
 			ClickNoError(
@@ -92,12 +115,14 @@ definition {
 
 	macro searchFilter {
 		VerifyElementPresent(locator1 = "ObjectPortlet#COLUMN_SEARCH_FIELD");
+
 		VerifyElementPresent(locator1 = "FrontendDataSet#FILTER_SEARCH_BUTTON");
+
 		Type(
 			locator1 = "ObjectPortlet#COLUMN_SEARCH_FIELD",
 			value1 = "${searchTerm}");
+
 		ClickNoError(locator1 = "FrontendDataSet#FILTER_SEARCH_BUTTON");
 	}
 
 }
-

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSFilters.macro
@@ -1,115 +1,103 @@
 definition {
-
 	macro addDateRangeFilters {
 		var key_fromDate = StringUtil.extractDigits("${key_fromDate}");
 		var key_toDate = StringUtil.extractDigits("${key_toDate}");
-
 		if (IsElementPresent(key_filter = "Date Range", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(
 				key_filter = "Date Range",
 				locator1 = "FrontendDataSet#FILTER_OPTION");
 		}
-
 		Type.sendKeys(
 			key_dateId = "from-date",
 			locator1 = "FrontendDataSet#FILTER_DATE_RANGE",
 			value1 = "${key_fromDate}");
-
 		Type.sendKeys(
 			key_dateId = "to-date",
 			locator1 = "FrontendDataSet#FILTER_DATE_RANGE",
 			value1 = "${key_toDate}");
-
 		Click(locator1 = "FrontendDataSet#ADD_FILTER_BUTTON");
 	}
-
 	macro closeFilters {
 		if (IsElementNotPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
 			ClickNoError(locator1 = "FrontendDataSet#FILTER_BACK_NAVIGATION");
-
 			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
 		}
 		else if (IsElementPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
 			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
 		}
 	}
-
 	macro disableStatusFilters {
 		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(
 				key_filter = "Status",
 				locator1 = "FrontendDataSet#FILTER_OPTION");
 		}
-
 		for (var status : list "${key_status}") {
 			Uncheck.uncheckNotVisible(
 				key_status = "${status}",
 				locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
 		}
 	}
-
 	macro editFilters {
 		FDSFilters.openFilters();
-
 		FDSFilters.searchFilter(searchTerm = "${key_filter}");
-
 		Click(
 			key_filter = "${key_filter}",
 			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL");
-
 		FDSFilters.disableStatusFilters(key_status = "${key_disableFilters}");
-
 		FDSFilters.enableStatusFilters(key_status = "${key_enableFilters}");
-
 		Click(locator1 = "FrontendDataSet#EDIT_FILTER_BUTTON");
-
 		Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
-
 		FDSFilters.closeFilters();
 	}
-
 	macro enableStatusFilters {
 		if (IsElementPresent(key_filter = "Status", locator1 = "FrontendDataSet#FILTER_OPTION")) {
 			Click(
 				key_filter = "Status",
 				locator1 = "FrontendDataSet#FILTER_OPTION");
 		}
-
 		for (var status : list "${key_status}") {
 			Check.checkNotVisibleNoErrors(
 				key_status = "${status}",
 				locator1 = "FrontendDataSet#STATUS_FILTER_CHECKBOX");
 		}
 	}
-
 	macro openFilters {
 		if (IsElementNotPresent(locator1 = "FrontendDataSet#FILTER_DROPDOWN")) {
 			Click(locator1 = "FrontendDataSet#FILTER_BUTTON");
 		}
 	}
-
 	macro removeAllFilters {
 		while (IsElementPresent(key_filter = "", locator1 = "FrontendDataSet#REMOVE_FILTER")) {
 			FDSFilters.removeFilter(key_filter = "");
 		}
 	}
-
 	macro removeFilter {
 		Click(
 			locator1 = "FrontendDataSet#REMOVE_FILTER",
 			value1 = "${key_filter}");
 	}
+	macro resetFilter {
+		if (!(isSet(reset_filter))) {
+			ClickNoError(
+				locator1 = "FrontendDataSet#RESET_FILTERS",
+				reset_filter = "Reset Filters");
+		}
+		else {
+			ClickNoError(
+				locator1 = "FrontendDataSet#RESET_FILTERS",
+				reset_filter = "${reset_filter}");
+		}
+	}
 
 	macro searchFilter {
 		VerifyElementPresent(locator1 = "ObjectPortlet#COLUMN_SEARCH_FIELD");
-
 		VerifyElementPresent(locator1 = "FrontendDataSet#FILTER_SEARCH_BUTTON");
-
 		Type(
 			locator1 = "ObjectPortlet#COLUMN_SEARCH_FIELD",
 			value1 = "${searchTerm}");
-
 		ClickNoError(locator1 = "FrontendDataSet#FILTER_SEARCH_BUTTON");
 	}
 
 }
+

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -192,5 +192,48 @@ definition {
 				key_valueIndex2 = "2");
 		}
 	}
+	@description = "LPS-164602 Frontend Dataset - column labels are not localized "
+    @priority = "4"
+    test ManagementBarCanBeLocalized {
+        task ("site URL localized to Spanish //localhost:8080/es/ and on a customized tab view") {
+            // Navigator.openSpecificURL(url = "http://localhost:8080/es/");
+			var portalURL = PropsUtil.get("portal.url");
+			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
+        }
+        task ("Filter button is localized ") {
+            AssertTextEquals(
+                locator1 = "FrontendDataSet#FILTER_BUTTON",
+                value1 = "Filtro");
+        }
+        task ("Search help text is localized ") {
+            AssertAttributeValue(
+                attribute1 = "placeholder",
+                key_placeholder = "Buscar",
+                locator1 = "FrontendDataSet#PLACEHOLDER",
+                value1 = "Buscar");
+        }
+        task ("Change Display dropdown items are localized") {
+            AssertTextEquals(
+                locator1 = "FrontendDataSet#FILTER_BUTTON",
+                value1 = "Filtro");
+        }
+        task ("Custom Views dropdown items are localized") {
+            Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+            AssertTextEquals(
+                locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+                value1 = "Vista por defecto");
+        }
+        task ("Ellipsis dropdown 'Save' is localized") {
+            Click(locator1 = "FrontendDataSet#ELLIPSIS");
+            AssertElementPresent(
+                key_itemName = "Guardar vista como",
+                locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+        }
+        task ("Reset Filters link is localized") {
+            AssertElementPresent(
+                locator1 = "FrontendDataSet#RESET_FILTERS",
+                reset_filter = "Restablecer filtros");
+        }
+    }
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -197,9 +197,7 @@ definition {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/ and when on a customized tab view") {
 			var portalURL = PropsUtil.get("portal.url");
 
-			Navigator.openURL(baseURL = "${portalURL}/es/home");
-
-			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+			Navigator.openSpecificURL(url = "${portalURL}/es/web/guest/frontend-data-set-test-page");
 		}
 
 		task ("Then Filter button is localized ") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -34,10 +34,6 @@ definition {
 	}
 
 	tearDown {
-		Navigator.openSpecificURL(url = "http://localhost:8080/en/home/");
-
-		var testPortalInstance = PropsUtil.get("test.portal.instance");
-
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
@@ -192,48 +188,57 @@ definition {
 				key_valueIndex2 = "2");
 		}
 	}
+
 	@description = "LPS-164602 Frontend Dataset - column labels are not localized "
-    @priority = "4"
-    test ManagementBarCanBeLocalized {
-        task ("site URL localized to Spanish //localhost:8080/es/ and on a customized tab view") {
-            // Navigator.openSpecificURL(url = "http://localhost:8080/es/");
+	@priority = "4"
+	test ManagementBarCanBeLocalized {
+		task ("site URL localized to Spanish //localhost:8080/es/ and on a customized tab view") {
 			var portalURL = PropsUtil.get("portal.url");
+
 			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
-        }
-        task ("Filter button is localized ") {
-            AssertTextEquals(
-                locator1 = "FrontendDataSet#FILTER_BUTTON",
-                value1 = "Filtro");
-        }
-        task ("Search help text is localized ") {
-            AssertAttributeValue(
-                attribute1 = "placeholder",
-                key_placeholder = "Buscar",
-                locator1 = "FrontendDataSet#PLACEHOLDER",
-                value1 = "Buscar");
-        }
-        task ("Change Display dropdown items are localized") {
-            AssertTextEquals(
-                locator1 = "FrontendDataSet#FILTER_BUTTON",
-                value1 = "Filtro");
-        }
-        task ("Custom Views dropdown items are localized") {
-            Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
-            AssertTextEquals(
-                locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-                value1 = "Vista por defecto");
-        }
-        task ("Ellipsis dropdown 'Save' is localized") {
-            Click(locator1 = "FrontendDataSet#ELLIPSIS");
-            AssertElementPresent(
-                key_itemName = "Guardar vista como",
-                locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
-        }
-        task ("Reset Filters link is localized") {
-            AssertElementPresent(
-                locator1 = "FrontendDataSet#RESET_FILTERS",
-                reset_filter = "Restablecer filtros");
-        }
-    }
+		}
+
+		task ("Filter button is localized ") {
+			AssertTextEquals(
+				locator1 = "FrontendDataSet#FILTER_BUTTON",
+				value1 = "Filtro");
+		}
+
+		task ("Search help text is localized ") {
+			AssertAttributeValue(
+				attribute1 = "placeholder",
+				key_placeholder = "Buscar",
+				locator1 = "FrontendDataSet#PLACEHOLDER",
+				value1 = "Buscar");
+		}
+
+		task ("Change Display dropdown items are localized") {
+			AssertTextEquals(
+				locator1 = "FrontendDataSet#FILTER_BUTTON",
+				value1 = "Filtro");
+		}
+
+		task ("Custom Views dropdown items are localized") {
+			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+
+			AssertTextEquals(
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+				value1 = "Vista por defecto");
+		}
+
+		task ("Ellipsis dropdown 'Save' is localized") {
+			Click(locator1 = "FrontendDataSet#ELLIPSIS");
+
+			AssertElementPresent(
+				key_itemName = "Guardar vista como",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+		}
+
+		task ("Reset Filters link is localized") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSet#RESET_FILTERS",
+				reset_filter = "Restablecer filtros");
+		}
+	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -34,6 +34,7 @@ definition {
 	}
 
 	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
@@ -192,19 +193,19 @@ definition {
 	@description = "LPS-164602 Frontend Dataset - column labels are not localized "
 	@priority = "4"
 	test ManagementBarCanBeLocalized {
-		task ("site URL localized to Spanish //localhost:8080/es/ and on a customized tab view") {
+		task ("And Given: site URL localized to Spanish //localhost:8080/es/ and when on a customized tab view") {
 			var portalURL = PropsUtil.get("portal.url");
 
 			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
 		}
 
-		task ("Filter button is localized ") {
+		task ("Then Filter button is localized ") {
 			AssertTextEquals(
 				locator1 = "FrontendDataSet#FILTER_BUTTON",
 				value1 = "Filtro");
 		}
 
-		task ("Search help text is localized ") {
+		task ("And Then Search help text is localized ") {
 			AssertAttributeValue(
 				attribute1 = "placeholder",
 				key_placeholder = "Buscar",
@@ -212,13 +213,13 @@ definition {
 				value1 = "Buscar");
 		}
 
-		task ("Change Display dropdown items are localized") {
+		task ("And Then Change Display dropdown items are localized") {
 			AssertTextEquals(
 				locator1 = "FrontendDataSet#FILTER_BUTTON",
 				value1 = "Filtro");
 		}
 
-		task ("Custom Views dropdown items are localized") {
+		task ("And Then Custom Views dropdown items are localized") {
 			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
 			AssertTextEquals(
@@ -226,7 +227,7 @@ definition {
 				value1 = "Vista por defecto");
 		}
 
-		task ("Ellipsis dropdown 'Save' is localized") {
+		task ("And Then Ellipsis dropdown 'Save' is localized") {
 			Click(locator1 = "FrontendDataSet#ELLIPSIS");
 
 			AssertElementPresent(
@@ -234,11 +235,10 @@ definition {
 				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 		}
 
-		task ("Reset Filters link is localized") {
+		task ("And Then Reset Filters link is localized") {
 			AssertElementPresent(
 				locator1 = "FrontendDataSet#RESET_FILTERS",
 				reset_filter = "Restablecer filtros");
 		}
 	}
-
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -1,16 +1,16 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-    property custom.properties = "upgrade.database.auto.run=false";
-    property osgi.modules.includes = "frontend-data-set-sample-web";
-    property portal.acceptance = "true";
-    property portal.release = "true";
-    property portal.upstream = "true";
-    property testray.component.names = "Frontend Dataset";
-    property testray.main.component.name = "Frontend Dataset";
+	property custom.properties = "upgrade.database.auto.run=false";
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
 
-    setUp {
-        TestCase.setUpPortalInstance();
+	setUp {
+		TestCase.setUpPortalInstance();
 
 		task ("Given Custom view enabled for a dataset display instance") {
 			User.firstLoginPG();
@@ -19,24 +19,24 @@ definition {
 				groupName = "Guest",
 				layoutName = "Frontend Data Set Test Page");
 
-            JSONLayout.addWidgetToPublicLayout(
-                groupName = "Guest",
-                layoutName = "Frontend Data Set Test Page",
-                widgetName = "Frontend Data Set Sample");
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
 
-            JSONLayout.updateLayoutTemplateOfPublicLayout(
-                groupName = "Guest",
-                layoutName = "Frontend Data Set Test Page",
-                layoutTemplate = "1 Column");
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
 
-            Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
-        }
-    }
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+	}
 
-    tearDown {
-        Navigator.openSpecificURL(url = "http://localhost:8080/en/home/");
+	tearDown {
+		Navigator.openSpecificURL(url = "http://localhost:8080/en/home/");
 
-        var testPortalInstance = PropsUtil.get("test.portal.instance");
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -1,16 +1,16 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "upgrade.database.auto.run=false";
-	property osgi.modules.includes = "frontend-data-set-sample-web";
-	property portal.acceptance = "true";
-	property portal.release = "true";
-	property portal.upstream = "true";
-	property testray.component.names = "Frontend Dataset";
-	property testray.main.component.name = "Frontend Dataset";
+    property custom.properties = "upgrade.database.auto.run=false";
+    property osgi.modules.includes = "frontend-data-set-sample-web";
+    property portal.acceptance = "true";
+    property portal.release = "true";
+    property portal.upstream = "true";
+    property testray.component.names = "Frontend Dataset";
+    property testray.main.component.name = "Frontend Dataset";
 
-	setUp {
-		TestCase.setUpPortalInstance();
+    setUp {
+        TestCase.setUpPortalInstance();
 
 		task ("Given Custom view enabled for a dataset display instance") {
 			User.firstLoginPG();
@@ -19,22 +19,24 @@ definition {
 				groupName = "Guest",
 				layoutName = "Frontend Data Set Test Page");
 
-			JSONLayout.addWidgetToPublicLayout(
-				groupName = "Guest",
-				layoutName = "Frontend Data Set Test Page",
-				widgetName = "Frontend Data Set Sample");
+            JSONLayout.addWidgetToPublicLayout(
+                groupName = "Guest",
+                layoutName = "Frontend Data Set Test Page",
+                widgetName = "Frontend Data Set Sample");
 
-			JSONLayout.updateLayoutTemplateOfPublicLayout(
-				groupName = "Guest",
-				layoutName = "Frontend Data Set Test Page",
-				layoutTemplate = "1 Column");
+            JSONLayout.updateLayoutTemplateOfPublicLayout(
+                groupName = "Guest",
+                layoutName = "Frontend Data Set Test Page",
+                layoutTemplate = "1 Column");
 
-			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
-		}
-	}
+            Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+        }
+    }
 
-	tearDown {
-		var testPortalInstance = PropsUtil.get("test.portal.instance");
+    tearDown {
+        Navigator.openSpecificURL(url = "http://localhost:8080/en/home/");
+
+        var testPortalInstance = PropsUtil.get("test.portal.instance");
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -196,8 +196,9 @@ definition {
 	test ManagementBarCanBeLocalized {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/ and when on a customized tab view") {
 			var portalURL = PropsUtil.get("portal.url");
-			
+
 			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
+
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -196,8 +196,9 @@ definition {
 	test ManagementBarCanBeLocalized {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/ and when on a customized tab view") {
 			var portalURL = PropsUtil.get("portal.url");
-
+			
 			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
 
 		task ("Then Filter button is localized ") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -197,7 +197,7 @@ definition {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/ and when on a customized tab view") {
 			var portalURL = PropsUtil.get("portal.url");
 
-			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
+			Navigator.openURL(baseURL = "${portalURL}/es/home");
 
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -35,6 +35,7 @@ definition {
 
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
@@ -241,4 +242,5 @@ definition {
 				reset_filter = "Restablecer filtros");
 		}
 	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSFilters.testcase
@@ -55,7 +55,7 @@ definition {
 		}
 
 		task ("Then all of them can be removed at once") {
-			ClickNoError(locator1 = "FrontendDataSet#RESET_FILTERS");
+			FDSFilters.resetFilter();
 		}
 
 		task ("Then the results will be displayed updated accordingly to it") {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -2,13 +2,11 @@
 <head>
 <title>FrontendDataSet</title>
 </head>
-
 <body>
 <table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FrontendDataSet</td></tr>
 </thead>
-
 <tbody>
 <tr>
 	<td>DELETE_ACTION_BUTTON</td>
@@ -95,6 +93,16 @@
 	<td>xpath=(//div[@class='dnd-td' and position()='${key_columnIndex}'])[${key_valueIndex}]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>PLACEHOLDER</td>
+	<td>//input[@placeholder='${key_placeholder}']</td>
+	<td></td>
+</tr>
+<tr>
+    <td>ELLIPSIS</td>
+    <td>//*[@class="dropdown custom-views-actions"]</td>
+    <td></td>
+</tr>
 
 <!--FILTERS-->
 
@@ -160,7 +168,7 @@
 </tr>
 <tr>
 	<td>RESET_FILTERS</td>
-	<td>//*[contains(@class,'management-bar')]//*[@type='button' and contains(text(), 'Reset Filters')]</td>
+	<td>//*[contains(@class,'management-bar')]//*[@type='button' and contains(text(), '${reset_filter}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -2,11 +2,13 @@
 <head>
 <title>FrontendDataSet</title>
 </head>
+
 <body>
 <table border="1" cellpadding="1" cellspacing="1">
 <thead>
 <tr><td rowspan="1" colspan="3">FrontendDataSet</td></tr>
 </thead>
+
 <tbody>
 <tr>
 	<td>DELETE_ACTION_BUTTON</td>
@@ -99,9 +101,9 @@
 	<td></td>
 </tr>
 <tr>
-    <td>ELLIPSIS</td>
-    <td>//*[@class="dropdown custom-views-actions"]</td>
-    <td></td>
+	<td>ELLIPSIS</td>
+	<td>//*[@class="dropdown custom-views-actions"]</td>
+	<td></td>
 </tr>
 
 <!--FILTERS-->


### PR DESCRIPTION
**Test Plan**

- Given: localized FDS sample portlet
- And Given: site URL localized to Spanish //localhost:8080/es/*
- When: on customized tab view
- Then: Filter button is localized //assert Filtro is present in first navbar-nav element
- And Then: Search help text is localized //assert Buscar is present in search field
- And Then: Change Display dropdown items are localized
- And Then: Custom Views dropdown items are localized
- And Then: Ellipsis dropdown "Save" is localized
- And Then: Reset Filters link is localized

**JIRA Ticket:
https://issues.liferay.com/browse/LPS-164602**