### PR TITLE
LPS-173179 Support `onClick` on FDS creation button

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CreationMenu.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CreationMenu.js
@@ -35,8 +35,10 @@ function CreationMenu({primaryItems}) {
 							onActiveChange={setActive}
 							trigger={
 								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get('new')}
 									className="nav-btn nav-btn-monospaced"
 									symbol="plus"
+									title={Liferay.Language.get('new')}
 								/>
 							}
 						>
@@ -46,11 +48,17 @@ function CreationMenu({primaryItems}) {
 										key={i}
 										onClick={(event) => {
 											event.preventDefault();
+
 											setActive(false);
-											triggerAction(
-												item,
-												frontendDataSetContext
-											);
+
+											item.onClick?.();
+
+											if (item.href || item.target) {
+												triggerAction(
+													item,
+													frontendDataSetContext
+												);
+											}
 										}}
 									>
 										{item.label}
@@ -60,16 +68,26 @@ function CreationMenu({primaryItems}) {
 						</ClayDropDown>
 					) : (
 						<ClayButtonWithIcon
+							aria-label={
+								primaryItems[0].label ??
+								Liferay.Language.get('new')
+							}
 							className="nav-btn nav-btn-monospaced"
 							data-tooltip-align="top"
-							onClick={() =>
-								triggerAction(
-									primaryItems[0],
-									frontendDataSetContext
-								)
-							}
+							onClick={() => {
+								const item = primaryItems[0];
+
+								item.onClick?.();
+
+								if (item.href || item.target) {
+									triggerAction(item, frontendDataSetContext);
+								}
+							}}
 							symbol="plus"
-							title={primaryItems[0].label}
+							title={
+								primaryItems[0].label ??
+								Liferay.Language.get('new')
+							}
 						/>
 					)}
 				</li>
@@ -81,15 +99,17 @@ function CreationMenu({primaryItems}) {
 CreationMenu.propTypes = {
 	primaryItems: PropTypes.arrayOf(
 		PropTypes.shape({
-			href: PropTypes.string.isRequired,
-			label: PropTypes.string.isRequired,
+			href: PropTypes.string,
+			label: PropTypes.string,
+			onClick: PropTypes.func,
 			target: PropTypes.oneOf(['modal', 'sidePanel', 'event', 'link']),
 		})
 	).isRequired,
 	secondaryItems: PropTypes.arrayOf(
 		PropTypes.shape({
-			href: PropTypes.string.isRequired,
-			label: PropTypes.string.isRequired,
+			href: PropTypes.string,
+			label: PropTypes.string,
+			onClick: PropTypes.func,
 			target: PropTypes.oneOf(['modal', 'sidePanel', 'event', 'link']),
 		})
 	),

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/NavBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/NavBar.js
@@ -57,6 +57,7 @@ function NavBar({creationMenu, showSearch}) {
 				{showSearch && (
 					<ManagementToolbar.Item className="navbar-breakpoint-d-none">
 						<ClayButton
+							aria-label={Liferay.Language.get('search')}
 							className="nav-link nav-link-monospaced"
 							displayType="unstyled"
 							onClick={() => setShowMobile(true)}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
@@ -360,6 +360,7 @@ export default class SidePanel extends React.Component {
 						<ul className="navbar-nav">
 							<li className="nav-item">
 								<button
+									aria-label={Liferay.Language.get('back')}
 									className="btn btn-unstyled nav-link"
 									onClick={() => this.close()}
 									title={Liferay.Language.get('back')}
@@ -389,6 +390,7 @@ export default class SidePanel extends React.Component {
 					)}
 
 					<ClayButton
+						aria-label={Liferay.Language.get('close')}
 						className={classNames(
 							'fds-side-panel-close',
 							this.state.closeButtonStyle === 'simple' &&


### PR DESCRIPTION
### References

- [LPS-173179 Support `onClick` on FDS creation button](https://issues.liferay.com/browse/LPS-173179)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/3012

### What is the goal of this PR?

The original PR contained an implementation of FDS View creation UI, with placeholder for backend. In the meantime, while it was going through reviews, we changed frontend and implemented backend, so there is no point in merging original PR.

I am reusing this ticket to send only improvements in FDS API and accessibility we did a part of the original implementation. It's a shame to let it go to waste. I'll send FDS Views creation UI along with backend in a separate ticket in PR.

**There is no need for peer review**, this code was already reviewed in original PR. Anybody is feel free to forward if CI is green.
