### PR TITLE
LPS-170536 | Add Autom. Test FDSAsyncItemAction#RequestInvalidIPCanReturnErrorConnectionRefused

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -1,0 +1,69 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Frontend Dataset sample portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+	}
+
+	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
+	@priority = "4"
+	test RequestInvalidIPCanReturnErrorConnectionRefused {
+		task ("When open action list dropdown menu in 1st row item") {
+			Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+		task ("And When access async connection refused to request invalid ip address") {
+			Click(
+				key_viewMode = "Async Connection Refused",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		}
+
+		task ("Then returns unexpected error alert toast") {
+            AssertElementPresent(locator1 = "Message#ERROR_DISMISSIBLE",
+			value1 = "An unexpected error occurred.");
+		}
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -61,8 +61,9 @@ definition {
 		}
 
 		task ("Then returns unexpected error alert toast") {
-            AssertElementPresent(locator1 = "Message#ERROR_DISMISSIBLE",
-			value1 = "An unexpected error occurred.");
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "An unexpected error occurred.");
 		}
 	}
 


### PR DESCRIPTION
**Test Plan**

- Given: Frontend Dataset sample portlet
- When open action list dropdown menu in 1st row item
- And When access async connection refused to request invalid ip address
- Then returns unexpected error alert toast

**Jira Ticket:**
https://issues.liferay.com/browse/LPS-170536