### PR TITLE
LPS-165263 | Add Autom. test FrontendJSCustomDialog#CanRenderOpenAlertModal

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FrontendJSCustomDialog.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FrontendJSCustomDialog.testcase
@@ -1,20 +1,18 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "upgrade.database.auto.run=false";
-	property osgi.modules.includes = "frontend-data-set-sample-web";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.component.names = "Frontend Dataset";
-	property testray.main.component.name = "Frontend Dataset";
+	property testray.component.names = "Frontend Custom Dialog";
+	property testray.main.component.name = "Frontend JS API";
 
 	setUp {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
 
-		task ("Given: Enabled custom Dialog") {
+		task ("Given: Enabled Custom Dialog") {
 			PortalSettings.openInstanceSettingsAdmin();
 
 			SystemSettings.gotoConfiguration(
@@ -41,7 +39,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-165262"
+	@description = "LPS-165263: This test validates that the liferay custom alert modal dialog can render."
 	@priority = "3"
 	test CanRenderOpenAlertModal {
 		task ("When: run JS code: Liferay.Util.openAlertModal({message: 'Test Alert Modal', onConfirm: ()=>{}})") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FrontendJSCustomDialog.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FrontendJSCustomDialog.testcase
@@ -1,0 +1,58 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property custom.properties = "upgrade.database.auto.run=false";
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given: Enabled custom Dialog") {
+			PortalSettings.openInstanceSettingsAdmin();
+
+			SystemSettings.gotoConfiguration(
+				configurationCategory = "Custom Dialogs",
+				configurationName = "Custom Dialogs",
+				configurationScope = "Virtual Instance Scope");
+
+			SystemSettings.configureSystemSetting(
+				enableSetting = "true",
+				settingFieldName = "Enabled");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			SystemSettings.configureSystemSetting(
+				enableSetting = "false",
+				settingFieldName = "Enabled");
+		}
+	}
+
+	@description = "LPS-165262"
+	@priority = "3"
+	test CanRenderOpenAlertModal {
+		task ("When: run JS code: Liferay.Util.openAlertModal({message: 'Test Alert Modal', onConfirm: ()=>{}})") {
+			RunScript(locator1 = "Liferay.Util.openAlertModal({message: 'Test Alert Modal', onConfirm: ()=>{}})");
+		}
+
+		task ("Then: text 'Test Alert Modal' is present in the modal") {
+			AssertTextEquals(
+				locator1 = "Modal#BODY",
+				value1 = "Test Alert Modal");
+		}
+	}
+
+}

--- a/test.properties
+++ b/test.properties
@@ -4307,7 +4307,9 @@ test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-db-partitio
         ) AND \
         (\
             (testray.main.component.name ~ "AMD Loader") OR \
+            (testray.main.component.name ~ "Frontend Custom Dialog") OR \
             (testray.main.component.name ~ "Frontend Dataset") OR \
+            (testray.main.component.name ~ "Frontend JS API") OR \
             (testray.main.component.name ~ "Remote Apps") OR \
             (testray.main.component.name ~ "Theme") OR \
             (testray.main.component.name ~ "User Interface")\
@@ -9265,7 +9267,9 @@ test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-db-partitio
         AUI,\
         Cadmin,\
         Clay,\
+        Frontend Custom Dialog,\
         Frontend Dataset,\
+        Frontend JS API,\
         Management Toolbar,\
         Maps,\
         Remote Apps,\


### PR DESCRIPTION
**Test Plan**

- Given: Enabled custom Dialog
- And When: run JS code: Liferay.Util.openAlertModal({message: "Test Alert Modal", onConfirm: ()=>{}})
- Then: text "Test Alert Modal" is present in the modal

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-165263