### PR TITLE
LPS-165904 Make form submission send a submit event in Modal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -100,11 +100,11 @@ const Modal = ({
 					const form = iframeDocument.getElementById(formId);
 
 					if (form) {
-						form.submit();
+						form.requestSubmit();
 					}
 				}
 				else if (forms.length >= 1) {
-					forms[0].submit();
+					forms[0].requestSubmit();
 				}
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -78,6 +78,21 @@ const Modal = ({
 	});
 
 	const onButtonClick = ({formId, onClick, type}) => {
+		const submitForm = (form) => {
+			if (form.requestSubmit) {
+				form.requestSubmit();
+			}
+			else {
+				const accepted = form.dispatchEvent(
+					new Event('submit', {cancelable: true})
+				);
+
+				if (accepted) {
+					form.submit();
+				}
+			}
+		};
+
 		if (type === 'cancel') {
 			processClose();
 		}
@@ -100,11 +115,11 @@ const Modal = ({
 					const form = iframeDocument.getElementById(formId);
 
 					if (form) {
-						form.requestSubmit();
+						submitForm(form);
 					}
 				}
 				else if (forms.length >= 1) {
-					forms[0].requestSubmit();
+					submitForm(forms[0]);
 				}
 			}
 		}

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/add_instance.jsp
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/add_instance.jsp
@@ -77,6 +77,8 @@
 
 			<p class="text-3 text-center text-secondary"><liferay-ui:message key="the-creation-of-the-site-may-take-some-time-.closing-the-window-will-not-cancel-the-process" /></p>
 		</div>
+
+		<input type="submit" hidden />
 	</liferay-frontend:edit-form>
 </clay:container-fluid>
 

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/add_instance.jsp
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/add_instance.jsp
@@ -69,12 +69,6 @@
 
 					</aui:select>
 				</c:if>
-
-				<liferay-frontend:edit-form-footer>
-					<liferay-frontend:edit-form-buttons
-						submitLabel="add"
-					/>
-				</liferay-frontend:edit-form-footer>
 			</div>
 		</div>
 

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,8 +1,4 @@
 .portlet-portal-instances {
-	.dialog-footer {
-		position: fixed;
-	}
-
 	.add-instance-loading {
 		margin-top: 30vh;
 

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/AddInstance.js
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/AddInstance.js
@@ -29,6 +29,14 @@ export default function ({namespace}) {
 		content.classList.remove('d-block');
 		loading.classList.add('d-flex');
 
+		const alertContainer = document.querySelector(
+			'.add-instance-alert-container'
+		);
+
+		if (alertContainer.hasChildNodes()) {
+			alertContainer.firstChild.remove();
+		}
+
 		fetch(form.action, {
 			body: formData,
 			method: 'POST',
@@ -36,14 +44,6 @@ export default function ({namespace}) {
 			.then((response) => response.json())
 			.then((response) => {
 				const opener = getOpener();
-
-				const alertContainer = document.querySelector(
-					'.add-instance-alert-container'
-				);
-
-				if (alertContainer.hasChildNodes()) {
-					alertContainer.firstChild.remove();
-				}
 
 				if (!response.error) {
 					opener.Liferay.fire('closeModal', {
@@ -58,9 +58,7 @@ export default function ({namespace}) {
 
 					openToast({
 						autoClose: false,
-						container: document.querySelector(
-							'.add-instance-alert-container'
-						),
+						container: alertContainer,
 						message: response.error,
 						toastProps: {
 							onClose: null,

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/PortalInstancesManagementToolbarPropsTransformer.js
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/PortalInstancesManagementToolbarPropsTransformer.js
@@ -14,13 +14,25 @@
 
 import {openModal} from 'frontend-js-web';
 
-export default function propsTransformer({...otherProps}) {
+export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {
 		...otherProps,
 		onCreateButtonClick(event, {item}) {
 			event.preventDefault();
 
 			openModal({
+				buttons: [
+					{
+						displayType: 'secondary',
+						label: Liferay.Language.get('cancel'),
+						type: 'cancel',
+					},
+					{
+						formId: `${portletNamespace}fm`,
+						label: Liferay.Language.get('add'),
+						type: 'submit',
+					},
+				],
 				height: '60vh',
 				iframeBodyCssClass: '',
 				size: 'md',


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-165904

In Modal.js there is an utility to allow publish the form inside the iframe when passing the type="submit" and formId in the buttons prop. It uses form.submit() directly which doesn't trigger a submit event, making it impossible to handle the event and prevent it

This pr fixes it using the requestSubmit method, that submit the form and also fires the event. I've also added a fallback since this method is not supported in safari 14 (which is in the compatibility matrix)

