### PR TITLE
LPS-165707 Management toolbar accesibility issues

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -195,6 +195,13 @@ const FilterOrderControls = ({
 				(showDesignImprovements && sortingURL && showOrderToggle)) && (
 				<ManagementToolbar.Item>
 					<LinkOrButton
+						aria-label={
+							showDesignImprovements
+								? Liferay.Language.get(
+										'reverse-order-direction'
+								  )
+								: Liferay.Language.get('reverse-sort-direction')
+						}
 						className="nav-link nav-link-monospaced"
 						disabled={disabled}
 						displayType="unstyled"

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -189,6 +189,9 @@ function ManagementToolbar({
 										trigger={
 											showDesignImprovementsFF ? (
 												<ClayButton
+													aria-label={Liferay.Language.get(
+														'show-view-options'
+													)}
 													className="nav-link"
 													displayType="unstyled"
 													title={Liferay.Language.get(
@@ -210,6 +213,9 @@ function ManagementToolbar({
 												</ClayButton>
 											) : (
 												<ClayButtonWithIcon
+													aria-label={Liferay.Language.get(
+														'show-view-options'
+													)}
 													className="nav-link nav-link-monospaced"
 													displayType="unstyled"
 													symbol={viewTypeIcon}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -59,6 +59,7 @@ const SearchControls = ({
 							/>
 
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get('search')}
 								disabled={disabled}
 								displayType="unstyled"
 								symbol="search"
@@ -89,6 +90,7 @@ const ShowMobileButton = ({disabled, setSearchMobile}) => {
 	return (
 		<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 			<ClayButtonWithIcon
+				aria-label={Liferay.Language.get('search')}
 				className="nav-link nav-link-monospaced"
 				disabled={disabled}
 				displayType="unstyled"


### PR DESCRIPTION
Issue https://issues.liferay.com/browse/LPS-165707

Recently discovered that some of the management toolbar buttons are unlabeled in screen readers. 

![MT unlabeled buttons](https://user-images.githubusercontent.com/8373764/203055480-394e7804-f023-4c63-b7c7-b71922c39762.png)

Added label to buttons: 
- Order (asc/desc)
- Search icon
- View options