### PR TITLE
LPS-177100 | Further investigation on failures from ClayCheckbox tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/claysample/ClaySamplePortlet.path
@@ -45,7 +45,7 @@
 </tr>
 <tr>
 	<td>CHECKBOX_NESTED</td>
-	<td>//div[contains(@class,'autofit-row')]//div[contains(text(),'${key_label}')]//..//..//input</td>
+	<td>//div[contains(@class,'autofit-row')]//span[contains(text(),'${key_label}')]//..//..//input</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Background
Test Fix "Further investigation on failures from ClayCheckbox tests"

Test Plan

- Given treeview with indeterminate state checkboxes
- And Given top most treeview checkbox state is indeterminate
- When all children checkboxes states are checked
- Then the parent checkbox is checked state

JIRA Ticket:
https://issues.liferay.com/browse/LPS-177100