### PR TITLE
LPS-168138 Adding role button [alternative]

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -47,6 +47,7 @@ const LinkOrButton = ({
 				})}
 				disabled={disabled}
 				href={href}
+				role="button"
 				{...otherProps}
 				title={symbol && title}
 			>


### PR DESCRIPTION
Alternative for this pr: https://github.com/liferay-frontend/liferay-portal/pull/3019
Not sure if `LinkOrButton` is in some use that we really need a link.

---

Add role button to identifies the element as a button to assistive technology such as screen readers.

---

**How to test it**:
- Go to a screen with management-toolbar, example: Users and Organizations > Users
- Activate your screen reader
- Tabbing until you get to the Ascending/descending icon:
- You will see the link is read like a button and it preserves its functionality
<img width="495" alt="image" src="https://user-images.githubusercontent.com/7963804/216309626-6bf97bd1-87bd-444e-ad46-0459d76124ae.png">
