### PR TITLE
LPS-173327 Expose FDS utilities to reload data and open side panel in custom actions and custom data renderers

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
@@ -91,7 +91,12 @@ public class FDSSampleDisplayContext {
 				"get", null, "async"),
 			new FDSActionDropdownItem(
 				portalURL + "/abc", "staging", "asyncErrorResourceNotFound",
-				"Async Resource Not Found", "get", null, "async"));
+				"Async Resource Not Found", "get", null, "async"),
+			new FDSActionDropdownItem(
+				null, "reload", "reload", "Reload Data", null, null, null),
+			new FDSActionDropdownItem(
+				null, "rectangle-split", "openSidePanel", "Open Side Panel",
+				null, null, null));
 	}
 
 	private final FDSRequestHelper _fdsRequestHelper;

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -50,6 +50,10 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 			"title", "title",
 			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
 		).add(
+			"creator.name", "author",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"sampleCustomDataRenderer")
+		).add(
 			"description", "description"
 		).add(
 			"date", "date"
@@ -68,10 +72,6 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 			"status", "status",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
 				"status")
-		).add(
-			"creator.name", "author",
-			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"sampleCustomDataRenderer")
 		).build();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleCustomDataRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleCustomDataRenderer.js
@@ -12,14 +12,76 @@
  * details.
  */
 
-import ClayIcon from '@clayui/icon';
+import ClayButton from '@clayui/button';
+import ClayLink from '@clayui/link';
+import {openModal} from 'frontend-js-web';
 import React from 'react';
 
