### PR TITLE
LPS-173575 Use flex class for unstyled to be displayed correctly

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
@@ -37,7 +37,7 @@
 			</div>
 		</div>
 
-		<#if !is_signed_in>
+		<#if !is_signed_in && show_sign_in>
 			<a data-redirect="${is_login_redirect_required?string}" href="${sign_in_url}" id="sign-in" rel="nofollow">${sign_in_text}</a>
 		</#if>
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_normal.ftl
@@ -18,9 +18,10 @@
 
 <@liferay_util["include"] page=body_top_include />
 
-<@liferay.control_menu />
+<div class="d-flex flex-column min-vh-100">
+	<@liferay.control_menu />
 
-<div class="container-fluid position-relative" id="wrapper">
+	<div class="d-flex flex-column flex-fill position-relative" id="wrapper">
 	<header id="banner" role="banner">
 		<div id="heading">
 			<div aria-level="1" class="site-title" role="heading">
@@ -69,6 +70,7 @@
 			/>
 		</p>
 	</footer>
+	</div>
 </div>
 
 <@liferay_util["include"] page=body_bottom_include />


### PR DESCRIPTION
Changes unstyled theme to use same flex classes as classic theme does: https://github.com/liferay/liferay-portal/blob/bacdae7fa302e5eb5cfae10661273b984ea9ed06/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl#L21-L24

Before:
![image](https://user-images.githubusercontent.com/59687465/214531596-70724319-2202-4d52-baef-f98f685a7740.png)
![image](https://user-images.githubusercontent.com/59687465/214531654-9fc290f1-c933-4a35-a6da-86ae8e687f62.png)

After this fix:
![image](https://user-images.githubusercontent.com/59687465/214531767-ce1405dd-d7de-460f-bf6d-bd542ea91ace.png)
![image](https://user-images.githubusercontent.com/59687465/214531820-a690262f-944d-4041-b147-6e45517d2d80.png)
