### PR TITLE
LPS-168316 Update logic

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/access_from_desktop.jsp
@@ -36,38 +36,35 @@ DLAccessFromDesktopDisplayContext dlAccessFromDesktopDisplayContext = new DLAcce
 </div>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />accessFromDesktop',
+		() => {
+			var webdavContentContainer = document.getElementById(
+				'<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav'
+			);
 
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />accessFromDesktop'
-	] = function () {
-		var webdavContentContainer = document.getElementById(
-			'<%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDav'
-		);
+			var html = '';
 
-		var html = '';
+			if (webdavContentContainer) {
+				html = webdavContentContainer.innerHTML;
 
-		if (webdavContentContainer) {
-			html = webdavContentContainer.innerHTML;
+				webdavContentContainer.remove();
 
-			webdavContentContainer.remove();
+				Liferay.Util.openModal({
+					bodyHTML: html,
+					onOpen: function (event) {
+						var webdavURLInput = document.getElementById(
+							'<portlet:namespace /><%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDavURL'
+						);
 
-			Liferay.Util.openModal({
-				bodyHTML: html,
-				onOpen: function (event) {
-					var webdavURLInput = document.getElementById(
-						'<portlet:namespace /><%= dlAccessFromDesktopDisplayContext.getRandomNamespace() %>webDavURL'
-					);
-
-					if (webdavURLInput) {
-						webdavURLInput.focus();
-					}
-				},
-				title:
-					'<%= UnicodeLanguageUtil.get(request, "access-from-desktop") %>',
-			});
+						if (webdavURLInput) {
+							webdavURLInput.focus();
+						}
+					},
+					title:
+						'<%= UnicodeLanguageUtil.get(request, "access-from-desktop") %>',
+				});
+			}
 		}
-	};
+	);
 </aui:script>

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration/icon/export_record_set.jsp
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/resources/META-INF/resources/configuration/icon/export_record_set.jsp
@@ -25,13 +25,10 @@ long recordSetId = ParamUtil.getLong(request, liferayPortletResponse.getNamespac
 </liferay-portlet:resourceURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />exportRecordSet'
-	] = function () {
-		<portlet:namespace />exportRecordSet('<%= exportRecordSetURL %>');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />exportRecordSet',
+		() => {
+			<portlet:namespace />exportRecordSet('<%= exportRecordSetURL %>');
+		}
+	);
 </aui:script>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/configuration/icon/export_form_instance.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/configuration/icon/export_form_instance.jsp
@@ -17,16 +17,13 @@
 <%@ include file="/admin/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />exportFormInstance'
