### PR TITLE
LPS-167569 - Tab key is trapped on "Select" button in logo selector

### DIFF
--- a/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp
@@ -135,9 +135,9 @@ String tempImageFileName = ParamUtil.getString(request, "tempImageFileName");
 
 				if (uploadImageButton) {
 					uploadImageButton.addEventListener('keydown', (event) => {
-						event.preventDefault();
-
 						if (event.key == 'Enter' || event.key == ' ') {
+							event.preventDefault();
+
 							uploadImageButton.click();
 						}
 					});


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167569

Steps to Reproduce:

1. Go to control panel.
2. Go to Users and Administration.
3. Select a user.
4. Go to General.
5. Go to Information.
6. Tab through to the "Change" button for changing the profile picture. press enter.
7. Tab through "Select" button observe.

**Expected Result:**

Tab key should not be trapped on "Select" button, and the SR must announce the roles like:"press enter" .

 **Actual Result:**

Tab key is trapped on "Select" button.

 

**How to fix, recommendation:**

- This issue is in the logo selector taglib. It also takes place when uploading a site logo.
- The problem is caused by calling event.preventDefault() on all keydown events instead of only `enter` and `space` keydown events. 
- https://github.com/ethib137/liferay-portal/blob/master/modules/apps/image-uploader/image-uploader-web/src/main/resources/META-INF/resources/upload_image.jsp#L138