### PR TITLE
LPS-168383 Add aria-current to selected link and add new disableAriaCurrent prop so it's optional

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 10.0.3
+Bundle-Version: 10.1.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.util

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -10,5 +10,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "10.0.3"
+	"version": "10.1.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
@@ -68,6 +68,10 @@ public class ScreenNavigationTag extends IncludeTag {
 		return super.doStartTag();
 	}
 
+	public String getAriaCurrent() {
+		return _ariaCurrent;
+	}
+
 	public String getContainerCssClass() {
 		return _containerCssClass;
 	}
@@ -122,6 +126,10 @@ public class ScreenNavigationTag extends IncludeTag {
 
 	public boolean isInverted() {
 		return _inverted;
+	}
+
+	public void setAriaCurrent(String ariaCurrent) {
+		_ariaCurrent = ariaCurrent;
 	}
 
 	public void setContainerCssClass(String containerCssClass) {
@@ -183,6 +191,7 @@ public class ScreenNavigationTag extends IncludeTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_ariaCurrent = "page";
 		_containerCssClass = "col-md-9";
 		_containerWrapperCssClass = StringPool.BLANK;
 		_context = null;
@@ -245,6 +254,8 @@ public class ScreenNavigationTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-frontend:screen-navigation:id", id);
 
+		httpServletRequest.setAttribute(
+			"liferay-frontend:screen-navigation:ariaCurrent", _ariaCurrent);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:screen-navigation:containerWrapperCssClass",
 			_containerWrapperCssClass);
@@ -371,6 +382,7 @@ public class ScreenNavigationTag extends IncludeTag {
 
 	private static final String _PAGE = "/screen_navigation/page.jsp";
 
+	private String _ariaCurrent = "page";
 	private String _containerCssClass = "col-md-9";
 	private String _containerWrapperCssClass = StringPool.BLANK;
 	private Object _context;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -541,6 +541,11 @@
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationTag</tag-class>
 		<body-content>JSP</body-content>
 		<attribute>
+			<name>ariaCurrent</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>containerCssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
@@ -17,6 +17,7 @@
 <%@ include file="/screen_navigation/init.jsp" %>
 
 <%
+String ariaCurrent = (String)request.getAttribute("liferay-frontend:screen-navigation:ariaCurrent");
 String containerCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:containerCssClass");
 String containerWrapperCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:containerWrapperCssClass");
 String fullContainerCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:fullContainerCssClass");
@@ -93,6 +94,7 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 
 								<li class="nav-item">
 									<a
+										aria-current="<%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? ariaCurrent : "false" %>"
 										class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %>" href="<%=
 PortletURLBuilder.create(
 									PortletURLUtil.clone(portletURL, liferayPortletResponse)

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
Hi guys! I'm sending the fix for this bug: https://issues.liferay.com/browse/LPS-168383.

The solution I've added is adding `aria-current` to vertical nav taglib (making it optional). At the same time, I have opened [an issue in Clay's repo](https://github.com/liferay/clay/issues/5307) so they can also make it optional in React navigation components. This way, we will be able to decide which navigation has the aria-current when we have more than one. Please tell me if you have any doubt.

Thanks in advance! 😄