### PR TITLE
LPS-167847 Fix false positives from rtl tests in release analysis

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/RightToLeftInfrastructure.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/RightToLeftInfrastructure.testcase
@@ -3,7 +3,7 @@ definition {
 
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.component.names = "User Interface";
+	property testray.component.names = "RTL Infrastructure,WYSIWYG";
 	property testray.main.component.name = "User Interface";
 
 	setUp {
@@ -27,12 +27,7 @@ definition {
 	@priority = "5"
 	@refactordone
 	test RTLDirectionStyleAppliedToTextField {
-		property app.server.types = "tomcat";
-		property database.types = "mysql";
-		property environment.acceptance = "true";
 		property portal.acceptance = "true";
-		property test.name.skip.portal.instance = "RightToLeftInfrastructure#RTLDirectionStyleAppliedToTextField";
-		property testray.component.names = "WYSIWYG";
 
 		ProductMenu.gotoPortlet(
 			category = "Content & Data",
@@ -57,12 +52,7 @@ definition {
 	@priority = "5"
 	@refactordone
 	test RTLStylesAppliedToPageLayout {
-		property app.server.types = "tomcat";
-		property database.types = "mysql";
-		property environment.acceptance = "true";
 		property portal.acceptance = "true";
-		property test.name.skip.portal.instance = "RightToLeftInfrastructure#RTLStylesAppliedToPageLayout";
-		property testray.component.names = "WYSIWYG";
 
 		JSONLayout.addPublicLayout(
 			groupName = "Guest",


### PR DESCRIPTION
**Description**
RTL tests are throwing prefers reduced motion error in console log when language of portal is switched to RTL. There hasn't been any detectable behavior or UI issue associated with this error and it's been causing false positives on release analysis. The proposed solution is to remove the tests from environment tester so we have more control on whether error logs should affect the result of the test.

**Test Plan**
- Remove RTL tests from environment tester

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-167847