### PR TITLE
LPS-175206 Add Autom. Test FrontendDataSetAdmin#CanReturnNoMatchedResults

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -1,13 +1,15 @@
-definition{
+definition {
+
 	macro searchProvider {
-        Click(locator1 = "CreateObject#OBJECT_LABEL");
+		Click(locator1 = "CreateObject#OBJECT_LABEL");
 
-        Type(
-        locator1 = "CreateObject#OBJECT_LABEL",
-        value1 = "${key_provider}");
+		Type(
+			locator1 = "CreateObject#OBJECT_LABEL",
+			value1 = "${key_provider}");
 
-        KeyPress(
-        locator1 = "CreateObject#OBJECT_LABEL",
-        value1 = "\ENTER");
-    }
+		KeyPress(
+			locator1 = "CreateObject#OBJECT_LABEL",
+			value1 = "\ENTER");
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -1,0 +1,13 @@
+definition{
+	macro searchProvider {
+        Click(locator1 = "CreateObject#OBJECT_LABEL");
+
+        Type(
+        locator1 = "CreateObject#OBJECT_LABEL",
+        value1 = "${key_provider}");
+
+        KeyPress(
+        locator1 = "CreateObject#OBJECT_LABEL",
+        value1 = "\ENTER");
+    }
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
@@ -1,0 +1,75 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-data-set-sample-web";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "User Interface";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if ("${testPortalInstance}" == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-174054: Display a list of headless resources in new FDS View modal"
+	test CanDisplayHeadlessDeliveryAPIResources {
+		property custom.properties = "feature.flag.LPS-164563=true";
+
+		task ("Given access Datasets admin page") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "Datasets");
+		}
+
+		task ("When go to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("Then displays list of headless resources") {
+			Click(locator1 = "CreateObject#OBJECT_LABEL");
+
+			AssertElementPresent(
+				key_item = "Liferay Headless Delivery",
+				locator1 = "ManagementBar#ACTIVE_DROPDOWN_ITEM");
+		}
+	}
+
+	@description = "LPS-174054: Display a list of headless resources in new FDS View modal"
+	test CanReturnNoMatchedResults {
+		property custom.properties = "feature.flag.LPS-164563=true";
+
+		task ("Given access Datasets admin page") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "Datasets");
+		}
+
+		task ("When go to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("And When search for a phrase that doesn't match available headless providers") {
+			FrontendDataSetAdmin.searchProvider(key_provider = "apple");
+		}
+
+		task ("Then suggested list contains 0 results") {
+			AssertElementNotPresent(
+				key_tagName = "${key_provider}",
+				locator1 = "AssetCategorization#TAG_AUTOCOMPLETE_SPECIFIC");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetAdmin.testcase
@@ -72,4 +72,5 @@ definition {
 		}
 	}
 
+
 }


### PR DESCRIPTION
Test plan

Given access Datasets admin page
When go to add Datasets
And When search for a phrase that doesn't match available headless providers
Then suggested list contains 0 results

[Poshi Report](https://drive.google.com/file/d/1GVapW3s2Fp9rDyjiL0N5iWNzG560yBu7/view?usp=share_link)

[Jira Ticket ](https://issues.liferay.com/browse/)