### PR TITLE
LPS-173639 Clay Alert adds symbol attribute

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/alerts.jsp
@@ -45,6 +45,12 @@
 	title="Warning"
 />
 
+<clay:alert
+	displayType="secondary"
+	message="This is a secondary message."
+	title="Secondary"
+/>
+
 <h3>STRIPE</h3>
 
 <blockquote>
@@ -76,6 +82,13 @@
 	displayType="warning"
 	message="This is a warning message."
 	title="Warning"
+/>
+
+<clay:stripe
+	dismissible="<%= true %>"
+	displayType="secondary"
+	message="This is a secondary message."
+	title="Secondary"
 />
 
 <div>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 13.0.5
+Bundle-Version: 13.1.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -84,5 +84,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "13.0.5"
+	"version": "13.1.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -59,6 +59,10 @@ public class AlertTag extends BaseContainerTag {
 		return _message;
 	}
 
+	public String getSymbol() {
+		return _symbol;
+	}
+
 	public String getTitle() {
 		return _title;
 	}
@@ -87,6 +91,10 @@ public class AlertTag extends BaseContainerTag {
 		_message = message;
 	}
 
+	public void setSymbol(String symbol) {
+		_symbol = symbol;
+	}
+
 	public void setTitle(String title) {
 		_title = title;
 	}
@@ -104,6 +112,7 @@ public class AlertTag extends BaseContainerTag {
 		_dismissible = false;
 		_displayType = "info";
 		_message = null;
+		_symbol = null;
 		_title = null;
 		_variant = null;
 	}
@@ -179,7 +188,12 @@ public class AlertTag extends BaseContainerTag {
 
 		IconTag iconTag = new IconTag();
 
-		iconTag.setSymbol(_getIcon(_displayType));
+		if (Validator.isNotNull(_symbol)) {
+			iconTag.setSymbol(_symbol);
+		}
+		else {
+			iconTag.setSymbol(_getIcon(_displayType));
+		}
 
 		iconTag.doTag(pageContext);
 
@@ -224,6 +238,9 @@ public class AlertTag extends BaseContainerTag {
 		else if (displayType.equals("warning")) {
 			return "warning-full";
 		}
+		else if (displayType.equals("secondary")) {
+			return "password-policies";
+		}
 
 		return "info-circle";
 	}
@@ -248,6 +265,7 @@ public class AlertTag extends BaseContainerTag {
 	private boolean _dismissible;
 	private String _displayType = "info";
 	private String _message;
+	private String _symbol;
 	private String _title;
 	private String _variant;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -59,6 +59,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>symbol</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>title</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173639
https://github.com/brianchandotcom/liferay-portal/pull/129251
https://github.com/liferay/clay/pull/5291

This adds the `symbol` attribute to `clay:alert`. The attribute specifies an icon to use as an indicator. We are no longer locked into using the default icon. It was added in [Clay 3.85.0](https://github.com/liferay/clay/releases/tag/v3.85.0). 