### PR TITLE
LPS-171673 Setting a custom name for FDS View results in error on view render

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -68,6 +68,11 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 	}
 
 	@Override
+	public String getName() {
+		return "customizedTable";
+	}
+
+	@Override
 	public boolean isDefault() {
 		return true;
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -131,9 +131,13 @@ const FrontendDataSet = ({
 			);
 
 			if (activeViewName) {
-				initialActiveView = views.find(
+				const activeView = views.find(
 					({name}) => name === activeViewName
 				);
+
+				if (activeView) {
+					initialActiveView = activeView;
+				}
 			}
 
 			if (visibleFieldNames) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/getViewComponent.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/getViewComponent.js
@@ -28,8 +28,8 @@ const VIEWS = {
 	timeline: Timeline,
 };
 
-const getViewComponent = (name) => {
-	return VIEWS[name];
+const getViewComponent = (contentRenderer) => {
+	return VIEWS[contentRenderer];
 };
 
 export default getViewComponent;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/viewsReducer.js
@@ -113,7 +113,7 @@ export function viewsReducer(state, {type, value}) {
 		const activeView = views.find(({name}) => name === value);
 
 		if (activeView) {
-			activeView.component = getViewComponent(value);
+			activeView.component = getViewComponent(activeView.contentRenderer);
 		}
 
 		return {


### PR DESCRIPTION
### References

- [LPS-171673 Setting a custom name for FDS View results in error on view render](https://issues.liferay.com/browse/LPS-171673)

### What is the goal of this PR?

Bugfix.

### What does it look like?

No changes in UI. Sample module should continue to work normally.

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.