### PR TITLE
LPS-178773 | Added automation test FrontendDataSetViews#CanCreateDataSet

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -38,13 +38,26 @@ definition {
 
 	}
 
-	@description = "Confirm that the user can create a data set view"
-	@ignore = "Test Stub"
+	@description = "LPS-178773 Confirm that the user can create a data set view"
 	@priority = 5
 	test CanCreateDataSet {
+		task ("When Create a DataSet ") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Liferay Analytics Settings REST");
+		}
 
-		// TODO CanCreateDataSet pending implementation JQuery enabled
+		task ("Then Confirm the name as expected") {
+			AssertElementPresent(
+				key_itemName = "Test Dataset",
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+		}
 
+		task ("And Confirm the Provider as expected") {
+			AssertElementPresent(
+				key_itemName = "Channel (Liferay Analytics Settings REST v1.0)",
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+		}
 	}
 
 	@description = "Confirm that the user can create a dataset view via API"


### PR DESCRIPTION
Description:
Add automation test about datasets

Plan:
- Given and When goto Control Panel>Datasets / Add new dataset, plus button
- And when filling the field name with the name
- And When you choose the Provider called channel
- And When clicking on the Save button
- And Then Confirm the name as expected
- And Then Confirm the Provider as expected

JIRA Ticket:
https://issues.liferay.com/browse/LPS-178773
