### PR TITLE
LPS-170578 | Create automated test for ClayAlertToast

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -52,11 +52,14 @@ definition {
 
 		task ("Then the alert disappears after 20 seconds") {
 
-			// For LPS-170578, need this pause to wait longer than the auto close time of the fail message
+			// For LPS-170578, need this to pause until right before auto close time of the fail message
 
 			Pause(locator1 = "19000");
 
 			if (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "Message#ERROR_DISMISSIBLE")) {
+
+				// For LPS-170578, need this to pause longer than the auto close time of the fail message
+
 				Pause(locator1 = "1100");
 
 				if (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "Message#ERROR_DISMISSIBLE")) {
@@ -90,7 +93,7 @@ definition {
 
 		task ("Then the alert does not disappear when hovered over") {
 
-			// For LPS-170578, need this pause to wait longer than the auto close time of the fail message
+			// For LPS-170578, need this to pause longer than the auto close time of the fail message
 
 			Pause(locator1 = "20100");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -1,8 +1,11 @@
 definition {
 
 	property portal.upstream = "true";
+    property testray.component.names = "Clay";
 
 	setUp {
+        TestCase.setUpPortalInstance();
+
 		User.firstLoginPG();
 
 		JSONLayout.addPublicLayout(
@@ -30,27 +33,29 @@ definition {
 		}
 	}
 
-	@description = "LPS-170578 - Assert that message remain after mouse is away from it."
+	@description = "LPS-170578 - Assert that alert message remain when mouse hover over it."
 	@priority = "5"
 	test DoesNotDisappearWhenHoveredOver {
 		property portal.acceptance = "true";
 
 		task ("When a toast alert appear") {
 			WaitForElementPresent(
-				key_text = "Success Submit",
+				key_text = "Fail Submit",
 				locator1 = "Button#ANY");
 
 			Click(
-				key_text = "Success Submit",
+				key_text = "Fail Submit",
 				locator1 = "Button#ANY");
 		}
 
 		task ("And user mouses over the alert") {
-			MouseOver(locator1 = "Message#SUCCESS");
+			MouseOver(locator1 = "Message#ERROR_DISMISSIBLE");
 		}
 
-		task ("Then the alert does not disappear when hovered ove") {
-			AssertElementPresent(locator1 = "Message#SUCCESS");
+		task ("Then the alert does not disappear when hovered over") {
+            Pause(locator1 = "25000");
+
+			AssertElementPresent(locator1 = "Message#ERROR_DISMISSIBLE");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -6,7 +6,7 @@ definition {
 	property testray.main.component.name = "User Interface";
 
 	setUp {
-        TestCase.setUpPortalInstance();
+		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
 
@@ -55,7 +55,10 @@ definition {
 		}
 
 		task ("Then the alert does not disappear when hovered over") {
-            Pause(locator1 = "20100");
+
+			// For LPS-170578, need this pause to wait longer than the auto close time of the fail message
+
+			Pause(locator1 = "20100");
 
 			AssertElementPresent(locator1 = "Message#ERROR_DISMISSIBLE");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -35,6 +35,40 @@ definition {
 		}
 	}
 
+	@description = "LPS-170578 Validate alert toast message does disapear."
+	@priority = "5"
+	test DisappearsWhenNotHoveredOver {
+		property portal.acceptance = "true";
+
+		task ("When a toast alert appears") {
+			WaitForElementPresent(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+		}
+
+		task ("Then the alert disappears after 20 seconds") {
+
+			// For LPS-170578, need this pause to wait longer than the auto close time of the fail message
+
+			Pause(locator1 = "19000");
+
+			if (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "Message#ERROR_DISMISSIBLE")) {
+				Pause(locator1 = "1100");
+
+				if (IsElementPresent.isElementPresentNoSPARefresh(locator1 = "Message#ERROR_DISMISSIBLE")) {
+					fail("Alert message did not disappear after 20 seconds");
+				}
+			}
+			else {
+				fail("Alert message disappeared before 20 seconds");
+			}
+		}
+	}
+
 	@description = "LPS-170578 Validate alert toast message does not disapear when mouse hovers over it."
 	@priority = "5"
 	test DoesNotDisappearWhenHoveredOver {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -1,7 +1,9 @@
 definition {
 
+	property portal.release = "true";
 	property portal.upstream = "true";
-    property testray.component.names = "Clay";
+	property testray.component.names = "Clay";
+	property testray.main.component.name = "User Interface";
 
 	setUp {
         TestCase.setUpPortalInstance();
@@ -33,12 +35,12 @@ definition {
 		}
 	}
 
-	@description = "LPS-170578 - Assert that alert message remain when mouse hover over it."
+	@description = "LPS-170578 Validate alert toast message does not disapear when mouse hovers over it."
 	@priority = "5"
 	test DoesNotDisappearWhenHoveredOver {
 		property portal.acceptance = "true";
 
-		task ("When a toast alert appear") {
+		task ("When a toast alert appears") {
 			WaitForElementPresent(
 				key_text = "Fail Submit",
 				locator1 = "Button#ANY");
@@ -53,7 +55,7 @@ definition {
 		}
 
 		task ("Then the alert does not disappear when hovered over") {
-            Pause(locator1 = "25000");
+            Pause(locator1 = "20100");
 
 			AssertElementPresent(locator1 = "Message#ERROR_DISMISSIBLE");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -37,7 +37,7 @@ definition {
 
 	@description = "LPS-170578 Validate alert toast message does disapear."
 	@priority = "5"
-	test DisappearsWhenNotHoveredOver {
+	test AutoclosesWhenNotHoveredOver {
 		property portal.acceptance = "true";
 
 		task ("When a toast alert appears") {
@@ -71,7 +71,7 @@ definition {
 
 	@description = "LPS-170578 Validate alert toast message does not disapear when mouse hovers over it."
 	@priority = "5"
-	test DoesNotDisappearWhenHoveredOver {
+	test DoesNotAutocloseWhenHoveredOver {
 		property portal.acceptance = "true";
 
 		task ("When a toast alert appears") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -1,0 +1,62 @@
+definition{
+
+    property portal.upstream = "true";
+
+    setUp{
+        
+        User.firstLoginPG();
+
+        JSONLayout.addPublicLayout(
+		    groupName = "Guest",			    
+            layoutName = "Clay Page");
+
+		JSONLayout.addWidgetToPublicLayout(
+		   groupName = "Guest",
+		    layoutName = "Clay Page",
+		    widgetName = "Clay Sample");
+
+		Navigator.gotoPage(pageName = "Clay Page");
+
+    }
+
+    tearDown{
+
+        var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Page");
+		}
+
+    }
+
+    @description = "LPS-170578 - Assert that message remain after mouse is away from it."
+    @priority = "5"
+    test DoesNotDisappearWhenHoveredOver {
+
+        property portal.acceptance = "true";
+
+        task("When a toast alert appear"){
+            WaitForElementPresent(
+                key_text = "Success Submit",
+                locator1 = "Button#ANY");
+
+            Click(
+                key_text = "Success Submit",
+                locator1 = "Button#ANY");
+        }
+
+        task("And user mouses over the alert"){
+            MouseOver(locator1 = "Message#SUCCESS");
+        }
+
+        task("Then the alert does not disappear when hovered ove"){
+            AssertElementPresent(locator1 = "Message#SUCCESS");
+        }
+
+    }
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -1,27 +1,24 @@
-definition{
+definition {
 
-    property portal.upstream = "true";
+	property portal.upstream = "true";
 
-    setUp{
-        
-        User.firstLoginPG();
+	setUp {
+		User.firstLoginPG();
 
-        JSONLayout.addPublicLayout(
-		    groupName = "Guest",			    
-            layoutName = "Clay Page");
+		JSONLayout.addPublicLayout(
+			groupName = "Guest",
+			layoutName = "Clay Page");
 
 		JSONLayout.addWidgetToPublicLayout(
-		   groupName = "Guest",
-		    layoutName = "Clay Page",
-		    widgetName = "Clay Sample");
+			groupName = "Guest",
+			layoutName = "Clay Page",
+			widgetName = "Clay Sample");
 
 		Navigator.gotoPage(pageName = "Clay Page");
+	}
 
-    }
-
-    tearDown{
-
-        var testPortalInstance = PropsUtil.get("test.portal.instance");
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
 		if ("${testPortalInstance}" == "true") {
 			PortalInstances.tearDownCP();
@@ -31,32 +28,30 @@ definition{
 				groupName = "Guest",
 				layoutName = "Clay Page");
 		}
+	}
 
-    }
+	@description = "LPS-170578 - Assert that message remain after mouse is away from it."
+	@priority = "5"
+	test DoesNotDisappearWhenHoveredOver {
+		property portal.acceptance = "true";
 
-    @description = "LPS-170578 - Assert that message remain after mouse is away from it."
-    @priority = "5"
-    test DoesNotDisappearWhenHoveredOver {
+		task ("When a toast alert appear") {
+			WaitForElementPresent(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
 
-        property portal.acceptance = "true";
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+		}
 
-        task("When a toast alert appear"){
-            WaitForElementPresent(
-                key_text = "Success Submit",
-                locator1 = "Button#ANY");
+		task ("And user mouses over the alert") {
+			MouseOver(locator1 = "Message#SUCCESS");
+		}
 
-            Click(
-                key_text = "Success Submit",
-                locator1 = "Button#ANY");
-        }
+		task ("Then the alert does not disappear when hovered ove") {
+			AssertElementPresent(locator1 = "Message#SUCCESS");
+		}
+	}
 
-        task("And user mouses over the alert"){
-            MouseOver(locator1 = "Message#SUCCESS");
-        }
-
-        task("Then the alert does not disappear when hovered ove"){
-            AssertElementPresent(locator1 = "Message#SUCCESS");
-        }
-
-    }
 }


### PR DESCRIPTION
**Description:**
- Assert that alert message remain when mouse hover over it

**Test Plan:**
- Given Clay Sample Portlet
- When a toast alert appears
- And user mouses over the alert
- Then the alert does not disappear when hovered over

**JIRA ticket:**
https://issues.liferay.com/browse/LPS-170578

cc/ @mateusralv  @mateussandes23