### PR TITLE
[TS]LPS-171572 Add src attribute later to trigger "load" event.

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded.jsp
@@ -19,12 +19,7 @@
 <%@ include file="/layout/view/embedded_js.jspf" %>
 
 <div id="iframe">
-
-	<%
-	UnicodeProperties typeSettingsUnicodeProperties = layout.getTypeSettingsProperties();
-	%>
-
-	<iframe frameborder="0" id="embeddedIframe" src="<%= HtmlUtil.escapeHREF(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")) %>" width="100%"></iframe>
+	<iframe frameborder="0" id="embeddedIframe" width="100%"></iframe>
 </div>
 
 <liferay-layout:layout-common />

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -14,6 +14,10 @@
  */
 --%>
 
+<%
+UnicodeProperties typeSettingsUnicodeProperties = layout.getTypeSettingsProperties();
+%>
+
 <aui:script use="aui-autosize-iframe">
 	var iframe = A.one('#embeddedIframe');
 
@@ -41,5 +45,10 @@
 
 			iframe.setStyle('height', height);
 		});
+
+		iframe.set(
+			'src',
+			'<%= HtmlUtil.escapeHREF(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")) %>'
+		);
 	}
 </aui:script>


### PR DESCRIPTION
Hi team,
Please help to review this PR that was implemented by @tototrinh
Thank you

**Reproduce step:** 
https://issues.liferay.com/browse/LPS-171572
**Solution notes**

- This issue doesn't occur in firefox.
- I did some research and found that the iframe load event not firing in Safari/Chrome because iframes generally start with `src="about:blank"` even if the src is specified directly in the HTML or before an iframe node is added to the DOM. And Chrome will wait until the content itself (via the attr method call) is specified to initiate the load event.
- My solution is to set the src Attribute to make it trigger the `load` event.