### PR TITLE
LPS-169541 FDS dropdown item async action has incorrect error handling

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
@@ -70,7 +70,18 @@ public class FDSSampleDisplayContext {
 				"Sample Delete", null, null, null),
 			new FDSActionDropdownItem(
 				"#test-copy", "copy", "sampleMoveFolderMessage", "Sample Copy",
-				null, null, null));
+				null, null, null),
+			new FDSActionDropdownItem(
+				"http://localhost:8080", "truck", "asyncSuccess",
+				"Async Success", "get", null, "async"),
+			new FDSActionDropdownItem(
+				"http://localhost", "times-circle",
+				"asyncErrorConnectionRefused", "Async Connection Refused",
+				"get", null, "async"),
+			new FDSActionDropdownItem(
+				"http://localhost:8080/abc", "staging",
+				"asyncErrorResourceNotFound", "Async Resource Not Found", "get",
+				null, "async"));
 	}
 
 	public PortletURL getPortletURL() throws PortletException {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openConfirmModal, openToast} from 'frontend-js-web';
+import {openConfirmModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
@@ -112,19 +112,13 @@ export function handleAction(
 			event.preventDefault();
 
 			setLoading(true);
-			executeAsyncItemAction(url, method)
-				.then(() => {
-					openToast({
-						message:
-							successMessage ||
-							Liferay.Language.get('action-completed'),
-						type: 'success',
-					});
-					setLoading(false);
-				})
-				.catch((_) => {
-					setLoading(false);
-				});
+
+			executeAsyncItemAction({
+				method,
+				setActionItemLoading: setLoading,
+				successMessage,
+				url,
+			});
 		}
 		else if (target === 'inlineEdit') {
 			event.preventDefault();

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
@@ -99,7 +99,7 @@ function ActionsDropdown({
 			/>
 
 			{loading ? (
-				<ClayLoadingIndicator small />
+				<ClayLoadingIndicator className="mb-2 mt-2" />
 			) : (
 				<ClayButtonWithIcon
 					disabled={!itemChanges}
@@ -136,7 +136,7 @@ function ActionsDropdown({
 		}
 
 		if (loading) {
-			return <ClayLoadingIndicator small />;
+			return <ClayLoadingIndicator className="mb-2 mt-2" />;
 		}
 
 		const content = action.icon ? (
@@ -210,7 +210,7 @@ function ActionsDropdown({
 	}
 
 	if (loading && !inlineEditingAlwaysOn) {
-		return <ClayLoadingIndicator small />;
+		return <ClayLoadingIndicator className="mb-2 mt-2" />;
 	}
 
 	const renderItems = (items) =>
@@ -241,7 +241,7 @@ function ActionsDropdown({
 		});
 
 	return (
-		<div className="d-flex justify-content-end ml-auto">
+		<div className="d-flex justify-content-end">
 			{inlineEditingAlwaysOn && inlineEditingActions}
 
 			<ClayDropDown

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
@@ -14,7 +14,7 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import {navigate, openConfirmModal, openToast} from 'frontend-js-web';
+import {navigate, openConfirmModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
@@ -87,16 +87,9 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 			) {
 				event.preventDefault();
 
-				executeAsyncItemAction(
-					formattedHref,
-					currentAction.method
-				).then(() => {
-					openToast({
-						message:
-							currentAction.data?.successMessage ||
-							Liferay.Language.get('action-completed'),
-						type: 'success',
-					});
+				executeAsyncItemAction({
+					method: currentAction.method,
+					url: formattedHref,
 				});
 			}
 			else if (currentAction.onClick) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
@@ -32,6 +32,10 @@
 		border-right: none;
 	}
 
+	&.item-actions {
+		min-height: 58px;
+	}
+
 	&.item-actions,
 	&.item-selector {
 		width: 1%;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -16,12 +16,6 @@ import {fetch} from 'frontend-js-web';
 
 import createOdataFilter from './odata';
 
-export function delay(duration) {
-	return new Promise((resolve) => {
-		setTimeout(() => resolve(), duration);
-	});
-}
-
 export function getData(apiURL, query) {
 	const url = new URL(apiURL);
 


### PR DESCRIPTION
### References

- [LPS-169541 FDS dropdown item async action has incorrect error handling](https://issues.liferay.com/browse/LPS-169541)

### What is the goal of this PR?

The main goal is fixing error handling of FDS actions. 

In addition:
- we are fixing styles when action loading indicator is active.
- we are adding samples for action success and two types of errors.

Notes:
- `delay(500)` and related code was a (pretty ugly) fix for the case where loading indicator state was set during data refresh. Instead of this, we are no longer updating loading indicator on action success; data refresh does this by refreshing entire table.
- I equalized styles by setting fixed min height. This may not be ideal solution, but I see no cleaner way of equalizing loading indicator and dropdown ellipsis icon.

### What does it look like?

#### Before PR

https://user-images.githubusercontent.com/5435511/203831550-864e78c6-2d16-4e79-a4af-ec8c101fb48c.mp4

#### After PR

https://user-images.githubusercontent.com/5435511/203831567-716090ad-fbeb-49ef-a3d9-1ee2f8fbd9e4.mp4

### Steps to reproduce
