### PR TITLE
LPS-164601 | Add Autom. test FDSTable#HeadersCanBeLocalized

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -31,10 +31,6 @@ definition {
 
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
-
-		task ("And Given: site URL localized to Spanish //localhost:8080/es/*") {
-			Navigator.openSpecificURL(url = "http://localhost:8080/es/frontend-data-set-test-page/");
-		}
 	}
 
 	tearDown {
@@ -53,6 +49,12 @@ definition {
 	@description = "LPS-165727. Assert the details shown in the FDS table"
 	@priority = "4"
 	test HeadersCanBeLocalized {
+		task ("And Given: site URL localized to Spanish //localhost:8080/es/*") {
+			var portalURL = PropsUtil.get("portal.url");
+
+			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
+		}
+
 		task ("When: on classic tab view") {
 			Click(
 				key_sampleTab = "Clásico",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -28,8 +28,6 @@ definition {
 				groupName = "Guest",
 				layoutName = "Frontend Data Set Test Page",
 				layoutTemplate = "1 Column");
-
-			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
 	}
 
@@ -52,7 +50,7 @@ definition {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/*") {
 			var portalURL = PropsUtil.get("portal.url");
 
-			Navigator.openSpecificURL(url = "${portalURL}/es/home");
+			Navigator.openURL(baseURL = "${portalURL}/es/home");
 
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -50,9 +50,8 @@ definition {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/*") {
 			var portalURL = PropsUtil.get("portal.url");
 
-			Navigator.openURL(baseURL = "${portalURL}/es/home");
+			Navigator.openSpecificURL(url = "${portalURL}/es/web/guest/frontend-data-set-test-page");
 
-			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
 
 		task ("When: on classic tab view") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -60,9 +60,13 @@ definition {
 		}
 
 		task ("Then: There is no hyphen in any header text") {
-			AssertTextNotPresent(
-				locator1 = "FrontendDataSet#HEADER_ROW",
-				value1 = "-");
+			var header = selenium.getText("FrontendDataSet#HEADER_ROW");
+
+			var containsHyphen = StringUtil.contains("${header}", "-");
+
+			TestUtils.assertEquals(
+				actual = "${containsHyphen}",
+				expected = "false");
 		}
 
 		task ("And Then: First letter is capitalized for all headers and localized Spanish headers are present") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -55,32 +55,33 @@ definition {
 	test HeadersCanBeLocalized {
 		task ("When: on classic tab view") {
 			Click(
-			locator1 = "FrontendDataSet#FDS_DATASET",
-			key_sampleTab = "Clásico");	
+				key_sampleTab = "Clásico",
+				locator1 = "FrontendDataSet#FDS_DATASET");
 		}
 
 		task ("Then: There is no hyphen in any header text") {
 			AssertTextNotPresent(
-				locator1 = "FrontendDataSet#TABLE_ITEM_ROW",
 				key_itemName = "Nombre",
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW",
 				value1 = "-");
 		}
 
 		task ("And Then: First letter is capitalized for all headers and localized Spanish headers are present") {
 			AssertTextEquals.assertTextCaseSensitive(
-				locator1 = "FrontendDataSet#COLUMN_NAME",
 				key_columnName = "Nombre",
+				locator1 = "FrontendDataSet#COLUMN_NAME",
 				value1 = "Nombre");
 
 			AssertTextEquals.assertTextCaseSensitive(
-				locator1 = "FrontendDataSet#COLUMN_NAME",
 				key_columnName = "Apellido",
+				locator1 = "FrontendDataSet#COLUMN_NAME",
 				value1 = "Apellido");
 
 			AssertTextEquals.assertTextCaseSensitive(
-				locator1 = "FrontendDataSet#COLUMN_NAME",
 				key_columnName = "Dirección de correo",
+				locator1 = "FrontendDataSet#COLUMN_NAME",
 				value1 = "Dirección de correo");
 		}
 	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -51,7 +51,6 @@ definition {
 			var portalURL = PropsUtil.get("portal.url");
 
 			Navigator.openSpecificURL(url = "${portalURL}/es/web/guest/frontend-data-set-test-page");
-
 		}
 
 		task ("When: on classic tab view") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -52,7 +52,9 @@ definition {
 		task ("And Given: site URL localized to Spanish //localhost:8080/es/*") {
 			var portalURL = PropsUtil.get("portal.url");
 
-			Navigator.openSpecificURL(url = "${portalURL}/es/frontend-data-set-test-page/");
+			Navigator.openSpecificURL(url = "${portalURL}/es/home");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
 
 		task ("When: on classic tab view") {
@@ -70,18 +72,18 @@ definition {
 
 		task ("And Then: First letter is capitalized for all headers and localized Spanish headers are present") {
 			AssertTextEquals.assertTextCaseSensitive(
-				key_columnName = "Nombre",
-				locator1 = "FrontendDataSet#COLUMN_NAME",
+				key_field = "Nombre",
+				locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN",
 				value1 = "Nombre");
 
 			AssertTextEquals.assertTextCaseSensitive(
-				key_columnName = "Apellido",
-				locator1 = "FrontendDataSet#COLUMN_NAME",
+				key_field = "Apellido",
+				locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN",
 				value1 = "Apellido");
 
 			AssertTextEquals.assertTextCaseSensitive(
-				key_columnName = "Dirección de correo",
-				locator1 = "FrontendDataSet#COLUMN_NAME",
+				key_field = "Dirección de correo",
+				locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN",
 				value1 = "Dirección de correo");
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -31,6 +31,10 @@ definition {
 
 			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
 		}
+
+		task ("And Given: site URL localized to Spanish //localhost:8080/es/*") {
+			Navigator.openSpecificURL(url = "http://localhost:8080/es/frontend-data-set-test-page/");
+		}
 	}
 
 	tearDown {
@@ -49,9 +53,34 @@ definition {
 	@description = "LPS-165727. Assert the details shown in the FDS table"
 	@priority = "4"
 	test HeadersCanBeLocalized {
+		task ("When: on classic tab view") {
+			Click(
+			locator1 = "FrontendDataSet#FDS_DATASET",
+			key_sampleTab = "Clásico");	
+		}
 
-		// To-do HeadersCanBeLocalized Autom. test
+		task ("Then: There is no hyphen in any header text") {
+			AssertTextNotPresent(
+				locator1 = "FrontendDataSet#TABLE_ITEM_ROW",
+				key_itemName = "Nombre",
+				value1 = "-");
+		}
 
+		task ("And Then: First letter is capitalized for all headers and localized Spanish headers are present") {
+			AssertTextEquals.assertTextCaseSensitive(
+				locator1 = "FrontendDataSet#COLUMN_NAME",
+				key_columnName = "Nombre",
+				value1 = "Nombre");
+
+			AssertTextEquals.assertTextCaseSensitive(
+				locator1 = "FrontendDataSet#COLUMN_NAME",
+				key_columnName = "Apellido",
+				value1 = "Apellido");
+
+			AssertTextEquals.assertTextCaseSensitive(
+				locator1 = "FrontendDataSet#COLUMN_NAME",
+				key_columnName = "Dirección de correo",
+				value1 = "Dirección de correo");
+		}
 	}
-
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -63,8 +63,7 @@ definition {
 
 		task ("Then: There is no hyphen in any header text") {
 			AssertTextNotPresent(
-				key_itemName = "Nombre",
-				locator1 = "FrontendDataSet#TABLE_ITEM_ROW",
+				locator1 = "FrontendDataSet#HEADER_ROW",
 				value1 = "-");
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -231,6 +231,11 @@
 	<td>//*[@class="dropdown custom-views-actions"]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>HEADER_ROW</td>
+	<td>xpath=(//div[contains(@class, "dnd-tr")])[1]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>


### PR DESCRIPTION
**Test Plan**

- Given: localized FDS sample portlet
- And Given: site URL localized to Spanish //localhost:8080/es/*
- When: on classic tab view
- Then: There is no hyphen in any header text
- And Then: First letter is capitalized for all headers
- And Then: localized Spanish headers are present //all headers have been translated to Spanish

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-164601