### PR TITLE
LPS-178775 | Automation FrontendDataSetViews#ErrorAppearsWhenNameBlank

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -6,7 +6,7 @@ definition {
 			locator1 = "ObjectField#ANY_DROPDOWN_LABEL");
 
 		Type(
-			locator1 = "ContentDashboard#SEARCH_FIELD",
+			locator1 = "FrontendDataSet#PROVIDER_SEARCH_FIELD",
 			value1 = ${key_provider});
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -144,6 +144,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>PROVIDER_SEARCH_FIELD</td>
+	<td>//div[contains(@class,'input-group-sm')]//div[@class='input-group-item']//*[contains(@class,'form-control input-group-inset input-group-inset-after')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FILTER_SEARCH_BUTTON</td>
 	<td>//div[@class='dropdown-menu show']//*[@type='button']//*[contains(@class,'lexicon-icon-search')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -65,13 +65,26 @@ definition {
 
 	}
 
-	@description = "Confirm the error message that appears when the user tries to create a data set view without the filled name"
-	@ignore = "Test Stub"
+	@description = "LPS-178775. Confirm the error message that appears when the user tries to create a data set view without the filled name"
 	@priority = 3
 	test ErrorAppearsWhenNameBlank {
+		task ("When the user goes to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO ErrorAppearsWhenNameBlank pending implementation JQuery enabled
+		task ("And filling the field name with 'Test Dataset'") {
+			FrontendDataSetAdmin.searchProvider(key_provider = "Test Dataset");
+		}
 
+		task ("And clicking on the Save button") {
+			PortletEntry.save();
+		}
+
+		task ("Then Confirm that 'This field is required' alert messages are present in the provider field") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#WARNING_FEEDBACK",
+				value1 = "This field is required.");
+		}
 	}
 
 	@description = "Confirm the error message that appears when the user tries to create a Data Set without the filled provider"


### PR DESCRIPTION
**Description**
Confirm the error message that appears when the user tries to create a data set view without the filled name.

**Steps**
- Given access Datasets admin page
// App Menu > Control Panel > Datasets
- When The user goes to add Datasets // clicking on the New dataset plus button
- And filling the field name with "Test Dataset"
//The Provider field remains unfilled
- And clicking on the Save button
- Then Confirm that "This field is required" alert messages are present in the provider field

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-178775