### PR TITLE
LPS-170299 Merge FDS Autocomplete and Selection filters into Selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 11.2.2
+Bundle-Version: 11.3.0
 Export-Package:\
 	com.liferay.frontend.data.set.constants,\
 	com.liferay.frontend.data.set.filter,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
@@ -25,6 +25,8 @@ import java.util.ResourceBundle;
  */
 public abstract class BaseSelectionFDSFilter implements FDSFilter {
 
+	public Boolean getAutocomplete() { return false; }
+
 	public ResourceBundle getResourceBundle(Locale locale) {
 		return ResourceBundleUtil.getBundle(
 			"content.Language", locale, getClass());

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.data.set.filter;
 
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -27,13 +28,25 @@ public abstract class BaseSelectionFDSFilter implements FDSFilter {
 
 	public Boolean getAutocomplete() { return false; }
 
+	public String getAPIURL() {
+		return null;
+	};
+
 	public ResourceBundle getResourceBundle(Locale locale) {
 		return ResourceBundleUtil.getBundle(
 			"content.Language", locale, getClass());
 	}
 
-	public abstract List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
-		Locale locale);
+	public String getItemKey() { return null; };
+
+	public String getItemLabel() { return null; };
+
+	public String getPlaceholder() { return "search"; }
+
+	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
+		Locale locale) {
+		return Collections.emptyList();
+	};
 
 	@Override
 	public String getType() {

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
@@ -26,25 +26,34 @@ import java.util.ResourceBundle;
  */
 public abstract class BaseSelectionFDSFilter implements FDSFilter {
 
-	public Boolean getAutocomplete() { return false; }
-
 	public String getAPIURL() {
 		return null;
 	};
+
+	public Boolean getAutocomplete() {
+		return false;
+	}
+
+	public String getItemKey() {
+		return null;
+};
+
+	public String getItemLabel() {
+		return null;
+};
+
+	public String getPlaceholder() {
+		return "search";
+	}
 
 	public ResourceBundle getResourceBundle(Locale locale) {
 		return ResourceBundleUtil.getBundle(
 			"content.Language", locale, getClass());
 	}
 
-	public String getItemKey() { return null; };
-
-	public String getItemLabel() { return null; };
-
-	public String getPlaceholder() { return "search"; }
-
 	public List<SelectionFDSFilterItem> getSelectionFDSFilterItems(
 		Locale locale) {
+
 		return Collections.emptyList();
 	};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/filter/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/filter/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
@@ -79,13 +79,28 @@ public class SelectionFDSFilterContextContributor
 				));
 		}
 
-		return HashMapBuilder.<String, Object>put(
+		HashMapBuilder.HashMapWrapper<String, Object> builder = HashMapBuilder.<String, Object>put(
 			"autocomplete", baseSelectionFDSFilter.getAutocomplete()
 		).put(
 			"items", jsonArray
 		).put(
 			"multiple", baseSelectionFDSFilter.isMultiple()
-		).build();
+		);
+
+		if (baseSelectionFDSFilter.getAutocomplete()) {
+			builder.put(
+				"apiURL", baseSelectionFDSFilter.getAPIURL()
+			).put(
+				"inputPlaceholder",
+				_language.get(locale, baseSelectionFDSFilter.getPlaceholder())
+			).put(
+				"itemKey", baseSelectionFDSFilter.getItemKey()
+			).put(
+				"itemLabel", baseSelectionFDSFilter.getItemLabel()
+			);
+		}
+
+		return builder.build();
 	}
 
 	@Reference

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
@@ -80,6 +80,8 @@ public class SelectionFDSFilterContextContributor
 		}
 
 		return HashMapBuilder.<String, Object>put(
+			"autocomplete", baseSelectionFDSFilter.getAutocomplete()
+		).put(
 			"items", jsonArray
 		).put(
 			"multiple", baseSelectionFDSFilter.isMultiple()

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/filter/SelectionFDSFilterContextContributor.java
@@ -79,13 +79,14 @@ public class SelectionFDSFilterContextContributor
 				));
 		}
 
