### PR TITLE
LPS-178778 | FrontendDataSetViews#ErrorAppearsWhenNameBlank

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -10,4 +10,14 @@ definition {
 			value1 = ${key_provider});
 	}
 
+	macro selectProvider {
+		Click(
+			dropdownLabel = "Choose an Option",
+			locator1 = "ObjectField#ANY_DROPDOWN_LABEL");
+
+		Click(
+			locator1 = "FrontendDataSet#SELECT_TYPE_PROVIDER",
+			value1 = ${key_type});
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -144,6 +144,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SELECT_TYPE_PROVIDER</td>
+	<td>//button[@class="dropdown-item"]//span[contains(.,'${key_type}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FILTER_SEARCH_BUTTON</td>
 	<td>//div[@class='dropdown-menu show']//*[@type='button']//*[contains(@class,'lexicon-icon-search')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -66,12 +66,25 @@ definition {
 	}
 
 	@description = "LPS-178778. Confirm the error message that appears when the user tries to create a data set view without the filled name"
-	@ignore = "Test Stub"
 	@priority = 3
 	test ErrorAppearsWhenNameBlank {
+		task ("When the user goes to add Datasets") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO ErrorAppearsWhenNameBlank pending implementation JQuery enabled
+		task ("And choose the Provider called channel") {
+			FrontendDataSetAdmin.selectProvider(key_type = "Channel");
+		}
 
+		task ("And clicking on the Save button") {
+			Button.clickSave();
+		}
+
+		task ("Then Confirm that 'This field is required' alert messages are present in the provider field") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#WARNING_FEEDBACK",
+				value1 = "This field is required.");
+		}
 	}
 
 	@description = "LPS-178775. Confirm the error message that appears when the user tries to create a Data Set without the filled provider"


### PR DESCRIPTION
**Description**
Confirm the error message that appears when the user tries to create a Data Set without the filled provider.

**Steps**
- Given access Datasets admin page
- When The user goes to add 
- And choose the Provider called channel
- And clicking on the Save button
- Then Confirm that "This field is required" alert messages are present in the name field

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-178778