### PR TITLE
[DRAFT] LPS-172771 Implement selection storage with sessionStorage

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -87,6 +87,11 @@ AUI.add(
 					value:
 						'dd[data-selectable="true"],li[data-selectable="true"],tr[data-selectable="true"]',
 				},
+
+				searchContainerId: {
+					validator: Lang.isString,
+					value: '',
+				},
 			},
 
 			EXTENDS: A.Plugin.Base,
@@ -218,6 +223,10 @@ AUI.add(
 				_notifyRowToggle() {
 					const instance = this;
 
+					if (!Liferay.SPA) {
+						instance._storeSelections();
+					}
+
 					const allSelectedElements = instance.getAllSelectedElements();
 
 					const payload = {
@@ -252,6 +261,48 @@ AUI.add(
 					) {
 						instance._addRestoreTask();
 						instance._addRestoreTaskState();
+					}
+				},
+
+				_storeSelections() {
+					const instance = this;
+
+					let selectedItems = [];
+
+					if (instance.getAllSelectedElements().size() > 0) {
+						selectedItems = instance.getAllSelectedElements().val();
+					}
+
+					if (
+						sessionStorage.getItem(
+							instance.get('searchContainerId') +
+								Liferay.ThemeDisplay.getUserId() +
+								'_selections'
+						)
+					) {
+						if (selectedItems.length) {
+							sessionStorage.setItem(
+								instance.get('searchContainerId') +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections',
+								selectedItems
+							);
+						}
+						else {
+							sessionStorage.removeItem(
+								instance.get('searchContainerId') +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							);
+						}
+					}
+					else if (selectedItems.length) {
+						sessionStorage.setItem(
+							instance.get('searchContainerId') +
+								Liferay.ThemeDisplay.getUserId() +
+								'_selections',
+							selectedItems
+						);
 					}
 				},
 
@@ -290,6 +341,8 @@ AUI.add(
 						'bulkSelection',
 						hostContentBox.getData('bulkSelection')
 					);
+
+					instance.set('searchContainerId', host.get('id'));
 
 					const toggleRowFn = A.bind(
 						'_onClickRowSelector',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -25,7 +25,9 @@ AUI.add(
 
 		const STR_ACTIONS_WILDCARD = '*';
 
-		const STR_CHECKBOX_SELECTOR = 'input[type=checkbox]:enabled';
+		const STR_CHECKBOX_ENABLED_SELECTOR = 'input[type=checkbox]:enabled';
+
+		const STR_CHECKBOX_SELECTOR = 'input[type="checkbox"]';
 
 		const STR_CHECKED = 'checked';
 
@@ -145,7 +147,7 @@ AUI.add(
 							selector:
 								instance.get(STR_ROW_SELECTOR) +
 								' ' +
-								STR_CHECKBOX_SELECTOR,
+								STR_CHECKBOX_ENABLED_SELECTOR,
 						},
 						owner: host.get('id'),
 					});
@@ -188,7 +190,7 @@ AUI.add(
 					const instance = this;
 
 					return instance._getElements(
-						STR_CHECKBOX_SELECTOR,
+						STR_CHECKBOX_ENABLED_SELECTOR,
 						onlySelected
 					);
 				},
@@ -199,7 +201,7 @@ AUI.add(
 					return instance._getElements(
 						instance.get(STR_ROW_SELECTOR) +
 							' ' +
-							STR_CHECKBOX_SELECTOR,
+							STR_CHECKBOX_ENABLED_SELECTOR,
 						onlySelected
 					);
 				},
@@ -261,6 +263,56 @@ AUI.add(
 					) {
 						instance._addRestoreTask();
 						instance._addRestoreTaskState();
+					}
+				},
+
+				_restoreFromSessionStorage(host) {
+					const instance = this;
+
+					if (
+						sessionStorage.getItem(
+							instance.get('searchContainerId') +
+								Liferay.ThemeDisplay.getUserId() +
+								'_selections'
+						)
+					) {
+						const container = A.one(host._getNodeToParse());
+
+						const selections = sessionStorage
+							.getItem(
+								instance.get('searchContainerId') +
+									Liferay.ThemeDisplay.getUserId() +
+									'_selections'
+							)
+							.split(',');
+
+						const itemName = host
+							.get('contentBox')
+							.one(STR_CHECKBOX_SELECTOR)
+							?.get('name');
+
+						let offScreenElementsHtml = '';
+
+						selections.map((item) => {
+							const input = container.one(
+								A.Lang.sub(TPL_INPUT_SELECTOR, {value: item})
+							);
+
+							if (input) {
+								input.attr('checked', true);
+								input
+									.ancestor(instance.get(STR_ROW_SELECTOR))
+									.addClass('active');
+							}
+							else {
+								offScreenElementsHtml += A.Lang.sub(
+									TPL_HIDDEN_INPUT_CHECKED,
+									{name: itemName, value: item}
+								);
+							}
+						});
+
+						container.append(offScreenElementsHtml);
 					}
 				},
 
@@ -366,7 +418,7 @@ AUI.add(
 								toggleRowCSSFn,
 								instance.get(STR_ROW_SELECTOR) +
 									' ' +
-									STR_CHECKBOX_SELECTOR,
+									STR_CHECKBOX_ENABLED_SELECTOR,
 								instance
 							),
 						host
@@ -385,10 +437,16 @@ AUI.add(
 							instance
 						),
 					];
