### PR TITLE
LPS-170287 Documents and Media - Wrong name is set when creating a folder with a lowercase

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FolderHorizontalCard.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/servlet/taglib/clay/FolderHorizontalCard.java
@@ -125,6 +125,11 @@ public class FolderHorizontalCard implements HorizontalCard {
 		return _rowChecker.isChecked(_folder);
 	}
 
+	@Override
+	public boolean isTranslated() {
+		return false;
+	}
+
 	private final DLPortletInstanceSettingsHelper
 		_dlPortletInstanceSettingsHelper;
 	private final Folder _folder;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/cards.jsp
@@ -582,7 +582,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 <clay:row>
 	<clay:col
 		id="simpleHorizontalCard"
-		md="4"
+		md="3"
 	>
 		<clay:horizontal-card
 			title="ReallySuperInsanelyJustIncrediblyLongAndTotallyNotPossibleWordButWeAreReallyTryingToCoverAllOurBasesHereJustInCaseSomeoneIsNutsAsPerUsual"
@@ -591,7 +591,7 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 
 	<clay:col
 		id="selectableHorizontalCard"
-		md="4"
+		md="3"
 	>
 		<clay:horizontal-card
 			actionDropdownItems="<%= cardsDisplayContext.getActionDropdownItems() %>"
@@ -603,10 +603,30 @@ ClaySampleUserCard claySampleUserCard = new ClaySampleUserCard();
 
 	<clay:col
 		id="modelHorizontalCard"
-		md="4"
+		md="2"
 	>
 		<clay:horizontal-card
 			horizontalCard="<%= new ClaySampleHorizontalCard() %>"
