### PR TITLE
LPS-177019 | Test Fix for ClientExtensionRepeatableFields#JSURLCanBeRepeated

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionRepeatableFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionRepeatableFields.testcase
@@ -223,22 +223,22 @@ definition {
 
 		task ("And Then repeatable button + and - are present for both CSS URL fields") {
 			AssertElementPresent(
-				key_fieldLabelName = "JS URL",
+				key_fieldLabelName = "JavaScript URL",
 				key_index = 1,
 				locator1 = "ClientExtensionEntry#DELETE_ROW_FIELD_LABEL_NAME_INDEX");
 
 			AssertElementPresent(
-				key_fieldLabelName = "JS URL",
+				key_fieldLabelName = "JavaScript URL",
 				key_index = 1,
 				locator1 = "ClientExtensionEntry#ADD_ROW_FIELD_LABEL_NAME_INDEX");
 
 			AssertElementPresent(
-				key_fieldLabelName = "JS URL",
+				key_fieldLabelName = "JavaScript URL",
 				key_index = 2,
 				locator1 = "ClientExtensionEntry#DELETE_ROW_FIELD_LABEL_NAME_INDEX");
 
 			AssertElementPresent(
-				key_fieldLabelName = "JS URL",
+				key_fieldLabelName = "JavaScript URL",
 				key_index = 2,
 				locator1 = "ClientExtensionEntry#ADD_ROW_FIELD_LABEL_NAME_INDEX");
 		}


### PR DESCRIPTION
**Background**
Fix "Element is not present in ClientExtensionRepeatableFields#JSURLCanBeRepeated"

**Test Plan**
- Given Remote Application > Custom Elements create page
- When click repeatable button for JS URL
- Then new JS URL field is added
- And Then repeatable button + and - are present for both CSS URL fields

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-177019