### PR TITLE
Lps 173758 [draft proposal] clay tabs tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/constants/ClaySamplePortletKeys.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/constants/ClaySamplePortletKeys.java
@@ -24,6 +24,9 @@ public class ClaySamplePortletKeys {
 	public static final String CLAY_SAMPLE =
 		"com_liferay_clay_sample_web_portlet_ClaySamplePortlet";
 
+	public static final String CLAY_SAMPLE_DISPLAY_CONTEXT =
+		"CLAY_SAMPLE_DISPLAY_CONTEXT";
+
 	public static final String DROPDOWNS_DISPLAY_CONTEXT =
 		"DROPDOWNS_DISPLAY_CONTEXT";
 
@@ -32,5 +35,7 @@ public class ClaySamplePortletKeys {
 
 	public static final String NAVIGATION_BARS_DISPLAY_CONTEXT =
 		"NAVIGATION_BARS_DISPLAY_CONTEXT";
+
+	public static final String TABS_DISPLAY_CONTEXT = "TABS_DISPLAY_CONTEXT";
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
+
+import java.util.List;
+
+/**
+ * @author Carlos Lancha
+ */
+public class ClaySampleDisplayContext {
+
+	public List<TabsItem> getTabsItems() {
+		if (_tabsItems != null) {
+			return _tabsItems;
+		}
+
+		_tabsItems = TabsItemListBuilder.add(
+			tabsItem -> {
+				tabsItem.setActive(true);
+				tabsItem.setLabel("Alerts");
+				tabsItem.setPanelId("alerts");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Badges");
+				tabsItem.setPanelId("badges");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Buttons");
+				tabsItem.setPanelId("buttons");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Cards");
+				tabsItem.setPanelId("cards");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Dropdowns");
+				tabsItem.setPanelId("dropdowns");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Form Elements");
+				tabsItem.setPanelId("form_elements");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Icons");
+				tabsItem.setPanelId("icons");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Labels");
+				tabsItem.setPanelId("labels");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Links");
+				tabsItem.setPanelId("links");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Management Toolbar");
+				tabsItem.setPanelId("management_toolbar");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Navigation Bars");
+				tabsItem.setPanelId("navigation_bars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Pagination Bars");
+				tabsItem.setPanelId("pagination_bars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Progress Bars");
+				tabsItem.setPanelId("progress_bars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Stickers");
+				tabsItem.setPanelId("stickers");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Tabs");
+				tabsItem.setPanelId("tabs");
+			}
+		).build();
+
+		return _tabsItems;
+	}
+
+	private List<TabsItem> _tabsItems;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
@@ -30,78 +30,7 @@ public class ClaySampleDisplayContext {
 		}
 
 		_tabsItems = TabsItemListBuilder.add(
-			tabsItem -> {
-				tabsItem.setActive(true);
-				tabsItem.setLabel("Alerts");
-				tabsItem.setPanelId("alerts");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Badges");
-				tabsItem.setPanelId("badges");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Buttons");
-				tabsItem.setPanelId("buttons");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Cards");
-				tabsItem.setPanelId("cards");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Dropdowns");
-				tabsItem.setPanelId("dropdowns");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Form Elements");
-				tabsItem.setPanelId("form_elements");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Icons");
-				tabsItem.setPanelId("icons");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Labels");
-				tabsItem.setPanelId("labels");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Links");
-				tabsItem.setPanelId("links");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Management Toolbar");
-				tabsItem.setPanelId("management_toolbar");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Navigation Bars");
-				tabsItem.setPanelId("navigation_bars");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Pagination Bars");
-				tabsItem.setPanelId("pagination_bars");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Progress Bars");
-				tabsItem.setPanelId("progress_bars");
-			}
-		).add(
-			tabsItem -> {
-				tabsItem.setLabel("Stickers");
-				tabsItem.setPanelId("stickers");
-			}
-		).add(
-			tabsItem -> {
+				tabsItem -> {
 				tabsItem.setLabel("Tabs");
 				tabsItem.setPanelId("tabs");
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/TabsDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/TabsDisplayContext.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
+
+import java.util.List;
+
+/**
+ * @author Carlos Lancha
+ */
+public class TabsDisplayContext {
+
+	public List<TabsItem> getDefaultTabsItems() {
+		if (_defaultTabsItems != null) {
+			return _defaultTabsItems;
+		}
+
+		_defaultTabsItems = TabsItemListBuilder.add(
+			tabsItem -> {
+				tabsItem.setLabel("Option 1");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setActive(true);
+				tabsItem.setLabel("Option 2");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setDisabled(true);
+				tabsItem.setLabel("Option 3");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setHref("#3");
+				tabsItem.setLabel("Option 4");
+			}
+		).build();
+
+		return _defaultTabsItems;
+	}
+
+	private List<TabsItem> _defaultTabsItems;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/ClaySamplePortlet.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/ClaySamplePortlet.java
@@ -16,9 +16,11 @@ package com.liferay.frontend.taglib.clay.sample.web.internal.portlet;
 
 import com.liferay.frontend.taglib.clay.sample.web.constants.ClaySamplePortletKeys;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.CardsDisplayContext;
+import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.DropdownsDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.MultiselectDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext;
+import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.TabsDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 
 import java.io.IOException;
@@ -66,6 +68,10 @@ public class ClaySamplePortlet extends MVCPortlet {
 			new CardsDisplayContext());
 
 		renderRequest.setAttribute(
+			ClaySamplePortletKeys.CLAY_SAMPLE_DISPLAY_CONTEXT,
+			new ClaySampleDisplayContext());
+
+		renderRequest.setAttribute(
 			ClaySamplePortletKeys.DROPDOWNS_DISPLAY_CONTEXT,
 			new DropdownsDisplayContext());
 
@@ -76,6 +82,10 @@ public class ClaySamplePortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			ClaySamplePortletKeys.NAVIGATION_BARS_DISPLAY_CONTEXT,
 			new NavigationBarsDisplayContext());
+
+		renderRequest.setAttribute(
+			ClaySamplePortletKeys.TABS_DISPLAY_CONTEXT,
+			new TabsDisplayContext());
 
 		super.doDispatch(renderRequest, renderResponse);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,6 +24,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.sample.web.constants.ClaySamplePortletKeys" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.CardsDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleFileCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleHorizontalCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleImageCard" %><%@
@@ -34,9 +35,11 @@ page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.contex
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.DropdownsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.MultiselectDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.TabsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.PaginationBarDelta" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.PaginationBarLabels" %><%@
-page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %>
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem" %>
 
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.Arrays" %><%@
@@ -50,7 +53,9 @@ page import="java.util.List" %>
 
 <%
 CardsDisplayContext cardsDisplayContext = (CardsDisplayContext)request.getAttribute(ClaySamplePortletKeys.CARDS_DISPLAY_CONTEXT);
+ClaySampleDisplayContext claySampleDisplayContext = (ClaySampleDisplayContext)request.getAttribute(ClaySamplePortletKeys.CLAY_SAMPLE_DISPLAY_CONTEXT);
 DropdownsDisplayContext dropdownsDisplayContext = (DropdownsDisplayContext)request.getAttribute(ClaySamplePortletKeys.DROPDOWNS_DISPLAY_CONTEXT);
 MultiselectDisplayContext multiselectDisplayContext = (MultiselectDisplayContext)request.getAttribute(ClaySamplePortletKeys.MULTISELECT_DISPLAY_CONTEXT);
 NavigationBarsDisplayContext navigationBarsDisplayContext = (NavigationBarsDisplayContext)request.getAttribute(ClaySamplePortletKeys.NAVIGATION_BARS_DISPLAY_CONTEXT);
+TabsDisplayContext tabsDisplayContext = (TabsDisplayContext)request.getAttribute(ClaySamplePortletKeys.TABS_DISPLAY_CONTEXT);
 %>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleButtonPropsTransformer.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/js/ClaySampleButtonPropsTransformer.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer(props) {
+	return {
+		...props,
+		onClick: () => {
+			alert('click!');
+		},
+	};
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/tabs.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/tabs.jsp
@@ -16,24 +16,13 @@
 
 <%@ include file="/init.jsp" %>
 
-<%
-List<TabsItem> tabsItems = claySampleDisplayContext.getTabsItems();
-%>
+<h3>TABS</h3>
 
 <clay:tabs
-	tabsItems="<%= tabsItems %>"
+	tabsItems="<%= tabsDisplayContext.getDefaultTabsItems() %>"
 >
-
-	<%
-	for (TabsItem tabsItem : tabsItems) {
-	%>
-
-		<clay:tabs-panel>
-			<liferay-util:include page='<%= "/partials/" + tabsItem.get("panelId") + ".jsp" %>' servletContext="<%= application %>" />
-		</clay:tabs-panel>
-
-	<%
-	}
-	%>
-
+	<clay:tabs-panel>Tab Content 1</clay:tabs-panel>
+	<clay:tabs-panel>Tab Content 2</clay:tabs-panel>
+	<clay:tabs-panel>Tab Content 3</clay:tabs-panel>
+	<clay:tabs-panel>Tab Content 4</clay:tabs-panel>
 </clay:tabs>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/tabs.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/tabs.jsp
@@ -1,4 +1,4 @@
-<%--
+<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -16,13 +16,32 @@
 
 <%@ include file="/init.jsp" %>
 
-<h3>TABS</h3>
+<h3>TABS hey</h3>
+
+<clay:link
+  additionalProps='<%=
+  		HashMapBuilder.<String, Object>put(
+  			"accountEntryName", "abc"
+  		).build()
+  	%>'
+
+	href="http://www.google.com"
+	icon="times-circle"
+/>
+
 
 <clay:tabs
 	tabsItems="<%= tabsDisplayContext.getDefaultTabsItems() %>"
 >
-	<clay:tabs-panel>Tab Content 1</clay:tabs-panel>
-	<clay:tabs-panel>Tab Content 2</clay:tabs-panel>
+	<clay:tabs-panel>
+    <clay:button label="One" propsTransformer='js/ClaySampleButtonPropsTransformer' />
+  </clay:tabs-panel>
+	<clay:tabs-panel>
+    Tab Content 2
+    <div>
+      <clay:button label="Two" propsTransformer='js/ClaySampleButtonPropsTransformer' />
+    </div>
+  </clay:tabs-panel>
 	<clay:tabs-panel>Tab Content 3</clay:tabs-panel>
 	<clay:tabs-panel>Tab Content 4</clay:tabs-panel>
 </clay:tabs>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsPanelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsPanelTag.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringPool;
+
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.BodyTag;
+
+/**
+ * @author Carlos Lancha
+ */
+public class TabsPanelTag extends BaseContainerTag implements BodyTag {
+
+	@Override
+	public int doEndTag() throws JspException {
+		_tabsTag.addPanel(bodyContent.getString());
+
+		return super.doEndTag();
+	}
+
+	@Override
+	public int doStartTag() throws JspException {
+		_tabsTag = (TabsTag)findAncestorWithClass(this, TabsTag.class);
+
+		if (_tabsTag == null) {
+			throw new JspException();
+		}
+
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setDynamicAttribute(StringPool.BLANK, "role", "tabpanel");
+		setDynamicAttribute(StringPool.BLANK, "tabindex", "0");
+
+		return super.doStartTag();
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("tab-pane");
+
+		if (_tabsTag.isFade()) {
+			cssClasses.add("fade");
+		}
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		return EVAL_BODY_BUFFERED;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:tabs:panel:";
+
+	private TabsTag _tabsTag;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.taglib.util.TagResourceBundleUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Carlos Lancha
+ */
+public class TabsTag extends BaseContainerTag {
+
+	public void addPanel(String panel) {
+		_panels.add(panel);
+	}
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		return super.doStartTag();
+	}
+
+	public String getActivation() {
+		return _activation;
+	}
+
+	public String getDisplayType() {
+		return _displayType;
+	}
+
+	public List<TabsItem> getTabsItems() {
+		return _tabsItems;
+	}
+
+	public boolean isFade() {
+		return _fade;
+	}
+
+	public boolean isJustified() {
+		return _justified;
+	}
+
+	public void setActivation(String activation) {
+		_activation = activation;
+	}
+
+	public void setDisplayType(String displayType) {
+		_displayType = displayType;
+	}
+
+	public void setFade(boolean fade) {
+		_fade = fade;
+	}
+
+	public void setJustified(boolean justified) {
+		_justified = justified;
+	}
+
+	public void setTabsItems(List<TabsItem> tabsItems) {
+		_tabsItems = tabsItems;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_activation = "manual";
+		_displayType = null;
+		_fade = false;
+		_justified = false;
+		_panels = new ArrayList<>();
+		_tabsItems = null;
+	}
+
+	@Override
+	protected String getHydratedModuleName() {
+		return "{Tabs} from frontend-taglib-clay";
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("activation", _activation);
+		props.put("displayType", _displayType);
+		props.put("fade", _fade);
+		props.put("justified", _justified);
+		props.put("panels", _panels);
+		props.put("tabsItems", _tabsItems);
+
+		return super.prepareProps(props);
+	}
+
+	@Override
+	protected int processEndTag() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("</div>");
+
+		return super.processEndTag();
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<ul class=\"nav nav-underline\" role=\"tablist\">");
+
+		for (TabsItem tabsItem : _tabsItems) {
+			jspWriter.write("<li class=\"nav-item\" role=\"none\">");
+
+			String itemCssClass = "nav-link";
+
+			String label = (String)tabsItem.get("label");
+
+			if (Validator.isNotNull(tabsItem.get("disabled"))) {
+				itemCssClass = itemCssClass + " disabled";
+			}
+
+			if (Validator.isNotNull(tabsItem.get("href"))) {
+				LinkTag linkTag = new LinkTag();
+
+				linkTag.setCssClass(itemCssClass);
+
+				linkTag.setHref((String)tabsItem.get("href"));
+
+				linkTag.setLabel(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						label));
+
+				linkTag.doTag(pageContext);
+			}
+			else {
+				ButtonTag buttonTag = new ButtonTag();
+
+				buttonTag.setCssClass(itemCssClass);
+
+				buttonTag.setDisplayType("unstyled");
+
+				buttonTag.setLabel(
+					LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						label));
+
+				buttonTag.doTag(pageContext);
+			}
+
+			jspWriter.write("</li>");
+		}
+
+		jspWriter.write("</ul><div class=\"tab-content\">");
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:tabs:";
+
+	private String _activation = "manual";
+	private String _displayType;
+	private boolean _fade;
+	private boolean _justified;
+	private List<String> _panels = new ArrayList<>();
+	private List<TabsItem> _tabsItems;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItem.java
@@ -1,4 +1,3 @@
-<%--
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
@@ -12,28 +11,16 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
---%>
 
-<%@ include file="/init.jsp" %>
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
 
-<%
-List<TabsItem> tabsItems = claySampleDisplayContext.getTabsItems();
-%>
+/**
+ * @author Carlos Lancha
+ */
+public class TabsItem extends NavigationItem {
 
-<clay:tabs
-	tabsItems="<%= tabsItems %>"
->
-
-	<%
-	for (TabsItem tabsItem : tabsItems) {
-	%>
-
-		<clay:tabs-panel>
-			<liferay-util:include page='<%= "/partials/" + tabsItem.get("panelId") + ".jsp" %>' servletContext="<%= application %>" />
-		</clay:tabs-panel>
-
-	<%
+	public void setPanelId(String panelId) {
+		put("panelId", panelId);
 	}
-	%>
 
-</clay:tabs>
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItemBuilder.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItemBuilder.java
@@ -1,0 +1,350 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import com.liferay.petra.function.UnsafeSupplier;
+
+import java.util.Map;
+
+import javax.portlet.PortletURL;
+
+/**
+ * @author Carlos Lancha
+ */
+public class TabsItemBuilder {
+
+	public static AfterPutDataStep putData(String key, String value) {
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.putData(key, value);
+	}
+
+	public static AfterPutDataStep putData(
+		String key, UnsafeSupplier<String, Exception> valueUnsafeSupplier) {
+
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.putData(key, valueUnsafeSupplier);
+	}
+
+	public static AfterActiveStep setActive(boolean active) {
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setActive(active);
+	}
+
+	public static AfterActiveStep setActive(
+		UnsafeSupplier<Boolean, Exception> activeUnsafeSupplier) {
+
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setActive(activeUnsafeSupplier);
+	}
+
+	public static AfterSetDataStep setData(Map<String, Object> data) {
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setData(data);
+	}
+
+	public static AfterDisabledStep setDisabled(boolean disabled) {
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setDisabled(disabled);
+	}
+
+	public static AfterDisabledStep setDisabled(
+		UnsafeSupplier<Boolean, Exception> disabledUnsafeSupplier) {
+
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setDisabled(disabledUnsafeSupplier);
+	}
+
+	public static AfterHrefStep setHref(Object href) {
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setHref(href);
+	}
+
+	public static AfterHrefStep setHref(
+		PortletURL portletURL, Object... parameters) {
+
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setHref(parameters);
+	}
+
+	public static AfterHrefStep setHref(
+		UnsafeSupplier<Object, Exception> hrefUnsafeSupplier) {
+
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setHref(hrefUnsafeSupplier);
+	}
+
+	public static AfterLabelStep setLabel(String label) {
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setLabel(label);
+	}
+
+	public static AfterLabelStep setLabel(
+		UnsafeSupplier<String, Exception> labelUnsafeSupplier) {
+
+		TabsItemStep tabsItemStep = new TabsItemStep();
+
+		return tabsItemStep.setLabel(labelUnsafeSupplier);
+	}
+
+	public static class TabsItemStep
+		implements ActiveStep, AfterActiveStep, AfterDisabledStep,
+				   AfterHrefStep, AfterLabelStep, AfterPutDataStep,
+				   AfterSetDataStep, BuildStep, DisabledStep, HrefStep,
+				   LabelStep, PutDataStep, SetDataStep {
+
+		@Override
+		public TabsItem build() {
+			return _tabsItem;
+		}
+
+		@Override
+		public AfterPutDataStep putData(String key, String value) {
+			_tabsItem.putData(key, value);
+
+			return this;
+		}
+
+		@Override
+		public AfterPutDataStep putData(
+			String key, UnsafeSupplier<String, Exception> valueUnsafeSupplier) {
+
+			try {
+				String value = valueUnsafeSupplier.get();
+
+				if (value != null) {
+					_tabsItem.putData(key, value);
+				}
+
+				return this;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		@Override
+		public AfterActiveStep setActive(boolean active) {
+			_tabsItem.setActive(active);
+
+			return this;
+		}
+
+		@Override
+		public AfterActiveStep setActive(
+			UnsafeSupplier<Boolean, Exception> activeUnsafeSupplier) {
+
+			try {
+				Boolean active = activeUnsafeSupplier.get();
+
+				if (active != null) {
+					_tabsItem.setActive(active.booleanValue());
+				}
+
+				return this;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		@Override
+		public AfterSetDataStep setData(Map<String, Object> data) {
+			_tabsItem.setData(data);
+
+			return this;
+		}
+
+		@Override
+		public AfterDisabledStep setDisabled(boolean disabled) {
+			_tabsItem.setDisabled(disabled);
+
+			return this;
+		}
+
+		@Override
+		public AfterDisabledStep setDisabled(
+			UnsafeSupplier<Boolean, Exception> disabledUnsafeSupplier) {
+
+			try {
+				Boolean disabled = disabledUnsafeSupplier.get();
+
+				if (disabled != null) {
+					_tabsItem.setDisabled(disabled.booleanValue());
+				}
+
+				return this;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		@Override
+		public AfterHrefStep setHref(Object href) {
+			_tabsItem.setHref(href);
+
+			return this;
+		}
+
+		@Override
+		public AfterHrefStep setHref(
+			PortletURL portletURL, Object... parameters) {
+
+			_tabsItem.setHref(portletURL, parameters);
+
+			return this;
+		}
+
+		@Override
+		public AfterHrefStep setHref(
+			UnsafeSupplier<Object, Exception> hrefUnsafeSupplier) {
+
+			try {
+				Object href = hrefUnsafeSupplier.get();
+
+				if (href != null) {
+					_tabsItem.setHref(href);
+				}
+
+				return this;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		@Override
+		public AfterLabelStep setLabel(String label) {
+			_tabsItem.setLabel(label);
+
+			return this;
+		}
+
+		@Override
+		public AfterLabelStep setLabel(
+			UnsafeSupplier<String, Exception> labelUnsafeSupplier) {
+
+			try {
+				String label = labelUnsafeSupplier.get();
+
+				if (label != null) {
+					_tabsItem.setLabel(label);
+				}
+
+				return this;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		private final TabsItem _tabsItem = new TabsItem();
+
+	}
+
+	public interface ActiveStep {
+
+		public AfterActiveStep setActive(boolean active);
+
+		public AfterActiveStep setActive(
+			UnsafeSupplier<Boolean, Exception> activeUnsafeSupplier);
+
+	}
+
+	public interface AfterActiveStep
+		extends BuildStep, DisabledStep, HrefStep, LabelStep, SetDataStep {
+	}
+
+	public interface AfterDisabledStep extends BuildStep, HrefStep, LabelStep {
+	}
+
+	public interface AfterHrefStep extends BuildStep, LabelStep {
+	}
+
+	public interface AfterLabelStep extends BuildStep {
+	}
+
+	public interface AfterPutDataStep
+		extends ActiveStep, BuildStep, DisabledStep, HrefStep, LabelStep,
+				PutDataStep, SetDataStep {
+	}
+
+	public interface AfterSetDataStep
+		extends BuildStep, DisabledStep, HrefStep, LabelStep {
+	}
+
+	public interface BuildStep {
+
+		public TabsItem build();
+
+	}
+
+	public interface DisabledStep {
+
+		public AfterDisabledStep setDisabled(boolean disabled);
+
+		public AfterDisabledStep setDisabled(
+			UnsafeSupplier<Boolean, Exception> disabledUnsafeSupplier);
+
+	}
+
+	public interface HrefStep {
+
+		public AfterHrefStep setHref(Object href);
+
+		public AfterHrefStep setHref(
+			PortletURL portletURL, Object... parameters);
+
+		public AfterHrefStep setHref(
+			UnsafeSupplier<Object, Exception> hrefUnsafeSupplier);
+
+	}
+
+	public interface LabelStep {
+
+		public AfterLabelStep setLabel(String label);
+
+		public AfterLabelStep setLabel(
+			UnsafeSupplier<String, Exception> labelUnsafeSupplier);
+
+	}
+
+	public interface PutDataStep {
+
+		public AfterPutDataStep putData(String key, String value);
+
+		public AfterPutDataStep putData(
+			String key, UnsafeSupplier<String, Exception> valueUnsafeSupplier);
+
+	}
+
+	public interface SetDataStep {
+
+		public AfterSetDataStep setData(Map<String, Object> data);
+
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItemList.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItemList.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
+
+import java.util.ArrayList;
+
+/**
+ * @author Carlos Lancha
+ */
+public class TabsItemList extends ArrayList<TabsItem> {
+
+	public static TabsItemList of(TabsItem... tabsItems) {
+		TabsItemList tabsItemList = new TabsItemList();
+
+		for (TabsItem tabsItem : tabsItems) {
+			if (tabsItem != null) {
+				tabsItemList.add(tabsItem);
+			}
+		}
+
+		return tabsItemList;
+	}
+
+	public static TabsItemList of(
+		UnsafeSupplier<TabsItem, Exception>... unsafeSuppliers) {
+
+		TabsItemList tabsItemList = new TabsItemList();
+
+		for (UnsafeSupplier<TabsItem, Exception> unsafeSupplier :
+				unsafeSuppliers) {
+
+			try {
+				TabsItem tabsItem = unsafeSupplier.get();
+
+				if (tabsItem != null) {
+					tabsItemList.add(tabsItem);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		return tabsItemList;
+	}
+
+	public void add(UnsafeConsumer<TabsItem, Exception> unsafeConsumer) {
+		TabsItem tabsItem = new TabsItem();
+
+		try {
+			unsafeConsumer.accept(tabsItem);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+
+		add(tabsItem);
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItemListBuilder.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/TabsItemListBuilder.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
+
+/**
+ * @author Carlos Lancha
+ */
+public class TabsItemListBuilder {
+
+	public static TabsItemListWrapper add(TabsItem tabsItem) {
+		TabsItemListWrapper tabsItemListWrapper = new TabsItemListWrapper();
+
+		return tabsItemListWrapper.add(tabsItem);
+	}
+
+	public static TabsItemListWrapper add(
+		UnsafeConsumer<TabsItem, Exception> unsafeConsumer) {
+
+		TabsItemListWrapper tabsItemListWrapper = new TabsItemListWrapper();
+
+		return tabsItemListWrapper.add(unsafeConsumer);
+	}
+
+	public static TabsItemListWrapper add(
+		UnsafeSupplier<Boolean, Exception> unsafeSupplier, TabsItem tabsItem) {
+
+		TabsItemListWrapper tabsItemListWrapper = new TabsItemListWrapper();
+
+		return tabsItemListWrapper.add(unsafeSupplier, tabsItem);
+	}
+
+	public static TabsItemListWrapper add(
+		UnsafeSupplier<Boolean, Exception> unsafeSupplier,
+		UnsafeConsumer<TabsItem, Exception> unsafeConsumer) {
+
+		TabsItemListWrapper tabsItemListWrapper = new TabsItemListWrapper();
+
+		return tabsItemListWrapper.add(unsafeSupplier, unsafeConsumer);
+	}
+
+	public static final class TabsItemListWrapper {
+
+		public TabsItemListWrapper add(TabsItem tabsItem) {
+			_tabsItemList.add(tabsItem);
+
+			return this;
+		}
+
+		public TabsItemListWrapper add(
+			UnsafeConsumer<TabsItem, Exception> unsafeConsumer) {
+
+			_tabsItemList.add(unsafeConsumer);
+
+			return this;
+		}
+
+		public TabsItemListWrapper add(
+			UnsafeSupplier<Boolean, Exception> unsafeSupplier,
+			TabsItem tabsItem) {
+
+			try {
+				if (unsafeSupplier.get()) {
+					_tabsItemList.add(tabsItem);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+
+			return this;
+		}
+
+		public TabsItemListWrapper add(
+			UnsafeSupplier<Boolean, Exception> unsafeSupplier,
+			UnsafeConsumer<TabsItem, Exception> unsafeConsumer) {
+
+			try {
+				if (unsafeSupplier.get()) {
+					_tabsItemList.add(unsafeConsumer);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+
+			return this;
+		}
+
+		public TabsItemList build() {
+			return _tabsItemList;
+		}
+
+		private final TabsItemList _tabsItemList = new TabsItemList();
+
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -2481,6 +2481,54 @@
 	</tag>
 	<tag>
 		<description></description>
+		<name>tabs</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.TabsTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<description></description>
+			<name>activation</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>additionalProps</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>displayType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>fade</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>justified</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>tabsItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
+		<description></description>
+		<name>tabs-panel</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.TabsPanelTag</tag-class>
+		<body-content>JSP</body-content>
+	</tag>
+	<tag>
+		<description></description>
 		<name>user-card</name>
 		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.UserCardTag</tag-class>
 		<body-content>empty</body-content>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayTabs from '@clayui/tabs';
+import React from 'react';
+
+export default function Tabs({
+	activation,
+	additionalProps: _additionalProps,
+	componentId: _componentId,
+	cssClass,
+	displayType,
+	fade,
+	justified,
+	locale: _locale,
+	panels,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	tabsItems,
+	...otherProps
+}) {
+
+	// TO REMOVE ONCE CLAY IS RELEASED
+
+	const activeIndex = tabsItems.indexOf(
+		tabsItems.find((item) => item.active)
+	);
+
+	return (
+		<>
+			<ClayTabs
+				activation={activation}
+				className={cssClass}
+				defaultActive={activeIndex}
+				displayType={displayType}
+				fade={fade}
+				justified={justified}
+				{...otherProps}
+			>
+				<ClayTabs.List>
+					{tabsItems.map(
+						({/* active,*/ disabled, href, label}, i) => (
+							<ClayTabs.Item
+
+								// active={active} REMOVE COMMENT ONCE CLAY IS RELEASED
+
+								disabled={disabled}
+								href={href}
+								key={i}
+							>
+								{label}
+							</ClayTabs.Item>
+						)
+					)}
+				</ClayTabs.List>
+
+				<ClayTabs.Panels>
+					{panels.map((panel, i) => (
+						<ClayTabs.TabPanel
+							dangerouslySetInnerHTML={{__html: panel}}
+							key={i}
+						/>
+					))}
+				</ClayTabs.Panels>
+			</ClayTabs>
+		</>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -13,7 +13,7 @@
  */
 
 import ClayTabs from '@clayui/tabs';
-import React from 'react';
+import React, {useEffect} from 'react';
 
 export default function Tabs({
 	activation,
@@ -36,6 +36,27 @@ export default function Tabs({
 	const activeIndex = tabsItems.indexOf(
 		tabsItems.find((item) => item.active)
 	);
+
+	function isRenderNode(element) {
+	  if (element.nodeName == "DIV" && element.innerText == "") {
+        const id = element.getAttribute("id");
+        if (id && id.startsWith("__RENDER__")) {
+          return id;
+      }
+    }
+	  return null;
+  }
+
+
+	useEffect(() => {
+    panels.map((panel) => {
+        const panelDocument = new DOMParser().parseFromString(panel, "text/html");
+        panelDocument.body.querySelectorAll("div div[id^=__RENDER__]").forEach((c) => {
+          const id = isRenderNode(c);
+          id && Liferay.fire(id)
+        })
+      })
+    })
 
 	return (
 		<>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/index.js
@@ -21,6 +21,7 @@ export {default as Multiselect} from './Multiselect';
 export {default as NavigationBar} from './NavigationBar';
 export {default as PaginationBar} from './PaginationBar';
 export {default as Select} from './Select';
+export {default as Tabs} from './Tabs';
 export {default as HorizontalCard} from './cards/HorizontalCard';
 export {default as NavigationCard} from './cards/NavigationCard';
 export {default as UserCard} from './cards/UserCard';

--- a/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererImpl.java
+++ b/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererImpl.java
@@ -46,7 +46,7 @@ public class ReactRendererImpl implements ReactRenderer {
 			HttpServletRequest httpServletRequest, Writer writer)
 		throws IOException {
 
-		String placeholderId = StringUtil.randomId();
+		String placeholderId = "__RENDER__" + StringUtil.randomId();
 
 		_renderPlaceholder(writer, placeholderId);
 

--- a/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererUtil.java
+++ b/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/java/com/liferay/portal/template/react/renderer/internal/ReactRendererUtil.java
@@ -97,7 +97,7 @@ public class ReactRendererUtil {
 
 		JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
 
-		contentSB.append("render(componentModule, ");
+		contentSB.append("debugger;render(componentModule, ");
 
 		if (Validator.isNotNull(propsTransformer)) {
 			contentSB.append("propsTransformer");

--- a/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/resources/META-INF/resources/render.es.js
+++ b/modules/apps/portal-template/portal-template-react-renderer-impl/src/main/resources/META-INF/resources/render.es.js
@@ -18,6 +18,18 @@ export default function (renderFunction, renderData, placeholderId) {
 	const element = document.getElementById(placeholderId);
 
 	if (element) {
+    console.log("Rendering (sync) " + placeholderId)
 		render(renderFunction, renderData, element.parentElement);
 	}
+	else {
+	  console.log("Could not find placeholder " + placeholderId + ". Registering async render handler")
+	  Liferay.on(placeholderId, ()=>{
+      console.log("Looks like " + placeholderId + " is available now")
+      const element = document.getElementById(placeholderId);
+      if (element) {
+          console.log("Rendering (async)" + placeholderId)
+      		render(renderFunction, renderData, element.parentElement);
+      	}
+    })
+  }
 }


### PR DESCRIPTION
In this PR I'm proposing a mechanism to mimick clay tags composition in the browser side when it comes to hydrate clay react composable components. Mechanism basically:
* Defers hydration of react components when the container div is not in the page
* Provides a way for composable react components to trigger the hydration for those markup they generate

Surprisingly, we did not need this before, as most od the clay composable tags don't use the react equivalent.

We discovered this while working on https://issues.liferay.com/browse/LPS-174606 in the clay tabs tab. I sent the pull on top of the initial WIP stuff Carlos started for the tag. Actual pull for the tag is https://github.com/liferay-frontend/liferay-portal/pull/3020

This is a draft pr to discuss the approach with @carloslancha, @markocikos and @kresimir-coko 

I'm also ccing @matuzalemsteles and @ethib137 fyi