### PR TITLE
[TS] LPS-172852 Prevent widget title gets saved without clicking on '✓' icon.

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -91,7 +91,7 @@
 											.get('boundingBox')
 											.contains(event.target)
 									) {
-										editable.save();
+										editable.fire('stopEditing');
 									}
 								}
 							);


### PR DESCRIPTION
Hi Team,

Here is the PR for fixing the [LPS-172852](https://issues.liferay.com/browse/LPS-172852) / [LPP-47667](https://issues.liferay.com/browse/LPP-47667). [The original PR](https://github.com/thienquach87/liferay-portal/pull/25) was passed my review. Please help review and leave your comments.
#cc @locpham97

Thanks,
Thien