### PR TITLE
LPS-174136 - Add support for external spritemaps

### DIFF
--- a/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/ThemeSpritemapCET.java
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/ThemeSpritemapCET.java
@@ -26,6 +26,12 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface ThemeSpritemapCET extends CET {
 
+	@CETProperty(
+		defaultValue = "false", name = "enableSVG4Everybody",
+		type = CETProperty.Type.Boolean
+	)
+	public boolean getEnableSVG4Everybody();
+
 	@CETProperty(defaultValue = "", name = "url", type = CETProperty.Type.URL)
 	public String getURL();
 

--- a/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/dependencies/client-extension-types.json
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/dependencies/client-extension-types.json
@@ -267,6 +267,11 @@
 				"type": "CETProperty.Type.String"
 			},
 			{
+				"default": "false",
+				"name": "enableSVG4Everybody",
+				"type": "CETProperty.Type.Boolean"
+			},
+			{
 				"default": "",
 				"name": "url",
 				"type": "CETProperty.Type.URL"

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/ThemeSpritemapCETImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/ThemeSpritemapCETImpl.java
@@ -43,6 +43,9 @@ public class ThemeSpritemapCETImpl
 			UnicodePropertiesBuilder.create(
 				true
 			).put(
+				"enableSVG4Everybody",
+				ParamUtil.getString(portletRequest, "enableSVG4Everybody")
+			).put(
 				"url", ParamUtil.getString(portletRequest, "url")
 			).build());
 	}
@@ -66,6 +69,11 @@ public class ThemeSpritemapCETImpl
 	@Override
 	public String getEditJSP() {
 		return "/admin/edit_theme_spritemap.jsp";
+	}
+
+	@Override
+	public boolean getEnableSVG4Everybody() {
+		return getBoolean("enableSVG4Everybody");
 	}
 
 	@Override

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_theme_spritemap.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_theme_spritemap.jsp
@@ -23,3 +23,5 @@ ThemeSpritemapCET themeSpritemapCET = editClientExtensionEntryDisplayContext.get
 %>
 
 <aui:input label="url" name="url" required="<%= true %>" type="text" value="<%= themeSpritemapCET.getURL() %>" />
+
+<aui:input helpMessage="enable-this-for-resources-that-are-hosted-on-a-different-domain" label="enable-cross-domain-support" name="enableSVG4Everybody" type="checkbox" value="<%= themeSpritemapCET.getEnableSVG4Everybody() %>" />

--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:client-extension:client-extension-api")
+	compileOnly project(":apps:client-extension:client-extension-type-api")
 	compileOnly project(":apps:portal-url-builder:portal-url-builder-api")
 }
 

--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
@@ -95,7 +95,10 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(
 			themeDisplay.getLayout());
 
-		if (cdnHostEnabled || themeSpritemapCET.getEnableSVG4Everybody()) {
+		if (cdnHostEnabled ||
+			((themeSpritemapCET != null) &&
+			 themeSpritemapCET.getEnableSVG4Everybody())) {
+
 			PrintWriter printWriter = httpServletResponse.getWriter();
 
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =

--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/src/main/java/com/liferay/frontend/js/svg4everybody/web/internal/servlet/taglib/SVG4EverybodyTopHeadDynamicInclude.java
@@ -14,12 +14,22 @@
 
 package com.liferay.frontend.js.svg4everybody.web.internal.servlet.taglib;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
+import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.ThemeSpritemapCET;
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilder;
 import com.liferay.portal.url.builder.AbsolutePortalURLBuilderFactory;
 import com.liferay.portal.url.builder.BundleScriptAbsolutePortalURLBuilder;
@@ -78,7 +88,14 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 			}
 		}
 
-		if (cdnHostEnabled) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		ThemeSpritemapCET themeSpritemapCET = _getThemeSpritemapCET(
+			themeDisplay.getLayout());
+
+		if (cdnHostEnabled || themeSpritemapCET.getEnableSVG4Everybody()) {
 			PrintWriter printWriter = httpServletResponse.getWriter();
 
 			AbsolutePortalURLBuilder absolutePortalURLBuilder =
@@ -116,6 +133,50 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 		_bundleContext = bundleContext;
 	}
 
+	private CET _getCET(
+		long classNameId, long classPK, long companyId, String type) {
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			_clientExtensionEntryRelLocalService.fetchClientExtensionEntryRel(
+				classNameId, classPK, type);
+
+		if (clientExtensionEntryRel == null) {
+			return null;
+		}
+
+		return _cetManager.getCET(
+			companyId, clientExtensionEntryRel.getCETExternalReferenceCode());
+	}
+
+	private ThemeSpritemapCET _getThemeSpritemapCET(Layout layout) {
+		CET cet = _getCET(
+			_portal.getClassNameId(Layout.class), layout.getPlid(),
+			layout.getCompanyId(),
+			ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP);
+
+		if (cet == null) {
+			cet = _getCET(
+				_portal.getClassNameId(Layout.class),
+				layout.getMasterLayoutPlid(), layout.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP);
+		}
+
+		if (cet == null) {
+			LayoutSet layoutSet = layout.getLayoutSet();
+
+			cet = _getCET(
+				_portal.getClassNameId(LayoutSet.class),
+				layoutSet.getLayoutSetId(), layout.getCompanyId(),
+				ClientExtensionEntryConstants.TYPE_THEME_SPRITEMAP);
+		}
+
+		if (cet != null) {
+			return (ThemeSpritemapCET)cet;
+		}
+
+		return null;
+	}
+
 	private static final String[] _JS_FILE_NAMES = {"/index.js"};
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -125,6 +186,13 @@ public class SVG4EverybodyTopHeadDynamicInclude extends BaseDynamicInclude {
 	private AbsolutePortalURLBuilderFactory _absolutePortalURLBuilderFactory;
 
 	private volatile BundleContext _bundleContext;
+
+	@Reference
+	private CETManager _cetManager;
+
+	@Reference
+	private ClientExtensionEntryRelLocalService
+		_clientExtensionEntryRelLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -1,3 +1,5 @@
+enable-cross-domain-support=Enable Cross Domain Support
+enable-this-for-resources-that-are-hosted-on-a-different-domain=Enable this for resources that are hosted on a different domain.
 +-add-address-line=+ Add Address Line
 0-analytics-cloud-connection=Analytics Cloud Connection
 1-account-was-added-to-x=1 account was added to {0}.


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174136
Here is a rough idea for enabling svg4everybody when the CET config enables cross domain support.

## How to test:
- Add FF "LPS-166479"
- Create "SVG" client extension
	- Use https://liferay.github.io/liferay-frontend-projects/spritemap-svg/spritemap-pencil-swapped-with-cog.svg for the URL
	- Enable cross domain support
- Save client extension
- Navigate to edit the "Look and Feel" of you page
- Select the registered "Theme Spritemap Client Extension"
- Save
- Go back to page and see new SVG used as spritemap
	- You can even inspect the page and see the the icons reference the CET spritemap