### PR TITLE
[TS] LPS-167597 Update portletId following to CETDeployer that any non-word character on ERC should be replaced to underline

### DIFF
--- a/modules/apps/client-extension/client-extension-test/build.gradle
+++ b/modules/apps/client-extension/client-extension-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal:portal-props-test-util")
+	testIntegrationCompile project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationCompile project(":core:osgi-service-tracker-collections")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_0_1/test/UpgradePortletIdTest.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.upgrade.v3_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.service.persistence.PortletPreferencesPersistence;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import javax.portlet.Portlet;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Binh Tran
+ */
+@RunWith(Arquillian.class)
+public class UpgradePortletIdTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() {
+		Bundle bundle = FrameworkUtil.getBundle(UpgradePortletIdTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_clientExtensionEntryErc = _portalUUID.generate() + "-TEST";
+
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_group.getGroupId());
+
+		String languageId = UpgradeProcessUtil.getDefaultLanguageId(
+			_layout.getCompanyId());
+
+		_clientExtensionEntryLocalService.addClientExtensionEntry(
+			_clientExtensionEntryErc, TestPropsValues.getUserId(),
+			StringPool.BLANK,
+			Collections.singletonMap(
+				LocaleUtil.fromLanguageId(languageId),
+				RandomTestUtil.randomString()),
+			StringPool.BLANK, StringPool.BLANK,
+			ClientExtensionEntryConstants.TYPE_CUSTOM_ELEMENT,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"htmlElementName", "valid-html-element-name"
+			).put(
+				"instanceable", false
+			).put(
+				"urls", "http://" + RandomTestUtil.randomString() + ".com"
+			).buildString());
+
+		_upgradeStepRegistrator.register(
+			(fromSchemaVersionString, toSchemaVersionString, upgradeSteps) -> {
+				for (UpgradeStep upgradeStep : upgradeSteps) {
+					Class<?> clazz = upgradeStep.getClass();
+
+					String className = clazz.getName();
+
+					if (className.contains(
+							"com.liferay.client.extension.web.internal." +
+								"upgrade.v3_0_1.UpgradePortletId")) {
+
+						_upgradeProcess = (UpgradeProcess)upgradeStep;
+					}
+				}
+			});
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Test
+	public void testUpdateClientExtensionEntryPortletIdInPortletReference()
+		throws Exception {
+
+		String portletIdWithoutCompanyId =
+			_PORTLET_ID_PREFIX +
+				_replaceNonwordCharacterToUnderline(_clientExtensionEntryErc);
+
+		_registerPortlet(portletIdWithoutCompanyId);
+
+		LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), _layout, portletIdWithoutCompanyId,
+			"column-1", new HashMap<>());
+
+		PortletPreferences portletPreferencesBeforeUpgrade =
+			_portletPreferencesLocalService.fetchPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, _layout.getPlid(),
+				portletIdWithoutCompanyId);
+
+		Assert.assertNotNull(portletPreferencesBeforeUpgrade);
+
+		Assert.assertEquals(
+			"Assert the portletPreferences portletId before upgrade",
+			portletIdWithoutCompanyId,
+			portletPreferencesBeforeUpgrade.getPortletId());
+
+		_upgradeProcess.upgrade();
+
+		String newPortletIdWithCompanyId = StringBundler.concat(
+			_PORTLET_ID_PREFIX, _layout.getCompanyId(), StringPool.UNDERLINE,
+			_replaceNonwordCharacterToUnderline(_clientExtensionEntryErc));
+
+		_portletPreferencesPersistence.clearCache();
+
+		PortletPreferences portletPreferencesWithOldId =
+			_portletPreferencesLocalService.fetchPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, _layout.getPlid(),
+				portletIdWithoutCompanyId);
+
+		PortletPreferences portletPreferencesWithNewId =
+			_portletPreferencesLocalService.fetchPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, _layout.getPlid(),
+				newPortletIdWithCompanyId);
+
+		Assert.assertNotNull(portletPreferencesWithNewId);
+
+		Assert.assertNull(portletPreferencesWithOldId);
+
+		Assert.assertEquals(
+			"Assert the portletPreferences portletId after upgrade",
+			newPortletIdWithCompanyId,
+			portletPreferencesWithNewId.getPortletId());
+	}
+
+	private void _registerPortlet(String portletName) {
+		_serviceRegistration = _bundleContext.registerService(
+			Portlet.class, new MVCPortlet(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"com.liferay.portlet.preferences-company-wide", "false"
+			).put(
+				"com.liferay.portlet.preferences-owned-by-group", false
+			).put(
+				"com.liferay.portlet.preferences-unique-per-layout", true
+			).put(
+				"javax.portlet.name", portletName
+			).build());
+	}
+
+	private String _replaceNonwordCharacterToUnderline(
+		String externalReferenceCode) {
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			return externalReferenceCode.replaceAll(
+				"\\W", StringPool.UNDERLINE);
+		}
+
+		return externalReferenceCode;
+	}
+
+	private static final String _PORTLET_ID_PREFIX =
+		"com_liferay_client_extension_web_internal_portlet_" +
+			"ClientExtensionEntryPortlet_";
+
+	private static BundleContext _bundleContext;
+
+	private String _clientExtensionEntryErc;
+
+	@Inject
+	private ClientExtensionEntryLocalService _clientExtensionEntryLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+
+	@Inject
+	private PortalUUID _portalUUID;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
+	private PortletPreferencesPersistence _portletPreferencesPersistence;
+
+	private ServiceRegistration<Portlet> _serviceRegistration;
+	private UpgradeProcess _upgradeProcess;
+
+	@Inject(
+		filter = "component.name=com.liferay.client.extension.web.internal.upgrade.registry.ClientExtensionWebUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.client.extension.type.deployer.CETDeployer;
 import com.liferay.client.extension.web.internal.portlet.ClientExtensionEntryFriendlyURLMapper;
 import com.liferay.client.extension.web.internal.portlet.ClientExtensionEntryPortlet;
 import com.liferay.client.extension.web.internal.portlet.action.ClientExtensionEntryConfigurationAction;
+import com.liferay.client.extension.web.internal.util.CETUtil;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -116,14 +117,12 @@ public class CETDeployerImpl implements CETDeployer {
 	}
 
 	private String _getPortletId(CET cet) {
-		String externalReferenceCode = cet.getExternalReferenceCode();
-
 		return StringBundler.concat(
 			"com_liferay_client_extension_web_internal_portlet_",
 			"ClientExtensionEntryPortlet_", cet.getCompanyId(),
 			StringPool.UNDERLINE,
-			externalReferenceCode.replaceAll(
-				"[^a-zA-Z0-9_]", StringPool.UNDERLINE));
+			CETUtil.replaceNonwordCharacterToUnderline(
+				cet.getExternalReferenceCode()));
 	}
 
 	private ServiceRegistration<ConfigurationAction>

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/registry/ClientExtensionWebUpgradeStepRegistrator.java
@@ -57,6 +57,11 @@ public class ClientExtensionWebUpgradeStepRegistrator
 			"2.0.0", "3.0.0",
 			new com.liferay.client.extension.web.internal.upgrade.v3_0_0.
 				UpgradePortletId());
