### PR TITLE
LPS-165319 Use setData instead of setHTML to avoid CKEditor content duplications during resizing

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -581,7 +581,9 @@ name = HtmlUtil.escapeJS(name);
 
 										window['<%= name %>'].create();
 
-										window['<%= name %>'].setHTML(ckEditorContent);
+										CKEDITOR.instances['<%= name %>'].setData(
+											ckEditorContent
+										);
 
 										initialEditor =
 											CKEDITOR.instances['<%= name %>'].id;


### PR DESCRIPTION
### References

- https://issues.liferay.com/browse/LPS-165319
- https://issues.liferay.com/browse/PTR-3373
- This is a followup on #2786

### What is the goal of this PR?

A revert to original solution from #2786. See the reasoning in https://github.com/liferay-frontend/liferay-portal/pull/2786#issuecomment-1307558112. 

I don't think there is a need for additional peer reviews, we can forward this if CI is green. We can deal with some of the concerns stated in #2786 in separate tasks.

@orsolyaDekany @georgel-pop-lr @rolandpakai 