### PR TITLE
LPS-173636 Adds attributes decoration, fontSize, and weight to clay-link

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -71,12 +71,20 @@ public class LinkTag extends BaseContainerTag {
 		return _borderless;
 	}
 
+	public String getDecoration() {
+		return _decoration;
+	}
+
 	public String getDisplayType() {
 		return _displayType;
 	}
 
 	public String getDownload() {
 		return _download;
+	}
+
+	public String getFontSize() {
+		return _fontSize;
 	}
 
 	public String getHref() {
@@ -107,6 +115,10 @@ public class LinkTag extends BaseContainerTag {
 		return _type;
 	}
 
+	public String getWeight() {
+		return _weight;
+	}
+
 	public void setBlock(boolean block) {
 		_block = block;
 	}
@@ -115,12 +127,20 @@ public class LinkTag extends BaseContainerTag {
 		_borderless = borderless;
 	}
 
+	public void setDecoration(String decoration) {
+		_decoration = decoration;
+	}
+
 	public void setDisplayType(String displayType) {
 		_displayType = displayType;
 	}
 
 	public void setDownload(String download) {
 		_download = download;
+	}
+
+	public void setFontSize(String fontSize) {
+		_fontSize = fontSize;
 	}
 
 	public void setHref(String href) {
@@ -151,14 +171,20 @@ public class LinkTag extends BaseContainerTag {
 		_type = type;
 	}
 
+	public void setWeight(String weight) {
+		_weight = weight;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
 
 		_block = false;
 		_borderless = false;
+		_decoration = null;
 		_displayType = null;
 		_download = null;
+		_fontSize = null;
 		_href = null;
 		_icon = null;
 		_label = null;
@@ -166,6 +192,7 @@ public class LinkTag extends BaseContainerTag {
 		_outline = false;
 		_small = false;
 		_type = "link";
+		_weight = null;
 	}
 
 	@Override
@@ -182,8 +209,11 @@ public class LinkTag extends BaseContainerTag {
 		props.put("block", _block);
 		props.put("borderless", _borderless);
 		props.put("button", _type.equals("button"));
+		props.put("decoration", _decoration);
 		props.put("displayType", _displayType);
+		props.put("fontSize", _fontSize);
 		props.put("icon", _icon);
+		props.put("weight", _weight);
 
 		if (Validator.isNotNull(_label)) {
 			props.put(
@@ -226,6 +256,10 @@ public class LinkTag extends BaseContainerTag {
 			cssClasses.add(cssPrefix + "sm");
 		}
 
+		if (Validator.isNotNull(_decoration)) {
+			cssClasses.add("text-decoration-" + _decoration);
+		}
+
 		if (Validator.isNotNull(_displayType)) {
 			if (_outline || _borderless) {
 				cssClasses.add(cssPrefix + "outline-" + _displayType);
@@ -233,6 +267,14 @@ public class LinkTag extends BaseContainerTag {
 			else {
 				cssClasses.add(cssPrefix + _displayType);
 			}
+		}
+
+		if (Validator.isNotNull(_fontSize)) {
+			cssClasses.add("text-" + _fontSize);
+		}
+
+		if (Validator.isNotNull(_weight)) {
+			cssClasses.add("font-weight-" + _weight);
 		}
 
 		return super.processCssClasses(cssClasses);
@@ -275,8 +317,10 @@ public class LinkTag extends BaseContainerTag {
 
 	private boolean _block;
 	private boolean _borderless;
+	private String _decoration;
 	private String _displayType;
 	private String _download;
+	private String _fontSize;
 	private String _href;
 	private String _icon;
 	private String _label;
@@ -284,5 +328,6 @@ public class LinkTag extends BaseContainerTag {
 	private boolean _outline;
 	private boolean _small;
 	private String _type = "link";
+	private String _weight;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1322,6 +1322,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>decoration</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>displayType</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -1329,6 +1335,12 @@
 		<attribute>
 			<description></description>
 			<name>download</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>fontSize</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -1389,6 +1401,12 @@
 		<attribute>
 			<description></description>
 			<name>type</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>weight</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173636
https://github.com/brianchandotcom/liferay-portal/pull/129251
https://github.com/liferay/clay/pull/5288

This adds the attributes `decoration`, `fontSize`, and `weight` to the `clay:link` tag. These were added in [Clay 3.85.0](https://github.com/liferay/clay/releases/tag/v3.85.0).