### PR TITLE
LPS-169277 | Make dropdown disappear after navigating with the keyboard 

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_time/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_time/page.jsp
@@ -119,6 +119,8 @@ Format format = FastDateFormatFactoryUtil.getSimpleDateFormat(simpleDateFormatPa
 							var date = event.newSelection[0];
 
 							instance.updateTime(date);
+
+							instance.hide();
 						}
 					},
 					popover: {


### PR DESCRIPTION
**Description**: This solution makes the time picker dropdown disappear when  navigating with the keyboard.

This solution solves the bug on the keyboard selection, but generates a new one as it makes impossible to select a time using the mouse once you have selected it with the keyboard.

As this component is out of our scope, I send you this PR in case you find this partial solution useful, and can fix what is missing . Note that this component is used in other places like Journal and they have the same bug.

**Jira Ticket**: https://issues.liferay.com/browse/LPS-169277