### PR TITLE
LPS-165903 The checkbox is visible in default page

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/AccountEntryAccountGroupManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/AccountEntryAccountGroupManagementToolbarDisplayContext.java
@@ -59,11 +59,6 @@ public class AccountEntryAccountGroupManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return false;
 	}

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/AccountUsersAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/AccountUsersAdminManagementToolbarDisplayContext.java
@@ -390,11 +390,6 @@ public class AccountUsersAdminManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isShowCreationMenu() {
 		return PortalPermissionUtil.contains(
 			_themeDisplay.getPermissionChecker(), ActionKeys.ADD_USER);

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/SelectAccountOrganizationsManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/SelectAccountOrganizationsManagementToolbarDisplayContext.java
@@ -52,11 +52,6 @@ public class SelectAccountOrganizationsManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	protected String getOrderByCol() {
 		return ParamUtil.getString(
 			liferayPortletRequest, getOrderByColParam(), "name");

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/SelectAccountUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/SelectAccountUsersManagementToolbarDisplayContext.java
@@ -129,11 +129,6 @@ public class SelectAccountUsersManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return !_selectAccountUsersDisplayContext.isSingleSelect();
 	}

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountEntriesManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountEntriesManagementToolbarDisplayContext.java
@@ -272,11 +272,6 @@ public class ViewAccountEntriesManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isShowCreationMenu() {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountEntryAddressesManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountEntryAddressesManagementToolbarDisplayContext.java
@@ -179,11 +179,6 @@ public class ViewAccountEntryAddressesManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isShowCreationMenu() {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountRolesManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountRolesManagementToolbarDisplayContext.java
@@ -140,11 +140,6 @@ public class ViewAccountRolesManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isShowCreationMenu() {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserManagementToolbarDisplayContext.java
@@ -208,11 +208,6 @@ public class AssetBrowserManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return _assetBrowserDisplayContext.isMultipleSelection();
 	}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanManagementToolbarDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanManagementToolbarDisplayContext.java
@@ -112,11 +112,6 @@ public class BatchPlannerPlanManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return false;
 	}

--- a/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/batch-planner/batch-planner-web/src/main/java/com/liferay/batch/planner/web/internal/display/context/BatchPlannerPlanTemplateManagementToolbarDisplayContext.java
@@ -108,11 +108,6 @@ public class BatchPlannerPlanTemplateManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	protected String getNavigation() {
 		return ParamUtil.getString(
 			liferayPortletRequest, getNavigationParam(), "all");

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -438,11 +438,6 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return false;
 	}

--- a/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/ViewDispatchLogManagementToolbarDisplayContext.java
+++ b/modules/apps/dispatch/dispatch-web/src/main/java/com/liferay/dispatch/web/internal/display/context/ViewDispatchLogManagementToolbarDisplayContext.java
@@ -69,11 +69,6 @@ public class ViewDispatchLogManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	protected String[] getOrderByKeys() {
 		return new String[] {"modified-date", "status"};
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 12.1.11
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -84,5 +84,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "12.1.11"
+	"version": "13.0.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/SearchContainerManagementToolbarDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/SearchContainerManagementToolbarDisplayContext.java
@@ -17,8 +17,6 @@ package com.liferay.frontend.taglib.clay.servlet.taglib.display.context;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import javax.portlet.PortletURL;
 
@@ -78,15 +76,12 @@ public class SearchContainerManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		if ((getItemsTotal() == 0) &&
-			Validator.isNull(
-				ParamUtil.getString(httpServletRequest, "keywords"))) {
-
-			return true;
+	public Boolean isSelectable() {
+		if (getItemsTotal() == 0) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/packageinfo
@@ -1,1 +1,1 @@
-version 1.9.0
+version 2.0.0

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewManagementToolbarDisplayContext.java
@@ -144,11 +144,6 @@ public class JournalArticleItemSelectorViewManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return false;
 	}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleItemSelectorViewManagementToolbarDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleItemSelectorViewManagementToolbarDisplayContext.java
@@ -68,11 +68,6 @@ public class KBArticleItemSelectorViewManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return false;
 	}

--- a/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/display/context/ViewManagementToolbarDisplayContext.java
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/java/com/liferay/portal/language/override/web/internal/display/context/ViewManagementToolbarDisplayContext.java
@@ -116,11 +116,6 @@ public class ViewManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isSelectable() {
 		return false;
 	}

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersManagementToolbarDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/ViewFlatUsersManagementToolbarDisplayContext.java
@@ -165,11 +165,6 @@ public class ViewFlatUsersManagementToolbarDisplayContext
 	}
 
 	@Override
-	public Boolean isDisabled() {
-		return false;
-	}
-
-	@Override
 	public Boolean isShowCreationMenu() {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(


### PR DESCRIPTION
This is an update for [LPS-165903](https://issues.liferay.com/browse/LPS-165903).

Hi all, will you please look over my changes? 

The main idea here is that the result of the default `isDisabled` method of `SearchContainerManagementToolbarDisplayContext` is almost never desirable because it will disable other potentially useful functionality like the search bar and filter menu. 

You can see that there are a number of places where I removed the overrides that restored the original behavior of [`ManagementToolbarDisplayContext#isDisabled`](https://github.com/liferay/liferay-portal/blob/aabc2f3ad7b8f11b3dcb9e8325a27ff51eaa3268/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/ManagementToolbarDisplayContext.java#L145-L147).

Instead, the default behavior will now be to simply remove the checkbox when there is nothing to check, but leave the toolbar enabled. To me this seems like a sensible default, but I'm open to suggestions.

Please let me know if you have any questions or concerns. Thanks!

/cc @pei-jung @ces-huynguyen @sontruongces