+
+		registry.register(
+			"3.0.0", "3.0.1",
+			new com.liferay.client.extension.web.internal.upgrade.v3_0_1.
+				UpgradePortletId());
 	}
 
 	@Reference(

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_1/UpgradePortletId.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/upgrade/v3_0_1/UpgradePortletId.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.web.internal.upgrade.v3_0_1;
+
+import com.liferay.client.extension.web.internal.util.CETUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.BasePortletIdUpgradeProcess;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class UpgradePortletId extends BasePortletIdUpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select externalReferenceCode, clientExtensionEntryId from " +
+					"ClientExtensionEntry")) {
+
+			while (resultSet.next()) {
+				String externalReferenceCode =
+					CETUtil.replaceNonwordCharacterToUnderline(
+						resultSet.getString("externalReferenceCode"));
+
+				runSQL(
+					StringBundler.concat(
+						"delete from Portlet where portletId = '",
+						"com_liferay_client_extension_web_internal_portlet_",
+						"ClientExtensionEntryPortlet_", externalReferenceCode,
+						"'"));
+
+				runSQL(
+					StringBundler.concat(
+						"delete from ResourcePermission where name = '",
+						"com_liferay_client_extension_web_internal_portlet_",
+						"ClientExtensionEntryPortlet_", externalReferenceCode,
+						"'"));
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		super.doUpgrade();
+	}
+
+	@Override
+	protected String[][] getRenamePortletIdsArray() {
+		return getRenamePortletIdsArray(
+			connection,
+			"com_liferay_client_extension_web_internal_" +
+				"portlet_ClientExtensionEntryPortlet_");
+	}
+
+	protected String[][] getRenamePortletIdsArray(
+		Connection connection, String portletIdPrefix) {
+
+		List<String[]> portletIds = new ArrayList<>();
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				"select externalReferenceCode, companyId from " +
+					"ClientExtensionEntry")) {
+
+			while (resultSet.next()) {
+				String externalReferenceCode =
+					CETUtil.replaceNonwordCharacterToUnderline(
+						resultSet.getString("externalReferenceCode"));
+
+				portletIds.add(
+					new String[] {
+						portletIdPrefix + externalReferenceCode,
+						StringBundler.concat(
+							portletIdPrefix, resultSet.getLong("companyId"),
+							StringPool.UNDERLINE, externalReferenceCode)
+					});
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		return portletIds.toArray(new String[0][0]);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradePortletId.class);
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/util/CETUtil.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/util/CETUtil.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.client.extension.web.internal.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Binh Tran
+ */
+public class CETUtil {
+
+	public static String replaceNonwordCharacterToUnderline(
+		String externalReferenceCode) {
+
+		if (Validator.isNotNull(externalReferenceCode)) {
+			return externalReferenceCode.replaceAll(
+				"\\W", StringPool.UNDERLINE);
+		}
+
+		return externalReferenceCode;
+	}
+
+}


### PR DESCRIPTION
We need to format ERC this way because each time the portal start, it re-deploy the client extension entry, then the portlet will register with the new id, checking the CETDeployerImpl we can see it always replaced the non-characters in ERC to UNDERLINE, that why I think the upgrade process v3_0_0 take no effects.

Sorry to bother you again @izaera, I sperate the fix into a new upgrade process.
Hopefully, it is what BC expected. Please help to review. Thank you.