### PR TITLE
LPS-170571 | Add Autom. test ClayAlert#CanPreventTextFromDisplayingUnderIcon

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
@@ -25,6 +25,16 @@
 	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>AUTOFIT_ROW</td>
+	<td>//div[@class='alert alert-${key_alertType}']//*[contains(@class, 'autofit-row')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_INDICATOR</td>
+	<td>//div[@class='alert alert-${key_alertType}']//*[@class = 'alert-indicator']</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -74,6 +74,30 @@ definition {
 		}
 	}
 
+	@description = "Verify the text on the next line will not flow under the icon on the alert"
+	@priority = "4"
+	test CanPreventTextFromDisplayingUnderIcon {
+		task ("When the alert contains class='alert-indicator'") {
+			VerifyElementPresent(
+				key_alertType = "success",
+				locator1 = "ClayAlert#ALERT_INDICATOR");
+		}
+
+		task ("Then the text on the next line will not flow under the icon") {
+			AssertCssValue(
+				key_alertType = "success",
+				locator1 = "ClayAlert#AUTOFIT_ROW",
+				locator2 = "display",
+				value1 = "flex");
+
+			AssertCssValue(
+				key_alertType = "success",
+				locator1 = "ClayAlert#AUTOFIT_ROW",
+				locator2 = "flex-direction",
+				value1 = "row");
+		}
+	}
+
 	@description = "Verify the keyword is semi-bold when alert contains status icon and keyword"
 	@priority = "4"
 	test KeywordCanDisplayInSemibold {
@@ -157,27 +181,4 @@ definition {
 		AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 	}
 
-	@description = "Verify if the text on the next line will not flow under the icon on the alert"
-	@priority = "4"
-	test CanPreventTextFromDisplayingUnderIcon {
-		task ("When the alert contains class='alert-indicator'") {
-			VerifyElementPresent(
-				locator1 = "ClayAlert#ALERT_INDICATOR",
-				key_alertType = "success");
-		}
-
-		task ("Then the text on the next line will not flow under the icon") {
-			AssertCssValue(
-				key_alertType = "success",
-				locator1 = "ClayAlert#AUTOFIT_ROW",
-				locator2 = "display",
-				value1 = "flex");
-			
-			AssertCssValue(
-				key_alertType = "success",
-				locator1 = "ClayAlert#AUTOFIT_ROW",
-				locator2 = "flex-direction",
-				value1 = "row");
-		}
-	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlert.testcase
@@ -157,4 +157,27 @@ definition {
 		AssertElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
 	}
 
+	@description = "Verify if the text on the next line will not flow under the icon on the alert"
+	@priority = "4"
+	test CanPreventTextFromDisplayingUnderIcon {
+		task ("When the alert contains class='alert-indicator'") {
+			VerifyElementPresent(
+				locator1 = "ClayAlert#ALERT_INDICATOR",
+				key_alertType = "success");
+		}
+
+		task ("Then the text on the next line will not flow under the icon") {
+			AssertCssValue(
+				key_alertType = "success",
+				locator1 = "ClayAlert#AUTOFIT_ROW",
+				locator2 = "display",
+				value1 = "flex");
+			
+			AssertCssValue(
+				key_alertType = "success",
+				locator1 = "ClayAlert#AUTOFIT_ROW",
+				locator2 = "flex-direction",
+				value1 = "row");
+		}
+	}
 }


### PR DESCRIPTION
**ClayAlert#CanPreventTextFromDisplayingUnderIcon**
**Test Plan**

- Given Clay Sample Portlet
- When the alert contains class="alert-indicator"
- Then the text on the next line will not flow under the icon

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-170571
