### PR TITLE
LPS-170535| Add Autom. Test  FDSAsyncItemAction#RequestValidIPCanReturnSuccess

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -49,21 +49,22 @@ definition {
 	@priority = "4"
 	test RequestValidIPCanReturnSuccess {
 		task ("When open action list dropdown menu in 1st row item") {
-           Click(
+			Click(
 				key_title = "Sample1",
 				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
 		}
 
-        task("And When access async success action item to request valid ip address"){
-            Click(
+		task ("And When access async success action item to request valid ip address") {
+			Click(
 				key_viewMode = "Async Success",
 				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
-        }
-        
-        task("Then returns success alert toast"){
-            AssertTextEquals(
+		}
+
+		task ("Then returns success alert toast") {
+			AssertTextEquals(
 				locator1 = "Message#SUCCESS_DISMISSIBLE",
 				value1 = "Success:Your request completed successfully.");
-        }
+		}
 	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -1,0 +1,69 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Frontend Dataset sample portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+	}
+
+	@description = "LPS-170535. Request Valid IP Can Return Success."
+	@priority = "4"
+	test RequestValidIPCanReturnSuccess {
+		task ("When open action list dropdown menu in 1st row item") {
+           Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+        task("And When access async success action item to request valid ip address"){
+            Click(
+				key_viewMode = "Async Success",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+        }
+        
+        task("Then returns success alert toast"){
+            AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+        }
+	}
+}


### PR DESCRIPTION
**Test Plan**

- Given: Frontend Dataset sample portlet
- When open action list dropdown menu in 1st row item
- And When access async success action item to request valid ip address
- Then returns success alert toast

**Jira Ticket:**
https://issues.liferay.com/browse/LPS-170535