### PR TITLE
LPS-167302 | Add Autom. test FDSCustomView#CanBeDeleted

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -46,9 +46,19 @@ definition {
 	macro deleteView {
 		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 
-		Click(locator1 = "FrontendDataSet#DELETE_VIEW_BUTTON");
+		Click(
+			key_itemName = "Delete View",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 
-		Click(locator1 = "FrontendDataSet#DELETE_BUTTON");
+			AssertTextEquals(
+				locator1 = "Modal#BODY",
+				value1 = "Are you sure you want to delete this? It will be deleted immediately.");
+
+			Click(
+				key_text = "Delete",
+				locator1 = "Modal#MODAL_FOOTER_BUTTON");
+
+		Alert.viewSuccessMessage();
 	}
 
 	macro getValueByPosition {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -50,13 +50,13 @@ definition {
 			key_itemName = "Delete View",
 			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 
-			AssertTextEquals(
-				locator1 = "Modal#BODY",
-				value1 = "Are you sure you want to delete this? It will be deleted immediately.");
+		AssertTextEquals(
+			locator1 = "Modal#BODY",
+			value1 = "Are you sure you want to delete this? It will be deleted immediately.");
 
-			Click(
-				key_text = "Delete",
-				locator1 = "Modal#MODAL_FOOTER_BUTTON");
+		Click(
+			key_text = "Delete",
+			locator1 = "Modal#MODAL_FOOTER_BUTTON");
 
 		Alert.viewSuccessMessage();
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -115,4 +115,12 @@ definition {
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
 	}
 
+	macro deleteView {
+		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+
+		Click(locator1 = "FrontendDataSet#DELETE_VIEW_BUTTON");
+
+		Click(locator1 = "FrontendDataSet#DELETE_BUTTON");
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -43,6 +43,14 @@ definition {
 			locator1 = "Button#GENERAL_BUTTON_MODAL_FOOTER");
 	}
 
+	macro deleteView {
+		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+
+		Click(locator1 = "FrontendDataSet#DELETE_VIEW_BUTTON");
+
+		Click(locator1 = "FrontendDataSet#DELETE_BUTTON");
+	}
+
 	macro getValueByPosition {
 		var key_columnIndex = "${columnIndex}";
 		var key_valueIndex = "${valueIndex}";
@@ -113,14 +121,6 @@ definition {
 		AssertElementNotPresent(
 			key_field = "${key_field}",
 			locator1 = "FrontendDataSet#TABLE_ITEM_COLUMN");
-	}
-
-	macro deleteView {
-		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
-
-		Click(locator1 = "FrontendDataSet#DELETE_VIEW_BUTTON");
-
-		Click(locator1 = "FrontendDataSet#DELETE_BUTTON");
 	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -243,4 +243,22 @@ definition {
 		}
 	}
 
+	@description = "LPS-159575 Automation Test Creation - Allow users to delete their custom viewsLPS"
+	@priority = "5"
+	test CanBeDeleted {
+
+		task("A custom view is created"){
+			FDSCustomView.createNewView(key_nameView = "New View");
+		}
+
+		task("Deleting the custom view"){
+			FDSCustomView.deleteView();
+		}
+
+		task("Assert the custom view no longer exists"){
+			FDSCustomView.verifyCustomView(key_nameCustomView = "New View");
+		}
+
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -46,6 +46,22 @@ definition {
 		}
 	}
 
+	@description = "LPS-159575 Automation Test Creation - Allow users to delete their custom viewsLPS"
+	@priority = "5"
+	test CanBeDeleted {
+		task ("A custom view is created") {
+			FDSCustomView.createNewView(key_nameView = "New View");
+		}
+
+		task ("Deleting the custom view") {
+			FDSCustomView.deleteView();
+		}
+
+		task ("Assert the custom view no longer exists") {
+			FDSCustomView.verifyCustomView(key_nameCustomView = "New View");
+		}
+	}
+
 	@description = "LPS-164617. Assert that it's possible to make changes in the FDS "
 	@priority = "4"
 	test CanBeEditted {
@@ -241,24 +257,6 @@ definition {
 				locator1 = "FrontendDataSet#RESET_FILTERS",
 				reset_filter = "Restablecer filtros");
 		}
-	}
-
-	@description = "LPS-159575 Automation Test Creation - Allow users to delete their custom viewsLPS"
-	@priority = "5"
-	test CanBeDeleted {
-
-		task("A custom view is created"){
-			FDSCustomView.createNewView(key_nameView = "New View");
-		}
-
-		task("Deleting the custom view"){
-			FDSCustomView.deleteView();
-		}
-
-		task("Assert the custom view no longer exists"){
-			FDSCustomView.verifyCustomView(key_nameCustomView = "New View");
-		}
-
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -234,15 +234,6 @@
 <tr>
 	<td>HEADER_ROW</td>
 	<td>xpath=(//div[contains(@class, "dnd-tr")])[1]</td>
-</tr>
-<tr>
-	<td>DELETE_VIEW_BUTTON</td>
-	<td>//button[@class='dropdown-item' and contains(text(), 'Delete View')]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>DELETE_BUTTON</td>
-	<td>//button[@class='btn btn-primary']</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -234,6 +234,15 @@
 <tr>
 	<td>HEADER_ROW</td>
 	<td>xpath=(//div[contains(@class, "dnd-tr")])[1]</td>
+</tr>
+<tr>
+	<td>DELETE_VIEW_BUTTON</td>
+	<td>//button[@class='dropdown-item' and contains(text(), 'Delete View')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DELETE_BUTTON</td>
+	<td>//button[@class='btn btn-primary']</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Forwarded manually to liferay-frontend.

PR original: https://github.com/mateusralv/liferay-portal/pull/21

---
**Test Plan:**

- Given A dataset display instance of a component
- And Given A custom view is created
- When Deleting the custom view
- Then Assert the custom view no longer exists

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-167302