### PR TITLE
LPS-177564 Navigate to FDS Views page on the 'view' action of FDS Entry

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -14,11 +14,14 @@
 
 package com.liferay.frontend.data.set.views.web.internal.display.context;
 
+import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
 import com.liferay.frontend.data.set.views.web.internal.resource.FDSHeadlessResource;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 
 import java.util.Comparator;
 import java.util.List;
@@ -40,6 +43,26 @@ public class FDSViewsDisplayContext {
 
 	public String getFDSEntriesAPIURL() {
 		return "/o/c/fdsentries";
+	}
+
+	public String getFDSEntriesURL() {
+		return PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				_portletRequest, FDSViewsPortletKeys.FDS_VIEWS,
+				PortletRequest.RENDER_PHASE)
+		).setMVCPath(
+			"/fds_entries.jsp"
+		).buildString();
+	}
+
+	public String getFDSViewsURL() {
+		return PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				_portletRequest, FDSViewsPortletKeys.FDS_VIEWS,
+				PortletRequest.RENDER_PHASE)
+		).setMVCPath(
+			"/fds_views.jsp"
+		).buildString();
 	}
 
 	public JSONArray getHeadlessResourcesJSONArray() {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_views.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_views.jsp
@@ -16,17 +16,9 @@
 
 <%@ include file="/init.jsp" %>
 
-<react:component
-	module="js/FDSEntries"
-	props='<%=
-		HashMapBuilder.<String, Object>put(
-			"apiURL", fdsViewsDisplayContext.getFDSEntriesAPIURL()
-		).put(
-			"fdsViewsURL", fdsViewsDisplayContext.getFDSViewsURL()
-		).put(
-			"headlessResources", fdsViewsDisplayContext.getHeadlessResourcesJSONArray()
-		).put(
-			"namespace", liferayPortletResponse.getNamespace()
-		).build()
-	%>'
-/>
+<%
+portletDisplay.setShowBackIcon(true);
+portletDisplay.setURLBack(fdsViewsDisplayContext.getFDSEntriesURL());
+
+renderResponse.setTitle(ParamUtil.getString(request, "fdsEntryLabel"));
+%>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,7 +21,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsWebKeys" %><%@
 page import="com.liferay.frontend.data.set.views.web.internal.display.context.FDSViewsDisplayContext" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %>
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
+page import="com.liferay.portal.kernel.util.ParamUtil" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -442,13 +442,6 @@ const FDSEntries = ({
 	const views = [
 		{
 			contentRenderer: 'table',
-			itemsActions: [
-				{
-					icon: 'view',
-					label: Liferay.Language.get('view'),
-					onClick: onViewClick,
-				},
-			],
 			label: Liferay.Language.get('table'),
 			name: 'table',
 			schema: {
@@ -479,6 +472,13 @@ const FDSEntries = ({
 					provider: ProviderRenderer,
 				}}
 				id={`${namespace}FDSEntries`}
+				itemsActions={[
+					{
+						icon: 'view',
+						label: Liferay.Language.get('view'),
+						onClick: onViewClick,
+					},
+				]}
 				pagination={{
 					deltas: [
 						{label: 4},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -20,7 +20,7 @@ import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
-import {fetch, openModal} from 'frontend-js-web';
+import {fetch, navigate, openModal} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useRef, useState} from 'react';
 
@@ -165,12 +165,14 @@ const DropdownMenu = ({
 
 interface IFDSEntriesProps {
 	apiURL: string;
+	fdsViewsURL: string;
 	headlessResources: Array<HeadlessResource>;
 	namespace: string;
 }
 
 const FDSEntries = ({
 	apiURL,
+	fdsViewsURL,
 	headlessResources,
 	namespace,
 }: IFDSEntriesProps) => {
@@ -430,9 +432,25 @@ const FDSEntries = ({
 		],
 	};
 
+	const onViewClick = ({itemData}: any) => {
+		const url = new URL(fdsViewsURL);
+
+		url.searchParams.set(`${namespace}fdsEntryId`, itemData.id);
+		url.searchParams.set(`${namespace}fdsEntryLabel`, itemData.label);
+
+		navigate(url);
+	};
+
 	const views = [
 		{
 			contentRenderer: 'table',
+			itemsActions: [
+				{
+					icon: 'view',
+					label: Liferay.Language.get('view'),
+					onClick: onViewClick,
+				},
+			],
 			label: Liferay.Language.get('table'),
 			name: 'table',
 			schema: {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -187,13 +187,11 @@ const FDSEntries = ({
 
 	type FDSEntry = {
 		entityClassName: string;
+		id: string;
+		label: string;
 	};
 
-	interface IProviderRendererProps {
-		itemData: FDSEntry;
-	}
-
-	const ProviderRenderer = ({itemData}: IProviderRendererProps) => {
+	const ProviderRenderer = ({itemData}: {itemData: FDSEntry}) => {
 		const headlessResource = headlessResourcesMapRef.current.get(
 			itemData.entityClassName
 		);
@@ -432,7 +430,7 @@ const FDSEntries = ({
 		],
 	};
 
-	const onViewClick = ({itemData}: any) => {
+	const onViewClick = ({itemData}: {itemData: FDSEntry}) => {
 		const url = new URL(fdsViewsURL);
 
 		url.searchParams.set(`${namespace}fdsEntryId`, itemData.id);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -23,11 +23,13 @@ declare type HeadlessResource = {
 };
 interface IFDSEntriesProps {
 	apiURL: string;
+	fdsViewsURL: string;
 	headlessResources: Array<HeadlessResource>;
 	namespace: string;
 }
 declare const FDSEntries: ({
 	apiURL,
+	fdsViewsURL,
 	headlessResources,
 	namespace,
 }: IFDSEntriesProps) => JSX.Element;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -168,14 +168,10 @@ function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 			};
 
 			if (onClick) {
-				event.preventDefault();
-
 				onClick(exposedProps);
 			}
 
 			if (onActionDropdownItemClick) {
-				event.preventDefault();
-
 				onActionDropdownItemClick(exposedProps);
 			}
 		};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -128,6 +128,7 @@ function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 				event.preventDefault();
 
 				highlightItems([itemId]);
+
 				openSidePanel({
 					size: 'lg',
 					title,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.js
@@ -70,12 +70,14 @@ function ActionsDropdown({
 
 	const inlineEditingAvailable =
 		inlineEditingSettings && itemData.actions?.update;
+
 	const inlineEditingAlwaysOn =
 		inlineEditingAvailable && inlineEditingSettings.alwaysOn;
 
 	const isMounted = useIsMounted();
 
 	const editModeActive = !!itemsChanges[itemId];
+
 	const itemChanges =
 		editModeActive && Object.keys(itemsChanges[itemId]).length
 			? itemsChanges[itemId]
@@ -128,6 +130,7 @@ function ActionsDropdown({
 		actions.length === 1
 	) {
 		const [action] = actions;
+
 		const {data: actionData} = action;
 
 		if (actionData?.id && !action?.href) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -69,6 +69,7 @@ type TItemsActions = {
 	icon?: string;
 	id?: string;
 	label?: string;
+	onClick?: Function;
 	target?: 'async' | 'headless' | 'link' | 'modal' | 'sidePanel' | 'event';
 };
 


### PR DESCRIPTION
### References

- [LPS-177564 Navigate to FDS Views page on the 'view' action of FDS Entry](https://issues.liferay.com/browse/LPS-177564)
- [Figma mockup](https://www.figma.com/file/VTOLTBFe99y9kA7AY3TcNR/lps-175276-design-app-to-manage-datasets?node-id=937-117695&t=gNfcz6mQplE92gsc-0)

### What is the goal of this PR?

This is the first PR of the story to manage FDS Views. We are adding navigation from FDS Entry action to the placeholder of FDS Views page.

Notes:
- The changes in FDS Views Manager are minimal, basically a sample of frontend setup of actions, with a placeholder Views page. I'll send FDS Views persistence and CRUD handling in a separate PR.
- Setting of `onClick` in actions was bugged, this is a part of our discovery of issues when using FDS directly as a React component. In the PR we fixing this, but also taking the opportunity to massively simplify handling of actions in FDS. @carloslancha I had something like this in mind when we discussed exposing of FDS context in custom actions. There is now a single point of placing exposed values, in `exposedProps` const. There are for sure other ways to simplify code, but I had to stop myself :slightly_smiling_face: 
  - As a part of the changes, we are fixing accessibility `aria-label` setting, fixing `PropTypes` setting, and removing unused `size` setting.
  - It may be that I missed some edge case, but I did test several places in commerce and FDS sample module.
- Inline icon for action is temporary, until we add other actions. Then, it will become a dropdown, as in mockups. cc @ugeortiz

### What does it look like?

https://user-images.githubusercontent.com/5435511/223713113-aa76822e-c2b1-4cca-a13b-d9cebc59d7a6.mp4


### Steps to reproduce
1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`
2. Open Global Menu > Control Panel > Object > Datasets