### PR TITLE
COMMERCE-10457 Organization list must auto-complete in in-flow account creation

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/account_selector/views/AccountCreationModalBody.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/components/account_selector/views/AccountCreationModalBody.js
@@ -31,6 +31,7 @@ export default function AccountCreationModalBody({
 	accountTypes,
 	setAccountData,
 }) {
+	const [availableOrganizations, setAvailableOrganizations] = useState([]);
 	const [organizationQuery, setOrganizationQuery] = useState('');
 	const [organizationData, setOrganizationData] = useState([]);
 	const [organizationError, setOrganizationError] = useState(false);
@@ -49,17 +50,15 @@ export default function AccountCreationModalBody({
 		[organizationData]
 	);
 
-	const filterOrganizations = (organizations, accountOrganizations) => {
-		if (!accountOrganizations.length) {
-			return organizations;
-		}
-
-		const accountValues = accountOrganizations.map((item) => item.value);
-
-		return organizations.filter(
-			(org) => !accountValues.includes(org.value)
+	useEffect(() => {
+		const accountValues = accountData.organizations.map(
+			(item) => item.value
 		);
-	};
+
+		setAvailableOrganizations(
+			organizations.filter((org) => !accountValues.includes(org.value))
+		);
+	}, [accountData.organizations, organizations]);
 
 	return (
 		<ClayModal.Body>
@@ -126,9 +125,10 @@ export default function AccountCreationModalBody({
 							organizations: validItems,
 						});
 					}}
-					sourceItems={filterOrganizations(
-						organizations,
-						accountData.organizations
+					sourceItems={availableOrganizations.filter((organization) =>
+						organization.label
+							.toLowerCase()
+							.match(organizationQuery.toLowerCase())
 					)}
 					value={organizationQuery}
 				/>


### PR DESCRIPTION
https://issues.liferay.com/browse/COMMERCE-10457

This PR is adding a little bit more functionality to the account creation process merged in a recent PR - #2834 

It filters available organizations to show unselected organisations matching the input string.