### PR TITLE
[DRAFT] LPS-168662 Research solutions for remembering user selections in search container

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -417,6 +417,23 @@ const openSelectionModal = ({
 
 						const allSelectedNodes = allSelectedElements.getDOMNodes();
 
+						const searchContainerId = searchContainer.get('id');
+
+						if (
+							!Liferay.SPA &&
+							sessionStorage.getItem(
+								searchContainerId +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							)
+						) {
+							sessionStorage.removeItem(
+								searchContainerId +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							);
+						}
+
 						onSelect(
 							allSelectedNodes.map((node) => {
 								let item = {};
@@ -479,6 +496,25 @@ const openSelectionModal = ({
 
 			eventHandlers.splice(0, eventHandlers.length);
 
+			if (!Liferay.SPA) {
+				const searchContainerId = iframeWindowObj.document.querySelector(
+					'.searchcontainer'
+				).id;
+
+				if (
+					sessionStorage.getItem(
+						searchContainerId +
+							Liferay.ThemeDisplay.getUserId() +
+							'_selections'
+					)
+				) {
+					sessionStorage.removeItem(
+						searchContainerId +
+							Liferay.ThemeDisplay.getUserId() +
+							'_selections'
+					);
+				}
+			}
 			if (onClose) {
 				onClose();
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -85,6 +85,15 @@ const ActionControls = ({
 									displayType="unstyled"
 									href={item.href}
 									onClick={(event) => {
+										if (!Liferay.SPA) {
+											sessionStorage.removeItem(
+												document.querySelector(
+													'.searchcontainer'
+												)?.id +
+													Liferay.ThemeDisplay.getUserId() +
+													'_selections'
+											);
+										}
 										onActionButtonClick(event, {
 											item,
 										});
@@ -100,6 +109,15 @@ const ActionControls = ({
 										displayType="unstyled"
 										href={item.href}
 										onClick={(event) => {
+											if (!Liferay.SPA) {
+												sessionStorage.removeItem(
+													document.querySelector(
+														'.searchcontainer'
+													)?.id +
+														Liferay.ThemeDisplay.getUserId() +
+														'_selections'
+												);
+											}
 											onActionButtonClick(event, {
 												item,
 											});

--- a/portal-web/docroot/html/taglib/ui/search_iterator/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/bottom.jspf
@@ -160,6 +160,39 @@
 		if (!Liferay.SPA && searchContainer.select){
 			var searchContainerId = searchContainer.get('id');
 
+			if (sessionStorage.getItem(searchContainerId + Liferay.ThemeDisplay.getUserId() + "_selections")) {
+				var TPL_HIDDEN_INPUT_CHECKED = '<input class="hide" name="{name}" value="{value}" type="checkbox" checked />';
+				var TPL_INPUT_SELECTOR = 'input[type="checkbox"][value="{value}"]';
+				var STR_CHECKBOX_SELECTOR = 'input[type="checkbox"]';
+				var STR_ROW_SELECTOR = 'dd[data-selectable="true"],li[data-selectable="true"],tr[data-selectable="true"]';
+				
+				var container = A.one(searchContainer._getNodeToParse());
+				var selections = sessionStorage.getItem(searchContainerId + Liferay.ThemeDisplay.getUserId() + "_selections").split(',');
+				var itemName = searchContainer.get('contentBox').one(STR_CHECKBOX_SELECTOR)?.get('name');
+				var offScreenElementsHtml = '';
+
+				selections.map( (item) => {
+					var input = container.one(
+						A.Lang.sub(TPL_INPUT_SELECTOR, {value:item})
+					);
+
+					if (input) {
+						input.attr('checked', true);
+						input
+							.ancestor(STR_ROW_SELECTOR)
+							.addClass('active');
+					}
+					else {
+						offScreenElementsHtml += A.Lang.sub(
+							TPL_HIDDEN_INPUT_CHECKED,
+							{value:item, name:itemName}
+						);
+					}
+				});
+
+				container.append(offScreenElementsHtml);
+			}
+
 			searchContainer.on('rowToggled', (event) => {
 				var selectedItems = [];
 

--- a/portal-web/docroot/html/taglib/ui/search_iterator/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/bottom.jspf
@@ -157,6 +157,29 @@
 
 		searchContainer.updateDataStore(<%= primaryKeysJSONArray.toString() %>);
 
+		if (!Liferay.SPA && searchContainer.select){
+			var searchContainerId = searchContainer.get('id');
+
+			searchContainer.on('rowToggled', (event) => {
+				var selectedItems = [];
+
+				if (event.elements.allSelectedElements.size() > 0) {
+					selectedItems = event.elements.allSelectedElements.val();
+				}
+
+				if(sessionStorage.getItem(searchContainerId + Liferay.ThemeDisplay.getUserId() + "_selections")) {
+					if (selectedItems.length > 0) {
+						sessionStorage.setItem(searchContainerId + Liferay.ThemeDisplay.getUserId() + "_selections", selectedItems)
+					} else {
+						sessionStorage.removeItem(searchContainerId + Liferay.ThemeDisplay.getUserId() + "_selections");
+					}
+
+				} else if(selectedItems.length > 0) {
+					sessionStorage.setItem(searchContainerId + Liferay.ThemeDisplay.getUserId() + "_selections", selectedItems);
+				}
+			});
+		}
+
 		var destroySearchContainer = function(event) {
 			if (event.portletId === '<%= portletDisplay.getRootPortletId() %>') {
 				searchContainer.destroy();


### PR DESCRIPTION
Hey,

This is a draft PR for [LPS-168662](https://issues.liferay.com/browse/LPS-168662)

**Motivation**:
I wanted to recreate the selection storing feature we have without SPA. When SPA is on this feature is handled by [search_container_select.js](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js#L99-L147) by saving and restoring state. Once a pagination is done, it creates hidden input fields under the form from the previous page items with the checkbox values, so we can keep track of what selections were already made

**Requirements**:
Backportable till 7.2 

- No impact on existing UI 
- No impact on existing backend logic 
- In case SPA is enabled, the code does not execute 
- Have no impact on existing behavior while being developed 
- No Junk in database or sessionStorage
- The feature should work without any change on the portlet sides.

**Implementation**:
When SPA is off we reload the full page and all the resources, hence I could not depend on a given module internal state, as it will be destoryed during navigation.

1. I listen on the 'rowToggled' event and store the selections in sessionStorage under a key that is pefixed with the searchContainerId and the  userId.
2. In case we are storing data in sessionStorage under the prefixed key, I retrieve it and either update the DOM by selecting the available already selected elements or append the selections as hidden input fields.
3. I determined 2 possible actions, where we can safely presume, the user is "done" with the selections.
- When the selections are in a modal we can listen to the onClose and onSelect events and clean up
- When the selections are made under a management-toolbar and an action is initiated on them.

**Implementation difference between SPA on and off**:
I only store the selected items and render them as hidden input fields. In case SPA is on, every element is rendered as hidden input fields from the previous pages.

**Possible improvements**:
The code from search_iterator/bottom.jspf could be moved to search_container_select.js it could share some of the code that is responsible handling selections in an SPA ON scenario

We should clean the whole sessionStorage when the user logs out.

**Remaining Problem**:
It would be nice, if we could clean up after an unexpected navigation, for example the user navigates away using an URL, or simply visits a different menu from the sidebar.

Right now aftert an unexpected navigation the selections would be kept in case the user revisits the searchcontainer again in the same session.

Please review my changes.

Thanks