### PR TITLE
LPS-178660 Classic FDS with selection type single does not show the radio button

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -202,8 +202,6 @@ const FrontendDataSet = ({
 		...currentViewProps
 	} = activeView;
 
-	const selectable = !!(bulkActions?.length && selectedItemsKey);
-
 	const requestData = useCallback(() => {
 		const activeFiltersOdataStrings = filters.reduce(
 			(activeFilters, filter) =>
@@ -761,7 +759,10 @@ const FrontendDataSet = ({
 				portletId,
 				searchParam,
 				selectItems,
-				selectable,
+				selectable: Boolean(
+					selectedItemsKey &&
+						(bulkActions?.length || selectionType === 'single')
+				),
 				selectedItemsKey,
 				selectedItemsValue,
 				selectionType,


### PR DESCRIPTION
### References

- [LPS-178660 Classic dataset with selection type single does not show the radio button](https://issues.liferay.com/browse/LPS-178660)

### What is the goal of this PR?

Regression bugfix.

The issue was caused by https://github.com/liferay/liferay-portal/commit/955abc4fa2a1471ebdf28217a01b8f36a9fb4049. After that commit, we are no longer unconditionally showing selection UI in `list` view. We show it only when it makes sense, when the right props are set. This is the `selectable` flag. We were already using that flag in the `table` visualization, now we are using it in `list` as well. The issue came from the fact that `list` visualization has single and multiple selection, while `table` has only multiple. That is why `selectable` flag was directly related to bulk actions. But, single selection UI does not require bulk action, as evidenced with few implementations in commerce. In this PR, we are changing to require bulk actions definition only on multiple selection.

### What does it look like?

See expected look in the linked JIRA ticket.

### Steps to reproduce

See steps in the linked JIRA ticket.