### PR TITLE
LPS-178217 The flag of languages with variant (ca_ES_VALENCIA or sr_RS_latin) are not correctly displayed when adding a translation

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/LanguageSelector.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/LanguageSelector.js
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
 function getLanguage(id) {
-	const text = id.replace('_', '-');
+	const text = id.replaceAll('_', '-');
 	const icon = text.toLowerCase();
 
 	return {

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/data-engine/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/data-engine/DataEngineLayoutBuilderHandler.es.js
@@ -71,7 +71,7 @@ export default function DataEngineLayoutBuilderHandler({namespace}) {
 					Liferay.Language.get(
 						'please-enter-a-valid-title-for-the-default-language-x'
 					),
-					defaultLanguageId.replace('_', '-')
+					defaultLanguageId.replaceAll('_', '-')
 				),
 				title: Liferay.Language.get('error'),
 				type: 'danger',

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/js/LanguageSelector.js
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/js/LanguageSelector.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
 function getLanguage(id) {
-	const text = id.replace('_', '-');
+	const text = id.replaceAll('_', '-');
 	const icon = text.toLowerCase();
 
 	return {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/DateTimeRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/DateTimeRenderer.js
@@ -19,7 +19,7 @@ function DateTimeRenderer({options, value}) {
 		return null;
 	}
 
-	const locale = themeDisplay.getLanguageId().replace('_', '-');
+	const locale = themeDisplay.getLanguageId().replaceAll('_', '-');
 	const dateOptions = options?.format || {
 		day: 'numeric',
 		hour: 'numeric',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -401,7 +401,7 @@ AUI.add(
 					const locales = instance.get('items').map((languageId) => {
 						const displayName = availableLocales[languageId];
 
-						const label = languageId.replace(/_/, '-');
+						const label = languageId.replaceAll(/_/g, '-');
 
 						return {
 							displayName,
@@ -415,7 +415,7 @@ AUI.add(
 						.get('translatedLanguages')
 						.values()
 						.reduce((accumulator, item) => {
-							const language = item.replace(/_/, '-');
+							const language = item.replaceAll(/_/g, '-');
 
 							if (!accumulator[language]) {
 								accumulator[language] = language;
@@ -669,7 +669,7 @@ AUI.add(
 					if (languageStatusNode) {
 						languageStatusNode.setHTML(
 							A.Lang.sub(instance.TRANSLATION_STATUS_TEMPLATE, {
-								languageId: languageId.replace(/_/, '-'),
+								languageId: languageId.replaceAll(/_/g, '-'),
 								translationAriaLabel,
 								translationStatus,
 								translationStatusCssClass,
@@ -690,7 +690,7 @@ AUI.add(
 							'currentlySelected'
 						];
 
-					languageId = languageId.replace('_', '-');
+					languageId = languageId.replaceAll('_', '-');
 
 					const triggerContent = A.Lang.sub(
 						instance.TRIGGER_TEMPLATE,

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/EventScreen.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/screen/EventScreen.js
@@ -139,8 +139,8 @@ class EventScreen extends HtmlScreen {
 	evaluateStyles(surfaces) {
 		const currentLanguageId = document
 			.querySelector('html')
-			.lang.replace('-', '_');
-		const languageId = this.virtualDocument.lang.replace('-', '_');
+			.lang.replaceAll('-', '_');
+		const languageId = this.virtualDocument.lang.replaceAll('-', '_');
 
 		if (currentLanguageId !== languageId) {
 			this.stylesPermanentSelector_ =

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DataEngineLayoutBuilderHandler.es.js
@@ -87,7 +87,7 @@ export default function DataEngineLayoutBuilderHandler({namespace}) {
 					Liferay.Language.get(
 						'please-enter-a-valid-title-for-the-default-language-x'
 					),
-					defaultLanguageId.replace('_', '-')
+					defaultLanguageId.replaceAll('_', '-')
 				),
 				title: Liferay.Language.get('error'),
 				type: 'danger',

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -163,7 +163,7 @@ export default function _JournalPortlet({
 					Liferay.Language.get(
 						'please-enter-a-valid-title-for-the-default-language-x'
 					),
-					defaultLanguageId.replace('_', '-')
+					defaultLanguageId.replaceAll('_', '-')
 				)
 			);
 		}
@@ -217,7 +217,7 @@ export default function _JournalPortlet({
 						Liferay.Language.get(
 							'please-enter-a-valid-title-for-the-default-language-x'
 						),
-						defaultLanguageId.replace('_', '-')
+						defaultLanguageId.replaceAll('_', '-')
 					)
 				);
 			}

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/CodeEditorLocalized.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/CodeEditorLocalized.tsx
@@ -53,7 +53,7 @@ const availableLocales = Object.keys(Liferay.Language.available)
 	.sort((languageId) => (languageId === defaultLanguageId ? -1 : 1))
 	.map((language) => ({
 		label: language as Liferay.Language.Locale,
-		symbol: language.replace('_', '-').toLowerCase(),
+		symbol: language.replace(/_/g, '-').toLowerCase(),
 	}));
 
 export function CodeEditorLocalized({
@@ -117,7 +117,7 @@ export function CodeEditorLocalized({
 						<span className="inline-item">
 							<ClayIcon
 								symbol={selectedLocale
-									.replace('_', '-')
+									.replace(/_/g, '-')
 									.toLowerCase()}
 							/>
 						</span>

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/InputLocalized.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/InputLocalized.tsx
@@ -47,7 +47,7 @@ const availableLocales = Object.keys(Liferay.Language.available)
 	.sort((languageId) => (languageId === defaultLanguageId ? -1 : 1))
 	.map((language) => ({
 		label: language as Liferay.Language.Locale,
-		symbol: language.replace('_', '-').toLowerCase(),
+		symbol: language.replace(/_/g, '-').toLowerCase(),
 	}));
 
 export function InputLocalized({

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/RichTextLocalized.tsx
@@ -33,7 +33,7 @@ const availableLocales = Object.keys(Liferay.Language.available)
 	.sort((languageId) => (languageId === defaultLanguageId ? -1 : 1))
 	.map((language) => ({
 		label: language as Liferay.Language.Locale,
-		symbol: language.replace('_', '-').toLowerCase(),
+		symbol: language.replace(/_/g, '-').toLowerCase(),
 	}));
 
 export function RichTextLocalized({
@@ -105,7 +105,7 @@ export function RichTextLocalized({
 							<span className="inline-item">
 								<ClayIcon
 									symbol={selectedLocale
-										.replace('_', '-')
+										.replace(/_/g, '-')
 										.toLowerCase()}
 								/>
 							</span>

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ListTypeDefinition/utils.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ListTypeDefinition/utils.ts
@@ -16,7 +16,7 @@ export function fixLocaleKeys(name_i18n: LocalizedValue<string>) {
 	const newTranslationsObject: {[key: string]: string} = {};
 
 	for (const [key, value] of Object.entries(name_i18n)) {
-		newTranslationsObject[key.replace('-', '_')] = value;
+		newTranslationsObject[key.replace(/-/g, '_')] = value;
 	}
 
 	return newTranslationsObject;

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/string.ts
@@ -40,7 +40,7 @@ export function checkIfFirstLetterIsUppercase(str: string) {
  * frontend with themeDisplay.getDefaultLanguageId()
  */
 export function normalizeLanguageId(languageId: string): string {
-	return languageId.replace('_', '-');
+	return languageId.replace(/_/g, '-');
 }
 
 /**

--- a/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/components/WorkflowInstanceTracker.js
+++ b/modules/apps/portal-workflow/portal-workflow-instance-tracker-web/src/main/resources/META-INF/resources/js/components/WorkflowInstanceTracker.js
@@ -39,7 +39,7 @@ export default function WorkflowInstanceTracker({workflowInstanceId}) {
 	const [transitions, setTransitions] = useState([]);
 	const [visitedNodes, setVisitedNodes] = useState([]);
 
-	const languageId = themeDisplay.getLanguageId().replace('_', '-');
+	const languageId = themeDisplay.getLanguageId().replaceAll('_', '-');
 
 	useEffect(() => {
 		fetch(

--- a/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar/LanguageSelector.js
+++ b/modules/apps/translation/translation-web/src/main/resources/META-INF/resources/js/translate/components/TranslateActionBar/LanguageSelector.js
@@ -19,7 +19,7 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
 function getLanguage(id) {
-	const text = id.replace('_', '-');
+	const text = id.replaceAll('_', '-');
 	const icon = text.toLowerCase();
 
 	return {

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/availableLocales.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-designer-web/src/main/resources/META-INF/resources/designer/js/definition-builder/util/availableLocales.js
@@ -16,7 +16,7 @@ export function getAvailableLocalesObject(displayNames, languageIds) {
 			displayName: displayNames[index],
 			id,
 			label: id,
-			symbol: id.toLowerCase().replace('_', '-'),
+			symbol: id.toLowerCase().replaceAll('_', '-'),
 		};
 	});
 }

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/query_builder_tab/SelectTypes.js
@@ -26,7 +26,7 @@ function SelectTypes({
 	const {locale} = useContext(ThemeContext);
 
 	const searchableTypesSorted = searchableTypes.sort((a, b) =>
-		a.displayName.localeCompare(b.displayName, locale.replace('_', '-'))
+		a.displayName.localeCompare(b.displayName, locale.replaceAll('_', '-'))
 	);
 
 	const _handleDelete = (type) => () => {

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/language/rename_keys.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/utils/language/rename_keys.js
@@ -15,7 +15,7 @@ describe('renameKeys', () => {
 	it('replaces the string for locale', () => {
 		expect(
 			renameKeys({'en-US': 'Hello', 'zh-CN': 'Ni Hao'}, (str) =>
-				str.replace('-', '_')
+				str.replaceAll('-', '_')
 			)
 		).toEqual({en_US: 'Hello', zh_CN: 'Ni Hao'});
 	});


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-178217

The flag of languages with variant (ca_ES_VALENCIA or sr_RS_latin) are not correctly displayed when adding a translation

This issue is similar to [LPS-176503](https://issues.liferay.com/browse/LPS-176503) but applied to other Liferay components

**Root cause of the issue:**

- Java Locale code uses underscore character in the locale code to separate language, country and variant, for example: ca_ES_VALENCIA
- But in the frontend side, we have to replace the underscore character with the dash, for example: ca-ES-VALENCIA
- The problem here is we don't usually consider there could be two underscore characters, so only the first one is replaced: ca_ES_VALENCIA => ca-ES_VALENCIA and the flag is not found

**Reproduction steps**

See [LPS-178217](https://issues.liferay.com/browse/LPS-178217) description

**Solution**

I am changing the `locale.replace('_','-')` usages with `locale.replaceAll('_','-')`

The first commit 8f0fc60b9233eaf3f46b00c3ea30d501019c5c73 fixes the flag issue.

I have added an additional commit 656c8f3d3f43d0df935a71d8739e96c55b650e2d that applies the same change everywhere
