### PR TITLE
LPS-167272 Update alloy-ui to 3.1.0-deprecated.108

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.106"
+String alloyUIVersion = "3.1.0-deprecated.108"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.106"
+String alloyUIVersion = "3.1.0-deprecated.108"
 
 String fontAwesomeVersion = "3.2.1"
 


### PR DESCRIPTION
## What's Changed
* fix: LPS-167272 Multiple events are being read in reverse order by @markocikos in https://github.com/liferay/liferay-frontend-projects/pull/1052
* fix: LPS-167272 set correct aria label for the next month button by @markocikos in https://github.com/liferay/yui3/pull/32

## New Contributors
* @markocikos made their first contribution in https://github.com/liferay/liferay-frontend-projects/pull/1052

**107 Changelog**: https://github.com/liferay/liferay-frontend-projects/compare/npm-scripts/v47.10.2...alloy-ui/v3.1.0-deprecated.107
**108 Changelog**: https://github.com/liferay/liferay-frontend-projects/compare/alloy-ui/v3.1.0-deprecated.107...alloy-ui/v3.1.0-deprecated.108