### PR TITLE
LPS-170577 | Add Autom. test ClayAlertToast#DisappearsAfter10SecsWithActions

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleToastAlert.js
@@ -12,11 +12,44 @@
  * details.
  */
 
+import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import {openToast} from 'frontend-js-web';
-import React from 'react';
+import React, {useState} from 'react';
+
+function ToastAlert10Secs({
+	autoClose,
+	buttonText,
+	displayType,
+	message,
+	onButtonClick,
+	onClose,
+	title,
+}) {
+	return (
+		<ClayAlert.ToastContainer id="ToastAlertContainer">
+			<ClayAlert
+				autoClose={autoClose}
+				displayType={displayType}
+				onClose={() => onClose()}
+				title={title}
+			>
+				<a href={themeDisplay.getURLHome()}>{message}</a>
+
+				<ClayAlert.Footer>
+					<ClayButton.Group>
+						<ClayButton alert onClick={() => onButtonClick()}>
+							{buttonText}
+						</ClayButton>
+					</ClayButton.Group>
+				</ClayAlert.Footer>
+			</ClayAlert>
+		</ClayAlert.ToastContainer>
+	);
+}
 
 export default function ClaySampleToastAlert() {
+	const [showAlert, setShowAlert] = useState(false);
 	const onClick5Seconds = () => {
 		openToast({
 			message: Liferay.Language.get(
@@ -50,6 +83,20 @@ export default function ClaySampleToastAlert() {
 		<div data-qa-id="claySampleToastAlert">
 			<h3>TOAST ALERT MESSAGE</h3>
 
+			{showAlert && (
+				<ToastAlert10Secs
+					autoClose={10000}
+					buttonText="Button"
+					displayType="info"
+					message="This toast alert with action button should disappear after 10 seconds"
+					onButtonClick={() => {
+						Liferay.Util.navigate(themeDisplay.getURLHome());
+					}}
+					onClose={() => setShowAlert(false)}
+					title="Info:"
+				/>
+			)}
+
 			<div className="sheet-footer">
 				<ClayButton.Group spaced>
 					<ClayButton onClick={onClickSuccess} type="submit">
@@ -66,6 +113,13 @@ export default function ClaySampleToastAlert() {
 
 					<ClayButton onClick={onClick5Seconds} type="submit">
 						{Liferay.Language.get('disappear-after-5-secs')}
+					</ClayButton>
+
+					<ClayButton
+						onClick={() => setShowAlert(true)}
+						type="submit"
+					>
+						{Liferay.Language.get('disappear-after-10-secs')}
 					</ClayButton>
 				</ClayButton.Group>
 			</div>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -5329,6 +5329,7 @@ disabled-inputs-condensed-with-value=Disabled Inputs Condensed With Value
 disabled-inputs-with-value=Disabled Inputs With Value
 disabling-the-recycle-bin-prevents-the-restoring-of-content-that-has-been-moved-to-the-recycle-bin=Disabling the Recycle Bin prevents the restoring of content that has been moved to the Recycle Bin.
 disappear-after-5-secs=Disappears After 5 Seconds
+disappear-after-10-secs=Disappears After 10 Seconds
 disassociate=Disassociate
 discard=Discard
 discard-change=Discard Change

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -106,7 +106,7 @@ definition {
 				locator1 = "Button#ANY");
 		}
 
-		task ("And there is an action button on it") {
+		task ("And When there is an action button on it") {
 			VerifyElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[contains(@class, 'alert-info')]//a");
 		}
 
@@ -116,9 +116,12 @@ definition {
 
 			Pause(locator1 = "10000");
 
-			AssertElementNotPresent.assertElementNotPresent(
-				key_type = "info",
-				locator1 = "ClayAlertToast#ALERT_TOAST");
+			if (!(IsElementPresent.isElementPresentNoSPARefresh(key_type = "info", locator1 = "ClayAlertToast#ALERT_TOAST"))) {
+				TestUtils.pass(message = "Test passed: Alert toast with action disappeared after 10 seconds");
+			}
+			else {
+				fail("Test failed: Clay Toast alert with action is still present after 10 seconds.");
+			}
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -97,6 +97,31 @@ definition {
 		}
 	}
 
+	@description = "LPS-170577 - Verify toast alert with action button disappears after 10 seconds"
+	@priority = "5"
+	test DisappearsAfter10SecsWithActions {
+		task ("When a toast alert appears") {
+			Click(
+				key_text = "Disappears After 10 Seconds",
+				locator1 = "Button#ANY");
+		}
+
+		task ("And there is an action button on it") {
+			VerifyElementPresent(locator1 = "//*[@id='ToastAlertContainer']//*[contains(@class, 'alert-info')]//a");
+		}
+
+		task ("Then the alert disappears after 10 secs") {
+
+			// For LPS-170577, need this pause to see if after 10 seconds, the alert is not showing anymore
+
+			Pause(locator1 = "10000");
+
+			AssertElementNotPresent.assertElementNotPresent(
+				key_type = "info",
+				locator1 = "ClayAlertToast#ALERT_TOAST");
+		}
+	}
+
 	@description = "LPS-170578 Validate alert toast message does not disapear when mouse hovers over it."
 	@priority = "5"
 	test DoesNotAutocloseWhenHoveredOver {


### PR DESCRIPTION
**ClayAlertToast#DisappearsAfter10SecsWithActions**
**Test Plan**

- Given Clay Sample Portlet
- When a toast alert appears
- And there is an action button on it
- Then the alert disappears after 10 secs

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-170577