### PR TITLE
LPS-167672: Ensure panel collapse listener is unregistered on navigate event

### DIFF
--- a/portal-web/docroot/html/taglib/ui/panel/end.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/end.jsp
@@ -24,7 +24,7 @@
 	<aui:script sandbox="<%= true %>" use="aui-base,liferay-store">
 		var storeTask = A.debounce(Liferay.Store, 100);
 
-		Liferay.on('liferay.collapse.show', function(event) {
+		function onPanelShow(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -32,9 +32,9 @@
 
 				storeTask(task);
 			}
-		});
+		}
 
-		Liferay.on('liferay.collapse.hide', function(event) {
+		function onPanelHide(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -42,6 +42,18 @@
 
 				storeTask(task);
 			}
-		});
+		}
+
+		function onStartNavigate() {
+			Liferay.detach('liferay.collapse.show', onPanelShow);
+			Liferay.detach('liferay.collapse.hide', onPanelHide);
+			Liferay.detach('startNavigate', onStartNavigate);
+		}
+
+		Liferay.on('liferay.collapse.show', onPanelShow);
+
+		Liferay.on('liferay.collapse.hide', onPanelHide);
+
+		Liferay.on('startNavigate', onStartNavigate);
 	</aui:script>
 </c:if>


### PR DESCRIPTION
The problem was observed in the documents and media administration panel: Every time the detail view of a file is opened a new collapse state save handler is registered. These handlers need to be unregistered when a navigation event happens.