### PR TITLE
LPS-179109 ActionLinkRender never finds actionId

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -45,7 +45,11 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 
 		return fdsTableSchemaBuilder.add(
 			"id", "id",
-			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
+			fdsTableSchemaField -> {
+				fdsTableSchemaField.setActionId("sampleEditMessage");
+				fdsTableSchemaField.setContentRenderer("actionLink");
+				fdsTableSchemaField.setSortable(true);
+			}
 		).add(
 			"title", "title",
 			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/data_renderers/ActionLinkRenderer.js
@@ -35,7 +35,7 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 	}
 
 	let currentAction = options?.actionId
-		? actions.find((action) => action.id === options.actionId)
+		? actions.find((action) => action.data?.id === options.actionId)
 		: actions[0];
 
 	if (!currentAction) {


### PR DESCRIPTION
### References

- [LPS-179109 Fix all the things](https://issues.liferay.com/browse/LPS-179109)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/3155

### What is the goal of this PR?

Added a sample for the case in the bug.

### What does it look like?

![screen](https://user-images.githubusercontent.com/5435511/227254123-7d0d4c70-382f-4be3-8562-13bc2b364a20.png)

### Steps to reproduce

1. Deploy `frontend-data-set-sample-web`.
2. Place `Frontend Data Set Sample` widget on any page.