### PR TITLE
LPS-178776 | Add CanChangePaginationInAdminPage Poshi test

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -38,4 +38,10 @@ definition {
 			value1 = ${key_type});
 	}
 
+	macro changePagination {
+		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
+
+		MenuItem.click(menuItem = ${itemsPerPage});
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -38,10 +38,4 @@ definition {
 			value1 = ${key_type});
 	}
 
-	macro changePagination {
-		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
-
-		MenuItem.click(menuItem = ${itemsPerPage});
-	}
-
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -34,28 +34,28 @@ definition {
 	test CanChangePaginationInAdminPage {
 		task ("Given create 6 data sets") {
 			FrontendDataSetAdmin.createDataSet(
-				key_type = "Channel",
-				key_name = "Test Dataset 1");
+				key_name = "Test Dataset 1",
+				key_type = "Channel");
 
 			FrontendDataSetAdmin.createDataSet(
-				key_type = "Account",
-				key_name = "Test Dataset 2");
+				key_name = "Test Dataset 2",
+				key_type = "Account");
 
 			FrontendDataSetAdmin.createDataSet(
-				key_type = "Cart",
-				key_name = "Test Dataset 3");
+				key_name = "Test Dataset 3",
+				key_type = "Cart");
 
 			FrontendDataSetAdmin.createDataSet(
-				key_type = "DataLayout",
-				key_name = "Test Dataset 4");
+				key_name = "Test Dataset 4",
+				key_type = "DataLayout");
 
 			FrontendDataSetAdmin.createDataSet(
-				key_type = "Diagram",
-				key_name = "Test Dataset 5");
+				key_name = "Test Dataset 5",
+				key_type = "Diagram");
 
 			FrontendDataSetAdmin.createDataSet(
-				key_type = "Form",
-				key_name = "Test Dataset 6");
+				key_name = "Test Dataset 6",
+				key_type = "Form");
 		}
 
 		task ("When changing the page to 4 entries") {
@@ -64,10 +64,11 @@ definition {
 
 		task ("Then confirm that only 4 entries are displayed") {
 			for (var num : list "1,2,3,4") {
-			AssertElementPresent(
-				locator1 = "FrontendDataSetAdmin#TABLE_CELL",
-				key_itemName = "Test Dataset ${num}");
-		}
+				AssertElementPresent(
+					key_itemName = "Test Dataset ${num}",
+					locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+			}
+
 			Pagination.viewResults(results = "Showing 1 to 4 of 6");
 		}
 
@@ -77,11 +78,12 @@ definition {
 
 		task ("Then 2 entries are displayed") {
 			for (var num : list "5,6") {
-			AssertElementPresent(
-				locator1 = "FrontendDataSetAdmin#TABLE_CELL",
-				key_itemName = "Test Dataset ${num}");
-		}
-		Pagination.viewResults(results = "Showing 5 to 6 of 6");
+				AssertElementPresent(
+					key_itemName = "Test Dataset ${num}",
+					locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+			}
+
+			Pagination.viewResults(results = "Showing 5 to 6 of 6");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -36,7 +36,7 @@ definition {
 			FrontendDataSetAdmin.canCreateDataSets(
 				key_type = "Channel",
 				name = "Test Dataset");
-			
+
 			FrontendDataSetAdmin.canCreateDataSets(
 				key_type = "Account",
 				name = "Test Dataset2");
@@ -55,7 +55,7 @@ definition {
 
 			FrontendDataSetAdmin.canCreateDataSets(
 				key_type = "Form",
-				name = "Test Dataset6");					
+				name = "Test Dataset6");
 		}
 
 		task ("When changing the page to 4 entries") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -30,12 +30,38 @@ definition {
 	}
 
 	@description = "Confirm that the user can change the pagination on the dataset admin page"
-	@ignore = "Test Stub"
 	@priority = 4
 	test CanChangePaginationInAdminPage {
+        task("Given create 6 data sets"){
+			for (var listDataSets : list "1,2,3,4,5,6") {
+				LexiconEntry.gotoAdd();
 
-		// TODO CanChangePaginationInAdminPage pending implementation JQuery enabled
+				PortletEntry.inputName(name = "Test Dataset");
 
+				FrontendDataSetAdmin.selectProvider(key_type = "Channel");
+
+				PortletEntry.save();
+		    }
+			task("When changing the page to 4 entries"){
+				ObjectPortlet.changePagination(itemsPerPage = "4 items");
+			}
+
+			task("Then confirm that only 4 entries are displayed "){
+				VerifyElementPresent(
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+				value1 = "Test Dataset");
+			}
+
+            task("When to switch to page 2 "){
+		        ObjectPortlet.checkAnyPage(pageNumber = 2);
+			}
+			
+			task(""){
+				VerifyElementPresent(
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+				value1 = "Test Dataset");
+			}
+		}
 	}
 
 	@description = "Confirm that the user can create a data set view"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -34,35 +34,32 @@ definition {
 	test CanChangePaginationInAdminPage {
 		task ("Given create 6 data sets") {
 			for (var listDataSets : list "1,2,3,4,5,6") {
-				LexiconEntry.gotoAdd();
-
-				PortletEntry.inputName(name = "Test Dataset");
-
-				FrontendDataSetAdmin.selectProvider(key_type = "Channel");
-
-				PortletEntry.save();
+				FrontendDataSetAdmin.canCreateDataSets(
+					name = "Test Dataset",
+					key_type = "Channel");
 			}
+		}	
 
-			task ("When changing the page to 4 entries") {
-				ObjectPortlet.changePagination(itemsPerPage = "4 items");
-			}
-
-			task ("Then confirm that only 4 entries are displayed") {
-				VerifyElementPresent(
-					locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-					value1 = "Test Dataset");
-			}
-
-			task ("When to switch to page 2") {
-				ObjectPortlet.checkAnyPage(pageNumber = 2);
-			}
-
-			task ("Then 2 entries are displayed") {
-				VerifyElementPresent(
-					locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-					value1 = "Test Dataset");
-			}
+		task ("When changing the page to 4 entries") {
+			ObjectPortlet.changePagination(itemsPerPage = "4 items");
 		}
+
+		task ("Then confirm that only 4 entries are displayed") {
+			VerifyElementPresent(
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+				value1 = "Test Dataset");
+		}
+
+		task ("When to switch to page 2") {
+			ObjectPortlet.checkAnyPage(pageNumber = 2);
+		}
+
+		task ("Then 2 entries are displayed") {
+			VerifyElementPresent(
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+				value1 = "Test Dataset");
+		}
+		
 	}
 
 	@description = "Confirm that the user can create a data set view"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -33,49 +33,55 @@ definition {
 	@priority = 4
 	test CanChangePaginationInAdminPage {
 		task ("Given create 6 data sets") {
-			FrontendDataSetAdmin.canCreateDataSets(
+			FrontendDataSetAdmin.createDataSet(
 				key_type = "Channel",
-				name = "Test Dataset");
+				key_name = "Test Dataset 1");
 
-			FrontendDataSetAdmin.canCreateDataSets(
+			FrontendDataSetAdmin.createDataSet(
 				key_type = "Account",
-				name = "Test Dataset2");
+				key_name = "Test Dataset 2");
 
-			FrontendDataSetAdmin.canCreateDataSets(
+			FrontendDataSetAdmin.createDataSet(
 				key_type = "Cart",
-				name = "Test Dataset3");
+				key_name = "Test Dataset 3");
 
-			FrontendDataSetAdmin.canCreateDataSets(
+			FrontendDataSetAdmin.createDataSet(
 				key_type = "DataLayout",
-				name = "Test Dataset4");
+				key_name = "Test Dataset 4");
 
-			FrontendDataSetAdmin.canCreateDataSets(
+			FrontendDataSetAdmin.createDataSet(
 				key_type = "Diagram",
-				name = "Test Dataset5");
+				key_name = "Test Dataset 5");
 
-			FrontendDataSetAdmin.canCreateDataSets(
+			FrontendDataSetAdmin.createDataSet(
 				key_type = "Form",
-				name = "Test Dataset6");
+				key_name = "Test Dataset 6");
 		}
 
 		task ("When changing the page to 4 entries") {
-			ObjectPortlet.changePagination(itemsPerPage = "4 items");
+			FrontendDataSetAdmin.changePagination(itemsPerPage = "4 items");
 		}
 
 		task ("Then confirm that only 4 entries are displayed") {
-			VerifyElementPresent(
-				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-				value1 = "Test Dataset");
+			for (var num : list "1,2,3,4") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL",
+				key_itemName = "Test Dataset ${num}");
+		}
+			Pagination.viewResults(results = "Showing 1 to 4 of 6");
 		}
 
 		task ("When to switch to page 2") {
-			ObjectPortlet.checkAnyPage(pageNumber = 2);
+			Click(locator1 = "Pagination#NEXT_LINK");
 		}
 
 		task ("Then 2 entries are displayed") {
-			VerifyElementPresent(
-				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-				value1 = "Test Dataset");
+			for (var num : list "5,6") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL",
+				key_itemName = "Test Dataset ${num}");
+		}
+		Pagination.viewResults(results = "Showing 5 to 6 of 6");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -35,10 +35,10 @@ definition {
 		task ("Given create 6 data sets") {
 			for (var listDataSets : list "1,2,3,4,5,6") {
 				FrontendDataSetAdmin.canCreateDataSets(
-					name = "Test Dataset",
-					key_type = "Channel");
+					key_type = "Channel",
+					name = "Test Dataset");
 			}
-		}	
+		}
 
 		task ("When changing the page to 4 entries") {
 			ObjectPortlet.changePagination(itemsPerPage = "4 items");
@@ -59,7 +59,6 @@ definition {
 				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
 				value1 = "Test Dataset");
 		}
-		
 	}
 
 	@description = "Confirm that the user can create a data set view"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -33,11 +33,29 @@ definition {
 	@priority = 4
 	test CanChangePaginationInAdminPage {
 		task ("Given create 6 data sets") {
-			for (var listDataSets : list "1,2,3,4,5,6") {
-				FrontendDataSetAdmin.canCreateDataSets(
-					key_type = "Channel",
-					name = "Test Dataset");
-			}
+			FrontendDataSetAdmin.canCreateDataSets(
+				key_type = "Channel",
+				name = "Test Dataset");
+			
+			FrontendDataSetAdmin.canCreateDataSets(
+				key_type = "Account",
+				name = "Test Dataset2");
+
+			FrontendDataSetAdmin.canCreateDataSets(
+				key_type = "Cart",
+				name = "Test Dataset3");
+
+			FrontendDataSetAdmin.canCreateDataSets(
+				key_type = "DataLayout",
+				name = "Test Dataset4");
+
+			FrontendDataSetAdmin.canCreateDataSets(
+				key_type = "Diagram",
+				name = "Test Dataset5");
+
+			FrontendDataSetAdmin.canCreateDataSets(
+				key_type = "Form",
+				name = "Test Dataset6");					
 		}
 
 		task ("When changing the page to 4 entries") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -47,17 +47,17 @@ definition {
 				ObjectPortlet.changePagination(itemsPerPage = "4 items");
 			}
 
-			task ("Then confirm that only 4 entries are displayed ") {
+			task ("Then confirm that only 4 entries are displayed") {
 				VerifyElementPresent(
 					locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
 					value1 = "Test Dataset");
 			}
 
-			task ("When to switch to page 2 ") {
+			task ("When to switch to page 2") {
 				ObjectPortlet.checkAnyPage(pageNumber = 2);
 			}
 
-			task ("") {
+			task ("Then 2 entries are displayed") {
 				VerifyElementPresent(
 					locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
 					value1 = "Test Dataset");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -32,7 +32,7 @@ definition {
 	@description = "Confirm that the user can change the pagination on the dataset admin page"
 	@priority = 4
 	test CanChangePaginationInAdminPage {
-        task("Given create 6 data sets"){
+		task ("Given create 6 data sets") {
 			for (var listDataSets : list "1,2,3,4,5,6") {
 				LexiconEntry.gotoAdd();
 
@@ -41,25 +41,26 @@ definition {
 				FrontendDataSetAdmin.selectProvider(key_type = "Channel");
 
 				PortletEntry.save();
-		    }
-			task("When changing the page to 4 entries"){
+			}
+
+			task ("When changing the page to 4 entries") {
 				ObjectPortlet.changePagination(itemsPerPage = "4 items");
 			}
 
-			task("Then confirm that only 4 entries are displayed "){
+			task ("Then confirm that only 4 entries are displayed ") {
 				VerifyElementPresent(
-				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-				value1 = "Test Dataset");
+					locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+					value1 = "Test Dataset");
 			}
 
-            task("When to switch to page 2 "){
-		        ObjectPortlet.checkAnyPage(pageNumber = 2);
+			task ("When to switch to page 2 ") {
+				ObjectPortlet.checkAnyPage(pageNumber = 2);
 			}
-			
-			task(""){
+
+			task ("") {
 				VerifyElementPresent(
-				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-				value1 = "Test Dataset");
+					locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
+					value1 = "Test Dataset");
 			}
 		}
 	}


### PR DESCRIPTION
Description:
Add automation test about datasets

Plan:

Given create 6 data sets
//using API or via UI
When changing the page to 4 entries
Then confirm that only 4 entries are displayed 
When to switch to page 2 
Then 2 entries are displayed.

JIRA Ticket:
https://issues.liferay.com/browse/LPS-178776