### PR TITLE
LPS-177322 Fix display of Objects headless resources in FDS View Manager

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Comparator;
 import java.util.List;
@@ -88,13 +89,27 @@ public class FDSViewsDisplayContext {
 				).put(
 					"entityClassName", fdsHeadlessResource.getEntityClassName()
 				).put(
-					"name", fdsHeadlessResource.getName()
+					"name", _getName(fdsHeadlessResource)
 				).put(
 					"version", fdsHeadlessResource.getVersion()
 				));
 		}
 
 		return jsonArray;
+	}
+
+	private String _getName(FDSHeadlessResource fdsHeadlessResource) {
+		String name = fdsHeadlessResource.getName();
+
+		if (name.startsWith("ObjectEntry")) {
+			String[] nameParts = StringUtil.split(name, "#C_");
+
+			if (nameParts.length == 2) {
+				return nameParts[1];
+			}
+		}
+
+		return name;
 	}
 
 	private final PortletRequest _portletRequest;


### PR DESCRIPTION
### References

- [LPS-177322 Fix display of Objects headless resources in FDS View Manager](https://issues.liferay.com/browse/LPS-177322)
- followup on https://github.com/liferay-frontend/liferay-portal/pull/3131

### What is the goal of this PR?

No changes in code from previous PR. I just set the wrong LPS on commit, so I'm resending. 

**No need for peer review on this PR.**

### What does it look like?

#### Before PR
![before](https://user-images.githubusercontent.com/5435511/225666544-e6da06a7-ed04-4651-8dce-12e0042f5db5.png)

#### After PR
![after](https://user-images.githubusercontent.com/5435511/225666567-4b8e656d-19c3-4839-9c2b-602717de9f94.png)

### Steps to reproduce

1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`. This enables FDS Views Manager.
1. Open Global Menu > Control Panel > Object > Datasets