### PR TITLE
LPS-177495 | Test Fix for ClayCheckbox#VerifyDefaultUI

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayCheckbox.testcase
@@ -196,8 +196,7 @@ definition {
 		// Temporarily remove sikuli assertion until fix in LRQA-65984
 
 		//SikuliAssertElementPresent(locator1 = "ClaySamplePortlet#CHECKBOX_UNCHECKED");
-
-		SikuliAssertElementPresent(locator1 = "ClaySamplePortlet#CHECKBOX_INDETERMINATE_PNG");
+		//SikuliAssertElementPresent(locator1 = "ClaySamplePortlet#CHECKBOX_INDETERMINATE_PNG");
 
 		takeScreenshot();
 	}


### PR DESCRIPTION
**Background**
Test shouldn't have sikuli assertion until fix in LRQA-65984. So, sikuli assertions were temporarily removed.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-177495