+
+					if (!Liferay.SPA) {
+						instance._restoreFromSessionStorage(host);
+					}
 				},
 
 				isSelected(element) {
-					return element.one(STR_CHECKBOX_SELECTOR).attr(STR_CHECKED);
+					return element
+						.one(STR_CHECKBOX_ENABLED_SELECTOR)
+						.attr(STR_CHECKED);
 				},
 
 				toggleAllRows(selected, bulkSelection) {
@@ -418,7 +476,7 @@ AUI.add(
 					const instance = this;
 
 					if (config && config.toggleCheckbox) {
-						const checkbox = row.one(STR_CHECKBOX_SELECTOR);
+						const checkbox = row.one(STR_CHECKBOX_ENABLED_SELECTOR);
 
 						checkbox.attr(STR_CHECKED, !checkbox.attr(STR_CHECKED));
 					}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -445,6 +445,10 @@ AUI.add(
 					if (!Liferay.SPA) {
 						instance._restoreFromSessionStorage(host);
 
+						host.on('clearFilter', () =>
+							instance._updateSessionWithSelections()
+						);
+
 						window.addEventListener('beforeunload', () => {
 							if (
 								document

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/search_container_select.js
@@ -153,6 +153,16 @@ AUI.add(
 					});
 				},
 
+				_clearSessionStorage() {
+					const instance = this;
+
+					sessionStorage.removeItem(
+						instance.get('searchContainerId') +
+							Liferay.ThemeDisplay.getUserId() +
+							'_selections'
+					);
+				},
+
 				_getActions(elements) {
 					const instance = this;
 
@@ -224,10 +234,6 @@ AUI.add(
 
 				_notifyRowToggle() {
 					const instance = this;
-
-					if (!Liferay.SPA) {
-						instance._storeSelections();
-					}
 
 					const allSelectedElements = instance.getAllSelectedElements();
 
@@ -313,10 +319,12 @@ AUI.add(
 						});
 
 						container.append(offScreenElementsHtml);
+
+						instance._clearSessionStorage();
 					}
 				},
 
-				_storeSelections() {
+				_updateSessionWithSelections() {
 					const instance = this;
 
 					let selectedItems = [];
@@ -341,11 +349,7 @@ AUI.add(
 							);
 						}
 						else {
-							sessionStorage.removeItem(
-								instance.get('searchContainerId') +
-									Liferay.ThemeDisplay.getUserId() +
-									'_selections'
-							);
+							instance._clearSessionStorage();
 						}
 					}
 					else if (selectedItems.length) {
@@ -440,6 +444,19 @@ AUI.add(
 
 					if (!Liferay.SPA) {
 						instance._restoreFromSessionStorage(host);
+
+						window.addEventListener('beforeunload', () => {
+							if (
+								document
+									.getElementById(
+										instance.get('searchContainerId') +
+											'PageIteratorBottom'
+									)
+									.contains(document.activeElement)
+							) {
+								instance._updateSessionWithSelections();
+							}
+						});
 					}
 				},
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -283,6 +283,7 @@ function ManagementToolbar({
 					clearResultsURL={clearResultsURL}
 					filterLabelItems={filterLabelItems}
 					itemsTotal={itemsTotal}
+					searchContainerId={searchContainerId}
 					searchValue={searchValue}
 				/>
 			)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -22,13 +22,32 @@ const ResultsBar = ({
 	clearResultsURL,
 	filterLabelItems,
 	itemsTotal,
+	searchContainerId,
 	searchValue,
 }) => {
 	const resultsBarRef = useRef();
 
+	const searchContainerRef = useRef();
+
+	useEffect(() => {
+		Liferay.componentReady(searchContainerId).then((searchContainer) => {
+			searchContainerRef.current = searchContainer;
+		});
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	useEffect(() => {
 		resultsBarRef.current?.focus();
 	}, [searchValue]);
+
+	const handleClick = (event) => {
+		event.preventDefault();
+
+		searchContainerRef.current?.fire('clearFilter');
+
+		window.location.href = clearResultsURL;
+	};
 
 	return (
 		<>
@@ -65,6 +84,9 @@ const ResultsBar = ({
 							className="component-label tbar-label"
 							closeButtonProps={{
 								onClick: () => {
+									searchContainerRef.current?.fire(
+										'clearFilter'
+									);
 									navigate(item.data?.removeLabelURL);
 								},
 							}}
@@ -87,7 +109,7 @@ const ResultsBar = ({
 							searchValue
 						)}
 						className="component-link tbar-link"
-						href={clearResultsURL}
+						onClick={(event) => handleClick(event)}
 					>
 						{Liferay.Language.get('clear')}
 					</ClayLink>


### PR DESCRIPTION
Hey there,

Last PR: https://github.com/liferay-frontend/liferay-portal/pull/2977

Changes:
Instead of figuring out when to clear the sessionStorage, we are clearing it as soon as we rendered the hidden input fields on search_container_select initializer. After that we store the selections on 2 distinct action:

1. When the user initiates an action from the PageIterator, that includes changing the available items on a given page, or paginating
2. When the user clears a filter from the searchContainer, that includes clearing only one filter or all of them.

Because we don't keep the selections in sessionStorage, just for that brief reload time on the above actions, I removed the sessionStorage clear logic from Modal.js as well as from the managementToolbar action buttons.

Please review my changes.

/cc @markocikos @dsanz 