### PR TITLE
LPS-173965 | Text Fix for ClientExtensionOSGI#HasViewAction

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtension.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtension.path
@@ -41,6 +41,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DROPDOWN_OPTIONS</td>
+	<td>//*[contains(@class,'dropdown-item') and contains(.,'${key_option}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>REMOTE_TABLE_ELLIPSIS</td>
 	<td>//button[contains(@class,'component-action')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
@@ -12,9 +12,9 @@ definition {
 		User.firstLoginPG();
 
 		task ("Given config file for client extension of type custom element created") {
-			ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
+			// ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
 
-			ClientExtension.checkConfigFileCreatedProperly();
+			// ClientExtension.checkConfigFileCreatedProperly();
 
 			ClientExtensionGeneral.goToRemoteAppsPortlet();
 		}
@@ -72,7 +72,7 @@ definition {
 		task ("Then View action is an available option") {
 			AssertElementPresent(
 				key_text = "View",
-				locator1 = "Button#ANY");
+				locator1 = "Button#ANY_VIEW");
 		}
 
 		task ("And Then Edit action is not an available option field information is displayed correctly") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
@@ -12,8 +12,8 @@ definition {
 		User.firstLoginPG();
 
 		task ("Given config file for client extension of type custom element created") {
-
 			ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
+
 			ClientExtension.checkConfigFileCreatedProperly();
 
 			ClientExtensionGeneral.goToRemoteAppsPortlet();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
@@ -12,9 +12,9 @@ definition {
 		User.firstLoginPG();
 
 		task ("Given config file for client extension of type custom element created") {
-			// ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
 
-			// ClientExtension.checkConfigFileCreatedProperly();
+			//ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
+			//ClientExtension.checkConfigFileCreatedProperly();
 
 			ClientExtensionGeneral.goToRemoteAppsPortlet();
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
@@ -13,8 +13,8 @@ definition {
 
 		task ("Given config file for client extension of type custom element created") {
 
-			//ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
-			//ClientExtension.checkConfigFileCreatedProperly();
+			ClientExtension.createGlobalVariableClientExtensionType(type = "customElement");
+			ClientExtension.checkConfigFileCreatedProperly();
 
 			ClientExtensionGeneral.goToRemoteAppsPortlet();
 		}
@@ -71,12 +71,14 @@ definition {
 
 		task ("Then View action is an available option") {
 			AssertElementPresent(
-				key_text = "View",
-				locator1 = "Button#ANY_VIEW");
+				key_option = "View",
+				locator1 = "ClientExtension#DROPDOWN_OPTIONS");
 		}
 
 		task ("And Then Edit action is not an available option field information is displayed correctly") {
-			MenuItem.viewNotPresent(menuItem = "Edit");
+			AssertElementNotPresent(
+				key_option = "Edit",
+				locator1 = "ClientExtension#DROPDOWN_OPTIONS");
 		}
 	}
 
@@ -102,9 +104,11 @@ definition {
 		property test.name.skip.portal.instance = "ClientExtensionOSGI#ViewActionCanDisplayFieldsAsNotEditable";
 
 		task ("When select view action") {
+			Click(locator1 = "ClientExtension#REMOTE_TABLE_ELLIPSIS");
+
 			Click(
-				key_text = "View",
-				locator1 = "Button#ANY");
+				key_option = "View",
+				locator1 = "ClientExtension#DROPDOWN_OPTIONS");
 		}
 
 		task ("Then field information is displayed correctly") {


### PR DESCRIPTION
**Background**
Fix "Element is not present in ClientExtensionOSGI"

**Test Plan**

- Given config file for client extension of type custom element created
- Then View action is an available option
- And Then Edit action is not an available option field information is displayed correctly

JIRA Ticket
https://issues.liferay.com/browse/LPS-173965