+		/>
+	</clay:col>
+
+	<clay:col
+		id="modelHorizontalCard"
+		md="2"
+	>
+		<clay:horizontal-card
+			title="a"
+			translated="<%= true %>"
+		/>
+	</clay:col>
+
+	<clay:col
+		id="modelHorizontalCard"
+		md="2"
+	>
+		<clay:horizontal-card
+			title="a"
+			translated="<%= false %>"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 13.3.1
+Bundle-Version: 13.4.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -83,5 +83,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "13.3.1"
+	"version": "13.4.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCard.java
@@ -25,4 +25,8 @@ public interface HorizontalCard extends BaseClayCard {
 
 	public String getTitle();
 
+	public default boolean isTranslated() {
+		return true;
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -79,9 +79,7 @@ public class HorizontalCardTag extends BaseCardTag {
 			title = horizontalCard.getTitle();
 		}
 
-		Boolean translated = isTranslated();
-
-		if (Boolean.TRUE.equals(translated)) {
+		if (isTranslated()) {
 			title = LanguageUtil.get(
 				TagResourceBundleUtil.getResourceBundle(pageContext), title);
 		}
@@ -90,14 +88,17 @@ public class HorizontalCardTag extends BaseCardTag {
 	}
 
 	public Boolean isTranslated() {
-		Boolean translated = _translated;
-		HorizontalCard horizontalCard = getHorizontalCard();
+		if (_translated == null) {
+			HorizontalCard horizontalCard = getHorizontalCard();
 
-		if ((_translated == null) && (horizontalCard != null)) {
-			translated = horizontalCard.isTranslated();
+			if (horizontalCard != null) {
+				return horizontalCard.isTranslated();
+			}
+
+			return true;
 		}
 
-		return translated;
+		return _translated;
 	}
 
 	public void setHorizontalCard(HorizontalCard horizontalCard) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -89,10 +89,6 @@ public class HorizontalCardTag extends BaseCardTag {
 		return title;
 	}
 
-	public Boolean getTranslated() {
-		return _translated;
-	}
-
 	public Boolean isTranslated() {
 		Boolean translated = _translated;
 		HorizontalCard horizontalCard = getHorizontalCard();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -73,15 +73,35 @@ public class HorizontalCardTag extends BaseCardTag {
 
 	public String getTitle() {
 		String title = _title;
-
 		HorizontalCard horizontalCard = getHorizontalCard();
 
 		if ((_title == null) && (horizontalCard != null)) {
 			title = horizontalCard.getTitle();
 		}
 
-		return LanguageUtil.get(
-			TagResourceBundleUtil.getResourceBundle(pageContext), title);
+		Boolean translated = isTranslated();
+
+		if (Boolean.TRUE.equals(translated)) {
+			title = LanguageUtil.get(
+				TagResourceBundleUtil.getResourceBundle(pageContext), title);
+		}
+
+		return title;
+	}
+
+	public Boolean getTranslated() {
+		return _translated;
+	}
+
+	public Boolean isTranslated() {
+		Boolean translated = _translated;
+		HorizontalCard horizontalCard = getHorizontalCard();
+
+		if ((_translated == null) && (horizontalCard != null)) {
+			translated = horizontalCard.isTranslated();
+		}
+
+		return translated;
 	}
 
 	public void setHorizontalCard(HorizontalCard horizontalCard) {
@@ -92,11 +112,16 @@ public class HorizontalCardTag extends BaseCardTag {
 		_title = title;
 	}
 
+	public void setTranslated(Boolean translated) {
+		_translated = translated;
+	}
+
 	@Override
 	protected void cleanUp() {
 		super.cleanUp();
 
 		_title = null;
+		_translated = null;
 	}
 
 	@Override
@@ -205,6 +230,10 @@ public class HorizontalCardTag extends BaseCardTag {
 		if ((href != null) && !disabled) {
 			LinkTag linkTag = new LinkTag();
 
+			if (isTranslated() != null) {
+				linkTag.setTranslated(isTranslated());
+			}
+
 			linkTag.setCssClass("text-truncate");
 			linkTag.setHref(href);
 
@@ -249,5 +278,6 @@ public class HorizontalCardTag extends BaseCardTag {
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:horizontal-card:";
 
 	private String _title;
+	private Boolean _translated;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -115,6 +115,10 @@ public class LinkTag extends BaseContainerTag {
 		return _small;
 	}
 
+	public boolean getTranslated() {
+		return _translated;
+	}
+
 	public String getType() {
 		return _type;
 	}
@@ -175,6 +179,10 @@ public class LinkTag extends BaseContainerTag {
 		_small = small;
 	}
 
+	public void setTranslated(boolean translated) {
+		_translated = translated;
+	}
+
 	public void setType(String type) {
 		_type = type;
 	}
@@ -200,6 +208,7 @@ public class LinkTag extends BaseContainerTag {
 		_monospaced = false;
 		_outline = false;
 		_small = false;
+		_translated = true;
 		_type = "link";
 		_weight = null;
 	}
@@ -312,9 +321,13 @@ public class LinkTag extends BaseContainerTag {
 			}
 
 			if (Validator.isNotNull(_label)) {
-				String label = LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_label);
+				String label = getLabel();
+
+				if (_translated) {
+					label = LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_label);
+				}
 
 				jspWriter.write(HtmlUtil.escape(label));
 			}
@@ -352,6 +365,7 @@ public class LinkTag extends BaseContainerTag {
 	private boolean _monospaced;
 	private boolean _outline;
 	private boolean _small;
+	private boolean _translated = true;
 	private String _type = "link";
 	private String _weight;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -951,6 +951,12 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
+		<attribute>
+			<description></description>
+			<name>translated</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
 	<tag>
@@ -1401,6 +1407,12 @@
 		<attribute>
 			<description></description>
 			<name>small</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>translated</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 7.3.0
+version 7.4.0


### PR DESCRIPTION
### References

- [LPS-170287 Fix all the things](https://issues.liferay.com/browse/LPS-170287)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/2917

### What is the goal of this PR?

We are fixing several issues from the previous version of PR:
- There were two getters for `translated`, `getTranslated` and `isTranslated`, with different implementations. This may have resulted in weird behaviors in different execution environments. We now have one getter,  `isTranslated`.
- The whole logic of `translated` setting priorities and defaults is now internal to `isTranslated`. When invoked from `getTitle`, we get a simple and final boolean.
- We are preserving the existing logic that translation is true by default. In the previous version of PR, this was correct for link label, but not for title. We are doing this while keeping the priorities in API:
  - the first priority is direct tag attribute `translated`
  - if direct tag attribute is not set, we are checking `horizontalCard` attribute, `horizontalCard.isTranslated()`
  - if neither if these are set, we are explicitly setting default to `true`.

There is no need for peer review on this PR, feel free to forward if CI is green.

/cc @thienquach87 @dsanz 

