### PR TITLE
LPS-169150 | master

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -523,7 +523,7 @@ for (String analyticsType : analyticsTypes) {
 						Liferay.on(
 							'endNavigate',
 							function(event) {
-								ga('set', 'page', event.path);
+								ga('set', 'page', Liferay.ThemeDisplay.getLayoutRelativeURL());
 								ga('send', 'pageview');
 							}
 						);


### PR DESCRIPTION
Hi Team,

could you please review my fix?

**Issue description:**
Customer noticed that when Google Analytics is enabled, the requests to google have a wrong dp (document path) parameter, which does not comply with the description at https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters : "The path portion of the page URL. Should begin with '/'."
This parameter always includes the host as well, when accessing pages through the navigation menu.

**Steps to reproduce:**
1. Go to Site Settings for the default site, Configuration/Analytics and write your GA tracking ID in the Google Analytics ID field 
2. Add 2 pages to the site: page1 and page2.
3. Open the browser with the inspecting tools (F12), Network tab enabled. Access localhost:8080
4. Filter for "google" in the developer tools below, so you can only see the requests related to google analytics.
5. Click back and forth between page1 and page2 in the navigation menu at the top and each time click below on the created google request and inspect the right side (click on the request on the right side to reveal the parameters)
**Result:** the dp parameter always looks like http://localhost:8080/page1 or http://localhost:8080/page2 (see screenshot)
**Expected:** It should look like /page1 or /page2

**Fix:** Set page value with Liferay.ThemeDisplay.getLayoutRelativeURL()

https://issues.liferay.com/browse/LPS-169150

Thanks, Roland