-	] = function () {
-		Liferay.fire('openExportFormModal', {
-			exportFormURL:
-				'<%= ddmFormAdminDisplayContext.getExportFormURL(ParamUtil.getLong(request, liferayPortletResponse.getNamespace() + "formInstanceId")) %>',
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />exportFormInstance',
+		() => {
+			Liferay.fire('openExportFormModal', {
+				exportFormURL:
+					'<%= ddmFormAdminDisplayContext.getExportFormURL(ParamUtil.getLong(request, liferayPortletResponse.getNamespace() + "formInstanceId")) %>',
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/configuration/icon/export_import.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/configuration/icon/export_import.jsp
@@ -17,23 +17,23 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />exportImport'
-	] = function () {
-		Liferay.Portlet.openModal({
-			iframeBodyCssClass: '',
-			namespace: '<portlet:namespace />',
-			onClose: function () {
-				Liferay.Portlet.refresh('#p_p_id_<%= portletDisplay.getId() %>_');
-			},
-			portletSelector: '#p_p_id_<%= portletDisplay.getId() %>_',
-			portletId: '<%= portletDisplay.getId() %>',
-			title: '<liferay-ui:message key="export-import" />',
-			url: '<%= HtmlUtil.escapeJS(portletDisplay.getURLExportImport()) %>',
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />exportImport',
+		() => {
+			Liferay.Portlet.openModal({
+				iframeBodyCssClass: '',
+				namespace: '<portlet:namespace />',
+				onClose: function () {
+					Liferay.Portlet.refresh(
+						'#p_p_id_<%= portletDisplay.getId() %>_'
+					);
+				},
+				portletSelector: '#p_p_id_<%= portletDisplay.getId() %>_',
+				portletId: '<%= portletDisplay.getId() %>',
+				title: '<liferay-ui:message key="export-import" />',
+				url:
+					'<%= HtmlUtil.escapeJS(portletDisplay.getURLExportImport()) %>',
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -84,6 +84,10 @@ import normalizeFriendlyURL from './util/normalize_friendly_url';
 import ns from './util/ns.es';
 import objectToURLSearchParams from './util/object_to_url_search_params.es';
 import openWindow from './util/open_window';
+import {
+	getPortletConfigurationIconAction,
+	setPortletConfigurationIconAction,
+} from './util/portlet_configuration_icon_action';
 import createActionURL from './util/portlet_url/create_action_url.es';
 import createPortletURL from './util/portlet_url/create_portlet_url.es';
 import createRenderURL from './util/portlet_url/create_render_url.es';
@@ -227,6 +231,7 @@ Liferay.Util.getFormElement = getFormElement;
 Liferay.Util.getLexiconIcon = getLexiconIcon;
 Liferay.Util.getLexiconIconTpl = getLexiconIconTpl;
 Liferay.Util.getOpener = getOpener;
+Liferay.Util.getPortletConfigurationIconAction = getPortletConfigurationIconAction;
 
 /**
  * @deprecated As of Athanasius (7.3.x), replaced by `import {getPortletId} from 'frontend-js-web'`
@@ -311,6 +316,7 @@ Liferay.Util.openToast = (...args) => {
 Liferay.Util.openWindow = openWindow;
 Liferay.Util.removeEntitySelection = removeEntitySelection;
 Liferay.Util.selectFolder = selectFolder;
+Liferay.Util.setPortletConfigurationIconAction = setPortletConfigurationIconAction;
 Liferay.Util.showCapsLock = showCapsLock;
 Liferay.Util.sub = sub;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/portlet_configuration_icon_action.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/portlet_configuration_icon_action.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+/**
+ */
+
+export const portletConfigurationIconActions = new Map();
+
+export function getPortletConfigurationIconAction(id) {
+	return portletConfigurationIconActions.get(id);
+}
+
+export function setPortletConfigurationIconAction(id, callback) {
+	portletConfigurationIconActions.set(id, callback);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/icon_options/js/PortletOptionsDropdownPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/icon_options/js/PortletOptionsDropdownPropsTransformer.js
@@ -73,9 +73,13 @@ export default function propsTransformer({
 						if (globalAction) {
 							event.preventDefault();
 
-							Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__?.[
+							const callback = Liferay.Util.getPortletConfigurationIconAction(
 								action
-							]?.(event);
+							);
+
+							if (callback) {
+								callback(event);
+							}
 						}
 						else {
 							event.preventDefault();

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/export_script.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/export_script.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />journalDDMTemplateExportScript'
-	] = function () {
-		Liferay.fire('<portlet:namespace />exportScript');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />journalDDMTemplateExportScript',
+		() => {
+			Liferay.fire('<portlet:namespace />exportScript');
+		}
+	);
 </aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/import_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/import_data_definition.jsp
@@ -37,17 +37,14 @@
 </div>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />importDataDefinition'
-	] = function () {
-		Liferay.componentReady(
-			'<portlet:namespace />importDataDefinitionModal'
-		).then((importDataDefinitionModal) => {
-			importDataDefinitionModal.open();
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />importDataDefinition',
+		() => {
+			Liferay.componentReady(
+				'<portlet:namespace />importDataDefinitionModal'
+			).then((importDataDefinitionModal) => {
+				importDataDefinitionModal.open();
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
@@ -17,15 +17,12 @@ import {openToast} from 'frontend-js-web';
 export default function ({namespace}) {
 	const fileInput = document.getElementById(`${namespace}importScriptInput`);
 
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		`${namespace}journalDDMTemplateImportScript`
-	] = function () {
-		fileInput.click();
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		`${namespace}journalDDMTemplateImportScript`,
+		() => {
+			fileInput.click();
+		}
+	);
 
 	const onChange = (event) => {
 		const target = event.target;

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/configuration/icon/print_kb_template.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/configuration/icon/print_kb_template.jsp
@@ -27,17 +27,14 @@ KBTemplate kbTemplate = (KBTemplate)liferayPortletRequest.getAttribute(KBWebKeys
 </portlet:renderURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />printKBTemplate'
-	] = function () {
-		window.open(
-			'<%= printURL %>',
-			'',
-			'directories=no,height=640,location=no, menubar=no,resizable=yes,scrollbars=yes,status=0, toolbar=0,width=680'
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />printKBTemplate',
+		() => {
+			window.open(
+				'<%= printURL %>',
+				'',
+				'directories=no,height=640,location=no, menubar=no,resizable=yes,scrollbars=yes,status=0, toolbar=0,width=680'
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/configuration/icon/import.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/configuration/icon/import.jsp
@@ -17,28 +17,25 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />import'
-	] = function () {
-		Liferay.Util.openModal({
-			onClose: function (event) {
-				window.location.reload();
-			},
-			title: '<liferay-ui:message key="import" />',
-			url:
-				'<%=
-					PortletURLBuilder.create(
-						PortalUtil.getControlPanelPortletURL(liferayPortletRequest, LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES, PortletRequest.RENDER_PHASE)
-					).setMVCPath(
-						"/view_import.jsp"
-					).setWindowState(
-						LiferayWindowState.POP_UP
-					).buildString()
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />import',
+		() => {
+			Liferay.Util.openModal({
+				onClose: function (event) {
+					window.location.reload();
+				},
+				title: '<liferay-ui:message key="import" />',
+				url:
+					'<%=
+						PortletURLBuilder.create(
+							PortalUtil.getControlPanelPortletURL(liferayPortletRequest, LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES, PortletRequest.RENDER_PHASE)
+						).setMVCPath(
+							"/view_import.jsp"
+						).setWindowState(
+							LiferayWindowState.POP_UP
+						).buildString()
 			%>',
-		});
-	};
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/configuration/icon/delivery.jsp
+++ b/modules/apps/notifications/notifications-web/src/main/resources/META-INF/resources/configuration/icon/delivery.jsp
@@ -17,29 +17,26 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />delivery'
-	] = function () {
-		Liferay.Portlet.openModal({
-			namespace: '<portlet:namespace />',
-			portletSelector: '#p_p_id_<%= portletDisplay.getId() %>_',
-			portletId: '<%= portletDisplay.getId() %>',
-			title: '<liferay-ui:message key="configuration" />',
-			url:
-				'<%=
-					HtmlUtil.escapeJS(
-						PortletURLBuilder.create(
-							PortletURLFactoryUtil.create(renderRequest, NotificationsPortletKeys.NOTIFICATIONS, PortletRequest.RENDER_PHASE)
-						).setMVCPath(
-							"/notifications/configuration.jsp"
-						).setWindowState(
-							LiferayWindowState.POP_UP
-						).buildString())
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />delivery',
+		() => {
+			Liferay.Portlet.openModal({
+				namespace: '<portlet:namespace />',
+				portletSelector: '#p_p_id_<%= portletDisplay.getId() %>_',
+				portletId: '<%= portletDisplay.getId() %>',
+				title: '<liferay-ui:message key="configuration" />',
+				url:
+					'<%=
+						HtmlUtil.escapeJS(
+							PortletURLBuilder.create(
+								PortletURLFactoryUtil.create(renderRequest, NotificationsPortletKeys.NOTIFICATIONS, PortletRequest.RENDER_PHASE)
+							).setMVCPath(
+								"/notifications/configuration.jsp"
+							).setWindowState(
+								LiferayWindowState.POP_UP
+							).buildString())
 			%>',
-		});
-	};
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/configuration/icon/import_object_definition.jsp
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/object_definitions/configuration/icon/import_object_definition.jsp
@@ -39,17 +39,14 @@
 <aui:script>
 	function <portlet:namespace />openImportObjectDefinitionModal() {}
 
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />importObjectDefinition'
-	] = function () {
-		Liferay.componentReady(
-			'<portlet:namespace />importObjectDefinitionModal'
-		).then((importObjectDefinitionModal) => {
-			importObjectDefinitionModal.open();
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />importObjectDefinition',
+		() => {
+			Liferay.componentReady(
+				'<portlet:namespace />importObjectDefinitionModal'
+			).then((importObjectDefinitionModal) => {
+				importObjectDefinitionModal.open();
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/configuration/icon/delete_password_policy.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/configuration/icon/delete_password_policy.jsp
@@ -17,15 +17,12 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />deletePasswordPolicy'
-	] = function () {
-		<portlet:namespace />deletePasswordPolicy(
-			'<%= ParamUtil.getLong(request, "passwordPolicyId") %>'
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />deletePasswordPolicy',
+		() => {
+			<portlet:namespace />deletePasswordPolicy(
+				'<%= ParamUtil.getLong(request, "passwordPolicyId") %>'
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/configuration/icon/delete_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/configuration/icon/delete_definition.jsp
@@ -17,25 +17,22 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />deleteDefinition'
-	] = function () {
-		<portlet:namespace />confirmDeleteDefinition(
-			'<%=
-				PortletURLBuilder.create(
-					PortalUtil.getControlPanelPortletURL(renderRequest, WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW, PortletRequest.ACTION_PHASE)
-				).setActionName(
-					"/portal_workflow/delete_workflow_definition"
-				).setParameter(
-					"name", renderRequest.getParameter("name")
-				).setParameter(
-					"version", renderRequest.getParameter("version")
-				).buildString()
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />deleteDefinition',
+		() => {
+			<portlet:namespace />confirmDeleteDefinition(
+				'<%=
+		PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(renderRequest, WorkflowPortletKeys.CONTROL_PANEL_WORKFLOW, PortletRequest.ACTION_PHASE)
+		).setActionName(
+			"/portal_workflow/delete_workflow_definition"
+		).setParameter(
+			"name", renderRequest.getParameter("name")
+		).setParameter(
+			"version", renderRequest.getParameter("version")
+		).buildString()
 		%>'
-		);
-	};
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/configuration/icon/duplicate_definition.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/configuration/icon/duplicate_definition.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />duplicateDefinition'
-	] = function () {
-		Liferay.fire('<portlet:namespace />duplicateDefinition');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />duplicateDefinition',
+		() => {
+			Liferay.fire('<portlet:namespace />duplicateDefinition');
+		}
+	);
 </aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-close/src/main/resources/META-INF/resources/configuration/icon/close.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-close/src/main/resources/META-INF/resources/configuration/icon/close.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/configuration/icon/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />close'
-	] = function () {
-		Liferay.Portlet.close('#p_p_id_<%= portletDisplay.getId() %>_');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />close',
+		() => {
+			Liferay.Portlet.close('#p_p_id_<%= portletDisplay.getId() %>_');
+		}
+	);
 </aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-maximize/src/main/resources/META-INF/resources/configuration/icon/maximize.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-maximize/src/main/resources/META-INF/resources/configuration/icon/maximize.jsp
@@ -17,16 +17,13 @@
 <%@ include file="/configuration/icon/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />maximize'
-	] = function () {
-		submitForm(
-			document.hrefFm,
-			'<%= HtmlUtil.escapeJS(portletDisplay.getURLMax()) %>'
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />maximize',
+		() => {
+			submitForm(
+				document.hrefFm,
+				'<%= HtmlUtil.escapeJS(portletDisplay.getURLMax()) %>'
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-minimize/src/main/resources/META-INF/resources/configuration/icon/minimize.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-minimize/src/main/resources/META-INF/resources/configuration/icon/minimize.jsp
@@ -17,16 +17,13 @@
 <%@ include file="/configuration/icon/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />minimize'
-	] = function (event) {
-		Liferay.Portlet.minimize(
-			'#p_p_id_<%= portletDisplay.getId() %>_',
-			event.target.closest('button')
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />minimize',
+		() => {
+			Liferay.Portlet.minimize(
+				'#p_p_id_<%= portletDisplay.getId() %>_',
+				event.target.closest('button')
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-refresh/src/main/resources/META-INF/resources/configuration/icon/refresh.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-icon/portlet-configuration-icon-refresh/src/main/resources/META-INF/resources/configuration/icon/refresh.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/configuration/icon/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />refresh'
-	] = function () {
-		Liferay.Portlet.refresh('#p_p_id_<%= portletDisplay.getId() %>_');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />refresh',
+		() => {
+			Liferay.Portlet.refresh('#p_p_id_<%= portletDisplay.getId() %>_');
+		}
+	);
 </aui:script>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/configuration/icon/configuration.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/configuration/icon/configuration.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />configuration'
-	] = function () {
-		<%= portletDisplay.getURLConfigurationJS() %>;
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />configuration',
+		() => {
+			<%= portletDisplay.getURLConfigurationJS() %>;
+		}
+	);
 </aui:script>

--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/configuration/icon/staging.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/configuration/icon/staging.jsp
@@ -17,19 +17,16 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />staging'
-	] = function () {
-		Liferay.Portlet.openModal({
-			namespace: '<portlet:namespace />',
-			portletSelector: '#p_p_id_<%= portletDisplay.getId() %>_',
-			portletId: '<%= portletDisplay.getId() %>',
-			title: '<liferay-ui:message key="staging" />',
-			url: '<%= HtmlUtil.escapeJS(portletDisplay.getURLStaging()) %>',
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />staging',
+		() => {
+			Liferay.Portlet.openModal({
+				namespace: '<portlet:namespace />',
+				portletSelector: '#p_p_id_<%= portletDisplay.getId() %>_',
+				portletId: '<%= portletDisplay.getId() %>',
+				title: '<liferay-ui:message key="staging" />',
+				url: '<%= HtmlUtil.escapeJS(portletDisplay.getURLStaging()) %>',
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/configuration/icon/import.jsp
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/configuration/icon/import.jsp
@@ -17,28 +17,25 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />import'
-	] = function () {
-		Liferay.Util.openModal({
-			onClose: function (event) {
-				window.location.reload();
-			},
-			title: '<liferay-ui:message key="import" />',
-			url:
-				'<%=
-					PortletURLBuilder.create(
-						PortalUtil.getControlPanelPortletURL(liferayPortletRequest, StyleBookPortletKeys.STYLE_BOOK, PortletRequest.RENDER_PHASE)
-					).setMVCRenderCommandName(
-						"/style_book/view_import"
-					).setWindowState(
-						LiferayWindowState.POP_UP
-					).buildString()
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />import',
+		() => {
+			Liferay.Util.openModal({
+				onClose: function (event) {
+					window.location.reload();
+				},
+				title: '<liferay-ui:message key="import" />',
+				url:
+					'<%=
+						PortletURLBuilder.create(
+							PortalUtil.getControlPanelPortletURL(liferayPortletRequest, StyleBookPortletKeys.STYLE_BOOK, PortletRequest.RENDER_PHASE)
+						).setMVCRenderCommandName(
+							"/style_book/view_import"
+						).setWindowState(
+							LiferayWindowState.POP_UP
+						).buildString()
 			%>',
-		});
-	};
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/configuration/icon/export_script.jsp
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/configuration/icon/export_script.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />templateExportScript'
-	] = function () {
-		Liferay.fire('<portlet:namespace />exportScript');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />templateExportScript',
+		() => {
+			Liferay.fire('<portlet:namespace />exportScript');
+		}
+	);
 </aui:script>

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/configuration/icon/ImportScript.js
@@ -17,15 +17,12 @@ import {openToast} from 'frontend-js-web';
 export default function ({namespace}) {
 	const fileInput = document.getElementById(`${namespace}importScriptInput`);
 
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		`${namespace}templateImportScript`
-	] = function () {
-		fileInput.click();
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		`${namespace}templateImportScript`,
+		() => {
+			fileInput.click();
+		}
+	);
 
 	const onChange = (event) => {
 		const target = event.target;

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/configuration/icon/empty_trash.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/configuration/icon/empty_trash.jsp
@@ -21,21 +21,21 @@
 </portlet:actionURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />emptyTrash'
-	] = function () {
-		Liferay.Util.openConfirmModal({
-			message:
-				'<liferay-ui:message key="are-you-sure-you-want-to-empty-the-recycle-bin" />',
-			onConfirm: (isConfirmed) => {
-				if (isConfirmed) {
-					submitForm(document.hrefFm, '<%= emptyTrashURL.toString() %>');
-				}
-			},
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />emptyTrash',
+		() => {
+			Liferay.Util.openConfirmModal({
+				message:
+					'<liferay-ui:message key="are-you-sure-you-want-to-empty-the-recycle-bin" />',
+				onConfirm: (isConfirmed) => {
+					if (isConfirmed) {
+						submitForm(
+							document.hrefFm,
+							'<%= emptyTrashURL.toString() %>'
+						);
+					}
+				},
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/configuration/icon/restore_trash.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/configuration/icon/restore_trash.jsp
@@ -29,13 +29,10 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 </portlet:renderURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />restoreTrash'
-	] = function () {
-		<portlet:namespace />restoreDialog('<%= restoreTrashURL %>');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />restoreTrash',
+		() => {
+			<portlet:namespace />restoreDialog('<%= restoreTrashURL %>');
+		}
+	);
 </aui:script>

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/configuration/icon/delete_user_group.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/configuration/icon/delete_user_group.jsp
@@ -21,16 +21,13 @@ UserGroup userGroup = ActionUtil.getUserGroup(renderRequest);
 %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />deleteUserGroup'
-	] = function () {
-		<portlet:namespace />doDeleteUserGroup(
-			'<%= UserGroup.class.getName() %>',
-			'<%= userGroup.getUserGroupId() %>'
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />deleteUserGroup',
+		() => {
+			<portlet:namespace />doDeleteUserGroup(
+				'<%= UserGroup.class.getName() %>',
+				'<%= userGroup.getUserGroupId() %>'
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/configuration/icon/delete_organization.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/configuration/icon/delete_organization.jsp
@@ -27,16 +27,13 @@ if (Validator.isNull(backURL)) {
 %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />deleteOrganization'
-	] = function () {
-		<portlet:namespace />deleteOrganization(
-			'<%= organization.getOrganizationId() %>',
-			'<%= HtmlUtil.escapeJS(backURL) %>'
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />deleteOrganization',
+		() => {
+			<portlet:namespace />deleteOrganization(
+				'<%= organization.getOrganizationId() %>',
+				'<%= HtmlUtil.escapeJS(backURL) %>'
+			);
+		}
+	);
 </aui:script>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/configuration/icon/export_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/configuration/icon/export_users.jsp
@@ -25,24 +25,21 @@ int status = GetterUtil.getInteger(request.getAttribute(UsersAdminWebKeys.STATUS
 </liferay-portlet:resourceURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />exportUsers'
-	] = function () {
-		Liferay.Util.openConfirmModal({
-			message:
-				'<liferay-ui:message key="warning-this-csv-file-contains-user-supplied-inputs" unicode="<%= true %>" />',
-			onConfirm: (isConfirmed) => {
-				if (isConfirmed) {
-					submitForm(
-						document.hrefFm,
-						'<%= exportURL + "&compress=0&etag=0&strip=0" %>'
-					);
-				}
-			},
-		});
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />exportUsers',
+		() => {
+			Liferay.Util.openConfirmModal({
+				message:
+					'<liferay-ui:message key="warning-this-csv-file-contains-user-supplied-inputs" unicode="<%= true %>" />',
+				onConfirm: (isConfirmed) => {
+					if (isConfirmed) {
+						submitForm(
+							document.hrefFm,
+							'<%= exportURL + "&compress=0&etag=0&strip=0" %>'
+						);
+					}
+				},
+			});
+		}
+	);
 </aui:script>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration/icon/print.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/configuration/icon/print.jsp
@@ -30,17 +30,14 @@ WikiPage wikiPage = ActionUtil.getPage(liferayPortletRequest);
 </portlet:renderURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />print'
-	] = function () {
-		window.open(
-			'<%= printURL %>',
-			'',
-			'directories=0,height=480,left=80,location=1, menubar=1,resizable=1,scrollbars=yes,status=0, toolbar=0,top=180,width=640'
-		);
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />print',
+		() => {
+			window.open(
+				'<%= printURL %>',
+				'',
+				'directories=0,height=480,left=80,location=1, menubar=1,resizable=1,scrollbars=yes,status=0, toolbar=0,top=180,width=640'
+			);
+		}
+	);
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/configuration/icon/delete_definition.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/configuration/icon/delete_definition.jsp
@@ -17,25 +17,22 @@
 <%@ include file="/designer/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />deleteDefinition'
-	] = function () {
-		<portlet:namespace />confirmDeleteDefinition(
-			'<%=
-				PortletURLBuilder.create(
-					PortalUtil.getControlPanelPortletURL(renderRequest, KaleoDesignerPortletKeys.CONTROL_PANEL_WORKFLOW, PortletRequest.ACTION_PHASE)
-				).setActionName(
-					"/portal_workflow/delete_workflow_definition"
-				).setParameter(
-					"name", renderRequest.getParameter("name")
-				).setParameter(
-					"version", renderRequest.getParameter("draftVersion")
-				).buildString()
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />deleteDefinition',
+		() => {
+			<portlet:namespace />confirmDeleteDefinition(
+				'<%=
+					PortletURLBuilder.create(
+						PortalUtil.getControlPanelPortletURL(renderRequest, KaleoDesignerPortletKeys.CONTROL_PANEL_WORKFLOW, PortletRequest.ACTION_PHASE)
+					).setActionName(
+						"/portal_workflow/delete_workflow_definition"
+					).setParameter(
+						"name", renderRequest.getParameter("name")
+					).setParameter(
+						"version", renderRequest.getParameter("draftVersion")
+					).buildString()
 		%>'
-		);
-	};
+			);
+		}
+	);
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/configuration/icon/duplicate_definition.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/configuration/icon/duplicate_definition.jsp
@@ -17,13 +17,10 @@
 <%@ include file="/designer/init.jsp" %>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />duplicateDefinition'
-	] = function () {
-		Liferay.fire('<portlet:namespace />duplicateDefinition');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />duplicateDefinition',
+		() => {
+			Liferay.fire('<portlet:namespace />duplicateDefinition');
+		}
+	);
 </aui:script>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/configuration/icon/export_kaleo_process.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/configuration/icon/export_kaleo_process.jsp
@@ -25,13 +25,10 @@ long kaleoProcessId = ParamUtil.getLong(request, liferayPortletResponse.getNames
 </portlet:resourceURL>
 
 <aui:script>
-	if (!Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__) {
-		Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__ = {};
-	}
-
-	Liferay.__PORTLET_CONFIGURATION_ICON_ACTIONS__[
-		'<portlet:namespace />exportKaleoProcess'
-	] = function () {
-		<portlet:namespace />exportKaleoProcess('<%= exportURL %>');
-	};
+	Liferay.Util.setPortletConfigurationIconAction(
+		'<portlet:namespace />exportKaleoProcess',
+		() => {
+			<portlet:namespace />exportKaleoProcess('<%= exportURL %>');
+		}
+	);
 </aui:script>


### PR DESCRIPTION
Motivation
---
In order to avoid a lot of code repetition, and pretty widespread usage of rather confusing **__PORTLET_CONFIGURATION_ICON_ACTIONS__**, wrap this logic in a dev-friendly utility.

See comments in: https://github.com/liferay-frontend/liferay-portal/pull/2837#discussion_r1015523483

[Link to the ticket](https://issues.liferay.com/browse/LPS-168315)

Proposed solution
---
 
To set the action:

```
Liferay.Util.setPortletConfigurationIconAction('<portlet:namespace />exportUsers', () =>
{...}
);
```
To access the action in PortletOptionsDropdownPropsTransformer:

```
getPortletConfigurationIconAction(action);
```

cc: @markocikos 