### PR TITLE
LPS-178779 | Automation for FrontendDataSetViews#CannotExceed280Characters

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -10,4 +10,14 @@ definition {
 			value1 = ${key_provider});
 	}
 
+	macro selectProvider {
+		Click(
+			dropdownLabel = "Choose an Option",
+			locator1 = "ObjectField#ANY_DROPDOWN_LABEL");
+
+		Click(
+			locator1 = "FrontendDataSet#SELECT_TYPE_PROVIDER",
+			value1 = ${key_type});
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -144,6 +144,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SELECT_TYPE_PROVIDER</td>
+	<td>//button[@class="dropdown-item"]//span[contains(.,'${key_type}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FILTER_SEARCH_BUTTON</td>
 	<td>//div[@class='dropdown-menu show']//*[@type='button']//*[contains(@class,'lexicon-icon-search')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -60,9 +60,27 @@ definition {
 	@ignore = "Test Stub"
 	@priority = 3
 	test CannotExceed280Characters {
+		task ("When the user goes to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO CannotExceed280Characters pending implementation JQuery enabled
+		task ("When a user types a name that is more than 280 characters") {
+			PortletEntry.inputName(name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam fermentum, est sed varius porttitor, odio tortor commodo ligula, quis auctor nulla massa ut eros. Vestibulum in eros maximus quam gravida dapibus. Proin vitae mi diam. Duis iaculis, nisi quis pharetra varius, arcu eros bibendum turpis, nec posuere nibh arcu id orci.");
+		}
 
+		task ("And choose the provider named Channel") {
+			FrontendDataSetAdmin.selectProvider(key_type = "Channel");
+		}
+
+		task ("And clicking on the Save button") {
+			Button.clickSave();
+		}
+
+		task ("Then Confirm that alert messages are present") {
+			AssertTextPresent(
+				locator1 = "Message#ERROR",
+				value1 = "Your request failed to complete.");
+		}
 	}
 
 	@description = "LPS-178778. Confirm the error message that appears when the user tries to create a data set view without the filled name"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -57,7 +57,6 @@ definition {
 	}
 
 	@description = "Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
-	@ignore = "Test Stub"
 	@priority = 3
 	test CannotExceed280Characters {
 		task ("When the user goes to add Datasets") {


### PR DESCRIPTION
**Description**
Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field.

**Steps**
- Given access Datasets admin page
- When The user goes to add Datasets
- When a user types a name that is more than 280 characters
- And choose the provider named Channel
- And clicking on the Save button
- Then Confirm that alert messages are present 

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-178779