### PR TITLE
LPS-175377 Improve UX of FDS Views Manager headless resource selection

### DIFF
--- a/modules/apps/account/account-admin-web/types/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.d.ts
+++ b/modules/apps/account/account-admin-web/types/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersForm.d.ts
@@ -11,14 +11,22 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /// <reference types="react" />
-import { MultiSelectItem } from './types';
+
+import {MultiSelectItem} from './types';
 interface IProps {
-    accountEntryId: number;
-    availableAccountRoles: MultiSelectItem[];
-    inviteAccountUsersURL: string;
-    portletNamespace: string;
-    redirectURL: string;
+	accountEntryId: number;
+	availableAccountRoles: MultiSelectItem[];
+	inviteAccountUsersURL: string;
+	portletNamespace: string;
+	redirectURL: string;
 }
-declare function InviteUsersForm({ accountEntryId, availableAccountRoles, inviteAccountUsersURL, portletNamespace, redirectURL, }: IProps): JSX.Element;
+declare function InviteUsersForm({
+	accountEntryId,
+	availableAccountRoles,
+	inviteAccountUsersURL,
+	portletNamespace,
+	redirectURL,
+}: IProps): JSX.Element;
 export default InviteUsersForm;

--- a/modules/apps/account/account-admin-web/types/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersFormGroup.d.ts
+++ b/modules/apps/account/account-admin-web/types/src/main/resources/META-INF/resources/account_entries_admin/js/InviteUsersFormGroup.d.ts
@@ -11,15 +11,25 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 /// <reference types="react" />
-import { InputGroup, MultiSelectItem } from './types';
+
+import {InputGroup, MultiSelectItem} from './types';
 declare type OnItemsChangeFn = (items: MultiSelectItem[]) => void;
 interface IProps extends InputGroup {
-    availableAccountRoles: MultiSelectItem[];
-    index: number;
-    onAccountRoleItemsChange: OnItemsChangeFn;
-    onEmailAddressItemsChange: OnItemsChangeFn;
-    portletNamespace: string;
+	availableAccountRoles: MultiSelectItem[];
+	index: number;
+	onAccountRoleItemsChange: OnItemsChangeFn;
+	onEmailAddressItemsChange: OnItemsChangeFn;
+	portletNamespace: string;
 }
-declare const InviteUserFormGroup: ({ accountRoles, availableAccountRoles, emailAddresses, index, onAccountRoleItemsChange, onEmailAddressItemsChange, portletNamespace, }: IProps) => JSX.Element;
+declare const InviteUserFormGroup: ({
+	accountRoles,
+	availableAccountRoles,
+	emailAddresses,
+	index,
+	onAccountRoleItemsChange,
+	onEmailAddressItemsChange,
+	portletNamespace,
+}: IProps) => JSX.Element;
 export default InviteUserFormGroup;

--- a/modules/apps/account/account-admin-web/types/src/main/resources/META-INF/resources/account_entries_admin/js/types.d.ts
+++ b/modules/apps/account/account-admin-web/types/src/main/resources/META-INF/resources/account_entries_admin/js/types.d.ts
@@ -11,15 +11,16 @@
  * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
  * details.
  */
+
 export interface MultiSelectItem {
-    label: string;
-    value: string;
+	label: string;
+	value: string;
 }
 export interface ValidatableMultiSelectItem extends MultiSelectItem {
-    errorMessage?: string;
+	errorMessage?: string;
 }
 export interface InputGroup {
-    accountRoles: ValidatableMultiSelectItem[];
-    emailAddresses: ValidatableMultiSelectItem[];
-    id: string;
+	accountRoles: ValidatableMultiSelectItem[];
+	emailAddresses: ValidatableMultiSelectItem[];
+	id: string;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@clayui/drop-down": "3.87.0",
 		"@liferay/frontend-data-set-web": "*",
 		"frontend-js-web": "*"
 	},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/AddFDSView.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/AddFDSView.scss
