### PR TITLE
LPS-168469 Use newer npm-scripts

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"@liferay/eslint-plugin": "1.4.0",
-		"@liferay/npm-scripts": "47.10.0",
+		"@liferay/npm-scripts": "47.10.1",
 		"acorn": "7.1.0",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1867,10 +1867,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@47.10.0":
-  version "47.10.0"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.10.0.tgz#f442f863ba8e0ca6258c08260896674aae638ddb"
-  integrity sha512-ui9inLqV/nr2W4Y6bhCyULT8Q+Mrud5gRpLW7QGi+BuPwHzRpvEiD6d0Xgtfmoh+yfvdgVuz/g1ZO2acrZo1rQ==
+"@liferay/npm-scripts@47.10.1":
+  version "47.10.1"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.10.1.tgz#c0976886fea545a16055ea8291e1be847371a3c2"
+  integrity sha512-V9Av9phvf8OjDkTceQrMuW4zyRMeImbyFMElSNoCOW81NoSQvYNhG3M5Kq3s3Xx55B+/BWvujSLCL7oa87e0iw==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
So that source maps are generated correctly for ESM modules.