### PR TITLE
[TS] LPS-170203 catch throwable and print as debug level if an error is thrown while minifying css

### DIFF
--- a/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
+++ b/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
@@ -111,6 +111,17 @@ public class MinifierUtil {
 
 			return unsyncStringWriter.toString();
 		}
+		catch (Throwable throwable) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to minify CSS with length:\n" + content.length(),
+					throwable);
+			}
+
+			unsyncStringWriter.append(content);
+
+			return unsyncStringWriter.toString();
+		}
 		finally {
 			if (_log.isDebugEnabled()) {
 				int length = 0;

--- a/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
+++ b/portal-impl/src/com/liferay/portal/minifier/MinifierUtil.java
@@ -104,19 +104,14 @@ public class MinifierUtil {
 
 			return unsyncStringWriter.toString();
 		}
-		catch (Exception exception) {
-			_log.error("Unable to minify CSS:\n" + content, exception);
-
-			unsyncStringWriter.append(content);
-
-			return unsyncStringWriter.toString();
-		}
 		catch (Throwable throwable) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to minify CSS with length:\n" + content.length(),
-					throwable);
+			String failingContent = content;
+
+			if (content.length() > 1048576) {
+				failingContent = failingContent.substring(0, 1048575);
 			}
+
+			_log.error("Unable to minify CSS:\n" + failingContent, throwable);
 
 			unsyncStringWriter.append(content);
 


### PR DESCRIPTION
//cc @georgel-pop-lr

Hi FEI team,

This PR aims to add more information in the logs when debug traces are enabled and if a error is thrown while minifying css in the portal. (I know this is deprecated in master, but for 7.3 and prior versions we still support it)

Currently we only catch Exceptions, but when minifying as we use pattern/matching in java, a StackOverflowError can be thrown. 
This leads to the situation where the file is not minified but there's no additional information in the logs, apart from 
"[MinifierUtil:133] Minification for XXX bytes of CSS took YYY ms" that could lead to a wrong conclussion.
