### PR TITLE
LPS-165783 - Update to newest npm-scripts and add command for clearing JS cache

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"@liferay/eslint-plugin": "1.4.0",
-		"@liferay/npm-scripts": "47.8.3",
+		"@liferay/npm-scripts": "47.10.0",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",
@@ -20,6 +20,7 @@
 		"webpack": "5.70.0"
 	},
 	"scripts": {
+		"cacheClean": "liferay-npm-scripts cache --clean",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix",
 		"types": "liferay-npm-scripts types"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1864,10 +1864,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@47.8.3":
-  version "47.8.3"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.8.3.tgz#fa23f358fb6f02f325b8c4ad88548c8b7a5b58bf"
-  integrity sha512-EXn1YQZojjcXEDm9pHMjlc2DetUYbLYo9Qe2H55wdneQRGukE6R5r6jeQpmJkr/661dVJUw/1Ck8DKBfL7JnkQ==
+"@liferay/npm-scripts@47.10.0":
+  version "47.10.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.10.0.tgz#f442f863ba8e0ca6258c08260896674aae638ddb"
+  integrity sha512-ui9inLqV/nr2W4Y6bhCyULT8Q+Mrud5gRpLW7QGi+BuPwHzRpvEiD6d0Xgtfmoh+yfvdgVuz/g1ZO2acrZo1rQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
Adds the following to npm-scripts

<img width="704" alt="Screen Shot 2022-11-03 at 7 37 18 PM" src="https://user-images.githubusercontent.com/6843530/199766026-bd2074f8-c6d0-4c99-b0f3-a0ec6ec9f397.png">