@@ -1,3 +1,14 @@
-.dropdown-menu.autocomplete-dropdown-menu {
+.headless-resources-dropdown-menu {
 	max-height: 500px;
+	max-width: 750px;
+	width: 100%;
+}
+
+.headless-resource {
+	align-items: baseline;
+	justify-content: space-between;
+
+	.context {
+		font-size: 0.775rem;
+	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
@@ -130,7 +130,11 @@ const DropdownMenu = ({
 
 	return (
 		<>
-			<ClayDropDown.Search onChange={onSearch} value={query} />
+			<ClayDropDown.Search
+				aria-label={Liferay.Language.get('search')}
+				onChange={onSearch}
+				value={query}
+			/>
 
 			<ClayDropDown.ItemList items={headlessResources}>
 				{(item: HeadlessResource) => (

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
@@ -136,13 +136,14 @@ const DropdownMenu = ({
 				value={query}
 			/>
 
-			<ClayDropDown.ItemList items={headlessResources}>
+			<ClayDropDown.ItemList items={headlessResources} role="listbox">
 				{(item: HeadlessResource) => (
 					<ClayDropDown.Item
 						key={item.entityClassName}
 						onClick={() => {
 							setSelectedHeadlessResource(item);
 						}}
+						roleItem="option"
 					>
 						<HeadlessResourceItem
 							headlessResource={item}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
@@ -30,7 +30,7 @@ type HeadlessResource = {
 	version: string;
 };
 
-interface IItemProps {
+interface IHeadlessResourceItemProps {
 	headlessResource: HeadlessResource;
 	query: string;
 }
@@ -40,7 +40,10 @@ const FUZZY_OPTIONS = {
 	pre: '<strong>',
 };
 
-const HeadlessResourceItem = ({headlessResource, query}: IItemProps) => {
+const HeadlessResourceItem = ({
+	headlessResource,
+	query,
+}: IHeadlessResourceItemProps) => {
 	const fuzzyNameMatch = fuzzy.match(
 		query,
 		headlessResource.name,
@@ -155,7 +158,7 @@ const DropdownMenu = ({
 	);
 };
 
-interface IFDSViewsProps {
+interface IAddFDSViewProps {
 	fdsViewsURL: string;
 	headlessResources: Array<HeadlessResource>;
 	namespace: string;
@@ -165,7 +168,7 @@ const AddFDSView = ({
 	fdsViewsURL,
 	headlessResources: initialHeadlessResources,
 	namespace,
-}: IFDSViewsProps) => {
+}: IAddFDSViewProps) => {
 	const [selectedHeadlessResource, setSelectedHeadlessResource] = useState<
 		HeadlessResource
 	>();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/AddFDSView.tsx
@@ -113,17 +113,14 @@ const DropdownMenu = ({
 	const onSearch = (query: string) => {
 		setQuery(query);
 
+		const regexp = new RegExp(query, 'i');
+
 		setHeadlessResources(
 			query
 				? initialHeadlessResources.filter(
 						({bundleLabel, name}: HeadlessResource) => {
-							const lowerCaseQuery = query.toLowerCase();
-
 							return (
-								bundleLabel
-									.toLowerCase()
-									.match(lowerCaseQuery) ||
-								name.toLowerCase().match(lowerCaseQuery)
+								bundleLabel.match(regexp) || name.match(regexp)
 							);
 						}
 				  ) || []

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/AddFDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/AddFDSView.d.ts
@@ -28,7 +28,7 @@ interface IFDSViewsProps {
 }
 declare const AddFDSView: ({
 	fdsViewsURL,
-	headlessResources,
+	headlessResources: initialHeadlessResources,
 	namespace,
 }: IFDSViewsProps) => JSX.Element;
 export default AddFDSView;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/AddFDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/AddFDSView.d.ts
@@ -21,7 +21,7 @@ declare type HeadlessResource = {
 	name: string;
 	version: string;
 };
-interface IFDSViewsProps {
+interface IAddFDSViewProps {
 	fdsViewsURL: string;
 	headlessResources: Array<HeadlessResource>;
 	namespace: string;
@@ -30,5 +30,5 @@ declare const AddFDSView: ({
 	fdsViewsURL,
 	headlessResources: initialHeadlessResources,
 	namespace,
-}: IFDSViewsProps) => JSX.Element;
+}: IAddFDSViewProps) => JSX.Element;
 export default AddFDSView;

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -236,6 +236,12 @@
 	<td>xpath=(//div[contains(@class, "dnd-tr")])[1]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>OPEN_DROPDOWN_MENU</td>
+	<td>//label[contains(.,'${key_label}')]//following-sibling::div//button[contains(@class,'dropdown-toggle')]</td>
+	<td></td>
+</tr>
+
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
@@ -39,7 +39,9 @@ definition {
 		}
 
 		task ("Then displays list of headless resources") {
-			Click(locator1 = "CreateObject#OBJECT_LABEL");
+			Click(
+				key_label = "Provider",
+				locator1 = "FrontendDataSet#OPEN_DROPDOWN_MENU");
 
 			AssertElementPresent(
 				key_item = "Liferay Headless Delivery",


### PR DESCRIPTION
### References

- [LPS-175377 Improve UX of headless resource selection](https://issues.liferay.com/browse/LPS-175377)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/3031
- [Figma mockups](https://www.figma.com/file/VTOLTBFe99y9kA7AY3TcNR/lps-175276-design-app-to-manage-datasets?node-id=68%3A99382&t=gzTL547Z7wFDfZdy-0)

### What is the goal of this PR?

We are replacing `ClayAutocomplete` component with `ClayDropDown`, implementing selection, filtering and highlighting logic manually. 

Notes:
- See previous discussions on the feature
  -  https://github.com/liferay-frontend/liferay-portal/pull/3031#discussion_r1099251104 
  -  https://github.com/liferay-frontend/liferay-portal/pull/3031#discussion_r1099285775
- With this lower-level approach, I could also implement styled appearance of selected item, going a bit beyond mockups cc @ugeortiz see end of movie below.
- I initially tried with the `ClayPicker` component, but I was not able to add functional search input into dropdown menu.
- `Dropdown` component is just for readability, to reduce line breaking.
- `DropdownMenu` component is a standalone component, containing state for querying, filtering and highlighting. This prevents issues with full component refreshing into closed dropdown menu.
 
/cc @bryceosterhaus @dsanz @kresimir-coko 

### What does it look like?


https://user-images.githubusercontent.com/5435511/218513111-3f2b48e8-4adc-484c-b431-a3920dba3ade.mp4



### Steps to reproduce

1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`
2. Open Global Menu > Control Panel > Object > Datasets