### PR TITLE
COMMERCE-10535 Enable customized cookie configuration 

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/package.json
+++ b/modules/apps/cookies/cookies-banner-web/package.json
@@ -4,6 +4,7 @@
 		"moment": "2.29.4",
 		"react-transition-group": "4.4.1"
 	},
+	"main": "js/index.js",
 	"name": "@liferay/cookies-banner-web",
 	"scripts": {
 		"build": "liferay-npm-scripts build",

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/display/context/CookiesBannerDisplayContext.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/display/context/CookiesBannerDisplayContext.java
@@ -72,6 +72,9 @@ public class CookiesBannerDisplayContext
 			cookiesConsentConfiguration.title();
 
 		return HashMapBuilder.<String, Object>put(
+			"configurationNamespace",
+			CookiesBannerPortletKeys.COOKIES_BANNER_CONFIGURATION
+		).put(
 			"configurationURL", getConfigurationURL()
 		).put(
 			"includeDeclineAllButton", isIncludeDeclineAllButton()

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
@@ -23,7 +23,7 @@ import {
 	userConfigCookieName,
 } from '../../js/CookiesUtil';
 
-const cookiesBannerDisplayContext = {};
+let openCookieConfigurationModal;
 
 export default function ({
 	configurationNamespace,
@@ -34,10 +34,6 @@ export default function ({
 	requiredConsentCookieTypeNames,
 	title,
 }) {
-	cookiesBannerDisplayContext.configurationURL = configurationURL;
-	cookiesBannerDisplayContext.configurationNamespace = configurationNamespace;
-	cookiesBannerDisplayContext.title = title;
-
 	const acceptAllButton = document.getElementById(
 		`${namespace}acceptAllButton`
 	);
@@ -77,7 +73,21 @@ export default function ({
 			setUserConfigCookie();
 		});
 
-		configurationButton.addEventListener('click', () => {
+		openCookieConfigurationModal = ({
+			alertDisplayType,
+			alertMessage,
+			customTitle,
+		}) => {
+			let url = configurationURL;
+
+			if (alertDisplayType) {
+				url = `${url}&_${configurationNamespace}_alertDisplayType=${alertDisplayType}`;
+			}
+
+			if (alertMessage) {
+				url = `${url}&_${configurationNamespace}_alertMessage=${alertMessage}`;
+			}
+
 			openModal({
 				buttons: [
 					{
@@ -144,9 +154,13 @@ export default function ({
 				height: '70vh',
 				id: 'cookiesBannerConfiguration',
 				size: 'lg',
-				title,
-				url: configurationURL,
+				title: customTitle || title,
+				url,
 			});
+		};
+
+		configurationButton.addEventListener('click', () => {
+			openCookieConfigurationModal({});
 		});
 
 		declineAllButton.addEventListener('click', () => {
@@ -170,32 +184,5 @@ function setBannerVisibility(cookieBanner) {
 		cookieBanner.style.display = 'block';
 	}
 }
-
-const openCookieConfigurationModal = ({
-	alertDisplayType,
-	alertMessage,
-	title,
-}) => {
-	let url = cookiesBannerDisplayContext.configurationURL;
-
-	const namespace = `_${cookiesBannerDisplayContext.configurationNamespace}_`;
-
-	if (alertDisplayType) {
-		url = `${url}&${namespace}alertDisplayType=${alertDisplayType}`;
-	}
-
-	if (alertMessage) {
-		url = `${url}&${namespace}alertMessage=${alertMessage}`;
-	}
-
-	openModal({
-		displayType: 'primary',
-		height: '70vh',
-		id: 'cookiesBannerConfiguration',
-		size: 'lg',
-		title: title || cookiesBannerDisplayContext.title || '',
-		url,
-	});
-};
 
 export {openCookieConfigurationModal};

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/js/CookiesBanner.js
@@ -23,7 +23,10 @@ import {
 	userConfigCookieName,
 } from '../../js/CookiesUtil';
 
+const cookiesBannerDisplayContext = {};
+
 export default function ({
+	configurationNamespace,
 	configurationURL,
 	includeDeclineAllButton,
 	namespace,
@@ -31,6 +34,10 @@ export default function ({
 	requiredConsentCookieTypeNames,
 	title,
 }) {
+	cookiesBannerDisplayContext.configurationURL = configurationURL;
+	cookiesBannerDisplayContext.configurationNamespace = configurationNamespace;
+	cookiesBannerDisplayContext.title = title;
+
 	const acceptAllButton = document.getElementById(
 		`${namespace}acceptAllButton`
 	);
@@ -163,3 +170,32 @@ function setBannerVisibility(cookieBanner) {
 		cookieBanner.style.display = 'block';
 	}
 }
+
+const openCookieConfigurationModal = ({
+	alertDisplayType,
+	alertMessage,
+	title,
+}) => {
+	let url = cookiesBannerDisplayContext.configurationURL;
+
+	const namespace = `_${cookiesBannerDisplayContext.configurationNamespace}_`;
+
+	if (alertDisplayType) {
+		url = `${url}&${namespace}alertDisplayType=${alertDisplayType}`;
+	}
+
+	if (alertMessage) {
+		url = `${url}&${namespace}alertMessage=${alertMessage}`;
+	}
+
+	openModal({
+		displayType: 'primary',
+		height: '70vh',
+		id: 'cookiesBannerConfiguration',
+		size: 'lg',
+		title: title || cookiesBannerDisplayContext.title || '',
+		url,
+	});
+};
+
+export {openCookieConfigurationModal};

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/view.jsp
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/view.jsp
@@ -18,6 +18,8 @@
 
 <%
 CookiesBannerConfigurationDisplayContext cookiesBannerConfigurationDisplayContext = (CookiesBannerConfigurationDisplayContext)request.getAttribute(CookiesBannerWebKeys.COOKIES_BANNER_CONFIGURATION_DISPLAY_CONTEXT);
+
+String alertMessage = ParamUtil.getString(request, "alertMessage");
 %>
 
 <clay:container-fluid
@@ -25,6 +27,17 @@ CookiesBannerConfigurationDisplayContext cookiesBannerConfigurationDisplayContex
 	id='<%= liferayPortletResponse.getNamespace() + "cookiesBannerConfigurationForm" %>'
 >
 	<clay:row>
+		<c:if test="<%= alertMessage != StringPool.BLANK %>">
+			<clay:col
+				size="12"
+			>
+				<clay:alert
+					displayType='<%= ParamUtil.getString(request, "alertDisplayType", "info") %>'
+					message="<%= alertMessage %>"
+				/>
+			</clay:col>
+		</c:if>
+
 		<clay:col
 			cssClass="mb-3"
 			size="12"

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/init.jsp
@@ -26,8 +26,10 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <%@ page import="com.liferay.cookies.banner.web.internal.constants.CookiesBannerWebKeys" %><%@
 page import="com.liferay.cookies.banner.web.internal.display.context.CookiesBannerConfigurationDisplayContext" %><%@
 page import="com.liferay.cookies.banner.web.internal.display.context.CookiesBannerDisplayContext" %><%@
+page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.cookies.ConsentCookieType" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %>
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/index.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+// Cookies API
+
+export {openCookieConfigurationModal} from '../cookies_banner/js/CookiesBanner';

--- a/modules/apps/cookies/cookies-sample-web/bnd.bnd
+++ b/modules/apps/cookies/cookies-sample-web/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Cookies Sample Web
+Bundle-SymbolicName: com.liferay.cookies.sample.web
+Bundle-Version: 1.0.0
+Web-ContextPath: /cookies-sample-web

--- a/modules/apps/cookies/cookies-sample-web/build.gradle
+++ b/modules/apps/cookies/cookies-sample-web/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/cookies/cookies-sample-web/package.json
+++ b/modules/apps/cookies/cookies-sample-web/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "@liferay/cookies-sample-web",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/cookies/cookies-sample-web/src/main/java/com/liferay/cookies/sample/web/internal/constants/CookiesSamplePortletKeys.java
+++ b/modules/apps/cookies/cookies-sample-web/src/main/java/com/liferay/cookies/sample/web/internal/constants/CookiesSamplePortletKeys.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.cookies.sample.web.internal.constants;
+
+/**
+ * @author Marko Cikos
+ */
+public class CookiesSamplePortletKeys {
+
+	public static final String COOKIES_SAMPLE =
+		"com_liferay_cookies_sample_web_internal_portlet_CookiesSamplePortlet";
+
+}

--- a/modules/apps/cookies/cookies-sample-web/src/main/java/com/liferay/cookies/sample/web/internal/portlet/CookiesSamplePortlet.java
+++ b/modules/apps/cookies/cookies-sample-web/src/main/java/com/liferay/cookies/sample/web/internal/portlet/CookiesSamplePortlet.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.cookies.sample.web.internal.portlet;
+
+import com.liferay.cookies.sample.web.internal.constants.CookiesSamplePortletKeys;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"com.liferay.portlet.instanceable=true",
+		"com.liferay.portlet.layout-cacheable=true",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.display-name=Cookies Sample",
+		"javax.portlet.expiration-cache=0",
+		"javax.portlet.init-param.template-path=/META-INF/resources/",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=" + CookiesSamplePortletKeys.COOKIES_SAMPLE,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=power-user,user",
+		"javax.portlet.version=3.0"
+	},
+	service = Portlet.class
+)
+public class CookiesSamplePortlet extends MVCPortlet {
+}

--- a/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/js/Cookies.js
+++ b/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/js/Cookies.js
@@ -34,7 +34,7 @@ const Cookie = () => {
 						alertDisplayType: 'info',
 						alertMessage:
 							'the-compare-function-requires-acceptance-of-functional-cookies',
-						title: Liferay.Language.get(
+						customTitle: Liferay.Language.get(
 							'product-comparison-uses-non-essential-cookies'
 						),
 					});

--- a/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/js/Cookies.js
+++ b/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/js/Cookies.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton from '@clayui/button';
+import {openCookieConfigurationModal} from '@liferay/cookies-banner-web';
+import React from 'react';
+
+const Cookie = () => {
+	return (
+		<>
+			<ClayButton
+				displayType="secondary"
+				onClick={() => {
+					openCookieConfigurationModal({});
+				}}
+			>
+				Default Modal
+			</ClayButton>
+
+			<ClayButton
+				onClick={() => {
+					openCookieConfigurationModal({
+						alertDisplayType: 'info',
+						alertMessage:
+							'the-compare-function-requires-acceptance-of-functional-cookies',
+						title: Liferay.Language.get(
+							'product-comparison-uses-non-essential-cookies'
+						),
+					});
+				}}
+			>
+				Modified Modal
+			</ClayButton>
+		</>
+	);
+};
+
+export default Cookie;

--- a/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/cookies/cookies-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,23 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<div>
+	<react:component
+		module="js/Cookies"
+	/>
+</div>

--- a/modules/modules.properties
+++ b/modules/modules.properties
@@ -31,6 +31,7 @@ bundle.symbolic.name[@liferay/commerce-warehouse-web]=com.liferay.commerce.wareh
 bundle.symbolic.name[@liferay/content-dashboard-document-library-impl]=com.liferay.content.dashboard.document.library.impl
 bundle.symbolic.name[@liferay/content-dashboard-web]=com.liferay.content.dashboard.web
 bundle.symbolic.name[@liferay/cookies-banner-web]=com.liferay.cookies.banner.web
+bundle.symbolic.name[@liferay/cookies-sample-web]=com.liferay.cookies.sample.web
 bundle.symbolic.name[@liferay/digital-signature-web]=com.liferay.digital.signature.web
 bundle.symbolic.name[@liferay/dispatch-web]=com.liferay.dispatch.web
 bundle.symbolic.name[@liferay/document-library-preview-css]=com.liferay.document.library.preview.css

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -35,6 +35,9 @@ module.exports = {
 					'@liferay/content-dashboard-web': {
 						'/': '*',
 					},
+					'@liferay/cookies-banner-web': {
+						'/': '*',
+					},
 					'@liferay/document-library-preview-css': {
 						'/': '*',
 					},


### PR DESCRIPTION
### References

- [COMMERCE-10449 Reject Cookies to be handled with Compare Products](https://issues.liferay.com/browse/COMMERCE-10449)
- mockup: https://www.figma.com/file/7Ad89Cj60hxNMJWTbN6mQq/Minium-B2B-Accelerator-v2?node-id=2307%3A138899&t=btt5zPhGBGZLSvTN-0

### What is the goal of this PR?

This is a POC for managing cookies configuration dynamically. Sample buttons are in a new module, `cookies-sample-web`. Exposed utility from `cookies-banner-web` is `openCookieConfigurationModal`.

TODO:
- [x] Add buttons functionality. Avoid code duplication in `CookiesBanner.js` `openModal`s. Confirm that cookies are being set.
- [x] Clarify with commerce team what to do with `Visit our Cookie Policy` link. We have this hardcoded in JSP, and set as mandatory in configuration, but it is not in commerce mockup. If we need to hide it, this needs to be added to arguments of `openCookieConfigurationModal`
- [ ] Cleanup code.
- [ ] After this PR is merged, apply to commerce. Clarify how exactly opening of modal fits in user workflow.  

### Steps to reproduce

1. Enable Cookies Banner FF:  `feature.flag.LPS-142518=true`
2. Enable Cookies Banner in Control Panel > Instance Settings > Cookies.
3. Deploy `cookies-sample-web`.
4. Place `Cookies Sample` widget on any page.