### PR TITLE
LPS-170037 Removed frontend taglibs CSS #2

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -678,14 +678,6 @@ html#{$cadmin-selector} {
 			padding: $cadmin-modal-inner-padding;
 		}
 
-		.management-bar-default {
-			border-left-width: 0;
-			border-radius: 0;
-			border-right-width: 0;
-			border-top-width: 0;
-			margin-bottom: 0;
-		}
-
 		.navbar ~ .portlet-configuration-setup,
 		.portlet-export-import-container {
 			height: calc(100% - 48px);

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_dialog.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_dialog.scss
@@ -49,14 +49,6 @@
 		padding: $modal-inner-padding;
 	}
 
-	.management-bar-default {
-		border-left-width: 0;
-		border-radius: 0;
-		border-right-width: 0;
-		border-top-width: 0;
-		margin-bottom: 0;
-	}
-
 	.navbar ~ .portlet-configuration-setup,
 	.portlet-export-import-container {
 		height: calc(100% - #{$dialog-navbar-height});

--- a/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/ddm-templates/styles/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-learn/src/main/resources/site-initializer/ddm-templates/styles/ddm-template.ftl
@@ -1875,13 +1875,6 @@ padding-top: 0;
 .portal-popup .login-container {
 padding: 1rem;
 }
-.portal-popup .management-bar-default {
-border-left-width: 0;
-border-radius: 0;
-border-right-width: 0;
-border-top-width: 0;
-margin-bottom: 0;
-}
 .portal-popup .navbar ~ .portlet-configuration-setup,
 .portal-popup .portlet-export-import-container {
 height: calc(100% - 48px);


### PR DESCRIPTION
This PR is the second part of https://github.com/liferay-frontend/liferay-portal/pull/3035 and it removes CSS classes from deprecated taglibs in https://issues.liferay.com/browse/LPS-170037