### PR TITLE
LPS-174349 - Fix dark background links

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_search_container.scss
@@ -71,7 +71,7 @@ $table-responsive-margin-left-md: 375px !default;
 		}
 	}
 
-	a:not(.component-action):not(.btn) {
+	a:not(.btn):not(.component-action):not(.page-link) {
 		color: $gray-700;
 		font-weight: 500;
 		text-decoration: underline;


### PR DESCRIPTION
New contrasted pagination inheriting incorrect styles.

Since we have a new paginator with new color the inherited color is not needed for page-link:
![image](https://user-images.githubusercontent.com/7963804/216089463-096f8988-a7e0-438d-98fd-c51d305e54ca.png)

After the fix:
<img width="1256" alt="image" src="https://user-images.githubusercontent.com/7963804/216089565-9afc1cab-d8f3-4bb2-b373-8e80d779f859.png">