-		HashMapBuilder.HashMapWrapper<String, Object> builder = HashMapBuilder.<String, Object>put(
-			"autocomplete", baseSelectionFDSFilter.getAutocomplete()
-		).put(
-			"items", jsonArray
-		).put(
-			"multiple", baseSelectionFDSFilter.isMultiple()
-		);
+		HashMapBuilder.HashMapWrapper<String, Object> builder =
+			HashMapBuilder.<String, Object>put(
+				"autocomplete", baseSelectionFDSFilter.getAutocomplete()
+			).put(
+				"items", jsonArray
+			).put(
+				"multiple", baseSelectionFDSFilter.isMultiple()
+			);
 
 		if (baseSelectionFDSFilter.getAutocomplete()) {
 			builder.put(

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
@@ -51,7 +51,11 @@ public class ColorSelectionFDSFilter extends BaseSelectionFDSFilter {
 		return HashMapBuilder.<String, Object>put(
 			"exclude", false
 		).put(
-			"itemsValues", new String[] {"Blue", "Green", "Yellow"}
+			"itemsValues",
+			ListUtil.fromArray(
+				new SelectionFDSFilterItem("Blue", "Blue"),
+				new SelectionFDSFilterItem("Green", "Green"),
+				new SelectionFDSFilterItem("Yellow", "Yellow"))
 		).build();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/SelectionFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/SelectionFilter.js
@@ -12,38 +12,63 @@
  * details.
  */
 
+import ClayAutocomplete from '@clayui/autocomplete';
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import {
-	ClayCheckbox,
-	ClayRadio,
-	ClayRadioGroup,
-	ClayToggle,
-} from '@clayui/form';
+import {ClayCheckbox, ClayRadio, ClayToggle} from '@clayui/form';
+import ClayLabel from '@clayui/label';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {useIsMounted} from '@liferay/frontend-js-react-web';
+import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import {isValuesArrayChanged} from '../../../utils/index';
+import {getValueFromItem, isValuesArrayChanged} from '../../../utils/index';
+import {logError} from '../../../utils/logError';
 
-const getSelectedItemsLabel = ({items, selectedData}) => {
-	const itemsValues = selectedData.itemsValues;
+const DEFAULT_PAGE_SIZE = 10;
 
-	const itemsLabel = itemsValues
-		? itemsValues
-				.map((itemsValue) => {
-					return items.reduce(
-						(found, item) =>
-							found ||
-							(item.value === itemsValue ? item.label : null),
-						null
-					);
-				})
-				.join(', ')
-		: '';
+function fetchData(apiURL, searchParam, currentPage = 1) {
+	const url = new URL(apiURL, themeDisplay.getPortalURL());
+
+	url.searchParams.append('page', currentPage);
+	url.searchParams.append('pageSize', DEFAULT_PAGE_SIZE);
+
+	if (searchParam) {
+		url.searchParams.append('search', encodeURIComponent(searchParam));
+	}
+
+	return fetch(url.pathname + url.search, {
+		headers: {
+			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+		},
+	}).then((response) => response.json());
+}
+
+function Item({multiple, ...props}) {
+	const Input = multiple ? ClayCheckbox : ClayRadio;
 
 	return (
-		(selectedData?.exclude ? `(${Liferay.Language.get('exclude')}) ` : '') +
-		itemsLabel
+		<li>
+			<Input {...props} />
+		</li>
+	);
+}
+
+Item.propTypes = {
+	checked: PropTypes.bool.isRequired,
+	label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+	multiple: PropTypes.bool,
+	onChange: PropTypes.func.isRequired,
+	value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};
+
+const getSelectedItemsLabel = ({selectedData}) => {
+	const {exclude, itemsValues} = selectedData;
+
+	return (
+		(exclude ? `(${Liferay.Language.get('exclude')}) ` : '') +
+		itemsValues.map((itemsValue) => itemsValue.label).join(', ')
 	);
 };
 
@@ -54,51 +79,149 @@ const getOdataString = ({entityFieldType, id, selectedData}) => {
 		return null;
 	}
 
-	const quotedItemValues = itemsValues.map((itemValue) => {
-		return typeof itemValue === 'string' ? `'${itemValue}'` : itemValue;
-	});
+	const quotedItemValues = itemsValues.map((itemValue) => 
+		 typeof itemValue.value === 'string' ? `'${itemValue.value}'` : itemValue.value
+	);
 
 	if (entityFieldType === 'collection') {
 		return `${id}/any(x:${quotedItemValues
-			.map((itemValue) => `(x ${exclude ? 'ne' : 'eq'} ${itemValue})`)
+			.map((value) => `(x ${exclude ? 'ne' : 'eq'} ${value})`)
 			.join(exclude ? ' and ' : ' or ')})`;
 	}
 	else if (itemsValues.length === 1) {
 		return `${id} ${exclude ? 'ne' : 'eq'} ${quotedItemValues[0]}`;
 	}
-	else if (!exclude) {
-		return `${id} in (${quotedItemValues.join(', ')})`;
-	}
 	else {
-		return quotedItemValues.reduce((previous, current) => {
-			const value = `(${id} ne ${current})`;
+		const expression = `${id} in (${quotedItemValues.join(', ')})`;
 
-			return previous ? `${previous} and ${value}` : value;
-		}, '');
+		if (exclude) {
+			return 'not (' + expression + ')';
+		}
+
+		return expression;
 	}
 };
 
-const SelectionFilter = ({
+function SelectionFilter({
+	apiURL,
+	autocomplete,
 	entityFieldType,
 	id,
-	items,
+	inputPlaceholder,
+	itemKey,
+	itemLabel: itemLabelProp,
+	items: initialItems,
 	multiple,
 	selectedData,
 	setFilter,
-}) => {
-	const [itemsValues, setItemsValues] = useState(
+}) {
+	const [query, setQuery] = useState('');
+	const [search, setSearch] = useState('');
+	const [selectedItems, setSelectedItems] = useState(
 		selectedData?.itemsValues || []
 	);
-	const [exclude, setExclude] = useState(selectedData?.exclude || false);
+	const [items, setItems] = useState(apiURL ? null : initialItems);
+	const [loading, setLoading] = useState(false);
+	const [currentPage, setCurrentPage] = useState(1);
+	const [total, setTotal] = useState(apiURL ? 0 : initialItems?.length);
+	const scrollingAreaRef = useRef(null);
+	const [scrollingAreaRendered, setScrollingAreaRendered] = useState(false);
+	const infiniteLoaderRef = useRef(null);
+	const [infiniteLoaderRendered, setInfiniteLoaderRendered] = useState(false);
+	const [exclude, setExclude] = useState(!!selectedData?.exclude);
+
+	const loaderVisible = items?.length < total;
 
 	useEffect(() => {
-		setItemsValues(selectedData?.itemsValues || []);
-		setExclude(selectedData?.exclude || false);
+		setSelectedItems(selectedData?.itemsValues || []);
 	}, [selectedData]);
+
+	useEffect(() => {
+		if (query === search) {
+			return;
+		}
+		setCurrentPage(1);
+		setSearch(query);
+	}, [query, search]);
+
+	const isMounted = useIsMounted();
+
+	useEffect(() => {
+		if (apiURL) {
+			setLoading(true);
+			fetchData(apiURL, search, currentPage)
+				.then((data) => {
+					if (!isMounted()) {
+						return;
+					}
+
+					setLoading(false);
+					if (currentPage === 1) {
+						setItems(data.items);
+					} else {
+						setItems((items) => [...items, ...data.items]);
+					}
+					setTotal(data.totalCount);
+				})
+				.catch((error) => {
+					logError(error);
+
+					if (isMounted()) {
+						setLoading(false);
+					}
+				});
+		}
+	}, [autocomplete, currentPage, isMounted, search, apiURL]);
+
+	const setScrollingArea = useCallback((node) => {
+		scrollingAreaRef.current = node;
+		setScrollingAreaRendered(true);
+	}, []);
+
+	const setInfiniteLoader = useCallback((node) => {
+		infiniteLoaderRef.current = node;
+		setInfiniteLoaderRendered(true);
+	}, []);
+
+	const setObserver = useCallback(() => {
+		if (
+			!scrollingAreaRef.current ||
+			!infiniteLoaderRef.current ||
+			!IntersectionObserver
+		) {
+			return;
+		}
+
+		const options = {
+			root: scrollingAreaRef.current,
+			rootMargin: '0px',
+			threshold: 1.0,
+		};
+
+		const observer = new IntersectionObserver((entries) => {
+			if (entries[0].intersectionRatio <= 0) {
+				return;
+			}
+			setCurrentPage((page) => page + 1);
+		}, options);
+
+		observer.observe(infiniteLoaderRef.current);
+	}, []);
+
+	useEffect(() => {
+		if (scrollingAreaRendered && infiniteLoaderRendered && loaderVisible) {
+			setObserver();
+		}
+	}, [
+		scrollingAreaRendered,
+		infiniteLoaderRendered,
+		loaderVisible,
+		setObserver,
+	]);
 
 	let actionType = 'edit';
 
-	if (selectedData?.itemsValues && !itemsValues.length) {
+	if (selectedData?.itemsValues && !selectedItems.length) {
 		actionType = 'delete';
 	}
 
@@ -110,17 +233,58 @@ const SelectionFilter = ({
 
 	if (
 		actionType === 'delete' ||
-		(!selectedData && itemsValues.length) ||
+		(!selectedData && selectedItems.length) ||
 		(selectedData &&
-			isValuesArrayChanged(selectedData.itemsValues, itemsValues)) ||
-		(selectedData && itemsValues.length && selectedData.exclude !== exclude)
+			isValuesArrayChanged(selectedData.itemsValues, selectedItems)) ||
+		(selectedData &&
+			selectedItems.length &&
+			selectedData.exclude !== exclude)
 	) {
 		submitDisabled = false;
 	}
 
 	return (
 		<>
-			<ClayDropDown.Caption className="pb-0">
+			{autocomplete && (
+				<>
+					<ClayDropDown.Caption>
+						<ClayAutocomplete>
+							<ClayAutocomplete.Input
+								onChange={(event) =>
+									setQuery(event.target.value)
+								}
+								placeholder={inputPlaceholder}
+							/>
+
+							{loading && <ClayAutocomplete.LoadingIndicator />}
+						</ClayAutocomplete>
+
+						{selectedItems.length ? (
+							<div className="mt-2 selected-elements-wrapper">
+								{selectedItems.map((selectedItem) => (
+									<ClayLabel
+										closeButtonProps={{
+											onClick: () =>
+												setSelectedItems((items) =>
+													items.filter(
+														(item) =>
+															item.value !==
+															selectedItem.value
+													)
+												),
+										}}
+										key={selectedItem.value}
+									>
+										{selectedItem.label}
+									</ClayLabel>
+								))}
+							</div>
+						) : null}
+					</ClayDropDown.Caption>
+					<ClayDropDown.Divider />
+				</>
+			)}
+			<ClayDropDown.Caption className="py-0">
 				<div className="row">
 					<div className="col">
 						<label htmlFor={`autocomplete-exclude-${id}`}>
@@ -139,34 +303,72 @@ const SelectionFilter = ({
 			</ClayDropDown.Caption>
 			<ClayDropDown.Divider />
 			<ClayDropDown.Caption>
-				<div className="inline-scroller mb-n2 mx-n2 px-2">
-					{multiple ? (
-						<MultipleSelectionItems
-							items={items}
-							itemsValues={itemsValues}
-							onChange={(itemValue) => {
-								if (itemsValues.includes(itemValue)) {
-									setItemsValues(
-										itemsValues.filter(
-											(value) => value !== itemValue
-										)
-									);
-								}
-								else {
-									setItemsValues(
-										itemsValues.concat(itemValue)
-									);
-								}
-							}}
-						/>
+				<div className="form-group">
+					{items && !!items.length ? (
+						<ul
+							className="inline-scroller mb-n2 mx-n2 px-2"
+							ref={setScrollingArea}
+						>
+							{items.map((item) => {
+								const itemValue = itemKey
+									? item[itemKey]
+									: item.value;
+								const itemLabel = itemLabelProp
+									? getValueFromItem(item, itemLabelProp)
+									: item.label;
+								const newValue = {
+									label: itemLabel,
+									value: itemValue,
+								};
+
+								return (
+									<Item
+										aria-label={itemLabel}
+										checked={Boolean(
+											selectedItems.find(
+												(element) =>
+													element.value === itemValue
+											)
+										)}
+										key={itemValue}
+										label={itemLabel}
+										multiple={multiple}
+										onChange={() => {
+											setSelectedItems(
+												selectedItems.find(
+													(element) =>
+														element.value ===
+														itemValue
+												)
+													? selectedItems.filter(
+															(element) =>
+																element.value !==
+																itemValue
+													  )
+													: multiple
+													? [
+															...selectedItems,
+															newValue,
+													  ]
+													: [newValue]
+											);
+										}}
+										value={itemValue}
+									/>
+								);
+							})}
+
+							{loaderVisible && (
+								<ClayLoadingIndicator
+									ref={setInfiniteLoader}
+									small
+								/>
+							)}
+						</ul>
 					) : (
-						<SingleSelectionItems
-							items={items}
-							itemsValues={itemsValues}
-							onChange={(itemValue) => {
-								setItemsValues([itemValue]);
-							}}
-						/>
+						<div className="mt-2 p-2 text-muted">
+							{Liferay.Language.get('no-items-were-found')}
+						</div>
 					)}
 				</div>
 			</ClayDropDown.Caption>
@@ -177,11 +379,10 @@ const SelectionFilter = ({
 					onClick={() => {
 						if (actionType === 'delete') {
 							setFilter({active: false, id});
-						}
-						else {
+						} else {
 							const newSelectedData = {
 								exclude,
-								itemsValues,
+								itemsValues: selectedItems,
 							};
 
 							setFilter({
@@ -190,11 +391,11 @@ const SelectionFilter = ({
 								odataFilterString: getOdataString({
 									entityFieldType,
 									id,
+									multiple,
 									selectedData: newSelectedData,
 								}),
 								selectedData: newSelectedData,
 								selectedItemsLabel: getSelectedItemsLabel({
-									items,
 									selectedData: newSelectedData,
 								}),
 							});
@@ -213,51 +414,17 @@ const SelectionFilter = ({
 			</ClayDropDown.Caption>
 		</>
 	);
-};
-
-const MultipleSelectionItems = ({items, itemsValues, onChange}) => {
-	return items.map((item) => {
-		let checked = false;
-
-		if (itemsValues) {
-			checked = itemsValues.reduce(
-				(acc, element) => acc || element === item.value,
-				false
-			);
-		}
-
-		return (
-			<ClayCheckbox
-				aria-label={item.label}
-				checked={checked}
-				key={item.value}
-				label={item.label}
-				onChange={() => onChange(item.value)}
-			/>
-		);
-	});
-};
-
-const SingleSelectionItems = ({items, itemsValues, onChange}) => {
-	return (
-		<ClayRadioGroup
-			onChange={onChange}
-			value={itemsValues?.length && itemsValues[0]}
-		>
-			{items.map((item) => (
-				<ClayRadio
-					key={item.value}
-					label={item.label}
-					value={item.value}
-				/>
-			))}
-		</ClayRadioGroup>
-	);
-};
+}
 
 SelectionFilter.propTypes = {
+	apiURL: PropTypes.string,
+	autocomplete: PropTypes.bool,
 	entityFieldType: PropTypes.string,
 	id: PropTypes.string.isRequired,
+	inputPlaceholder: PropTypes.string,
+	itemKey: PropTypes.string.isRequired,
+	itemLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
+		.isRequired,
 	items: PropTypes.arrayOf(
 		PropTypes.shape({
 			label: PropTypes.string,
@@ -268,9 +435,19 @@ SelectionFilter.propTypes = {
 	selectedData: PropTypes.shape({
 		exclude: PropTypes.bool,
 		itemsValues: PropTypes.arrayOf(
-			PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+			PropTypes.shape({
+				label: PropTypes.oneOfType([
+					PropTypes.string,
+					PropTypes.number,
+				]),
+				value: PropTypes.oneOfType([
+					PropTypes.string,
+					PropTypes.number,
+				]),
+			})
 		),
 	}),
+	setFilter: PropTypes.func.isRequired,
 };
 
 export {getSelectedItemsLabel, getOdataString};


### PR DESCRIPTION
### References

- [LPS-170299](https://issues.liferay.com/browse/LPS-170299)

### What is the goal?

* Merge FDS Autocomplete and Selection filters
   * UI:
      * Used Autocomplete as a base, since the more complex common logic lied there, but final name is Selection 
      * Make `SelectionFilter` populate initial data with the previous `Selection` props (`selectedData?.itemsValues`), but also fetch the new values considering the user's input when the `apiURL` prop is present
      * Add `autocomplete` prop to show/hide the autocomplete input
   * Backend:
      * Change the format for `itemsValues` in the `preloadedData` field, as they don't follow the same format as the API call responses
      * Unify `isMultiple` and `isMultipleSelection` in `isMultiple` (was the name in the Selection class)
      * Add `autocomplete` field and set it to true for all use cases of previous `BaseAutocompleteFDSFilter`
      * Change `entityFieldType` to be null by default, and added `collection` for all use cases that used `BaseAutocompleteFDSFilter` filter and didn't override it

### What does it look like?

Previously using the Selection filter - Object and FDS Sample:

https://user-images.githubusercontent.com/6642927/205266557-14b36560-93ea-4d38-9912-33419dc2b3e5.mov



https://user-images.githubusercontent.com/6642927/205266621-c0749a23-f959-4647-8bef-464c5f0f6ec3.mov






