### PR TITLE
LPS-174054 Add Autom. Test FrontendDataSetAdmin#CanDisplayHeadlessDeliveryAPIResources

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
@@ -1,0 +1,50 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-174054: Display a list of headless resources in new FDS View modal"
+	@priority = "5"
+	test CanDisplayHeadlessDeliveryAPIResources {
+		property custom.properties = "feature.flag.LPS-164563=true";
+
+		task ("Given access Datasets admin page") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "Datasets");
+		}
+
+		task ("When go to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("Then displays list of headless resources") {
+			Click(locator1 = "CreateObject#OBJECT_LABEL");
+
+			AssertElementPresent(
+				key_item = "Liferay Headless Delivery",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+		}
+	}
+
+}


### PR DESCRIPTION
FrontendDataSetAdmin#CanDisplayHeadlessDeliveryAPIResources
Test Plan

Given access Datasets admin page
When go to add Datasets
Then displays list of headless resources
Jira Ticket:
https://issues.liferay.com/browse/LPS-174054

[Poshi Report](https://drive.google.com/file/d/1Ao24vvF_uMIWbZ8wuLPBRkRYAuEcmBhA/view?usp=share_link)