### PR TITLE
LPS-168383 Add aria-current to the proper navigation

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 13.1.2
+Bundle-Version: 13.2.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -84,5 +84,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "13.1.2"
+	"version": "13.2.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -39,12 +39,20 @@ public class NavigationBarTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
+	public String getActiveItemAriaCurrent() {
+		return _activeItemAriaCurrent;
+	}
+
 	public boolean getInverted() {
 		return _inverted;
 	}
 
 	public List<NavigationItem> getNavigationItems() {
 		return _navigationItems;
+	}
+
+	public void setActiveItemAriaCurrent(String activeItemAriaCurrent) {
+		_activeItemAriaCurrent = activeItemAriaCurrent;
 	}
 
 	public void setInverted(boolean inverted) {
@@ -59,6 +67,7 @@ public class NavigationBarTag extends BaseContainerTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_activeItemAriaCurrent = "page";
 		_inverted = false;
 		_navigationItems = null;
 	}
@@ -70,6 +79,7 @@ public class NavigationBarTag extends BaseContainerTag {
 
 	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("activeItemAriaCurrent", _activeItemAriaCurrent);
 		props.put("inverted", _inverted);
 		props.put("navigationItems", _navigationItems);
 
@@ -141,6 +151,7 @@ public class NavigationBarTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:navigation_bar:";
 
+	private String _activeItemAriaCurrent = "page";
 	private boolean _inverted;
 	private List<NavigationItem> _navigationItems;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1869,6 +1869,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>activeItemAriaCurrent</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>cssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -17,9 +17,15 @@ import ClayLink from '@clayui/link';
 import ClayNavigationBar from '@clayui/navigation-bar';
 import React from 'react';
 
-export default function NavigationBar({cssClass, inverted, navigationItems}) {
+export default function NavigationBar({
+	activeItemAriaCurrent,
+	cssClass,
+	inverted,
+	navigationItems,
+}) {
 	return (
 		<ClayNavigationBar
+			aria-current={activeItemAriaCurrent}
 			className={cssClass}
 			inverted={inverted}
 			triggerLabel={navigationItems.find(({active}) => active)?.label}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0


### PR DESCRIPTION
Hi guys! This is a follow-up to https://github.com/liferay-frontend/liferay-portal/pull/2978.

After Clay merging https://github.com/liferay/clay/issues/5307, we have discussed the behavior of the `screen-navigation` taglib and we think this new approach is more correct.

The `screen-navigation` taglib has two different navigations, the navigation bar in the top and the vertical navigation (they are optional, users can combine both or use only one of them).

As it's incorrect having the `aria-current` in both navigations, now we will decide in the taglib itself wether we add it to the top navigation bar or to the vertical one (the top one will only have it if the vertical is not present).

So what I do in this PR is:
- Adapt `clay:navigation-bar` taglib so it supports getting the `aria-current` by param, just as the Clay component do
- Remove the `ariaCurrent` param in `screen-navigation` taglib as it doesn't make sense that it's optional, we will always want `aria-current` in one of the navigations
- Apply `aria-current` to the correct navigation in each case in `screen-navigation` taglib

Thanks in advance and please tell me if I can clarify something!