### PR TITLE
LPS-170572 | Add Autom. test ClayAlertStripe#CanDisplayCloseButton

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
@@ -55,23 +55,27 @@
 	displayType="danger"
 	message="This is an error message."
 	title="Error"
+	dismissible = "<%= true %>"
 />
 
 <clay:stripe
 	displayType="success"
 	message="This is a success message."
 	title="Success"
+	dismissible = "<%= true %>"
 />
 
 <clay:stripe
 	message="This is an info message."
 	title="Info"
+	dismissible = "<%= true %>"
 />
 
 <clay:stripe
 	displayType="warning"
 	message="This is a warning message."
 	title="Warning"
+	dismissible = "<%= true %>"
 />
 
 <div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
@@ -52,30 +52,30 @@
 </blockquote>
 
 <clay:stripe
+	dismissible="<%= true %>"
 	displayType="danger"
 	message="This is an error message."
 	title="Error"
-	dismissible = "<%= true %>"
 />
 
 <clay:stripe
+	dismissible="<%= true %>"
 	displayType="success"
 	message="This is a success message."
 	title="Success"
-	dismissible = "<%= true %>"
 />
 
 <clay:stripe
+	dismissible="<%= true %>"
 	message="This is an info message."
 	title="Info"
-	dismissible = "<%= true %>"
 />
 
 <clay:stripe
+	dismissible="<%= true %>"
 	displayType="warning"
 	message="This is a warning message."
 	title="Warning"
-	dismissible = "<%= true %>"
 />
 
 <div>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlert.path
@@ -25,6 +25,16 @@
 	<td>//div[@class='alert alert-${key_alertType}']//strong[contains(@class,'lead') and contains(text(), '${key_alertBold}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>ALERT_STRIPE</td>
+	<td>//div[contains(@class, 'alert-fluid') and contains(@class, 'alert-${key_alertType}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>ALERT_STRIPE_CLOSE</td>
+	<td>//div[contains(@class, 'alert-fluid') and contains(@class, 'alert-${key_alertType}')]//button[@class='close']</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertStripe.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertStripe.testcase
@@ -43,19 +43,20 @@ definition {
 		}
 	}
 
-    @description = "Verify stripe alert contains close button"
+	@description = "Verify stripe alert contains close button"
 	@priority = "5"
 	test CanDisplayAllAttributes {
-        task("When the alert is a stripe variation") {
-            VerifyElementPresent(
-                locator1 = "ClayAlert#ALERT_STRIPE",
-                key_alertType = "success");
-        }
+		task ("When the alert is a stripe variation") {
+			VerifyElementPresent(
+				key_alertType = "success",
+				locator1 = "ClayAlert#ALERT_STRIPE");
+		}
 
-        task("Then the alert contains a close button") {
-            AssertElementPresent(
-                locator1 = "ClayAlert#ALERT_STRIPE_CLOSE",
-                key_alertType = "success");
-        }
-    }
+		task ("Then the alert contains a close button") {
+			AssertElementPresent(
+				key_alertType = "success",
+				locator1 = "ClayAlert#ALERT_STRIPE_CLOSE");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertStripe.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertStripe.testcase
@@ -45,7 +45,7 @@ definition {
 
 	@description = "Verify stripe alert contains close button"
 	@priority = "5"
-	test CanDisplayAllAttributes {
+	test CanDisplayCloseButton {
 		task ("When the alert is a stripe variation") {
 			VerifyElementPresent(
 				key_alertType = "success",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertStripe.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertStripe.testcase
@@ -1,0 +1,61 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Clay";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+    @description = "Verify stripe alert contains close button"
+	@priority = "5"
+	test CanDisplayAllAttributes {
+        task("When the alert is a stripe variation") {
+            VerifyElementPresent(
+                locator1 = "ClayAlert#ALERT_STRIPE",
+                key_alertType = "success");
+        }
+
+        task("Then the alert contains a close button") {
+            AssertElementPresent(
+                locator1 = "ClayAlert#ALERT_STRIPE_CLOSE",
+                key_alertType = "success");
+        }
+    }
+}


### PR DESCRIPTION
**ClayAlertStripe#CanDisplayCloseButton**
 **Test Plan**
- Given Clay Sample Portlet
- When the alert is a stripe variation
- Then the alert contains a close button

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-170572