### PR TITLE
[DRAFT] LPS-172771 Implement selection storage with sessionStorage

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -87,6 +87,11 @@ AUI.add(
 					value:
 						'dd[data-selectable="true"],li[data-selectable="true"],tr[data-selectable="true"]',
 				},
+
+				searchContainerId: {
+					validator: Lang.isString,
+					value: '',
+				},
 			},
 
 			EXTENDS: A.Plugin.Base,
@@ -218,6 +223,10 @@ AUI.add(
 				_notifyRowToggle() {
 					const instance = this;
 
+					if (!Liferay.SPA) {
+						instance._storeSelections();
+					}
+
 					const allSelectedElements = instance.getAllSelectedElements();
 
 					const payload = {
@@ -252,6 +261,48 @@ AUI.add(
 					) {
 						instance._addRestoreTask();
 						instance._addRestoreTaskState();
+					}
+				},
+
+				_storeSelections() {
+					const instance = this;
+
+					let selectedItems = [];
+
+					if (instance.getAllSelectedElements().size() > 0) {
+						selectedItems = instance.getAllSelectedElements().val();
+					}
+
+					if (
+						sessionStorage.getItem(
+							instance.get('searchContainerId') +
+								Liferay.ThemeDisplay.getUserId() +
+								'_selections'
+						)
+					) {
+						if (selectedItems.length) {
+							sessionStorage.setItem(
+								instance.get('searchContainerId') +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections',
+								selectedItems
+							);
+						}
+						else {
+							sessionStorage.removeItem(
+								instance.get('searchContainerId') +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							);
+						}
+					}
+					else if (selectedItems.length) {
+						sessionStorage.setItem(
+							instance.get('searchContainerId') +
+								Liferay.ThemeDisplay.getUserId() +
+								'_selections',
+							selectedItems
+						);
 					}
 				},
 
@@ -290,6 +341,8 @@ AUI.add(
 						'bulkSelection',
 						hostContentBox.getData('bulkSelection')
 					);
+
+					instance.set('searchContainerId', host.get('id'));
 
 					const toggleRowFn = A.bind(
 						'_onClickRowSelector',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -25,7 +25,9 @@ AUI.add(
 
 		const STR_ACTIONS_WILDCARD = '*';
 
-		const STR_CHECKBOX_SELECTOR = 'input[type=checkbox]:enabled';
+		const STR_CHECKBOX_ENABLED_SELECTOR = 'input[type=checkbox]:enabled';
+
+		const STR_CHECKBOX_SELECTOR = 'input[type="checkbox"]';
 
 		const STR_CHECKED = 'checked';
 
@@ -145,7 +147,7 @@ AUI.add(
 							selector:
 								instance.get(STR_ROW_SELECTOR) +
 								' ' +
-								STR_CHECKBOX_SELECTOR,
+								STR_CHECKBOX_ENABLED_SELECTOR,
 						},
 						owner: host.get('id'),
 					});
@@ -188,7 +190,7 @@ AUI.add(
 					const instance = this;
 
 					return instance._getElements(
-						STR_CHECKBOX_SELECTOR,
+						STR_CHECKBOX_ENABLED_SELECTOR,
 						onlySelected
 					);
 				},
@@ -199,7 +201,7 @@ AUI.add(
 					return instance._getElements(
 						instance.get(STR_ROW_SELECTOR) +
 							' ' +
-							STR_CHECKBOX_SELECTOR,
+							STR_CHECKBOX_ENABLED_SELECTOR,
 						onlySelected
 					);
 				},
@@ -261,6 +263,56 @@ AUI.add(
 					) {
 						instance._addRestoreTask();
 						instance._addRestoreTaskState();
+					}
+				},
+
+				_restoreFromSessionStorage(host) {
+					const instance = this;
+
+					if (
+						sessionStorage.getItem(
+							instance.get('searchContainerId') +
+								Liferay.ThemeDisplay.getUserId() +
+								'_selections'
+						)
+					) {
+						const container = A.one(host._getNodeToParse());
+
+						const selections = sessionStorage
+							.getItem(
+								instance.get('searchContainerId') +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							)
+							.split(',');
+
+						const itemName = host
+							.get('contentBox')
+							.one(STR_CHECKBOX_SELECTOR)
+							?.get('name');
+
+						let offScreenElementsHtml = '';
+
+						selections.map((item) => {
+							const input = container.one(
+								A.Lang.sub(TPL_INPUT_SELECTOR, {value: item})
+							);
+
+							if (input) {
+								input.attr('checked', true);
+								input
+									.ancestor(instance.get(STR_ROW_SELECTOR))
+									.addClass('active');
+							}
+							else {
+								offScreenElementsHtml += A.Lang.sub(
+									TPL_HIDDEN_INPUT_CHECKED,
+									{name: itemName, value: item}
+								);
+							}
+						});
+
+						container.append(offScreenElementsHtml);
 					}
 				},
 
@@ -366,7 +418,7 @@ AUI.add(
 								toggleRowCSSFn,
 								instance.get(STR_ROW_SELECTOR) +
 									' ' +
-									STR_CHECKBOX_SELECTOR,
+									STR_CHECKBOX_ENABLED_SELECTOR,
 								instance
 							),
 						host
@@ -385,10 +437,16 @@ AUI.add(
 							instance
 						),
 					];
