### PR TITLE
LPS-178655 | Fix accessibility issues on modals and popovers, prevent from losing focus

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_event_recorder.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_event_recorder.js
@@ -477,6 +477,78 @@ AUI.add(
 						!!schedulerEvent
 					);
 
+					const idPopoverBB = popoverBB._node.getAttribute('id');
+
+					let focusableElements;
+					const keysPressed = {};
+
+					const setFocusableElemeents = () => {
+						if (!focusableElements) {
+							focusableElements = [
+								...document
+									.getElementById(idPopoverBB)
+									.querySelectorAll(
+										'a[href], button, input:not([type="hidden"]), textarea, select, details, [tabindex]:not([tabindex="-1"])'
+									),
+							].filter(
+								(element) =>
+									!element.hasAttribute('disabled') &&
+									!element.getAttribute('aria-hidden') &&
+									!element.classList.contains('hide')
+							);
+						}
+					};
+
+					popoverBB.delegate(
+						'keydown',
+						(event) => {
+							keysPressed[event.keyCode] = true;
+
+							setFocusableElemeents();
+
+							const lastIndexElem = focusableElements.length - 1;
+							const isTabPressed =
+								event.keyCode === A.Event.KeyMap.TAB ||
+								keysPressed[A.Event.KeyMap.TAB];
+							const isShiftPressed =
+								event.keyCode === A.Event.KeyMap.SHIFT ||
+								keysPressed[A.Event.KeyMap.SHIFT];
+							const isForwardNavigation =
+								isTabPressed && !isShiftPressed;
+							const isBackwardNavigation =
+								isTabPressed && isShiftPressed;
+
+							if (isForwardNavigation) {
+								const isLastFocusableElement =
+									focusableElements &&
+									focusableElements[lastIndexElem] ===
+										event.target._node;
+								if (isLastFocusableElement) {
+									focusableElements[0].focus();
+									event.preventDefault();
+								}
+							}
+							else if (isBackwardNavigation) {
+								const isFirstFocusableElement =
+									focusableElements &&
+									focusableElements[0] === event.target._node;
+								if (isFirstFocusableElement) {
+									focusableElements[lastIndexElem].focus();
+									event.preventDefault();
+								}
+							}
+						},
+						'#' + idPopoverBB
+					);
+
+					popoverBB.delegate(
+						'keyup',
+						(event) => {
+							delete keysPressed[event.keyCode];
+						},
+						'#' + idPopoverBB
+					);
+
 					const calendarContainer = instance.get('calendarContainer');
 
 					const defaultCalendar = calendarContainer.get(

--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.109"
+String alloyUIVersion = "3.1.0-deprecated.111"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.109"
+String alloyUIVersion = "3.1.0-deprecated.111"
 
 String fontAwesomeVersion = "3.2.1"
 


### PR DESCRIPTION
Steps to reproduce:

1. Add a calendar widget in the default site
2. Add an event
3. Start the windows reader
4. Once you get into the event with the TAB, hit enter to open it in order to edit it
5. Move with the TAB through the calendar edit pop over and you can navigate behind it