### PR TITLE
LPS-165193 - Migrate frontend-js-walkthrough-web to new storage API

### DIFF
--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/Walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/Walkthrough.js
@@ -19,7 +19,7 @@ import {ClayCheckbox} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayPopover from '@clayui/popover';
 import {ReactPortal, usePrevious} from '@liferay/frontend-js-react-web';
-import {navigate} from 'frontend-js-web';
+import {localStorage, navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
@@ -350,7 +350,10 @@ const Step = ({
 		<>
 			{!popoverVisible &&
 				currentStep !== steps.length &&
-				!localStorage.getItem(LOCAL_STORAGE_KEYS.SKIPPABLE) && (
+				!localStorage.getItem(
+					LOCAL_STORAGE_KEYS.SKIPPABLE,
+					localStorage.TYPES.NECESSARY
+				) && (
 					<Hotspot
 						onHotspotClick={() => onPopoverVisible(true)}
 						ref={hotspotRef}
@@ -424,7 +427,8 @@ const Step = ({
 
 											localStorage.setItem(
 												LOCAL_STORAGE_KEYS.SKIPPABLE,
-												!checkboxValue
+												!checkboxValue,
+												localStorage.TYPES.NECESSARY
 											);
 										}}
 									/>

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/hooks/useLocalStorage.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/hooks/useLocalStorage.js
@@ -12,6 +12,7 @@
  * details.
  */
 
+import {localStorage} from 'frontend-js-web';
 import {useCallback, useState} from 'react';
 
 export function useLocalStorage(key, initialValue) {
@@ -20,7 +21,10 @@ export function useLocalStorage(key, initialValue) {
 			typeof initialValue === 'function' ? initialValue() : initialValue;
 
 		try {
-			const item = window.localStorage.getItem(key);
+			const item = localStorage.getItem(
+				key,
+				localStorage.TYPES.NECESSARY
+			);
 
 			return item ? JSON.parse(item) : value;
 		}
@@ -39,12 +43,11 @@ export function useLocalStorage(key, initialValue) {
 
 				setStoredValue(valueToStore);
 
-				if (typeof window !== 'undefined') {
-					window.localStorage.setItem(
-						key,
-						JSON.stringify(valueToStore)
-					);
-				}
+				localStorage.setItem(
+					key,
+					JSON.stringify(valueToStore),
+					localStorage.TYPES.NECESSARY
+				);
 			}
 			catch (error) {
 				console.error(error);

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
@@ -13,6 +13,7 @@
  */
 
 import {render} from '@liferay/frontend-js-react-web';
+import {localStorage} from 'frontend-js-web';
 import React from 'react';
 
 import Walkthrough from './components/Walkthrough';
@@ -33,7 +34,12 @@ const getDefaultContainer = () => {
 };
 
 function Root(props) {
-	if (!localStorage.getItem(LOCAL_STORAGE_KEYS.SKIPPABLE)) {
+	if (
+		!localStorage.getItem(
+			LOCAL_STORAGE_KEYS.SKIPPABLE,
+			localStorage.TYPES.NECESSARY
+		)
+	) {
 		return <Walkthrough {...props} />;
 	}
 

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/Walkthrough.test.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/test/js/Walkthrough.test.js
@@ -56,8 +56,11 @@ function renderWalkthrough(props) {
 }
 
 jest.mock('frontend-js-web', () => ({
-	navigate: jest.fn((url) => url),
+	...jest.requireActual('frontend-js-web'),
+	navigate: jest.fn(),
 }));
+
+navigate.mockImplementation(jest.fn((url) => url));
 
 /**
  * List of tuples containing as the first member


### PR DESCRIPTION
### References

- [LPS-165193](https://issues.liferay.com/browse/LPS-165193)

### What is the goal?

* Migrate `localStorage` usages in `frontend-js-walkthrough-web` to new storage API


### How to replicate
* In your terminal, navigate to `liferay-portal/modules/apps/frontend-js/frontend-js-walkthrough-sample-web`, run `gradlew deploy -a`
* In your DXP instance, in the site menu navigate to `Site Builder > Pages`
* Add two widget pages: `/widget-page-1` and `/widget-page-2`
* Edit those pages so the routes correspond to the name
* Navigate to those pages and add the `JS Walkthrough sample` widget, as follows:

https://user-images.githubusercontent.com/6642927/200358879-24151668-5c2a-495b-ad1a-9fa751a9623c.mov

* Access `/widget-page-1`
* See that the blue button now has a blue circle (aka hotspot), as follows:
<img width="1228" alt="Captura de pantalla 2022-11-07 a las 17 13 08" src="https://user-images.githubusercontent.com/6642927/200359330-ceff5c72-c93b-445e-b0a7-c95858665c12.png">

* See that if you click it, the walkthrough is displayed, as follows:
<img width="1227" alt="Captura de pantalla 2022-11-07 a las 17 14 05" src="https://user-images.githubusercontent.com/6642927/200359490-354c569a-e2f9-43af-8eb6-818ef3e5c1bb.png">

* Follow the previous steps with the cookie feature flag (`feature.flag.LPS-142518`) enabled and disabled, and with cookie management enabled and disabled, check that nothing breaks

