### PR TITLE
LPS-174358 FDS | Tab key navigation skips dropdown on filter label

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FilterResume.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FilterResume.js
@@ -12,9 +12,9 @@
  * details.
  */
 
+import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayLabel from '@clayui/label';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
@@ -28,17 +28,48 @@ function FilterResume(props) {
 
 	const [open, setOpen] = useState(false);
 
-	const label = (
-		<ClayLabel
+	const button = (
+		<ClayButton
 			className={classNames(
-				'filter-resume component-label tbar-label mr-2',
+				'filter-resume component-label tbar-label',
 				props.disabled && 'disabled',
 				open && 'active'
 			)}
-			closeButtonProps={{
-				className: 'filter-resume-close',
-				disabled: props.disabled,
-				onClick: () => {
+			displayType="secondary"
+			size="sm"
+		>
+			<div className="filter-resume-content">
+				<ClayIcon
+					className="mr-2"
+					symbol={open ? 'caret-top' : 'caret-bottom'}
+				/>
+
+				<div className="label-section">
+					{props.label}: {props.selectedItemsLabel}
+				</div>
+			</div>
+		</ClayButton>
+	);
+
+	const dropDownButtonGroup = (
+		<ClayButton.Group>
+			<ClayDropDown
+				active={open}
+				className="d-inline-flex"
+				onActiveChange={setOpen}
+				trigger={button}
+			>
+				<li className="dropdown-subheader">{props.label}</li>
+
+				<Filter {...props} />
+			</ClayDropDown>
+
+			<ClayButton
+				className="filter-resume-close"
+				disabled={props.disabled}
+				displayType="secondary"
+				monospaced
+				onClick={() =>
 					viewsDispatch({
 						type: VIEWS_ACTION_TYPES.UPDATE_FILTERS,
 						value: filters.map((filter) => ({
@@ -51,39 +82,17 @@ function FilterResume(props) {
 								  }
 								: {}),
 						})),
-					});
-				},
-				title: Liferay.Language.get('remove-filter'),
-			}}
-			role="button"
-		>
-			<div className="filter-resume-content">
-				<ClayIcon
-					className="mr-2"
-					symbol={open ? 'caret-top' : 'caret-bottom'}
-				/>
-
-				<div className="label-section">
-					{props.label}: {props.selectedItemsLabel}
-				</div>
-			</div>
-		</ClayLabel>
+					})
+				}
+				size="sm"
+				title={Liferay.Language.get('remove-filter')}
+			>
+				<ClayIcon symbol="times-small" />
+			</ClayButton>
+		</ClayButton.Group>
 	);
 
-	const dropDown = (
-		<ClayDropDown
-			active={open}
-			className="d-inline-flex"
-			onActiveChange={setOpen}
-			trigger={label}
-		>
-			<li className="dropdown-subheader">{props.label}</li>
-
-			<Filter {...props} />
-		</ClayDropDown>
-	);
-
-	return props.disabled ? label : dropDown;
+	return props.disabled ? button : dropDownButtonGroup;
 }
 
 FilterResume.propTypes = {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FilterResume.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FilterResume.js
@@ -32,9 +32,9 @@ function FilterResume(props) {
 		<ClayButton
 			className={classNames(
 				'filter-resume component-label tbar-label',
-				props.disabled && 'disabled',
 				open && 'active'
 			)}
+			disabled={props.disabled}
 			displayType="secondary"
 			size="sm"
 		>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FiltersDropdown.js
@@ -30,6 +30,7 @@ const FiltersDropdown = () => {
 
 	const onSearch = (query) => {
 		setQuery(query);
+
 		setFilters(
 			query
 				? initialFilters.filter(({label}) =>
@@ -77,6 +78,7 @@ const FiltersDropdown = () => {
 
 						{activeFilter.label}
 					</li>
+
 					<Filter {...activeFilter} />
 				</>
 			) : (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/SelectionFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/SelectionFilter.js
@@ -271,9 +271,11 @@ function SelectionFilter({
 							</div>
 						) : null}
 					</ClayDropDown.Caption>
+
 					<Divider />
 				</>
 			)}
+
 			<ClayDropDown.Caption className="pb-0">
 				<div className="row">
 					<div className="col">
@@ -291,7 +293,9 @@ function SelectionFilter({
 					</div>
 				</div>
 			</ClayDropDown.Caption>
+
 			<Divider />
+
 			<div className="pb-1 pl-3 pr-3 pt-1">
 				{items && !!items.length ? (
 					<ul
@@ -356,7 +360,9 @@ function SelectionFilter({
 					</div>
 				)}
 			</div>
+
 			<Divider />
+
 			<ClayDropDown.Caption>
 				<ClayButton
 					disabled={submitDisabled}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174358

In order to have the proper focus behaviour it was needed to pass a `ClayButton` component instead of the `ClayLabel` component as a `trigger` for the `ClayDropDown`.

I have also noticed a lot of SF inconsistencies in the `frontend-data-set-web` module, for example missing empty lines between sibling elements. Are we disabling our ESLint rules somehow in this module?
