### PR TITLE
LPS-167280 Add liferay npm scripts for frontend-css-common

### DIFF
--- a/modules/apps/frontend-css/frontend-css-common/package.json
+++ b/modules/apps/frontend-css/frontend-css-common/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "@liferay/frontend-css-common",
+	"private": true,
+	"scripts": {
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "6.0.8"
+}


### PR DESCRIPTION
Here is the original pr https://github.com/liferay-frontend/liferay-portal/pull/2966, Brain Chan has merged it, but there is a license issue when publishing "frontend-css-common" module, so he reverted that commit. 

I have asked the colleague who manage the gradle plugin, he said it's ok for him to add '"private": true' property. But if so, the npm will refuse to publish the module, so I want to check with frontend team again, is that OK, if I set it to private?