### PR TITLE
LPS-178775 | Automation FrontendDataSetViews#ErrorAppearsWhenProviderBlank

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -65,13 +65,26 @@ definition {
 
 	}
 
-	@description = "Confirm the error message that appears when the user tries to create a data set view without the filled name"
-	@ignore = "Test Stub"
+	@description = "LPS-178775. Confirm the error message that appears when the user tries to create a data set view without the filled name"
 	@priority = 3
 	test ErrorAppearsWhenNameBlank {
+		task ("When the user goes to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO ErrorAppearsWhenNameBlank pending implementation JQuery enabled
+		task ("And filling the field name with 'Test Dataset'") {
+			PortletEntry.inputName(name = "Test Dataset");
+		}
 
+		task ("And clicking on the Save button") {
+			PortletEntry.save();
+		}
+
+		task ("Then Confirm that 'This field is required' alert messages are present in the provider field") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#WARNING_FEEDBACK",
+				value1 = "This field is required.");
+		}
 	}
 
 	@description = "Confirm the error message that appears when the user tries to create a Data Set without the filled provider"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -65,9 +65,18 @@ definition {
 
 	}
 
-	@description = "LPS-178775. Confirm the error message that appears when the user tries to create a data set view without the filled name"
+	@description = "LPS-178778. Confirm the error message that appears when the user tries to create a data set view without the filled name"
+	@ignore = "Test Stub"
 	@priority = 3
 	test ErrorAppearsWhenNameBlank {
+
+		// TODO ErrorAppearsWhenNameBlank pending implementation JQuery enabled
+
+	}
+
+	@description = "LPS-178775. Confirm the error message that appears when the user tries to create a Data Set without the filled provider"
+	@priority = 3
+	test ErrorAppearsWhenProviderBlank {
 		task ("When the user goes to add Datasets") {
 			LexiconEntry.gotoAdd();
 		}
@@ -85,15 +94,6 @@ definition {
 				locator1 = "Message#WARNING_FEEDBACK",
 				value1 = "This field is required.");
 		}
-	}
-
-	@description = "Confirm the error message that appears when the user tries to create a Data Set without the filled provider"
-	@ignore = "Test Stub"
-	@priority = 3
-	test ErrorAppearsWhenProviderBlank {
-
-		// TODO CannotExceed280Characters pending implementation JQuery enabled
-
 	}
 
 	@description = "Confirm that the user can cancel the creation of a data set view"


### PR DESCRIPTION
**Description**
Confirm the error message that appears when the user tries to create a data set view without the filled name.

**Steps**
- Given access Datasets admin page
- When The user goes to add Datasets // clicking on the New dataset plus button
- And filling the field name with "Test Dataset"
- And clicking on the Save button
- Then Confirm that "This field is required" alert messages are present in the provider field

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-178775