### PR TITLE
LRQA-78438 | Fix path in UIInfrastructureUsecase file.

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/usecase/UIInfrastructureUsecase.testcase
@@ -41,12 +41,12 @@ definition {
 		Refresh();
 
 		AssertCssValue(
-			locator1 = "//ul[contains(@id,'controlMenu')]",
+			locator1 = "//*[contains(@id,'controlMenu')]",
 			locator2 = "display",
 			value1 = "flex");
 
 		AssertCssValue(
-			locator1 = "//ul[contains(@id,'controlMenu')]",
+			locator1 = "//*[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
 			value1 = "outside none none");
 
@@ -303,12 +303,12 @@ definition {
 		Refresh();
 
 		AssertCssValue(
-			locator1 = "//ul[contains(@id,'controlMenu')]",
+			locator1 = "//*[contains(@id,'controlMenu')]",
 			locator2 = "display",
 			value1 = "flex");
 
 		AssertCssValue(
-			locator1 = "//ul[contains(@id,'controlMenu')]",
+			locator1 = "//*[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
 			value1 = "outside none none");
 
@@ -319,12 +319,12 @@ definition {
 		Refresh();
 
 		AssertCssValue(
-			locator1 = "//ul[contains(@id,'controlMenu')]",
+			locator1 = "//*[contains(@id,'controlMenu')]",
 			locator2 = "display",
 			value1 = "flex");
 
 		AssertCssValue(
-			locator1 = "//ul[contains(@id,'controlMenu')]",
+			locator1 = "//*[contains(@id,'controlMenu')]",
 			locator2 = "list-style",
 			value1 = "outside none none");
 


### PR DESCRIPTION
**Background:**
Fixing of the test cases: 
[LocalFile.UIInfrastructureUsecase#AdminPageCanDisplayStyleCorrectlyAfterPageRefresh](https://issues.liferay.com/issues/?jql=project+in+%2813681%2C+17780%2C+16981%2C+12181%2C+15480%2C+10952%2C+13882%29+AND+cf%5B17320%5D+%3D+%22LocalFile.UIInfrastructureUsecase%23AdminPageCanDisplayStyleCorrectlyAfterPageRefresh%22) [LocalFile.UIInfrastructureUsecase#SitePageCanDisplayStyleCorrectlyAfterPageRefresh](https://issues.liferay.com/issues/?jql=project+in+%2813681%2C+17780%2C+16981%2C+12181%2C+15480%2C+10952%2C+13882%29+AND+cf%5B17320%5D+%3D+%22LocalFile.UIInfrastructureUsecase%23SitePageCanDisplayStyleCorrectlyAfterPageRefresh%22)