### PR TITLE
[TECHNICAL SUPPORT] LPS-170901 CKEditors embedded videos resizer tool doesn't work properly with multible HTML field structure

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/Resizer.es.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/Resizer.es.js
@@ -73,7 +73,8 @@
 
 		init() {
 			this.container = this.document.createElement('div');
-			this.container.id = 'ckimgrsz';
+			this.container.classList.add('ckimgrszwrapper');
+			this.container.id = 'ckimgrsz' + this.editor.id;
 
 			this.preview = this.document.createElement('span');
 
@@ -90,6 +91,10 @@
 			for (let i = 0; i < keys.length; i++) {
 				this.container.appendChild(this.handles[keys[i]]);
 			}
+
+			this.editor.on('destroy', () => {
+				this.container.remove();
+			});
 		}
 
 		createHandle(name) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
@@ -669,16 +669,21 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 				CKEDITOR.getUrl(path + 'Resizer.es.js'),
 			];
 
-			CKEDITOR.scriptLoader.load(dependencies, () => {
-				editor.resizer = new Liferay.ResizerCKEditor(editor, {
-					onComplete(element, width, height) {
-						resizeElement(element, width, height);
+			editor.on('dataReady', () => {
+				CKEDITOR.scriptLoader.load(dependencies, () => {
+					editor.resizer = new Liferay.ResizerCKEditor(editor, {
+						onComplete(element, width, height) {
+							resizeElement(element, width, height);
 
-						if (currentAlignment && currentElement) {
-							setEmbedAlignment(currentElement, currentAlignment);
-						}
-						selectWidget(editor);
-					},
+							if (currentAlignment && currentElement) {
+								setEmbedAlignment(
+									currentElement,
+									currentAlignment
+								);
+							}
+							selectWidget(editor);
+						},
+					});
 				});
 			});
 		},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
@@ -258,7 +258,6 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 
 	let currentAlignment = null;
 	let currentElement = null;
-	let resizer = null;
 
 	// CSS is added in a compressed form
 
@@ -366,13 +365,13 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 
 				editor.focus();
 
-				resizer.hide();
+				editor.resizer.hide();
 			}, 0);
 		},
 
 		afterInit(editor) {
 			editor.on('resize', () => {
-				resizer.hide();
+				editor.resizer.hide();
 				selectWidget(editor);
 			});
 
@@ -423,7 +422,7 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 								);
 
 								if (imageElement) {
-									resizer.show(imageElement.$);
+									editor.resizer.show(imageElement.$);
 								}
 
 								event.cancel();
@@ -531,8 +530,8 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 						currentAlignment = result.alignment;
 						currentElement = result.element;
 
-						if (resizer.isHandle(event.target)) {
-							resizer.initDrag(event);
+						if (editor.resizer.isHandle(event.target)) {
+							editor.resizer.initDrag(event);
 						}
 					}
 
@@ -602,7 +601,7 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 			window.addEventListener(
 				'resize',
 				() => {
-					resizer.hide();
+					editor.resizer.hide();
 					selectWidget(editor);
 				},
 				false
@@ -644,11 +643,11 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 						);
 
 						if (imageElement) {
-							resizer.show(imageElement.$);
+							editor.resizer.show(imageElement.$);
 						}
 					}
 					else {
-						resizer.hide();
+						editor.resizer.hide();
 					}
 				}
 			});
@@ -662,7 +661,7 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 			});
 
 			editor.on('blur', () => {
-				resizer.hide();
+				editor.resizer.hide();
 			});
 
 			editor.filter.addElementCallback((element) => {
@@ -679,7 +678,7 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 			];
 
 			CKEDITOR.scriptLoader.load(dependencies, () => {
-				resizer = new Liferay.ResizerCKEditor(editor, {
+				editor.resizer = new Liferay.ResizerCKEditor(editor, {
 					onComplete(element, width, height) {
 						resizeElement(element, width, height);
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
@@ -262,7 +262,7 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 	// CSS is added in a compressed form
 
 	CKEDITOR.addCss(
-		'img::selection{color:rgba(0,0,0,0)}img.ckimgrsz{outline:1px dashed #000}#ckimgrsz{position:absolute;width:0;height:0;cursor:default;z-index:10001}#ckimgrsz span{display:none;position:absolute;top:0;left:0;width:0;height:0;background-size:100% 100%;opacity:.65;outline:1px dashed #000}#ckimgrsz i{position:absolute;display:block;width:5px;height:5px;background:#fff;border:1px solid #000}#ckimgrsz i.active,#ckimgrsz i:hover{background:#000}#ckimgrsz i.br,#ckimgrsz i.tl{cursor:nwse-resize}#ckimgrsz i.bm,#ckimgrsz i.tm{cursor:ns-resize}#ckimgrsz i.bl,#ckimgrsz i.tr{cursor:nesw-resize}#ckimgrsz i.lm,#ckimgrsz i.rm{cursor:ew-resize}body.dragging-br,body.dragging-br *,body.dragging-tl,body.dragging-tl *{cursor:nwse-resize!important}body.dragging-bm,body.dragging-bm *,body.dragging-tm,body.dragging-tm *{cursor:ns-resize!important}body.dragging-bl,body.dragging-bl *,body.dragging-tr,body.dragging-tr *{cursor:nesw-resize!important}body.dragging-lm,body.dragging-lm *,body.dragging-rm,body.dragging-rm *{cursor:ew-resize!important}'
+		'img::selection{color:rgba(0,0,0,0)}img.ckimgrsz{outline:1px dashed #000}.ckimgrszwrapper{position:absolute;width:0;height:0;cursor:default;z-index:10001}.ckimgrszwrapper span{display:none;position:absolute;top:0;left:0;width:0;height:0;background-size:100% 100%;opacity:.65;outline:1px dashed #000}.ckimgrszwrapper i{position:absolute;display:block;width:5px;height:5px;background:#fff;border:1px solid #000}.ckimgrszwrapper i.active,.ckimgrszwrapper i:hover{background:#000}.ckimgrszwrapper i.br,.ckimgrszwrapper i.tl{cursor:nwse-resize}.ckimgrszwrapper i.bm,.ckimgrszwrapper i.tm{cursor:ns-resize}.ckimgrszwrapper i.bl,.ckimgrszwrapper i.tr{cursor:nesw-resize}.ckimgrszwrapper i.lm,.ckimgrszwrapper i.rm{cursor:ew-resize}body.dragging-br,body.dragging-br *,body.dragging-tl,body.dragging-tl *{cursor:nwse-resize!important}body.dragging-bm,body.dragging-bm *,body.dragging-tm,body.dragging-tm *{cursor:ns-resize!important}body.dragging-bl,body.dragging-bl *,body.dragging-tr,body.dragging-tr *{cursor:nesw-resize!important}body.dragging-lm,body.dragging-lm *,body.dragging-rm,body.dragging-rm *{cursor:ew-resize!important}'
 	);
 
 	/**
@@ -649,14 +649,6 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 					else {
 						editor.resizer.hide();
 					}
-				}
-			});
-
-			editor.on('destroy', () => {
-				const resizeElement = document.getElementById('ckimgrsz');
-
-				if (resizeElement) {
-					resizeElement.remove();
 				}
 			});
 


### PR DESCRIPTION
Hey,

our video resizert was not ready to handle multiple instances of the editor at the same page. I made sure we create a new instance of resizer for every editor, modified the css to avoid the usage of a hardocded id as well as made sure the resizer has a unique id. Finally I had to make sure we load the resizer once the editor is fully loaded (in case of repeated fields), because the resizer is depending on the editor's document node.

Please review it.