### PR TITLE
LPS-170528 Stabilize Theme#CanBeAppliedToPageWhenClassicThemeNotAvailable

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -70,6 +70,10 @@ definition {
 
 		Navigator.openURL();
 
+		WaitForConsoleTextPresent(value1 = "1 theme for classic-theme was unregistered");
+
+		WaitForConsoleTextPresent(value1 = "No theme found for specified theme id classic_WAR_classictheme. Returning the default theme.");
+
 		AssertConsoleTextPresent(value1 = "No theme found for specified theme id classic_WAR_classictheme. Returning the default theme.");
 
 		AssertConsoleTextNotPresent(value1 = "java.lang.NullPointerException");


### PR DESCRIPTION
**Description**
It looks like there's a race condition in the [test](https://testray.liferay.com/home/-/testray/case_results/2109565826). The test is too fast in trying to assert console log messages before the instance can fully stop the removed jar file. The proposed fix is to add wait for steps in order to try and slow down the test so it can make assertions when the instance has caught up. 

**Test Plan**
- [x] Monitor [EE Package Tester](https://testray.liferay.com/home/-/testray/case_results/2098197085/history?tab=result&hideFilterPin=true) and check that Theme#CanBeAppliedToPageWhenClassicThemeNotAvailable passes more consistently

**JIRA TICKET**
https://issues.liferay.com/browse/LPS-170528