### PR TITLE
LPS-165672 Add autom. test FDSCustomView#HasActionsOnlyOnEllipsis

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -24,6 +24,12 @@ definition {
 			value1 = "${key_filter}");
 	}
 
+	macro assertMenuItem {
+		AssertElementPresent(
+			key_itemName = "${key_menuItem}",
+			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+	}
+
 	macro changeCustomView {
 		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
@@ -127,9 +133,4 @@ definition {
 			value1 = "${key_itemName}");
 	}
 
-	macro assertMenuItem {
-		AssertElementPresent(
-				key_itemName = "${key_menuItem}",
-				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
-	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -20,7 +20,7 @@ definition {
 
 	macro assertFilterSummaryLabel {
 		AssertElementPresent(
-			locator1 = "Fron	tendDataSet#FILTER_SUMMARY_LABEL",
+			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL",
 			value1 = "${key_filter}");
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -81,8 +81,6 @@ definition {
 		Click(
 			key_text = "Delete",
 			locator1 = "Modal#MODAL_FOOTER_BUTTON");
-
-		Alert.viewSuccessMessage();
 	}
 
 	macro getValueByPosition {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FDSCustomView.macro
@@ -20,7 +20,7 @@ definition {
 
 	macro assertFilterSummaryLabel {
 		AssertElementPresent(
-			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL",
+			locator1 = "Fron	tendDataSet#FILTER_SUMMARY_LABEL",
 			value1 = "${key_filter}");
 	}
 
@@ -49,7 +49,7 @@ definition {
 		Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 
 		Click(
-			key_itemName = "Save View As",
+			key_itemName = "Save View As...",
 			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 
 		Type(
@@ -127,4 +127,9 @@ definition {
 			value1 = "${key_itemName}");
 	}
 
+	macro assertMenuItem {
+		AssertElementPresent(
+				key_itemName = "${key_menuItem}",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -46,18 +46,18 @@ definition {
 		}
 	}
 
-	@description = "LPS-159575 Automation Test Creation - Allow users to delete their custom viewsLPS"
+	@description = "LPS-159575 Automation Test Creation - Allow users to delete their custom views"
 	@priority = "5"
 	test CanBeDeleted {
-		task ("A custom view is created") {
+		task ("Given A custom view is created") {
 			FDSCustomView.createNewView(key_nameView = "New View");
 		}
 
-		task ("Deleting the custom view") {
+		task ("When Deleting the custom view") {
 			FDSCustomView.deleteView();
 		}
 
-		task ("Assert the custom view no longer exists") {
+		task ("Then Assert the custom view no longer exists") {
 			FDSCustomView.assertCustomViewName(key_nameCustomView = "New View");
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -239,24 +239,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-164616. Assert that it's possible to create A new custom view and selected as current view"
-	@priority = "4"
-	test HasOptionToEditName {
-		task ("And Given created custom view") {
-			FDSCustomView.createNewView(key_nameView = "TEST");
-		}
-
-		task ("When open ellisis next to custom view") {
-			Click(locator1 = "FrontendDataSet#ELLIPSIS");
-		}
-
-		task ("Then actions to edit custom view name is available") {
-			AssertElementPresent(
-				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER",
-				value1 = "Rename View");
-		}
-	}
-
 	@description = "LPS-165672 - Simplify how actions are shown in the custom views section"
 	@priority = "3"
 	test HasActionsOnlyOnEllipsis {
@@ -288,6 +270,24 @@ definition {
 			AssertElementNotPresent(
 				key_itemName = "Delete View",
 				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+		}
+	}
+
+	@description = "LPS-164616. Assert that it's possible to create A new custom view and selected as current view"
+	@priority = "4"
+	test HasOptionToEditName {
+		task ("And Given created custom view") {
+			FDSCustomView.createNewView(key_nameView = "TEST");
+		}
+
+		task ("When open ellisis next to custom view") {
+			Click(locator1 = "FrontendDataSet#ELLIPSIS");
+		}
+
+		task ("Then actions to edit custom view name is available") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER",
+				value1 = "Rename View");
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -254,6 +254,39 @@ definition {
 			AssertElementPresent(
 				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER",
 				value1 = "Rename View");
+=======
+	@description = "LPS-165672 - Simplify how actions are shown in the custom views section"
+	@priority = "3"
+	test HasActionsOnlyOnEllipsis {
+		task ("And Given created custom view") {
+			FDSCustomView.createNewView(key_nameView = "New View");
+		}
+
+		task ("When open ellipsis next to custom view") {
+			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+		}
+
+		task ("Then actions to save and delete views are available in dropdown menu") {
+			FDSCustomView.assertMenuItem(key_menuItem = "Save View");
+
+			FDSCustomView.assertMenuItem(key_menuItem = "Delete View");
+		}
+
+		task ("When open select custom view button") {
+			FDSCustomView.changeCustomView(key_itemName = "Default View");
+
+			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
+		}
+
+		task ("Then actions to save and delete views are not available in dropdown menu") {
+			AssertElementNotPresent(
+				key_itemName = "Save View",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+
+			AssertElementNotPresent(
+				key_itemName = "Delete View",
+				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+>>>>>>> 1800f1b (LPS-165672 SF)
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -332,7 +332,7 @@ definition {
 			Click(locator1 = "FrontendDataSet#ELLIPSIS");
 
 			AssertElementPresent(
-				key_itemName = "Guardar vista como",
+				key_itemName = "Guardar vista como…",
 				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSCustomView.testcase
@@ -254,7 +254,9 @@ definition {
 			AssertElementPresent(
 				locator1 = "FrontendDataSet#SELECT_OPTION_HEADER",
 				value1 = "Rename View");
-=======
+		}
+	}
+
 	@description = "LPS-165672 - Simplify how actions are shown in the custom views section"
 	@priority = "3"
 	test HasActionsOnlyOnEllipsis {
@@ -286,7 +288,6 @@ definition {
 			AssertElementNotPresent(
 				key_itemName = "Delete View",
 				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
->>>>>>> 1800f1b (LPS-165672 SF)
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -231,6 +231,11 @@
 	<td>//*[@class="dropdown custom-views-actions"]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>HEADER_ROW</td>
+	<td>xpath=(//div[contains(@class, "dnd-tr")])[1]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -231,11 +231,6 @@
 	<td>//*[@class="dropdown custom-views-actions"]</td>
 	<td></td>
 </tr>
-<tr>
-	<td>DELETE_BUTTON</td>
-	<td>//button[@class='btn btn-primary']</td>
-	<td></td>
-</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -218,7 +218,7 @@
 </tr>
 <tr>
 	<td>SELECT_OPTION_CUSTOM_VIEW</td>
-	<td>//button[contains(@class,'dropdown-item') and contains(text(), '${key_itemName}')]</td>
+	<td>//button[@class='dropdown-item'][normalize-space(text())='${key_itemName}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -232,8 +232,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>HEADER_ROW</td>
-	<td>xpath=(//div[contains(@class, "dnd-tr")])[1]</td>
+	<td>DELETE_BUTTON</td>
+	<td>//button[@class='btn btn-primary']</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
Forwarded manually to liferay-frontend.

PR original: https://github.com/mateusralv/liferay-portal/pull/22

---
Background
Create automation tests for FDSCustomView and refactor FDSCustomView#CanBeDeleted test (see https://github.com/liferay-frontend/liferay-portal/pull/2857#issuecomment-1317399703)

**Test Plan:**

- Given FDS Sample Portlet
- And Given Custom tab
- And Given created custom view
- When open ellipsis next to custom view
- Then actions to save and delete views are available in dropdown menu
- When open select custom view button // Default View button next to ellipsis
- Then actions to save and delete views are not available in dropdown menu

JIRA Ticket:
https://issues.liferay.com/browse/LPS-168707