### PR TITLE
LPS-177512 | Investigate failure in ClientExtension#ErrorAppearsWhenHTMLBlank

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtensionEntry.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtensionEntry.path
@@ -75,6 +75,11 @@
 	<td>//div[contains(@class, 'alert alert-dismissible alert-danger') and contains(.,'${text}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>WARNING_SPECIFIC</td>
+	<td>//div[contains(@class, 'form-feedback-item') and contains(.,'${key_text}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtension.testcase
@@ -631,8 +631,8 @@ definition {
 
 		task ("Then error message 'HTML element name is empty'") {
 			AssertElementPresent(
-				locator1 = "ClientExtensionEntry#REMOTE_APPS_ERROR_WITH_MESSAGE",
-				text = "HTML Element field is required");
+				key_text = "The HTML Element Name field is required",
+				locator1 = "ClientExtensionEntry#WARNING_SPECIFIC");
 		}
 
 		task ("And Then Remote App is not added") {


### PR DESCRIPTION
Background:
selecting on the, new custom element (the HTML Element Name field is required).

Plan:
- Given Add Custom Element Client Extensions admin page
- When required fields Name, HTML Element Name, and JS URL are blank and When attempt to save remote app
- Then error message 'HTML element name is empty
- And Then Remote App is not added

JIRA Ticket:
https://issues.liferay.com/browse/LPS-177512
