### PR TITLE
LPS-170575 | Add Autom. test ClayAlertToast#DisappearsAfter5SecsWithoutActions

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
@@ -40,9 +40,11 @@ export default function ClaySampleToastAlert() {
 	const onClick5Seconds = () => {
 		openToast({
 			autoClose: 5000,
-			message: Liferay.Language.get('your-request-completed-successfully'),
+			message: Liferay.Language.get(
+				'your-request-completed-successfully'
+			),
 			type: 'info',
-		})
+		});
 	};
 
 	return (
@@ -62,7 +64,12 @@ export default function ClaySampleToastAlert() {
 					>
 						{Liferay.Language.get('fail-submit')}
 					</ClayButton>
-					<ClayButton onClick={onClick5Seconds} type="submit" _dismissible='false'>
+
+					<ClayButton
+						_dismissible="false"
+						onClick={onClick5Seconds}
+						type="submit"
+					>
 						{Liferay.Language.get('disappear-after-5-secs')}
 					</ClayButton>
 				</ClayButton.Group>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
@@ -37,6 +37,14 @@ export default function ClaySampleToastAlert() {
 		});
 	};
 
+	const onClick5Seconds = () => {
+		openToast({
+			autoClose: 5000,
+			message: Liferay.Language.get('your-request-completed-successfully'),
+			type: 'info',
+		})
+	};
+
 	return (
 		<div data-qa-id="claySampleToastAlert">
 			<h3>TOAST ALERT MESSAGE</h3>
@@ -53,6 +61,9 @@ export default function ClaySampleToastAlert() {
 						type="submit"
 					>
 						{Liferay.Language.get('fail-submit')}
+					</ClayButton>
+					<ClayButton onClick={onClick5Seconds} type="submit" _dismissible='false'>
+						{Liferay.Language.get('disappear-after-5-secs')}
 					</ClayButton>
 				</ClayButton.Group>
 			</div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
@@ -64,10 +64,7 @@ export default function ClaySampleToastAlert() {
 						{Liferay.Language.get('fail-submit')}
 					</ClayButton>
 
-					<ClayButton
-						onClick={onClick5Seconds}
-						type="submit"
-					>
+					<ClayButton onClick={onClick5Seconds} type="submit">
 						{Liferay.Language.get('disappear-after-5-secs')}
 					</ClayButton>
 				</ClayButton.Group>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
@@ -39,7 +39,6 @@ export default function ClaySampleToastAlert() {
 
 	const onClick5Seconds = () => {
 		openToast({
-			autoClose: 5000,
 			message: Liferay.Language.get(
 				'your-request-completed-successfully'
 			),
@@ -66,7 +65,6 @@ export default function ClaySampleToastAlert() {
 					</ClayButton>
 
 					<ClayButton
-						_dismissible="false"
 						onClick={onClick5Seconds}
 						type="submit"
 					>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -5303,6 +5303,7 @@ disabled-inputs-condensed=Disabled Inputs Condensed
 disabled-inputs-condensed-with-value=Disabled Inputs Condensed With Value
 disabled-inputs-with-value=Disabled Inputs With Value
 disabling-the-recycle-bin-prevents-the-restoring-of-content-that-has-been-moved-to-the-recycle-bin=Disabling the Recycle Bin prevents the restoring of content that has been moved to the Recycle Bin.
+disappear-after-5-secs=DisappearsAfter5Secs
 disassociate=Disassociate
 discard=Discard
 discard-change=Discard Change

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -15,6 +15,11 @@
 	<td>//*[@id='ToastAlertContainer']//*[@class='lexicon-icon lexicon-icon-${key_icon}']</td>
 	<td></td>
 </tr>
+<tr>
+	<td>ALERT_TOAST</td>
+	<td>//*[@id='ToastAlertContainer']</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -17,7 +17,7 @@
 </tr>
 <tr>
 	<td>ALERT_TOAST</td>
-	<td>//*[@id='ToastAlertContainer']</td>
+	<td>//*[@id='ToastAlertContainer']//*[contains(@class, 'alert-${key_type}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -72,6 +72,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-170575 - Verify toast alert with no actions disappears after 5 seconds"
+	@priority = "5"
+	test DisappearsAfter5SecsWithoutActions {
+		task ("When a toast alert appears") {
+			Click(
+				key_text = "DisappearsAfter5Secs",
+				locator1 = "Button#ANY");
+		}
+
+		task ("And no actions on alert") {
+			VerifyElementNotPresent(locator1 = "//*[@id='ToastAlertContainer']//a");
+		}
+
+		task ("Then the alert disappears after 5 secs") {
+			Pause(locator1 = "5000");
+
+			AssertNotVisible(locator1 = "ClayAlertToast#ALERT_TOAST");
+		}
+	}
+
 	@description = "LPS-170578 Validate alert toast message does not disapear when mouse hovers over it."
 	@priority = "5"
 	test DoesNotAutocloseWhenHoveredOver {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -91,7 +91,9 @@ definition {
 
 			Pause(locator1 = "5000");
 
-			AssertNotVisible(locator1 = "ClayAlertToast#ALERT_TOAST");
+			AssertElementNotPresent(
+				key_type = "info",
+				locator1 = "ClayAlertToast#ALERT_TOAST");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -86,6 +86,9 @@ definition {
 		}
 
 		task ("Then the alert disappears after 5 secs") {
+
+			// For LPS-170575, need this pause to see if after 5 seconds, the alert is not showing anymore
+
 			Pause(locator1 = "5000");
 
 			AssertNotVisible(locator1 = "ClayAlertToast#ALERT_TOAST");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -81,7 +81,7 @@ definition {
 				locator1 = "Button#ANY");
 		}
 
-		task ("And no actions on alert") {
+		task ("And When no actions on alert") {
 			VerifyElementNotPresent(locator1 = "//*[@id='ToastAlertContainer']//a");
 		}
 


### PR DESCRIPTION
****ClayAlertToast#DisappearsAfter5SecsWithoutActions**
Test Plan**

- Given Clay Sample Portlet
- When a toast alert appears
- And no actions on alert
- Then the alert disappears after 5 secs

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-170575