### PR TITLE
LPS-175587 - Bump date-fns version to 2.29.3

### DIFF
--- a/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"clipboard": "2.0.4",
 		"dagre": "0.8.2",
-		"date-fns": "2.14.0",
+		"date-fns": "2.29.3",
 		"dom-align": "1.12.2",
 		"fuzzy": "0.1.3",
 		"image-promise": "5.0.1",

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@liferay/frontend-js-react-web": "*",
+		"date-fns": "2.29.3",
 		"frontend-js-web": "*",
 		"moment": "2.29.4",
 		"numeral": "2.0.6",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -5841,15 +5841,15 @@ dataloader@2.0.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
-date-fns@2.14.0, date-fns@^2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
-  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
-
 date-fns@2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
+date-fns@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
+  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
 
 dateformat@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-175587

date-fns at 2.14 didn't have the function that was erroring out above. I think 2.14 slipped in on a merge conflict in the original PR