-const SampleCustomDataRenderer = ({value}) => {
+const SampleCustomDataRenderer = ({
+	actions,
+	itemData,
+	itemId,
+	loadData,
+	openSidePanel,
+	options,
+	rootPropertyName,
+	value,
+	valuePath,
+}) => {
+	const ModalBody = ({closeModal}) => {
+		return (
+			<>
+				<div>First action label: {actions[0].label}</div>
+				<div>Item ID: {itemId}</div>
+				<div>Item color: {itemData.color}</div>
+				<div>Field label: {options.label}</div>
+				<div>First field name: {rootPropertyName}</div>
+				<div>Second field name: {valuePath[1]}</div>
+				<br />
+				<div>
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={() => {
+								closeModal();
+
+								loadData();
+							}}
+						>
+							Reload Data
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => {
+								closeModal();
+
+								openSidePanel({
+									url: 'about:blank',
+								});
+							}}
+						>
+							Open Side Panel
+						</ClayButton>
+					</ClayButton.Group>
+				</div>
+			</>
+		);
+	};
+
 	return (
 		<>
-			<ClayIcon symbol="user" />
-			{value}
+			<ClayLink
+				onClick={() =>
+					openModal({
+						bodyComponent: ModalBody,
+						title: Liferay.Language.get('details'),
+					})
+				}
+				style={{cursor: 'pointer'}}
+			>
+				{value}
+			</ClayLink>
 		</>
 	);
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/SampleFDSPropsTransformer.js
@@ -26,12 +26,22 @@ export default function propsTransformer({
 		customDataRenderers: {
 			sampleCustomDataRenderer: SampleCustomDataRenderer,
 		},
-		onActionDropdownItemClick({action, itemData}) {
+		onActionDropdownItemClick({action, itemData, loadData, openSidePanel}) {
 			if (action.data.id === 'sampleMessage') {
 				alert(`${greeting} ${itemData.title}!`);
 			}
+			else if (action.data.id === 'reload') {
+				loadData();
+			}
+			else if (action.data.id === 'openSidePanel') {
+				openSidePanel({url: 'about:blank'});
+			}
 		},
-		onBulkActionItemClick({action, selectedData: {items, keyValues}}) {
+		onBulkActionItemClick({
+			action,
+			loadData,
+			selectedData: {items, keyValues},
+		}) {
 			if (action.data.id === 'sampleBulkAction') {
 				openModal({
 					bodyHTML: `
@@ -52,6 +62,8 @@ export default function propsTransformer({
 							label: 'OK',
 							onClick: ({processClose}) => {
 								processClose();
+
+								loadData();
 							},
 						},
 					],

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -156,14 +156,19 @@ export function handleAction(
 	}
 }
 function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
-	const context = useContext(FrontendDataSetContext);
+	const frontendDataSetContext = useContext(FrontendDataSetContext);
 	const [
 		{
 			activeView: {quickActionsEnabled},
 		},
 	] = useContext(ViewsContext);
 
-	const {inlineEditingSettings, onActionDropdownItemClick} = context;
+	const {
+		inlineEditingSettings,
+		loadData,
+		onActionDropdownItemClick,
+		openSidePanel,
+	} = frontendDataSetContext;
 
 	const [loading, setLoading] = useState(false);
 
@@ -195,6 +200,8 @@ function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 				action,
 				event,
 				itemData,
+				loadData,
+				openSidePanel,
 			});
 		}
 
@@ -217,7 +224,7 @@ function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 					target,
 					url: formatActionURL(action.href, itemData),
 				},
-				context
+				frontendDataSetContext
 			);
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
@@ -72,19 +72,26 @@ function ActionsDropdown({
 	onMenuActiveChange,
 	setLoading,
 }) {
-	const context = useContext(FrontendDataSetContext);
+	const frontendDataSetContext = useContext(FrontendDataSetContext);
+
+	const {
+		inlineEditingSettings,
+		loadData,
+		openSidePanel,
+	} = frontendDataSetContext;
 
 	const inlineEditingAvailable =
-		context.inlineEditingSettings && itemData.actions?.update;
+		inlineEditingSettings && itemData.actions?.update;
 	const inlineEditingAlwaysOn =
-		inlineEditingAvailable && context.inlineEditingSettings.alwaysOn;
+		inlineEditingAvailable && inlineEditingSettings.alwaysOn;
 
 	const isMounted = useIsMounted();
 
-	const editModeActive = !!context.itemsChanges[itemId];
+	const editModeActive = !!frontendDataSetContext.itemsChanges[itemId];
 	const itemChanges =
-		editModeActive && Object.keys(context.itemsChanges[itemId]).length
-			? context.itemsChanges[itemId]
+		editModeActive &&
+		Object.keys(frontendDataSetContext.itemsChanges[itemId]).length
+			? frontendDataSetContext.itemsChanges[itemId]
 			: null;
 
 	const inlineEditingActions = (
@@ -93,7 +100,9 @@ function ActionsDropdown({
 				className="mr-1"
 				disabled={inlineEditingAlwaysOn && !itemChanges}
 				displayType="secondary"
-				onClick={() => context.toggleItemInlineEdit(itemId)}
+				onClick={() =>
+					frontendDataSetContext.toggleItemInlineEdit(itemId)
+				}
 				small
 				symbol="times-small"
 			/>
@@ -106,11 +115,13 @@ function ActionsDropdown({
 					monospaced
 					onClick={() => {
 						setLoading(true);
-						context.applyItemInlineUpdates(itemId).finally(() => {
-							if (isMounted()) {
-								setLoading(false);
-							}
-						});
+						frontendDataSetContext
+							.applyItemInlineUpdates(itemId)
+							.finally(() => {
+								if (isMounted()) {
+									setLoading(false);
+								}
+							});
 					}}
 					small
 					symbol="check"
@@ -145,7 +156,8 @@ function ActionsDropdown({
 			action.label
 		);
 
-		const onActionDropdownItemClick = context.onActionDropdownItemClick;
+		const onActionDropdownItemClick =
+			frontendDataSetContext.onActionDropdownItemClick;
 
 		const url = formatActionURL(action.href, itemData);
 
@@ -168,6 +180,8 @@ function ActionsDropdown({
 							action,
 							event,
 							itemData,
+							loadData,
+							openSidePanel,
 						});
 					}
 				}}
@@ -187,6 +201,8 @@ function ActionsDropdown({
 							action,
 							event,
 							itemData,
+							loadData,
+							openSidePanel,
 						});
 					}
 
@@ -201,7 +217,7 @@ function ActionsDropdown({
 							url,
 							...action,
 						},
-						context
+						frontendDataSetContext
 					);
 				}}
 			>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/BulkActions.js
@@ -86,6 +86,7 @@ function BulkActions({
 		else if (onBulkActionItemClick) {
 			onBulkActionItemClick({
 				action: actionDefinition,
+				loadData,
 				selectedData: {
 					items: selectedItems,
 					keyValues: selectedItemsValue,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.js
@@ -58,6 +58,7 @@ const Card = ({item, schema}) => {
 		executeAsyncItemAction,
 		highlightItems,
 		itemsActions,
+		loadData,
 		onActionDropdownItemClick,
 		openModal,
 		openSidePanel,
@@ -80,6 +81,8 @@ const Card = ({item, schema}) => {
 							action,
 							event,
 							itemData: item,
+							loadData,
+							openSidePanel,
 						});
 					}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.js
@@ -76,9 +76,12 @@ function TableCell({
 	valuePath,
 	view,
 }) {
-	const {customDataRenderers, inlineEditingSettings} = useContext(
-		FrontendDataSetContext
-	);
+	const {
+		customDataRenderers,
+		inlineEditingSettings,
+		loadData,
+		openSidePanel,
+	} = useContext(FrontendDataSetContext);
 
 	const [loading, setLoading] = useState(false);
 
@@ -146,6 +149,8 @@ function TableCell({
 					actions={actions}
 					itemData={itemData}
 					itemId={itemId}
+					loadData={loadData}
+					openSidePanel={openSidePanel}
 					options={options}
 					rootPropertyName={rootPropertyName}
 					value={value}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -136,7 +136,7 @@ const Modal = ({
 
 		return (
 			<div className="liferay-modal-body" ref={bodyRef}>
-				{BodyComponent && <BodyComponent />}
+				{BodyComponent && <BodyComponent closeModal={processClose} />}
 			</div>
 		);
 	};


### PR DESCRIPTION
### References

- [LPS-173327 Expose FDS context in custom actions and custom data renderers](https://issues.liferay.com/browse/LPS-173327)
- Related Slack discussion: https://liferay.slack.com/archives/CNBG06JS3/p1674074856364879

### What is the goal of this PR?

In this PR:
1. We are exposing `loadData` and `openSidePanel` utilites in custom actions and custom data renderers.
2. We are adding samples for exposed props, both new and existing ones.
3. We are exposing utility to close modal, as I found this useful in modal example.

Notes:
- I considered exposing the entire `FrontendDataSetContext`. While this would be an easier solution and more powerful tool for customization, I concluded that this would not be a good idea. This would expose too much, adding risk to any internal changes  down the line. Even if we wouldn't use something from Context, there would be a possibility that some customers do. Instead, I think it's a better idea if we expose only explicit utilities that we need.
- There is a bug that `x` close button of empty side panel does not work. This is unrelated to this PR. In real usages, this gets overlayed by panel content, and panel content contains the close button. We should probably remove this button, but that's outside of scope of this ticket.
- I don't think that we need to expose `openSidePanel` utilites for bulk actions, side panel seems related only to workflows related to single item. If I'm wrong, we can add this later.

### What does it look like?

https://user-images.githubusercontent.com/5435511/213746867-86d6a0ea-0d98-4faa-bf0b-e05c3e690edf.mp4

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
4. Place `Frontend Data Set Sample` widget on any page.