### PR TITLE
LPS-174606 Add support for Nested React Tags

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -86,6 +86,18 @@ export default function render(
 
 		container.classList.add('lfr-tooltip-scope');
 
+		if (renderData._hasBodyContent) {
+			const children = container.querySelectorAll(
+				'.tag-body-content > *'
+			);
+
+			if (children.length) {
+				renderData.children = children;
+			}
+
+			delete renderData._hasBodyContent;
+		}
+
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(
 			<ClayIconSpriteContext.Provider value={spritemap}>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/constants/ClaySamplePortletKeys.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/constants/ClaySamplePortletKeys.java
@@ -24,6 +24,9 @@ public class ClaySamplePortletKeys {
 	public static final String CLAY_SAMPLE =
 		"com_liferay_clay_sample_web_portlet_ClaySamplePortlet";
 
+	public static final String CLAY_SAMPLE_DISPLAY_CONTEXT =
+		"CLAY_SAMPLE_DISPLAY_CONTEXT";
+
 	public static final String DROPDOWNS_DISPLAY_CONTEXT =
 		"DROPDOWNS_DISPLAY_CONTEXT";
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
@@ -32,77 +32,77 @@ public class ClaySampleDisplayContext {
 		_tabsItems = TabsItemListBuilder.add(
 			tabsItem -> {
 				tabsItem.setActive(true);
-				tabsItem.setLabel("alerts");
+				tabsItem.setLabel("Alerts");
 				tabsItem.setPanelId("alerts");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("badges");
+				tabsItem.setLabel("Badges");
 				tabsItem.setPanelId("badges");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("buttons");
+				tabsItem.setLabel("Buttons");
 				tabsItem.setPanelId("buttons");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("cards");
+				tabsItem.setLabel("Cards");
 				tabsItem.setPanelId("cards");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("dropdowns");
+				tabsItem.setLabel("Dropdowns");
 				tabsItem.setPanelId("dropdowns");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("form_elements");
+				tabsItem.setLabel("Form Elements");
 				tabsItem.setPanelId("form_elements");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("icons");
+				tabsItem.setLabel("Icons");
 				tabsItem.setPanelId("icons");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("labels");
+				tabsItem.setLabel("Labels");
 				tabsItem.setPanelId("labels");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("links");
+				tabsItem.setLabel("Links");
 				tabsItem.setPanelId("links");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("management_toolbars");
+				tabsItem.setLabel("Management Toolbars");
 				tabsItem.setPanelId("management_toolbars");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("navigation_bars");
+				tabsItem.setLabel("Navigation Bars");
 				tabsItem.setPanelId("navigation_bars");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("pagination_bars");
+				tabsItem.setLabel("Pagination Bars");
 				tabsItem.setPanelId("pagination_bars");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("progress_bars");
+				tabsItem.setLabel("Progress Bars");
 				tabsItem.setPanelId("progress_bars");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("stickers");
-				tabsItem.setPanelId("stickers");
+				tabsItem.setLabel("Stickers");
+				tabsItem.setPanelId("Stickers");
 			}
 		).add(
 			tabsItem -> {
-				tabsItem.setLabel("tabs");
+				tabsItem.setLabel("Tabs");
 				tabsItem.setPanelId("tabs");
 			}
 		).build();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
+
+import java.util.List;
+
+/**
+ * @author Carlos Lancha
+ */
+public class ClaySampleDisplayContext {
+
+	public List<TabsItem> getTabsItems() {
+		if (_tabsItems != null) {
+			return _tabsItems;
+		}
+
+		_tabsItems = TabsItemListBuilder.add(
+			tabsItem -> {
+				tabsItem.setActive(true);
+				tabsItem.setLabel("alerts");
+				tabsItem.setPanelId("alerts");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("badges");
+				tabsItem.setPanelId("badges");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("buttons");
+				tabsItem.setPanelId("buttons");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("cards");
+				tabsItem.setPanelId("cards");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("dropdowns");
+				tabsItem.setPanelId("dropdowns");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("form_elements");
+				tabsItem.setPanelId("form_elements");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("icons");
+				tabsItem.setPanelId("icons");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("labels");
+				tabsItem.setPanelId("labels");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("links");
+				tabsItem.setPanelId("links");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("management_toolbars");
+				tabsItem.setPanelId("management_toolbars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("navigation_bars");
+				tabsItem.setPanelId("navigation_bars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("pagination_bars");
+				tabsItem.setPanelId("pagination_bars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("progress_bars");
+				tabsItem.setPanelId("progress_bars");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("stickers");
+				tabsItem.setPanelId("stickers");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("tabs");
+				tabsItem.setPanelId("tabs");
+			}
+		).build();
+
+		return _tabsItems;
+	}
+
+	private List<TabsItem> _tabsItems;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/ClaySamplePortlet.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/ClaySamplePortlet.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.sample.web.internal.portlet;
 
 import com.liferay.frontend.taglib.clay.sample.web.constants.ClaySamplePortletKeys;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.CardsDisplayContext;
+import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.DropdownsDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.MultiselectDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext;
@@ -65,6 +66,10 @@ public class ClaySamplePortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			ClaySamplePortletKeys.CARDS_DISPLAY_CONTEXT,
 			new CardsDisplayContext());
+		renderRequest.setAttribute(
+			ClaySamplePortletKeys.CLAY_SAMPLE_DISPLAY_CONTEXT,
+			new ClaySampleDisplayContext());
+
 		renderRequest.setAttribute(
 			ClaySamplePortletKeys.DROPDOWNS_DISPLAY_CONTEXT,
 			new DropdownsDisplayContext());

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,11 +19,11 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.taglib.clay.sample.web.constants.ClaySamplePortletKeys" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.CardsDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleFileCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleHorizontalCard" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.ClaySampleImageCard" %><%@
@@ -37,7 +37,8 @@ page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.contex
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.TabsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.PaginationBarDelta" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.PaginationBarLabels" %><%@
-page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %>
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem" %>
 
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.Arrays" %><%@
@@ -51,6 +52,7 @@ page import="java.util.List" %>
 
 <%
 CardsDisplayContext cardsDisplayContext = (CardsDisplayContext)request.getAttribute(ClaySamplePortletKeys.CARDS_DISPLAY_CONTEXT);
+ClaySampleDisplayContext claySampleDisplayContext = (ClaySampleDisplayContext)request.getAttribute(ClaySamplePortletKeys.CLAY_SAMPLE_DISPLAY_CONTEXT);
 DropdownsDisplayContext dropdownsDisplayContext = (DropdownsDisplayContext)request.getAttribute(ClaySamplePortletKeys.DROPDOWNS_DISPLAY_CONTEXT);
 MultiselectDisplayContext multiselectDisplayContext = (MultiselectDisplayContext)request.getAttribute(ClaySamplePortletKeys.MULTISELECT_DISPLAY_CONTEXT);
 NavigationBarsDisplayContext navigationBarsDisplayContext = (NavigationBarsDisplayContext)request.getAttribute(ClaySamplePortletKeys.NAVIGATION_BARS_DISPLAY_CONTEXT);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,25 +16,24 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-ui:tabs
-	names="Alerts,Badges,Buttons,Cards,Dropdowns,Form Elements,Icons,Labels,Links,Management Toolbars,Navigation Bars,Pagination Bars,Progress Bars,Stickers,Tabs"
-	refresh="<%= false %>"
+<%
+List<TabsItem> tabsItems = claySampleDisplayContext.getTabsItems();
+%>
+
+<clay:tabs
+	tabsItems="<%= tabsItems %>"
 >
 
 	<%
-	String[] sections = {"alerts", "badges", "buttons", "cards", "dropdowns", "form_elements", "icons", "labels", "links", "management_toolbars", "navigation_bars", "pagination_bars", "progress_bars", "stickers", "tabs"};
-
-	for (int i = 0; i < sections.length; i++) {
+	for (TabsItem tabsItem : tabsItems) {
 	%>
 
-		<liferay-ui:section>
-			<clay:container-fluid>
-				<liferay-util:include page='<%= "/partials/" + sections[i] + ".jsp" %>' servletContext="<%= application %>" />
-			</clay:container-fluid>
-		</liferay-ui:section>
+		<clay:tabs-panel>
+			<liferay-util:include page='<%= "/partials/" + tabsItem.get("panelId") + ".jsp" %>' servletContext="<%= application %>" />
+		</clay:tabs-panel>
 
 	<%
 	}
 	%>
 
-</liferay-ui:tabs>
+</clay:tabs>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -55,6 +55,10 @@ public class BaseContainerTag extends AttributesTagSupport {
 	@Override
 	public int doEndTag() throws JspException {
 		try {
+			if (_hasBodyContent()) {
+				processEndBodyTag();
+			}
+
 			return processEndTag();
 		}
 		catch (Exception exception) {
@@ -68,7 +72,13 @@ public class BaseContainerTag extends AttributesTagSupport {
 	@Override
 	public int doStartTag() throws JspException {
 		try {
-			return processStartTag();
+			_includeBody = processStartTag();
+
+			if (_hasBodyContent()) {
+				processStartBodyTag();
+			}
+
+			return _includeBody;
 		}
 		catch (Exception exception) {
 			throw new JspException(exception);
@@ -267,6 +277,7 @@ public class BaseContainerTag extends AttributesTagSupport {
 		_elementClasses = null;
 		_hydratedContainerElement = "div";
 		_id = null;
+		_includeBody = EVAL_BODY_INCLUDE;
 		_namespace = null;
 		_propsTransformer = null;
 		_propsTransformerServletContext = null;
@@ -305,11 +316,19 @@ public class BaseContainerTag extends AttributesTagSupport {
 			props.put("defaultEventHandler", defaultEventHandler);
 		}
 
+		props.put("_hasBodyContent", _hasBodyContent());
+
 		props.put("id", getId());
 
 		props.putAll(getDynamicAttributes());
 
 		return props;
+	}
+
+	protected String processBodyCssClasses(Set<String> cssClasses) {
+		cssClasses.add("tag-body-content");
+
+		return StringUtil.merge(cssClasses, StringPool.SPACE);
 	}
 
 	protected String processCssClasses(Set<String> cssClasses) {
@@ -328,6 +347,12 @@ public class BaseContainerTag extends AttributesTagSupport {
 	@Deprecated
 	protected Map<String, Object> processData(Map<String, Object> data) {
 		return data;
+	}
+
+	protected void processEndBodyTag() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("</div>");
 	}
 
 	protected int processEndTag() throws Exception {
@@ -390,6 +415,16 @@ public class BaseContainerTag extends AttributesTagSupport {
 		return EVAL_PAGE;
 	}
 
+	protected void processStartBodyTag() throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<div ");
+
+		writeBodyCssClassAttribute();
+
+		jspWriter.write(">");
+	}
+
 	protected int processStartTag() throws Exception {
 		JspWriter jspWriter = pageContext.getOut();
 
@@ -419,12 +454,12 @@ public class BaseContainerTag extends AttributesTagSupport {
 		return EVAL_BODY_INCLUDE;
 	}
 
-	protected void writeCssClassAttribute() throws Exception {
-		JspWriter jspWriter = pageContext.getOut();
+	protected void writeBodyCssClassAttribute() throws Exception {
+		_writeCssClassAttribute(processBodyCssClasses(new LinkedHashSet<>()));
+	}
 
-		jspWriter.write(" class=\"");
-		jspWriter.write(processCssClasses(new LinkedHashSet<>()));
-		jspWriter.write("\"");
+	protected void writeCssClassAttribute() throws Exception {
+		_writeCssClassAttribute(processCssClasses(new LinkedHashSet<>()));
 	}
 
 	protected void writeDynamicAttributes() throws Exception {
@@ -445,6 +480,16 @@ public class BaseContainerTag extends AttributesTagSupport {
 		jspWriter.write(" id=\"");
 		jspWriter.write(getId());
 		jspWriter.write("\"");
+	}
+
+	private boolean _hasBodyContent() {
+		if ((_includeBody == EVAL_BODY_INCLUDE) &&
+			(getHydratedModuleName() != null)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isPositionInLine() {
@@ -481,6 +526,14 @@ public class BaseContainerTag extends AttributesTagSupport {
 		return false;
 	}
 
+	private void _writeCssClassAttribute(String cssClasses) throws Exception {
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write(" class=\"");
+		jspWriter.write(cssClasses);
+		jspWriter.write("\"");
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseContainerTag.class);
 
@@ -494,6 +547,7 @@ public class BaseContainerTag extends AttributesTagSupport {
 	private String _elementClasses;
 	private String _hydratedContainerElement = "div";
 	private String _id;
+	private int _includeBody = EVAL_BODY_INCLUDE;
 	private String _namespace;
 	private String _propsTransformer;
 	private ServletContext _propsTransformerServletContext;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsPanelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsPanelTag.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.servlet.jsp.JspException;
-import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.tagext.BodyTag;
 
 /**
@@ -31,19 +30,14 @@ import javax.servlet.jsp.tagext.BodyTag;
 public class TabsPanelTag extends BaseContainerTag implements BodyTag {
 
 	@Override
-	public int doEndTag() throws JspException {
-		_tabsTag.addPanel(bodyContent.getString());
-
-		return super.doEndTag();
-	}
-
-	@Override
 	public int doStartTag() throws JspException {
 		_tabsTag = (TabsTag)findAncestorWithClass(this, TabsTag.class);
 
 		if (_tabsTag == null) {
 			throw new JspException();
 		}
+
+		_tabsTag.setPanelsCount(_tabsTag.getPanelsCount() + 1);
 
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
 
@@ -69,28 +63,10 @@ public class TabsPanelTag extends BaseContainerTag implements BodyTag {
 		return super.processCssClasses(cssClasses);
 	}
 
-	@Override
-	protected int processEndTag() throws Exception {
-		JspWriter jspWriter = pageContext.getOut();
-
-		jspWriter.write(bodyContent.getString());
-
-		return super.processEndTag();
-	}
-
-	@Override
-	protected int processStartTag() throws Exception {
-		super.processStartTag();
-
-		return EVAL_BODY_BUFFERED;
-	}
-
 	private boolean _isActive() {
 		List<TabsItem> tabsItems = _tabsTag.getTabsItems();
 
-		List<String> panels = _tabsTag.getPanels();
-
-		TabsItem tabsItem = tabsItems.get(panels.size());
+		TabsItem tabsItem = tabsItems.get(_tabsTag.getPanelsCount() - 1);
 
 		Boolean active = (Boolean)tabsItem.get("active");
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
@@ -137,9 +137,9 @@ public class TabsTag extends BaseContainerTag {
 
 			String label = (String)tabsItem.get("label");
 
-			Boolean isActive = (Boolean)tabsItem.get("active");
+			Boolean active = (Boolean)tabsItem.get("active");
 
-			if (Validator.isNotNull(isActive) && isActive) {
+			if ((active != null) && active) {
 				itemCssClass = itemCssClass + " active";
 			}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
@@ -137,6 +137,12 @@ public class TabsTag extends BaseContainerTag {
 
 			String label = (String)tabsItem.get("label");
 
+			Boolean isActive = (Boolean)tabsItem.get("active");
+
+			if (Validator.isNotNull(isActive) && isActive) {
+				itemCssClass = itemCssClass + " active";
+			}
+
 			if (Validator.isNotNull(tabsItem.get("disabled"))) {
 				itemCssClass = itemCssClass + " disabled";
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/TabsTag.java
@@ -20,9 +20,9 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
@@ -31,10 +31,6 @@ import javax.servlet.jsp.JspWriter;
  * @author Carlos Lancha
  */
 public class TabsTag extends BaseContainerTag {
-
-	public void addPanel(String panel) {
-		_panels.add(panel);
-	}
 
 	@Override
 	public int doStartTag() throws JspException {
@@ -51,8 +47,8 @@ public class TabsTag extends BaseContainerTag {
 		return _displayType;
 	}
 
-	public List<String> getPanels() {
-		return _panels;
+	public int getPanelsCount() {
+		return _panelsCount;
 	}
 
 	public List<TabsItem> getTabsItems() {
@@ -83,6 +79,10 @@ public class TabsTag extends BaseContainerTag {
 		_justified = justified;
 	}
 
+	public void setPanelsCount(int panelsCount) {
+		_panelsCount = panelsCount;
+	}
+
 	public void setTabsItems(List<TabsItem> tabsItems) {
 		_tabsItems = tabsItems;
 	}
@@ -95,7 +95,7 @@ public class TabsTag extends BaseContainerTag {
 		_displayType = null;
 		_fade = false;
 		_justified = false;
-		_panels = new ArrayList<>();
+		_panelsCount = 0;
 		_tabsItems = null;
 	}
 
@@ -110,19 +110,16 @@ public class TabsTag extends BaseContainerTag {
 		props.put("displayType", _displayType);
 		props.put("fade", _fade);
 		props.put("justified", _justified);
-		props.put("panels", _panels);
 		props.put("tabsItems", _tabsItems);
 
 		return super.prepareProps(props);
 	}
 
 	@Override
-	protected int processEndTag() throws Exception {
-		JspWriter jspWriter = pageContext.getOut();
+	protected String processBodyCssClasses(Set<String> cssClasses) {
+		cssClasses.add("tab-content");
 
-		jspWriter.write("</div>");
-
-		return super.processEndTag();
+		return super.processBodyCssClasses(cssClasses);
 	}
 
 	@Override
@@ -172,7 +169,7 @@ public class TabsTag extends BaseContainerTag {
 			jspWriter.write("</li>");
 		}
 
-		jspWriter.write("</ul><div class=\"tab-content\">");
+		jspWriter.write("</ul>");
 
 		return EVAL_BODY_INCLUDE;
 	}
@@ -183,7 +180,7 @@ public class TabsTag extends BaseContainerTag {
 	private String _displayType;
 	private boolean _fade;
 	private boolean _justified;
-	private List<String> _panels = new ArrayList<>();
+	private int _panelsCount;
 	private List<TabsItem> _tabsItems;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -41,18 +41,11 @@ export default function Tabs({
 	...otherProps
 }) {
 
-	// TO REMOVE ONCE CLAY IS RELEASED
-
-	const activeIndex = tabsItems.indexOf(
-		tabsItems.find((item) => item.active)
-	);
-
 	return (
 		<>
 			<ClayTabs
 				activation={activation}
 				className={cssClass}
-				defaultActive={activeIndex}
 				displayType={displayType}
 				fade={fade}
 				justified={justified}
@@ -60,11 +53,9 @@ export default function Tabs({
 			>
 				<ClayTabs.List>
 					{tabsItems.map(
-						({/* active,*/ disabled, href, label}, i) => (
+						({active, disabled, href, label}, i) => (
 							<ClayTabs.Item
-
-								// active={active} REMOVE COMMENT ONCE CLAY IS RELEASED
-
+								active={active}
 								disabled={disabled}
 								href={href}
 								key={i}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -40,7 +40,6 @@ export default function Tabs({
 	tabsItems,
 	...otherProps
 }) {
-
 	return (
 		<>
 			<ClayTabs
@@ -52,18 +51,16 @@ export default function Tabs({
 				{...otherProps}
 			>
 				<ClayTabs.List>
-					{tabsItems.map(
-						({active, disabled, href, label}, i) => (
-							<ClayTabs.Item
-								active={active}
-								disabled={disabled}
-								href={href}
-								key={i}
-							>
-								{label}
-							</ClayTabs.Item>
-						)
-					)}
+					{tabsItems.map(({active, disabled, href, label}, i) => (
+						<ClayTabs.Item
+							active={active}
+							disabled={disabled}
+							href={href}
+							key={i}
+						>
+							{label}
+						</ClayTabs.Item>
+					))}
 				</ClayTabs.List>
 
 				<ClayTabs.Panels>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -13,18 +13,28 @@
  */
 
 import ClayTabs from '@clayui/tabs';
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
+
+const Panel = ({children}) => {
+	const ref = useRef();
+
+	useEffect(() => {
+		ref.current.appendChild(children);
+	}, [children]);
+
+	return <div ref={ref}></div>;
+};
 
 export default function Tabs({
 	activation,
 	additionalProps: _additionalProps,
+	children: panelsContent,
 	componentId: _componentId,
 	cssClass,
 	displayType,
 	fade,
 	justified,
 	locale: _locale,
-	panels,
 	portletId: _portletId,
 	portletNamespace: _portletNamespace,
 	tabsItems,
@@ -66,11 +76,10 @@ export default function Tabs({
 				</ClayTabs.List>
 
 				<ClayTabs.Panels>
-					{panels.map((panel, i) => (
-						<ClayTabs.TabPanel
-							dangerouslySetInnerHTML={{__html: panel}}
-							key={i}
-						/>
+					{Array.from(panelsContent).map((panelContent, i) => (
+						<ClayTabs.TabPanel key={i}>
+							<Panel>{panelContent}</Panel>
+						</ClayTabs.TabPanel>
 					))}
 				</ClayTabs.Panels>
 			</ClayTabs>


### PR DESCRIPTION
The main idea of this POC is to store the Tag body nodes before they are removed from the DOM by the React Renderer, and pass them to the component so it can be rendered where we need. This way we're keeping all the js behavior and renderer React Components since we're repositioning the already existing DOM element.

This works because Tags are being rendered inside out so all those children are rendered first, we store them, render the parent, reposition the  children.