### PR TITLE
[TECHNICAL SUPPORT] LPS-177707 When Toggle Controls is off, portlet-topper is still displayed in the DOM and blocks some userInteraction

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -115,4 +115,10 @@ body.portlet {
 	.portlet-topper-toolbar {
 		display: none !important;
 	}
+
+	.portlet-topper {
+		.portlet-title-default {
+			display: none !important;
+		}
+	}
 }


### PR DESCRIPTION
Hey,

[LPS-177707](https://issues.liferay.com/browse/LPS-177707)
Based on the answer I got in [PTR-3736](https://issues.liferay.com/browse/PTR-3736), I fixed the issue of portlet-topper blocking user interactions in case the Toggle Controls is off.

Please review my changes