### PR TITLE
LPS-170580 | Add Autom. test ClayAlertToast#CanTransitionToFillGapOfDeletedToast

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
@@ -42,4 +42,10 @@ definition {
 			locator1 = "ClayAlertToast#ALERT_TOAST_CLOSE_BUTTON"
 		);
 	}
+	macro openToastAlert {
+		Click(
+			locator1 = "Button#ANY",
+			key_text = "${key_text}"
+		);
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
@@ -36,4 +36,10 @@ definition {
 		return "${position_y}";
 	}
 
+	macro closeToastAlert {
+		Click(
+			key_type = "${key_type}",
+			locator1 = "ClayAlertToast#ALERT_TOAST_CLOSE_BUTTON"
+		);
+	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
@@ -1,5 +1,6 @@
 definition {
-    macro getElementRectanglePositionX {
+
+	macro getElementRectanglePositionX {
 		WaitForSPARefresh();
 
 		var javascript = '''
@@ -34,4 +35,5 @@ definition {
 
 		return "${position_y}";
 	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
@@ -1,5 +1,11 @@
 definition {
 
+	macro closeToastAlert {
+		Click(
+			key_type = "${key_type}",
+			locator1 = "ClayAlertToast#ALERT_TOAST_CLOSE_BUTTON");
+	}
+
 	macro getElementRectanglePositionX {
 		WaitForSPARefresh();
 
@@ -36,16 +42,10 @@ definition {
 		return "${position_y}";
 	}
 
-	macro closeToastAlert {
-		Click(
-			key_type = "${key_type}",
-			locator1 = "ClayAlertToast#ALERT_TOAST_CLOSE_BUTTON"
-		);
-	}
 	macro openToastAlert {
 		Click(
-			locator1 = "Button#ANY",
-			key_text = "${key_text}"
-		);
+			key_text = "${key_text}",
+			locator1 = "Button#ANY");
 	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/clay/ClayAlertToast.macro
@@ -1,0 +1,37 @@
+definition {
+    macro getElementRectanglePositionX {
+		WaitForSPARefresh();
+
+		var javascript = '''
+		let elem = document.querySelectorAll('${code}')[${index}];
+
+		let elementCoordinates = elem.getBoundingClientRect();
+
+		let positionX = Math.round(elementCoordinates.x).toString();
+
+		return positionX;
+		''';
+
+		var position_x = selenium.getEval("${javascript}");
+
+		return "${position_x}";
+	}
+
+	macro getElementRectanglePositionY {
+		WaitForSPARefresh();
+
+		var javascript = '''
+		let elem = document.querySelectorAll('${code}')[${index}];
+
+		let elementCoordinates = elem.getBoundingClientRect();
+
+		let positionY = Math.round(elementCoordinates.y).toString();
+
+		return positionY;
+		''';
+
+		var position_y = selenium.getEval("${javascript}");
+
+		return "${position_y}";
+	}
+}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/ClayAlertToast.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>ALERT_TOAST_CLOSE_BUTTON</td>
-	<td>//*[@id='ToastAlertContainer']//button[@class='close']</td>
+	<td>//*[@id='ToastAlertContainer']//*[contains(@class, 'alert-${key_type}')]//button[@class='close']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -76,29 +76,34 @@ definition {
 	@description = "LPS-170580 - Verify alert in the middle of stack is closed, the others fill the stack"
 	@priority = "4"
 	test CanTransitionToFillGapOfDeletedToast {
-		task("Given the known first (top) alert position from two stacked toast alert success messages") {
-			ClayAlertToast.openToastAlert(key_text="Success Submit");
-			ClayAlertToast.openToastAlert(key_text="Success Submit");
+		task ("Given the known first (top) alert position from two stacked toast alert success messages") {
+			ClayAlertToast.openToastAlert(key_text = "Success Submit");
+
+			ClayAlertToast.openToastAlert(key_text = "Success Submit");
+
 			var position_x = ClayAlertToast.getElementRectanglePositionX(
 				code = "#ToastAlertContainer .alert-success",
 				index = "0");
 			var position_y = ClayAlertToast.getElementRectanglePositionY(
 				code = "#ToastAlertContainer .alert-success",
 				index = "0");
+
 			ClayAlertToast.closeToastAlert(key_type = "success");
+
 			ClayAlertToast.closeToastAlert(key_type = "success");
 		}
+
 		task ("And multiple toast alerts") {
-			ClayAlertToast.openToastAlert(key_text="Success Submit");
+			ClayAlertToast.openToastAlert(key_text = "Success Submit");
 
-			ClayAlertToast.openToastAlert(key_text="Fail Submit");
+			ClayAlertToast.openToastAlert(key_text = "Fail Submit");
 
-			ClayAlertToast.openToastAlert(key_text="Success Submit");
+			ClayAlertToast.openToastAlert(key_text = "Success Submit");
 		}
 
 		task ("When an alert in the middle of the stack is closed") {
 			ClayAlertToast.closeToastAlert(key_type = "danger");
-		}	
+		}
 
 		task ("Then the alerts transition to fill the stack") {
 			var positionAlertX = ClayAlertToast.getElementRectanglePositionX(
@@ -110,11 +115,13 @@ definition {
 
 			if ("${positionAlertX}" != "${position_x}") {
 				takeScreenshot();
+
 				fail("FAIL. X coordinate positions do not match.");
 			}
 
 			if ("${positionAlertY}" != "${position_y}") {
 				takeScreenshot();
+
 				fail("FAIL. Y coordinate positions do not match.");
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -76,29 +76,31 @@ definition {
 	@description = "LPS-170580 - Verify alert in the middle of stack is closed, the others fill the stack"
 	@priority = "4"
 	test CanTransitionToFillGapOfDeletedToast {
+		task("Given the known first (top) alert position from two stacked toast alert success messages") {
+			ClayAlertToast.openToastAlert(key_text="Success Submit");
+			ClayAlertToast.openToastAlert(key_text="Success Submit");
+			var position_x = ClayAlertToast.getElementRectanglePositionX(
+				code = "#ToastAlertContainer .alert-success",
+				index = "0");
+			var position_y = ClayAlertToast.getElementRectanglePositionY(
+				code = "#ToastAlertContainer .alert-success",
+				index = "0");
+			ClayAlertToast.closeToastAlert(key_type = "success");
+			ClayAlertToast.closeToastAlert(key_type = "success");
+		}
 		task ("And multiple toast alerts") {
-			Click(
-				key_text = "Success Submit",
-				locator1 = "Button#ANY");
+			ClayAlertToast.openToastAlert(key_text="Success Submit");
 
-			Click(
-				key_text = "Fail Submit",
-				locator1 = "Button#ANY");
+			ClayAlertToast.openToastAlert(key_text="Fail Submit");
 
-			Click(
-				key_text = "Success Submit",
-				locator1 = "Button#ANY");
+			ClayAlertToast.openToastAlert(key_text="Success Submit");
 		}
 
 		task ("When an alert in the middle of the stack is closed") {
-			Click(
-				key_type = "danger",
-				locator1 = "ClayAlertToast#ALERT_TOAST_CLOSE_BUTTON");
-		}
+			ClayAlertToast.closeToastAlert(key_type = "danger");
+		}	
 
 		task ("Then the alerts transition to fill the stack") {
-			var position_x = "20";
-			var position_y = "710";
 			var positionAlertX = ClayAlertToast.getElementRectanglePositionX(
 				code = "#ToastAlertContainer .alert-success",
 				index = "0");
@@ -107,10 +109,12 @@ definition {
 				index = "0");
 
 			if ("${positionAlertX}" != "${position_x}") {
+				takeScreenshot();
 				fail("FAIL. X coordinate positions do not match.");
 			}
 
 			if ("${positionAlertY}" != "${position_y}") {
+				takeScreenshot();
 				fail("FAIL. Y coordinate positions do not match.");
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -73,6 +73,49 @@ definition {
 		}
 	}
 
+	@description = "LPS-170580 - Verify alert in the middle of stack is closed, the others fill the stack"
+	@priority = "4"
+	test CanTransitionToFillGapOfDeletedToast {
+		task ("And multiple toast alerts") {
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+
+			Click(
+				key_text = "Fail Submit",
+				locator1 = "Button#ANY");
+
+			Click(
+				key_text = "Success Submit",
+				locator1 = "Button#ANY");
+		}
+
+		task ("When an alert in the middle of the stack is closed") {
+			Click(
+				key_type = "danger",
+				locator1 = "ClayAlertToast#ALERT_TOAST_CLOSE_BUTTON");
+		}
+
+		task ("Then the alerts transition to fill the stack") {
+			var position_x = "20";
+			var position_y = "710";
+			var positionAlertX = ClayAlertToast.getElementRectanglePositionX(
+				code = "#ToastAlertContainer .alert-success",
+				index = "0");
+			var positionAlertY = ClayAlertToast.getElementRectanglePositionY(
+				code = "#ToastAlertContainer .alert-success",
+				index = "0");
+
+			if ("${positionAlertX}" != "${position_x}") {
+				fail("FAIL. X coordinate positions do not match.");
+			}
+
+			if ("${positionAlertY}" != "${position_y}") {
+				fail("FAIL. Y coordinate positions do not match.");
+			}
+		}
+	}
+
 	@description = "LPS-170575 - Verify toast alert with no actions disappears after 5 seconds"
 	@priority = "5"
 	test DisappearsAfter5SecsWithoutActions {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAlertToast.testcase
@@ -124,6 +124,8 @@ definition {
 
 				fail("FAIL. Y coordinate positions do not match.");
 			}
+
+			takeScreenshot();
 		}
 	}
 


### PR DESCRIPTION
**ClayAlertToast#CanTransitionToFillGapOfDeletedToast**
**Test Plan**

- Given Clay Sample Portlet
- And multiple toast alerts
- When an alert in the middle of the stack is closed
- Then the alerts transition to fill the stack

https://issues.liferay.com/browse/LPS-170580