### PR TITLE
LPS-170579 | Create autom test for Clay Toast Alert

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -101,4 +101,30 @@ definition {
 		}
 	}
 
+	@description = "LPS-170579 - Assert that multiples messages can be displayed"
+	@priority = "5"
+	test MultipleContainersCanBeDisplayed {
+		task ("When a toast alert appears") {
+			WaitForElementPresent(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+		}
+
+		task ("Then user should be able to activate another toast alert") {
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+		}
+
+		task ("And both toast alerts should be displayed") {
+			AssertElementPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
+
+			AssertElementPresent(locator1 = "Message#ERROR_DISMISSIBLE");
+		}
+	}
+
 }


### PR DESCRIPTION
*Description:*

Create test for Alert Toast

*Test plan:*

- Given Clay Sample Portlet
- When a toast alert appears
- Then user should be able to activate another toast alert
- And both toast alerts should be displayed

*JIRA ticket:*
https://issues.liferay.com/browse/LPS-170579

@john-co @mateusralv 