+
+					if (!Liferay.SPA) {
+						instance._restoreFromSessionStorage(host);
+					}
 				},
 
 				isSelected(element) {
-					return element.one(STR_CHECKBOX_SELECTOR).attr(STR_CHECKED);
+					return element
+						.one(STR_CHECKBOX_ENABLED_SELECTOR)
+						.attr(STR_CHECKED);
 				},
 
 				toggleAllRows(selected, bulkSelection) {
@@ -418,7 +476,7 @@ AUI.add(
 					const instance = this;
 
 					if (config && config.toggleCheckbox) {
-						const checkbox = row.one(STR_CHECKBOX_SELECTOR);
+						const checkbox = row.one(STR_CHECKBOX_ENABLED_SELECTOR);
 
 						checkbox.attr(STR_CHECKED, !checkbox.attr(STR_CHECKED));
 					}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -440,6 +440,59 @@ AUI.add(
 
 					if (!Liferay.SPA) {
 						instance._restoreFromSessionStorage(host);
+						window.addEventListener('beforeunload', () => {
+							if (
+								sessionStorage.getItem(
+									instance.get('searchContainerId') +
+										Liferay.ThemeDisplay.getUserId() +
+										'_selections'
+								)
+							) {
+
+								// Cleaning sessionStorage if the user navigates away
+
+								if (
+									!document
+										.getElementById(
+											instance.get('searchContainerId')
+										)
+										.contains(document.activeElement) &&
+									!document
+										.getElementsByClassName(
+											'management-bar'
+										)[0]
+										?.contains(document.activeElement) &&
+									!document
+										.getElementsByClassName('tbar-nav')[0]
+										?.contains(document.activeElement)
+								) {
+									sessionStorage.removeItem(
+										instance.get('searchContainerId') +
+											Liferay.ThemeDisplay.getUserId() +
+											'_selections'
+									);
+								}
+
+								// Cleaning sessionsSotre if the user initated a single action on an item
+
+								else if (
+									document
+										.getElementById(
+											instance.get('searchContainerId')
+										)
+										.contains(document.activeElement) &&
+									document.activeElement.classList.contains(
+										'component-action'
+									)
+								) {
+									sessionStorage.removeItem(
+										instance.get('searchContainerId') +
+											Liferay.ThemeDisplay.getUserId() +
+											'_selections'
+									);
+								}
+							}
+						});
 					}
 				},
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -418,6 +418,23 @@ const openSelectionModal = ({
 
 						const allSelectedNodes = allSelectedElements.getDOMNodes();
 
+						const searchContainerId = searchContainer.get('id');
+
+						if (
+							!Liferay.SPA &&
+							sessionStorage.getItem(
+								searchContainerId +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							)
+						) {
+							sessionStorage.removeItem(
+								searchContainerId +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							);
+						}
+
 						onSelect(
 							allSelectedNodes.map((node) => {
 								let item = {};
@@ -480,6 +497,25 @@ const openSelectionModal = ({
 
 			eventHandlers.splice(0, eventHandlers.length);
 
+			if (!Liferay.SPA) {
+				const searchContainerId = iframeWindowObj.document.querySelector(
+					'.searchcontainer'
+				).id;
+
+				if (
+					sessionStorage.getItem(
+						searchContainerId +
+							Liferay.ThemeDisplay.getUserId() +
+							'_selections'
+					)
+				) {
+					sessionStorage.removeItem(
+						searchContainerId +
+							Liferay.ThemeDisplay.getUserId() +
+							'_selections'
+					);
+				}
+			}
 			if (onClose) {
 				onClose();
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -85,6 +85,15 @@ const ActionControls = ({
 									displayType="unstyled"
 									href={item.href}
 									onClick={(event) => {
+										if (!Liferay.SPA) {
+											sessionStorage.removeItem(
+												document.querySelector(
+													'.searchcontainer'
+												)?.id +
+													Liferay.ThemeDisplay.getUserId() +
+													'_selections'
+											);
+										}
 										onActionButtonClick(event, {
 											item,
 										});
@@ -100,6 +109,15 @@ const ActionControls = ({
 										displayType="unstyled"
 										href={item.href}
 										onClick={(event) => {
+											if (!Liferay.SPA) {
+												sessionStorage.removeItem(
+													document.querySelector(
+														'.searchcontainer'
+													)?.id +
+														Liferay.ThemeDisplay.getUserId() +
+														'_selections'
+												);
+											}
 											onActionButtonClick(event, {
 												item,
 											});


### PR DESCRIPTION
Hey,

This is the second Draft for [LPS-172771](https://issues.liferay.com/browse/LPS-172771)
Previous Draft: https://github.com/liferay-frontend/liferay-portal/pull/2964
(I went into more details about the implementation and the intent behind it on the previous PR, please check it as it still applies)

Improvements I made:
I moved the selection storing and retrieving logic to search_container_select.js

Notes:
I also looked into wether I could clean the sessionStorage when the user navigates away, by listening on the window 'beforeunload' event. However I was not able to differentiate between the navigations. For example a pagination, a reload or the case where the user indeed navigates away.

Could you offer some help regarding that?

Thanks,

cc/ @markocikos @dsanz 