### PR TITLE
LPS-166676 Fix error when clicking on Menu Item does not call the callback

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -63,7 +63,7 @@ const ItemList = ({
 					return false;
 				}
 
-				return <Item item={item} key={index} />;
+				return <Item item={item} key={index} onClick={onItemClick} />;
 			})}
 
 			{secondaryItems?.map((secondaryItemsGroup, index) => (


### PR DESCRIPTION
**Ticket**: [LPS-166676](https://issues.liferay.com/browse/LPS-166676)

When clicking on a Menu item, it was throwing the TypeError error for not finding the `onClick` function and not doing the desired action. It seems to be just a problem of not passing the callback to the `Item` component for the iteration of items in the `primaryItems`.

You can better see the behavior in the [video that demonstrates the error that is thrown on the console](https://issues.liferay.com/secure/attachment/472535/Bug%20dropdown.webm) and doing nothing when clicking on the item.

@tinycarol let me know if this is expected.