### PR TITLE
LPS-172644 Allow passing Modal's role through props 

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -673,6 +673,7 @@ Modal.propTypes = {
 	buttons: PropTypes.arrayOf(
 		PropTypes.shape({
 			displayType: PropTypes.oneOf([
+				'danger',
 				'link',
 				'primary',
 				'secondary',

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -44,6 +44,7 @@ const Modal = ({
 	iframeProps = {},
 	onClose,
 	onOpen,
+	role = 'dialog',
 	size,
 	status,
 	title,
@@ -191,7 +192,7 @@ const Modal = ({
 					disableAutoClose={disableAutoClose}
 					id={id}
 					observer={observer}
-					role="dialog"
+					role={role}
 					size={url && !size ? 'full-screen' : size}
 					status={status}
 					zIndex={zIndex}
@@ -701,6 +702,7 @@ Modal.propTypes = {
 	iframeProps: PropTypes.object,
 	onClose: PropTypes.func,
 	onOpen: PropTypes.func,
+	role: PropTypes.string,
 	size: PropTypes.oneOf(['full-screen', 'lg', 'md', 'sm']),
 	status: PropTypes.string,
 	title: PropTypes.string,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -702,6 +702,7 @@ Modal.propTypes = {
 	onClose: PropTypes.func,
 	onOpen: PropTypes.func,
 	size: PropTypes.oneOf(['full-screen', 'lg', 'md', 'sm']),
+	status: PropTypes.string,
 	title: PropTypes.string,
 	url: PropTypes.string,
 };

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteModal.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/openDeleteSiteModal.js
@@ -36,6 +36,7 @@ export default function openDeleteSiteModal({multiple = false, onDelete}) {
 				},
 			},
 		],
+		role: 'alert',
 		status: 'danger',
 		title: sub(
 			Liferay.Language.get('delete-x'),


### PR DESCRIPTION
Steps to reproduce (using JAWS):
- Go to Global Menu > Sites.
- Create a new site (can be blank).
- Go back to Global Menu > Sites.
- Try to delete the site you created and wait for the confirmation modal.
- JAWS should read it's content as an alert.

This PR fixes part of the issue (adding the proper role to the delete dialog https://issues.liferay.com/browse/LPS-172552). I will handle the focus situation in a different PR.