### PR TITLE
LPS-168138 Adding role button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -212,6 +212,7 @@ const FilterOrderControls = ({
 						disabled={disabled}
 						displayType="unstyled"
 						href={sortingURL}
+						role="button"
 						symbol={classNames({
 							'order-list-down': sortingOrder === 'desc',
 							'order-list-up':


### PR DESCRIPTION
**Alternative**: https://github.com/liferay-frontend/liferay-portal/pull/3022

---

Add role button to identifies the element as a button to assistive technology such as screen readers.

---

**How to test it**:
- Go to a screen with management-toolbar, example: Users and Organizations > Users
- Activate your screen reader
- Tabbing until you get to the Ascending/descending icon:
- You will see the link is read like a button and it preserves its functionality
<img width="495" alt="image" src="https://user-images.githubusercontent.com/7963804/216309626-6bf97bd1-87bd-444e-ad46-0459d76124ae.png">
