### PR TITLE
LPS-157838 - Always show FDS quick actions when actions menu is expanded

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -159,7 +159,7 @@ export function handleAction(
 		doAction();
 	}
 }
-function Actions({actions, itemData, itemId}) {
+function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 	const context = useContext(FrontendDataSetContext);
 	const [
 		{
@@ -247,7 +247,9 @@ function Actions({actions, itemData, itemId}) {
 				itemData={itemData}
 				itemId={itemId}
 				loading={loading}
+				menuActive={menuActive}
 				onClick={handleClick}
+				onMenuActiveChange={onMenuActiveChange}
 				setLoading={setLoading}
 			/>
 		</>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
@@ -19,7 +19,7 @@ import ClayLink from '@clayui/link';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import PropTypes from 'prop-types';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 
 import FrontendDataSetContext from '../FrontendDataSetContext';
 import {formatActionURL} from '../utils/index';
@@ -67,12 +67,12 @@ function ActionsDropdown({
 	itemData,
 	itemId,
 	loading,
+	menuActive,
 	onClick,
+	onMenuActiveChange,
 	setLoading,
 }) {
 	const context = useContext(FrontendDataSetContext);
-
-	const [menuActive, setMenuActive] = useState(false);
 
 	const inlineEditingAvailable =
 		context.inlineEditingSettings && itemData.actions?.update;
@@ -228,7 +228,7 @@ function ActionsDropdown({
 			return (
 				<DropdownItem
 					action={item}
-					closeMenu={() => setMenuActive(false)}
+					closeMenu={() => onMenuActiveChange(false)}
 					handleAction={handleAction}
 					itemData={itemData}
 					itemId={itemId}
@@ -246,7 +246,7 @@ function ActionsDropdown({
 
 			<ClayDropDown
 				active={menuActive}
-				onActiveChange={setMenuActive}
+				onActiveChange={onMenuActiveChange}
 				trigger={
 					<ClayButton
 						className="component-action dropdown-toggle ml-1"

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
@@ -161,7 +161,7 @@
 
 	&.with-quick-actions {
 		.dnd-tr:hover:not(.nested):not(.selected),
-		.dnd-tr.expanded:not(.nested):not(.selected) {
+		.dnd-tr.menu-active:not(.nested):not(.selected) {
 			.item-actions {
 				overflow: visible;
 				position: relative;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
@@ -160,7 +160,8 @@
 	}
 
 	&.with-quick-actions {
-		.dnd-tr:hover:not(.nested):not(.selected) {
+		.dnd-tr:hover:not(.nested):not(.selected),
+		.dnd-tr.expanded:not(.nested):not(.selected) {
 			.item-actions {
 				overflow: visible;
 				position: relative;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
@@ -98,9 +98,6 @@ function Table({items, itemsActions, schema, style}) {
 		)
 	);
 
-	const SelectionComponent =
-		selectionType === 'multiple' ? ClayCheckbox : ClayRadio;
-
 	const columnNames = [];
 
 	if (selectable) {
@@ -161,46 +158,18 @@ function Table({items, itemsActions, schema, style}) {
 											item={item}
 											itemId={itemId}
 											itemsActions={itemsActions}
+											itemsChanges={itemsChanges}
+											selectItems={selectItems}
+											selectable={selectable}
 											selected={selectedItemsValue.includes(
 												itemId
 											)}
-										>
-											{selectable && (
-												<DndTable.Cell
-													className="item-selector"
-													columnName="item-selector"
-												>
-													<SelectionComponent
-														checked={
-															!!selectedItemsValue.find(
-																(element) =>
-																	String(
-																		element
-																	) ===
-																	String(
-																		itemId
-																	)
-															)
-														}
-														onChange={() =>
-															selectItems(itemId)
-														}
-														title={Liferay.Language.get(
-															'select-item'
-														)}
-														value={itemId}
-													/>
-												</DndTable.Cell>
-											)}
-
-											{getItemFields(
-												item,
-												visibleFields,
-												itemId,
-												itemsActions,
-												itemsChanges[itemId]
-											)}
-										</RowWithActions>
+											selectedItemsValue={
+												selectedItemsValue
+											}
+											selectionType={selectionType}
+											visibleFields={visibleFields}
+										/>
 
 										{nestedItems &&
 											nestedItems.map((nestedItem, i) => (
@@ -259,59 +228,75 @@ function Table({items, itemsActions, schema, style}) {
 	);
 }
 
-const ActionsCell = ({
-	item,
-	itemId,
-	itemsActions,
-	menuActive,
-	onMenuActiveChange,
-}) => {
-	return (
-		<DndTable.Cell className="item-actions" columnName="item-actions">
-			{(itemsActions?.length > 0 ||
-				item.actionDropdownItems?.length > 0) && (
-				<Actions
-					actions={itemsActions || item.actionDropdownItems}
-					itemData={item}
-					itemId={itemId}
-					menuActive={menuActive}
-					onMenuActiveChange={onMenuActiveChange}
-				/>
-			)}
-		</DndTable.Cell>
-	);
-};
-
 const RowWithActions = ({
 	active,
-	children,
 	className,
 	item,
 	itemId,
 	itemsActions,
+	itemsChanges,
+	selectItems,
+	selectable,
 	selected,
+	selectedItemsValue,
+	selectionType,
+	visibleFields,
 	...props
 }) => {
 	const [menuActive, setMenuActive] = useState(false);
+
+	const SelectionComponent =
+		selectionType === 'multiple' ? ClayCheckbox : ClayRadio;
 
 	return (
 		<DndTable.Row
 			className={classNames(className, {
 				active,
-				expanded: menuActive,
+				'menu-active': menuActive,
 				selected,
 			})}
 			{...props}
 		>
-			{children}
+			{selectable && (
+				<DndTable.Cell
+					className="item-selector"
+					columnName="item-selector"
+				>
+					<SelectionComponent
+						checked={
+							!!selectedItemsValue.find(
+								(element) => String(element) === String(itemId)
+							)
+						}
+						onChange={() => selectItems(itemId)}
+						title={Liferay.Language.get(
+							'select-item'
+						)}
+						value={itemId}
+					/>
+				</DndTable.Cell>
+			)}
 
-			<ActionsCell
-				item={item}
-				itemId={itemId}
-				itemsActions={itemsActions}
-				menuActive={menuActive}
-				onMenuActiveChange={setMenuActive}
-			/>
+			{getItemFields(
+				item,
+				visibleFields,
+				itemId,
+				itemsActions,
+				itemsChanges[itemId]
+			)}
+
+			<DndTable.Cell className="item-actions" columnName="item-actions">
+				{(itemsActions?.length > 0 ||
+					item.actionDropdownItems?.length > 0) && (
+					<Actions
+						actions={itemsActions || item.actionDropdownItems}
+						itemData={item}
+						itemId={itemId}
+						menuActive={menuActive}
+						onMenuActiveChange={setMenuActive}
+					/>
+				)}{' '}
+			</DndTable.Cell>
 		</DndTable.Row>
 	);
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
@@ -269,9 +269,7 @@ const RowWithActions = ({
 							)
 						}
 						onChange={() => selectItems(itemId)}
-						title={Liferay.Language.get(
-							'select-item'
-						)}
+						title={Liferay.Language.get('select-item')}
 						value={itemId}
 					/>
 				</DndTable.Cell>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js
@@ -16,7 +16,7 @@ import ClayEmptyState from '@clayui/empty-state';
 import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useContext, useRef} from 'react';
+import React, {useContext, useRef, useState} from 'react';
 
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import Actions from '../../actions/Actions';
@@ -154,15 +154,16 @@ function Table({items, itemsActions, schema, style}) {
 
 								return (
 									<React.Fragment key={itemId}>
-										<DndTable.Row
-											className={classNames({
-												active: highlightedItemsValue.includes(
-													itemId
-												),
-												selected: selectedItemsValue.includes(
-													itemId
-												),
-											})}
+										<RowWithActions
+											active={highlightedItemsValue.includes(
+												itemId
+											)}
+											item={item}
+											itemId={itemId}
+											itemsActions={itemsActions}
+											selected={selectedItemsValue.includes(
+												itemId
+											)}
 										>
 											{selectable && (
 												<DndTable.Cell
@@ -199,13 +200,7 @@ function Table({items, itemsActions, schema, style}) {
 												itemsActions,
 												itemsChanges[itemId]
 											)}
-
-											<ActionsCell
-												item={item}
-												itemId={itemId}
-												itemsActions={itemsActions}
-											/>
-										</DndTable.Row>
+										</RowWithActions>
 
 										{nestedItems &&
 											nestedItems.map((nestedItem, i) => (
@@ -264,7 +259,13 @@ function Table({items, itemsActions, schema, style}) {
 	);
 }
 
-const ActionsCell = ({item, itemId, itemsActions}) => {
+const ActionsCell = ({
+	item,
+	itemId,
+	itemsActions,
+	menuActive,
+	onMenuActiveChange,
+}) => {
 	return (
 		<DndTable.Cell className="item-actions" columnName="item-actions">
 			{(itemsActions?.length > 0 ||
@@ -273,9 +274,45 @@ const ActionsCell = ({item, itemId, itemsActions}) => {
 					actions={itemsActions || item.actionDropdownItems}
 					itemData={item}
 					itemId={itemId}
+					menuActive={menuActive}
+					onMenuActiveChange={onMenuActiveChange}
 				/>
 			)}
 		</DndTable.Cell>
+	);
+};
+
+const RowWithActions = ({
+	active,
+	children,
+	className,
+	item,
+	itemId,
+	itemsActions,
+	selected,
+	...props
+}) => {
+	const [menuActive, setMenuActive] = useState(false);
+
+	return (
+		<DndTable.Row
+			className={classNames(className, {
+				active,
+				expanded: menuActive,
+				selected,
+			})}
+			{...props}
+		>
+			{children}
+
+			<ActionsCell
+				item={item}
+				itemId={itemId}
+				itemsActions={itemsActions}
+				menuActive={menuActive}
+				onMenuActiveChange={setMenuActive}
+			/>
+		</DndTable.Row>
 	);
 };
 


### PR DESCRIPTION
### References

- [LPS-157838](https://issues.liferay.com/browse/LPS-157838)

### What is the goal?

* Keep FDS table row quick actions visible when actions drop-down is expanded even when row isn't hovered  

### What does it look like?

https://user-images.githubusercontent.com/6642927/202224409-3c39a657-8eeb-49ac-8f36-68e416851162.mov


### Notes
I don't like this solution because it adds an unnecessary re-render to the entire row when the drop-down is expanded, but since we need to use the state of that drop-down to show/hide another element of the row, with the current tools the only way is to move the state up to the common ancestor, in this case the row. There's alternatives (using a context maybe), but the one I like the most is this:

#### Alternative: use the `:has()` pseudo-class.

Currently the visibility of the quick actions is handled using CSS (SASS in this case):
```scss
.dnd-tr:hover:not(.nested):not(.selected) {
	.item-actions {
		overflow: visible;
		position: relative;
	}

	.quick-action-menu {
		background-color: inherit;
		display: flex;
		right: 48px;
	}

	.dnd-td:nth-last-child(2) {
		visibility: hidden;
	}
}
```
As you can see, this will apply the necessary styles when the row is being hovered.

Adding a second selector would do the same thing as the 65 lines of code in the PR:
```scss
.dnd-tr:hover:not(.nested):not(.selected),
.dnd-tr:has(button[aria-expanded="true"]):not(.nested):not(.selected) { 
	...
}
```

This will apply the nested styles to the table row when it contains an expanded drop-down. Just one line!

The downside is that, as we can see in [the caniuse page for `:has`](https://caniuse.com/css-has), it is a fairly recent spec that is only supported by **82.92%** of all users. **It's already available in all Chromium-based browsers**, but it's only available in Firefox under a feature flag (and with plenty of bugs) and in the tech preview of Safari.

Now, adding this code wouldn't break the page in the browsers that don't support `:has`, it would just stay the way it is now in those browsers (the quick actions would disappear if we hover a different row). So nothing actually breaks, but it results in inconsistencies between browsers.

I think we could add the simpler solution, since nothing breaks and it's only a matter of time that Firefox/Safari release this functionality. On the other hand, I don't know how this would affect QA tests, since I don't know if they run all tests in different browsers to check for compatibility.

TL;DR: We could replace all the changes in this PR with [this commit](https://github.com/liferay-frontend/liferay-portal/commit/3c9ca484bdf0de7b9fb7782eedf81b8e9adcef71), but with compat issues that don't break anything.