### PR TITLE
LPS-170537 | Add Autom. Test FDSAsyncItemAction#RequestNonExistingResourceCanReturnErrorNotFound

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSet.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSet.macro
@@ -1,13 +1,13 @@
 definition {
-    
-    macro selectItemActionDropdownMenuList {
-        Click(
-            key_title = "${key_title}",
-            locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
-        Click(
-            key_viewMode = "${key_viewMode}",
-            locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+
+	macro selectItemActionDropdownMenuList {
+		Click(
+			key_title = "${key_title}",
+			locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+
+		Click(
+			key_viewMode = "${key_viewMode}",
+			locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
 	}
+
 }
-
-

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSet.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSet.macro
@@ -1,0 +1,13 @@
+definition {
+    
+    macro selectItemActionDropdownMenuList {
+        Click(
+            key_title = "${key_title}",
+            locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+        Click(
+            key_viewMode = "${key_viewMode}",
+            locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+	}
+}
+
+

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -45,8 +45,8 @@ definition {
 		}
 	}
 
-	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
-	@priority = "4"
+	@description = "LPS-170537. Request Non Existing Resource Can Return Error Not Found."
+	@priority = "3"
 	test RequestNonExistingResourceCanReturnErrorNotFound {
 		task ("When open action list dropdown menu in 1st row item") {
 			Click(

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -81,21 +81,22 @@ definition {
 	@priority = "3"
 	test RequestValidIPCanReturnSuccess {
 		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
-			// FrontendDataSet.selectItemActionDropdownMenuList(
-			// 	key_title = "Sample1",
-			// 	key_viewMode = "Async Success");
+
+			//FrontendDataSet.selectItemActionDropdownMenuList(
+			//	key_title = "Sample1",
+			//	key_viewMode = "Async Success");
 
 			Click(
-			key_title = "Sample1",
-			locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
 
 			takeScreenshot();
 
 			Click(
-			key_viewMode = "Async Success",
-			locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
-			takeScreenshot();
+				key_viewMode = "Async Success",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
 
+			takeScreenshot();
 		}
 
 		task ("Then returns success alert toast") {
@@ -104,22 +105,22 @@ definition {
 				value1 = "Success:Your request completed successfully.");
 		}
 	}
+
 	@description = "LPS-170535. Request Valid IP Can Return Success."
 	@priority = "3"
 	test RequestValidIPCanReturnSuccess2 {
 		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
-
 			Click.pauseClickAt(
-			key_title = "Sample1",
-			locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
 
 			takeScreenshot();
 
 			Click.pauseClickAt(
-			key_viewMode = "Async Success",
-			locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
-			takeScreenshot();
+				key_viewMode = "Async Success",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
 
+			takeScreenshot();
 		}
 
 		task ("Then returns success alert toast") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -48,18 +48,13 @@ definition {
 	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
 	@priority = "3"
 	test RequestInvalidIPCanReturnErrorConnectionRefused {
-		task ("When open action list dropdown menu in 1st row item") {
-			Click(
+
+		task ("When open action list dropdown menu in 1st row item. And When access async connection refused to request invalid ip address") {
+
+			FrontendDataSet.selectItemActionDropdownMenuList(
 				key_title = "Sample1",
-				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+				key_viewMode = "Async Connection Refused");
 		}
-
-		task ("And When access async connection refused to request invalid ip address") {
-			Click(
-				key_viewMode = "Async Connection Refused",
-				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
-		}
-
 		task ("Then returns unexpected error alert toast") {
 			AssertElementPresent(
 				locator1 = "Message#ERROR_DISMISSIBLE",
@@ -70,16 +65,12 @@ definition {
 	@description = "LPS-170537. Request Non Existing Resource Can Return Error Not Found."
 	@priority = "3"
 	test RequestNonExistingResourceCanReturnErrorNotFound {
-		task ("When open action list dropdown menu in 1st row item") {
-			Click(
-				key_title = "Sample1",
-				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
-		}
 
-		task ("And When access async success action item to request a resource that does not exist") {
-			Click(
-				key_viewMode = "Async Resource Not Found",
-				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request a resource that does not exist") {
+
+			FrontendDataSet.selectItemActionDropdownMenuList(
+				key_title = "Sample1",
+				key_viewMode = "Async Resource Not Found");			
 		}
 
 		task ("Then returns unexpected error alert toast") {
@@ -92,16 +83,13 @@ definition {
 	@description = "LPS-170535. Request Valid IP Can Return Success."
 	@priority = "3"
 	test RequestValidIPCanReturnSuccess {
-		task ("When open action list dropdown menu in 1st row item") {
-			Click(
-				key_title = "Sample1",
-				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
-		}
 
-		task ("And When access async success action item to request valid ip address") {
-			Click(
-				key_viewMode = "Async Success",
-				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
+
+			FrontendDataSet.selectItemActionDropdownMenuList(
+				key_title = "Sample1",
+				key_viewMode = "Async Success");
+			
 		}
 
 		task ("Then returns success alert toast") {
@@ -110,5 +98,5 @@ definition {
 				value1 = "Success:Your request completed successfully.");
 		}
 	}
-
 }
+

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -45,6 +45,28 @@ definition {
 		}
 	}
 
+	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
+	@priority = "3"
+	test RequestInvalidIPCanReturnErrorConnectionRefused {
+		task ("When open action list dropdown menu in 1st row item") {
+			Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+		task ("And When access async connection refused to request invalid ip address") {
+			Click(
+				key_viewMode = "Async Connection Refused",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		}
+
+		task ("Then returns unexpected error alert toast") {
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "An unexpected error occurred.");
+		}
+	}
+
 	@description = "LPS-170537. Request Non Existing Resource Can Return Error Not Found."
 	@priority = "3"
 	test RequestNonExistingResourceCanReturnErrorNotFound {
@@ -86,28 +108,6 @@ definition {
 			AssertTextEquals(
 				locator1 = "Message#SUCCESS_DISMISSIBLE",
 				value1 = "Success:Your request completed successfully.");
-		}
-	}
-
-	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
-	@priority = "3"
-	test RequestInvalidIPCanReturnErrorConnectionRefused {
-		task ("When open action list dropdown menu in 1st row item") {
-			Click(
-				key_title = "Sample1",
-				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
-		}
-
-		task ("And When access async connection refused to request invalid ip address") {
-			Click(
-				key_viewMode = "Async Connection Refused",
-				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
-		}
-
-		task ("Then returns unexpected error alert toast") {
-			AssertElementPresent(
-				locator1 = "Message#ERROR_DISMISSIBLE",
-				value1 = "An unexpected error occurred.");
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -129,5 +129,28 @@ definition {
 				value1 = "Success:Your request completed successfully.");
 		}
 	}
+	
+	@description = "LPS-170535. Request Valid IP Can Return Success."
+	@priority = "3"
+	test RequestValidIPCanReturnSucces3 {
+		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
+			Click(
+				locator1 ="//*[@class='dropdown-toggle component-action dropdown-toggle ml-1 btn btn-unstyled']");
+
+			takeScreenshot();
+
+			Click(
+				key_viewMode = "Async Success",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+
+			takeScreenshot();
+		}
+
+		task ("Then returns success alert toast") {
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+		}
+	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -1,0 +1,70 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Frontend Dataset sample portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+	}
+
+	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
+	@priority = "4"
+	test RequestNonExistingResourceCanReturnErrorNotFound {
+		task ("When open action list dropdown menu in 1st row item") {
+			Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+		task ("And When access async success action item to request a resource that does not exist") {
+			Click(
+				key_viewMode = "Async Resource Not Found",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		}
+
+		task ("Then returns unexpected error alert toast") {
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "An unexpected error occurred.");
+		}
+	}
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -67,4 +67,48 @@ definition {
 		}
 	}
 
+	@description = "LPS-170535. Request Valid IP Can Return Success."
+	@priority = "3"
+	test RequestValidIPCanReturnSuccess {
+		task ("When open action list dropdown menu in 1st row item") {
+			Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+		task ("And When access async success action item to request valid ip address") {
+			Click(
+				key_viewMode = "Async Success",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		}
+
+		task ("Then returns success alert toast") {
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+		}
+	}
+
+	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
+	@priority = "3"
+	test RequestInvalidIPCanReturnErrorConnectionRefused {
+		task ("When open action list dropdown menu in 1st row item") {
+			Click(
+				key_title = "Sample1",
+				locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+		}
+
+		task ("And When access async connection refused to request invalid ip address") {
+			Click(
+				key_viewMode = "Async Connection Refused",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+		}
+
+		task ("Then returns unexpected error alert toast") {
+			AssertElementPresent(
+				locator1 = "Message#ERROR_DISMISSIBLE",
+				value1 = "An unexpected error occurred.");
+		}
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -79,6 +79,28 @@ definition {
 
 	@description = "LPS-170535. Request Valid IP Can Return Success."
 	@priority = "3"
+	test RequestValidIPCanReturnSucces3 {
+		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
+			Click(locator1 = "//*[@class='dropdown-toggle component-action dropdown-toggle ml-1 btn btn-unstyled']");
+
+			takeScreenshot();
+
+			Click(
+				key_viewMode = "Async Success",
+				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+
+			takeScreenshot();
+		}
+
+		task ("Then returns success alert toast") {
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+		}
+	}
+
+	@description = "LPS-170535. Request Valid IP Can Return Success."
+	@priority = "3"
 	test RequestValidIPCanReturnSuccess {
 		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
 
@@ -117,29 +139,6 @@ definition {
 			takeScreenshot();
 
 			Click.pauseClickAt(
-				key_viewMode = "Async Success",
-				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
-
-			takeScreenshot();
-		}
-
-		task ("Then returns success alert toast") {
-			AssertTextEquals(
-				locator1 = "Message#SUCCESS_DISMISSIBLE",
-				value1 = "Success:Your request completed successfully.");
-		}
-	}
-	
-	@description = "LPS-170535. Request Valid IP Can Return Success."
-	@priority = "3"
-	test RequestValidIPCanReturnSucces3 {
-		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
-			Click(
-				locator1 ="//*[@class='dropdown-toggle component-action dropdown-toggle ml-1 btn btn-unstyled']");
-
-			takeScreenshot();
-
-			Click(
 				key_viewMode = "Async Success",
 				locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -81,9 +81,45 @@ definition {
 	@priority = "3"
 	test RequestValidIPCanReturnSuccess {
 		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
-			FrontendDataSet.selectItemActionDropdownMenuList(
-				key_title = "Sample1",
-				key_viewMode = "Async Success");
+			// FrontendDataSet.selectItemActionDropdownMenuList(
+			// 	key_title = "Sample1",
+			// 	key_viewMode = "Async Success");
+
+			Click(
+			key_title = "Sample1",
+			locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+
+			takeScreenshot();
+
+			Click(
+			key_viewMode = "Async Success",
+			locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+			takeScreenshot();
+
+		}
+
+		task ("Then returns success alert toast") {
+			AssertTextEquals(
+				locator1 = "Message#SUCCESS_DISMISSIBLE",
+				value1 = "Success:Your request completed successfully.");
+		}
+	}
+	@description = "LPS-170535. Request Valid IP Can Return Success."
+	@priority = "3"
+	test RequestValidIPCanReturnSuccess2 {
+		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
+
+			Click.pauseClickAt(
+			key_title = "Sample1",
+			locator1 = "FrontendDataSet#ENTRY_VERTICAL_ELLIPSIS");
+
+			takeScreenshot();
+
+			Click.pauseClickAt(
+			key_viewMode = "Async Success",
+			locator1 = "FrontendDataSet#ITEMS_VIEW_TYPE_DROPDOWN");
+			takeScreenshot();
+
 		}
 
 		task ("Then returns success alert toast") {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/tests/FDSAsyncItemAction.testcase
@@ -48,13 +48,12 @@ definition {
 	@description = "LPS-170536. Request Invalid IP Can Return Error Connection Refused."
 	@priority = "3"
 	test RequestInvalidIPCanReturnErrorConnectionRefused {
-
 		task ("When open action list dropdown menu in 1st row item. And When access async connection refused to request invalid ip address") {
-
 			FrontendDataSet.selectItemActionDropdownMenuList(
 				key_title = "Sample1",
 				key_viewMode = "Async Connection Refused");
 		}
+
 		task ("Then returns unexpected error alert toast") {
 			AssertElementPresent(
 				locator1 = "Message#ERROR_DISMISSIBLE",
@@ -65,12 +64,10 @@ definition {
 	@description = "LPS-170537. Request Non Existing Resource Can Return Error Not Found."
 	@priority = "3"
 	test RequestNonExistingResourceCanReturnErrorNotFound {
-
 		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request a resource that does not exist") {
-
 			FrontendDataSet.selectItemActionDropdownMenuList(
 				key_title = "Sample1",
-				key_viewMode = "Async Resource Not Found");			
+				key_viewMode = "Async Resource Not Found");
 		}
 
 		task ("Then returns unexpected error alert toast") {
@@ -83,13 +80,10 @@ definition {
 	@description = "LPS-170535. Request Valid IP Can Return Success."
 	@priority = "3"
 	test RequestValidIPCanReturnSuccess {
-
 		task ("When open action list dropdown menu in 1st row item. And When access async success action item to request valid ip address") {
-
 			FrontendDataSet.selectItemActionDropdownMenuList(
 				key_title = "Sample1",
 				key_viewMode = "Async Success");
-			
 		}
 
 		task ("Then returns success alert toast") {
@@ -98,5 +92,5 @@ definition {
 				value1 = "Success:Your request completed successfully.");
 		}
 	}
-}
 
+}


### PR DESCRIPTION
**Test Plan:**

- Given: Frontend Dataset sample portlet
- When open action list dropdown menu in 1st row item
- And When ** access async success action item to request a resource that does not exist
- Then returns unexpected error alert toast

**Jira Ticket:**
https://issues.liferay.com/browse/LPS-170537