### PR TITLE
LPS-170678 | Create automated test for Custom Element

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionCustomElement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionCustomElement.testcase
@@ -59,13 +59,13 @@ definition {
 
 		task ("Then custom element is available under category 'Client Extensions'") {
 			AssertTextEquals(
-				locator1 = "PageEditor#FRAGMENT_SIDEBAR_COLLECTION_PANEL",
 				key_collectionName = "Client Extensions",
+				locator1 = "PageEditor#FRAGMENT_SIDEBAR_COLLECTION_PANEL",
 				value1 = "Client Extensions");
 
 			AssertTextEquals(
-				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_RESULTS",
 				key_fragmentName = "Vanilla Counter",
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_RESULTS",
 				value1 = "Vanilla Counter");
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionCustomElement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionCustomElement.testcase
@@ -1,0 +1,65 @@
+definition {
+
+    property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Remote Apps";
+	property testray.main.component.name = "Remote Apps";
+
+    setUp{
+        TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+    }
+
+    tearDown{
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			RemoteApps.tearDown();
+
+			Navigator.gotoPage(pageName = "Home");
+        }
+    }
+
+    @description = "LPS-170678 - Assert if 'Custom Element' can be categorized as 'Client Extension'"
+    @priority = "3"
+    test CanBeCategorizedInAddWidgetList {
+
+        property app.server.types = "tomcat";
+		property database.types = "mysql";
+		property environment.acceptance = "true";
+		property portal.acceptance = "true";
+
+		task("When client extension has portal category 'Client Extensions'"){
+        	RemoteApps.goToRemoteAppsPortlet();
+
+			RemoteApps.addCustomElementAllFields(
+			entryCssurl = "https://liferay.github.io/liferay-frontend-projects/index.css",
+			entryHtmlName = "vanilla-counter",
+			entryName = "Vanilla Counter",
+			entryProperties = "test-data-user=QAuser",
+			entryURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
+		}
+
+		task("And When on Content Page"){
+			Navigator.openURL();
+
+			Click(locator1 = "//span[@title='Edit']");
+		}
+
+		task("And When access add widget list"){
+			Type(
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_FIELD",
+				value1 = "Client Extensions");
+		}
+
+		task("Then custom element is available under category 'Client Extensions'"){
+			AssertTextEquals(
+				locator1 = "//span[@class='c-inner text-truncate']",
+				value1 = "Client Extensions");
+		}
+    }
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionCustomElement.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionCustomElement.testcase
@@ -1,65 +1,73 @@
 definition {
 
-    property portal.release = "true";
+	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.component.names = "Remote Apps";
 	property testray.main.component.name = "Remote Apps";
 
-    setUp{
-        TestCase.setUpPortalInstance();
+	setUp {
+		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
-    }
+	}
 
-    tearDown{
+	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
 		}
 		else {
-			RemoteApps.tearDown();
-
 			Navigator.gotoPage(pageName = "Home");
-        }
-    }
 
-    @description = "LPS-170678 - Assert if 'Custom Element' can be categorized as 'Client Extension'"
-    @priority = "3"
-    test CanBeCategorizedInAddWidgetList {
+			RemoteApps.tearDown();
+		}
+	}
 
-        property app.server.types = "tomcat";
+	@description = "LPS-170678 - Assert if 'Custom Element' can be categorized as 'Client Extension'"
+	@priority = "3"
+	test CanBeCategorizedInAddWidgetList {
+		property app.server.types = "tomcat";
 		property database.types = "mysql";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 
-		task("When client extension has portal category 'Client Extensions'"){
-        	RemoteApps.goToRemoteAppsPortlet();
+		task ("When client extension has portal category 'Client Extensions'") {
+			RemoteApps.goToRemoteAppsPortlet();
 
 			RemoteApps.addCustomElementAllFields(
-			entryCssurl = "https://liferay.github.io/liferay-frontend-projects/index.css",
-			entryHtmlName = "vanilla-counter",
-			entryName = "Vanilla Counter",
-			entryProperties = "test-data-user=QAuser",
-			entryURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
+				entryCssurl = "https://liferay.github.io/liferay-frontend-projects/index.css",
+				entryHtmlName = "vanilla-counter",
+				entryName = "Vanilla Counter",
+				entryProperties = "test-data-user=QAuser",
+				entryURL = "https://liferay.github.io/liferay-frontend-projects/vanilla-counter/index.js");
 		}
 
-		task("And When on Content Page"){
+		task ("And When on Content Page") {
 			Navigator.openURL();
 
-			Click(locator1 = "//span[@title='Edit']");
+			ContentPagesNavigator.openEditContentPage(
+				pageName = "Home",
+				siteName = "guest");
 		}
 
-		task("And When access add widget list"){
+		task ("And When access add widget list") {
 			Type(
 				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_FIELD",
 				value1 = "Client Extensions");
 		}
 
-		task("Then custom element is available under category 'Client Extensions'"){
+		task ("Then custom element is available under category 'Client Extensions'") {
 			AssertTextEquals(
-				locator1 = "//span[@class='c-inner text-truncate']",
+				locator1 = "PageEditor#FRAGMENT_SIDEBAR_COLLECTION_PANEL",
+				key_collectionName = "Client Extensions",
 				value1 = "Client Extensions");
+
+			AssertTextEquals(
+				locator1 = "PageEditor#FRAGMENTS_AND_WIDGETS_SEARCH_RESULTS",
+				key_fragmentName = "Vanilla Counter",
+				value1 = "Vanilla Counter");
 		}
-    }
+	}
+
 }


### PR DESCRIPTION
**Background:**
Assert if Custom Element can be categorized as 'Client Extension'

**Test plan:**
- Given a Custom Element client extension
- When client extension has portal category "Client Extensions"
- And When on Content Page
- And When access add widget list
- Then custom element is available under category "Client Extensions"

**JIRA Ticket:**
https://issues.liferay.com/browse/LPS-170678

cc/ @john-co @mateusralv 