### PR TITLE
LPS-168731 Fix failing test FDSTable#HeadersCanBeLocalized

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSTable.testcase
@@ -60,6 +60,8 @@ definition {
 		}
 
 		task ("Then: There is no hyphen in any header text") {
+			WaitForElementPresent(locator1 = "FrontendDataSet#HEADER_ROW");
+
 			var header = selenium.getText("FrontendDataSet#HEADER_ROW");
 
 			var containsHyphen = StringUtil.contains("${header}", "-");


### PR DESCRIPTION
**Description**
Due to the fail `Element is not present at "xpath=(//div[contains(@class, "dnd-tr")])[1]"`, I added a function to wait for the element to be present and fix the test. 

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-168731