### PR TITLE
LPS-168122 Activate portlet 3.0 for ClientExtensionEntryPortlet

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -169,6 +169,8 @@ public class CETDeployerImpl implements CETDeployer {
 				"javax.portlet.name", portletName
 			).put(
 				"javax.portlet.security-role-ref", "power-user,user"
+			).put(
+				"javax.portlet.version", "3.0"
 			).build();
 
 		if (customElementCET != null) {


### PR DESCRIPTION
This is to avoid error messages in the server console. Apparently, if portlet 2.0 and 3.0 portlets are mixed in the same OSGi bundle, some errors like:

java.lang.UnsupportedOperationException: Requires 3.0 opt-in

may appear randomly because depending on the request flow, if for any one request a 2.0 portlet accesses the request, and then a 3.0 portlet accesses the request, the error is thrown.

In other words: a portlet request can only be in 2.0 or 3.0 mode, but doesn't support both at the same time, thus all portlets contributing to the same request must be either all 2.0, or 3.0, but not a mix.