### PR TITLE
LPS-178039 | Story Automation - Delete FDS Entry

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
@@ -1,3 +1,5 @@
+const isRTL = document.documentElement.classList.contains('rtl');
+
 const buttonElement = fragmentElement.querySelector('.btn');
 const dropdownElement = fragmentElement.querySelector('.dropdown-menu');
 const optionListElement = fragmentElement.querySelector('.list-unstyled');
@@ -396,7 +398,10 @@ function repositionDropdownElement() {
 	}
 
 	dropdownElement.style.transform = `
-		translateX(${uiInputRect.left + window.scrollX}px)
+		translateX(${
+			(isRTL ? uiInputRect.right - window.innerWidth : uiInputRect.left) +
+			window.scrollX
+		}px)
 		translateY(${uiInputRect.bottom + window.scrollY}px)
 	`;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -18,6 +18,16 @@ definition {
 		PortletEntry.save();
 	}
 
+	macro deleteDataSet {
+		Click(
+			key_entry = ${entry},
+			locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+		AssertElementPresent(locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+	}
+
 	macro searchProvider {
 		Click(
 			dropdownLabel = "Choose an Option",
@@ -36,12 +46,6 @@ definition {
 		Click(
 			locator1 = "FrontendDataSet#SELECT_TYPE_PROVIDER",
 			value1 = ${key_type});
-	}
-
-	macro changePagination {
-		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
-
-		MenuItem.click(menuItem = ${itemsPerPage});
 	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -38,4 +38,10 @@ definition {
 			value1 = ${key_type});
 	}
 
+	macro changePagination {
+		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
+
+		MenuItem.click(menuItem = ${itemsPerPage});
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -25,7 +25,9 @@ definition {
 
 		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
 
-		AssertElementPresent(locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+		AssertElementPresent(
+			key_modalText = ${modalText},
+			locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 	}
 
 	macro searchProvider {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -26,8 +26,10 @@ definition {
 		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
 
 		AssertElementPresent(
-			key_modalText = ${modalText},
+			key_modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
 			locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+
+		Button.clickDelete();
 	}
 
 	macro searchProvider {

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/macros/JSONTestray.macro
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/macros/JSONTestray.macro
@@ -159,6 +159,7 @@ definition {
 		var requirementId = JSONTestrayAPI.createRequirementAPI(
 			componentId = ${componentId},
 			linkTitle = ${linkTitle},
+			linkURL = ${linkURL},
 			projectId = ${projectId},
 			requirementName = ${requirementName});
 	}

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/macros/TestrayFilter.macro
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/macros/TestrayFilter.macro
@@ -49,4 +49,10 @@ definition {
 		Button.click(button = "Apply");
 	}
 
+    macro assertNoResultsFound {
+		AssertTextEquals(
+			locator1 = "Message#EMPTY_STATE_INFO",
+			value1 = "No Results Found");
+	}
+
 }

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/macros/TestrayFilter.macro
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/macros/TestrayFilter.macro
@@ -8,6 +8,12 @@ definition {
 		}
 	}
 
+	macro assertNoResultsFound {
+		AssertTextEquals(
+			locator1 = "Message#EMPTY_STATE_INFO",
+			value1 = "No Results Found");
+	}
+
 	macro clickColumn {
 		Click(locator1 = "TestrayFilter#COLUMNS_ICON");
 	}
@@ -47,12 +53,6 @@ definition {
 		}
 
 		Button.click(button = "Apply");
-	}
-
-    macro assertNoResultsFound {
-		AssertTextEquals(
-			locator1 = "Message#EMPTY_STATE_INFO",
-			value1 = "No Results Found");
 	}
 
 }

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -19,36 +19,36 @@ definition {
 
 			User.firstLoginPG();
 
-			// Testray.addTR2Site(siteName = ${testSiteName});
+			Testray.addTR2Site(siteName = ${testSiteName});
 		}
 
-		// task ("create all objects: projects, teams, components, requirements") {
-		// 	JSONTestray.addProject(
-		// 		projectDescription = "Project Description 1",
-		// 		projectName = ${projectName});
+		task ("create all objects: projects, teams, components, requirements") {
+			JSONTestray.addProject(
+				projectDescription = "Project Description 1",
+				projectName = ${projectName});
 
-		// 	JSONTestray.addTeam(
-		// 		projectName = ${projectName},
-		// 		teamName = ${teamName});
+			JSONTestray.addTeam(
+				projectName = ${projectName},
+				teamName = ${teamName});
 
-		// 	JSONTestray.addComponent(
-		// 		componentName = ${componentName},
-		// 		projectName = ${projectName},
-		// 		teamName = ${teamName});
+			JSONTestray.addComponent(
+				componentName = ${componentName},
+				projectName = ${projectName},
+				teamName = ${teamName});
 
-        //     JSONTestray.addRequirement(
-		// 		componentName = ${componentName},
-		// 		linkTitle = "The front page of the internet",
-		// 		projectName = ${projectName},
-		// 		requirementName = "Requirement 1");
+            JSONTestray.addRequirement(
+				componentName = ${componentName},
+				linkTitle = "The front page of the internet",
+				projectName = ${projectName},
+				requirementName = "Requirement 1");
 
-        //       JSONTestray.addRequirement(
-		// 		componentName = ${componentName},
-		// 		linkTitle = "Page of the internet 2",
-        //         linkURL = "https://reddit.com",
-		// 		projectName = ${projectName},
-		// 		requirementName = "Requirement 2");
-		// }
+              JSONTestray.addRequirement(
+				componentName = ${componentName},
+				linkTitle = "Page of the internet 2",
+                linkURL = "https://reddit.com",
+				projectName = ${projectName},
+				requirementName = "Requirement 2");
+		}
 
 		task ("Go to the Requirements page") {
 			ApplicationsMenu.gotoSite(site = ${testSiteName});
@@ -63,21 +63,21 @@ definition {
 		}
 	}
 
-	// tearDown {
-	// 	var testPortalInstance = PropsUtil.get("test.portal.instance");
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-	// 	JSONTestrayAPI.deleteObjectViaAPI(
-	// 		object = "teams",
-	// 		objectName = ${teamName});
+		JSONTestrayAPI.deleteObjectViaAPI(
+			object = "teams",
+			objectName = ${teamName});
 
-	// 	JSONTestrayAPI.deleteProject(projectName = ${projectName});
+		JSONTestrayAPI.deleteProject(projectName = ${projectName});
 
-	// 	Testray.testrayApisTearDown();
+		Testray.testrayApisTearDown();
 
-	// 	if (${testPortalInstance} == "true") {
-	// 		PortalInstances.tearDownCP();
-	// 	}
-	// }
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
 
 	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by link"
 	@priority = 5
@@ -122,6 +122,25 @@ definition {
 			Testray.assertItemName(key_name = "Requirement 1");
 
 			Testray.assertItemNotPresent(key_name = "Requirement 2");
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should not see case that don't exist when I try filtering for them"
+	@priority = 4
+	test AdminCanFilterForNonexistantRequirements {
+		task ("When the user filters a requirement by its non-existent name") {
+			TestrayFilter.clickFilter();
+
+			Type(
+				key_fieldLabel = "Summary",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
+				value1 = "Requirement 3");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see message no results found") {
+			TestrayFilter.assertNoResultsFound();
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -187,4 +187,27 @@ definition {
 		}
 	}
 
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by team"
+	@priority = 5
+	test AdminCanFilterRequirementsByTeam {
+		task ("When the user filter a requirement by team") {
+			TestrayFilter.clickFilter();
+
+			TestrayFilter.multiSelect(
+				header = "Team",
+				label = "Team",
+				listMultiSelect = "Team 1");
+
+			TestrayFilter.assertMultiSelect(
+				label = "Team",
+				listMultiSelect = "Team 1");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see the team selected in the table") {
+			Testray.assertItemName(key_name = "Team 1");
+		}
+	}
+
 }

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -1,0 +1,107 @@
+@component-name = "portal-solutions"
+definition {
+
+	property custom.properties = "feature.flag.LPS-163118=true";
+	property osgi.modules.includes = "site-initializer-testray";
+	property portal.release = "false";
+	property portal.upstream = "true";
+	property release.feature.flags.disable.DISABLE_PRIVATE_LAYOUTS = "true";
+	property testray.main.component.name = "Site Initializer Testray";
+
+	var componentName = "Component 1";
+	var projectName = "Project 1";
+	var teamName = "Team 1";
+	var testSiteName = "Testray 2";
+
+	setUp {
+		task ("Login and create a Testray Site") {
+			TestCase.setUpPortalInstance();
+
+			User.firstLoginPG();
+
+			Testray.addTR2Site(siteName = ${testSiteName});
+		}
+
+		task ("create all objects: projects, teams, components, requirements") {
+			JSONTestray.addProject(
+				projectDescription = "Project Description 1",
+				projectName = ${projectName});
+
+			JSONTestray.addTeam(
+				projectName = ${projectName},
+				teamName = ${teamName});
+
+			JSONTestray.addComponent(
+				componentName = ${componentName},
+				projectName = ${projectName},
+				teamName = ${teamName});
+
+            JSONTestray.addRequirement(
+				componentName = ${componentName},
+				linkTitle = "The front page of the internet",
+				projectName = ${projectName},
+				requirementName = "Requirement 1");
+
+              JSONTestray.addRequirement(
+				componentName = ${componentName},
+				linkTitle = "Page of the internet 2",
+                linkURL = "https://reddit.com",
+				projectName = ${projectName},
+				requirementName = "Requirement 2");
+		}
+
+		task ("Go to the Requirements page") {
+			ApplicationsMenu.gotoSite(site = ${testSiteName});
+
+			Testray.changePagination(
+				numberItems = 20,
+				valuePagination = 150);
+
+			Testray.goToProjectPage(projectName = ${projectName});
+
+			Testray.projectTabNavigator(navTabName = "Requirements");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		JSONTestrayAPI.deleteObjectViaAPI(
+			object = "teams",
+			objectName = ${teamName});
+
+		JSONTestrayAPI.deleteProject(projectName = ${projectName});
+
+		Testray.testrayApisTearDown();
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by link"
+	@priority = 5
+	test AdminCanFilterRequirementsByLink {
+		task ("When the user filter a requirement by link") {
+			TestrayFilter.clickFilter();
+
+			Type(
+				key_fieldLabel = "Link",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
+				value1 = "google");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see the filters apply in the list by name") {
+			TestrayRequirements.verifyRequirement(
+				linkTitle = "The front page of the internet",
+				requirementComponent = "Component 1",
+				requirementSummary = "Requirement 1",
+				requirementTeam = "Team 1");
+
+			Testray.assertItemNotPresent(key_name = "Requirement 2");
+		}
+	}
+
+}

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -36,16 +36,16 @@ definition {
 				projectName = ${projectName},
 				teamName = ${teamName});
 
-            JSONTestray.addRequirement(
+			JSONTestray.addRequirement(
 				componentName = ${componentName},
 				linkTitle = "The front page of the internet",
 				projectName = ${projectName},
 				requirementName = "Requirement 1");
 
-              JSONTestray.addRequirement(
+			JSONTestray.addRequirement(
 				componentName = ${componentName},
 				linkTitle = "Page of the internet 2",
-                linkURL = "https://reddit.com",
+				linkURL = "https://reddit.com",
 				projectName = ${projectName},
 				requirementName = "Requirement 2");
 		}
@@ -76,6 +76,48 @@ definition {
 
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should not see requirement that don't exist when I try filtering for them"
+	@priority = 4
+	test AdminCanFilterForNonexistantRequirements {
+		task ("When the user filters a requirement by its non-existent name") {
+			TestrayFilter.clickFilter();
+
+			Type(
+				key_fieldLabel = "Summary",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
+				value1 = "Requirement 3");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see message no results found") {
+			TestrayFilter.assertNoResultsFound();
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by component"
+	@priority = 5
+	test AdminCanFilterRequirementsByComponent {
+		task ("When the user filter a requirement by component") {
+			TestrayFilter.clickFilter();
+
+			TestrayFilter.multiSelect(
+				header = "Component",
+				label = "Component",
+				listMultiSelect = "Component 1");
+
+			TestrayFilter.assertMultiSelect(
+				label = "Component",
+				listMultiSelect = "Component 1");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see the component selected in the table") {
+			Testray.assertItemName(key_name = "Component 1");
 		}
 	}
 
@@ -122,68 +164,6 @@ definition {
 			Testray.assertItemName(key_name = "Requirement 1");
 
 			Testray.assertItemNotPresent(key_name = "Requirement 2");
-		}
-	}
-
-	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should not see requirement that don't exist when I try filtering for them"
-	@priority = 4
-	test AdminCanFilterForNonexistantRequirements {
-		task ("When the user filters a requirement by its non-existent name") {
-			TestrayFilter.clickFilter();
-
-			Type(
-				key_fieldLabel = "Summary",
-				locator1 = "TextInput#GENERIC_TEXT_INPUT",
-				value1 = "Requirement 3");
-
-			Button.click(button = "Apply");
-		}
-
-		task ("Then can see message no results found") {
-			TestrayFilter.assertNoResultsFound();
-		}
-	}
-
-	@description = "Story ID: LPS-173519 | Test Summary: Verify that can search for a field"
-	@priority = 5
-	test AdminCanSearchForField {
-		task ("When the user search field called link") {
-			TestrayFilter.clickFilter();
-
-			TestrayFilter.searchFilter(value = "Link");
-		}
-
-		task ("Then can see the field called link and do not see the field key") {
-			AssertElementPresent(
-				key_fieldLabel = "Link",
-				locator1 = "TextInput#GENERIC_TEXT_INPUT");
-
-            AssertElementNotPresent(
-				key_fieldLabel = "Key",
-				locator1 = "TextInput#GENERIC_TEXT_INPUT");
-		}
-	}
-
-	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by component"
-	@priority = 5
-	test AdminCanFilterRequirementsByComponent {
-		task ("When the user filter a requirement by component") {
-			TestrayFilter.clickFilter();
-
-			TestrayFilter.multiSelect(
-				header = "Component",
-				label = "Component",
-				listMultiSelect = "Component 1");
-
-			TestrayFilter.assertMultiSelect(
-				label = "Component",
-				listMultiSelect = "Component 1");
-
-			Button.click(button = "Apply");
-		}
-
-		task ("Then can see the component selected in the table") {
-			Testray.assertItemName(key_name = "Component 1");
 		}
 	}
 
@@ -242,6 +222,26 @@ definition {
 				requirementTeam = "Team 1");
 
 			Testray.assertItemNotPresent(key_name = "Requirement 2");
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify that can search for a field"
+	@priority = 5
+	test AdminCanSearchForField {
+		task ("When the user search field called link") {
+			TestrayFilter.clickFilter();
+
+			TestrayFilter.searchFilter(value = "Link");
+		}
+
+		task ("Then can see the field called link and do not see the field key") {
+			AssertElementPresent(
+				key_fieldLabel = "Link",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT");
+
+			AssertElementNotPresent(
+				key_fieldLabel = "Key",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT");
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -164,4 +164,27 @@ definition {
 		}
 	}
 
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by component"
+	@priority = 5
+	test AdminCanFilterRequirementsByComponent {
+		task ("When the user filter a requirement by component") {
+			TestrayFilter.clickFilter();
+
+			TestrayFilter.multiSelect(
+				header = "Component",
+				label = "Component",
+				listMultiSelect = "Component 1");
+
+			TestrayFilter.assertMultiSelect(
+				label = "Component",
+				listMultiSelect = "Component 1");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see the component selected in the table") {
+			Testray.assertItemName(key_name = "Component 1");
+		}
+	}
+
 }

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -125,7 +125,7 @@ definition {
 		}
 	}
 
-	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should not see case that don't exist when I try filtering for them"
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should not see requirement that don't exist when I try filtering for them"
 	@priority = 4
 	test AdminCanFilterForNonexistantRequirements {
 		task ("When the user filters a requirement by its non-existent name") {
@@ -141,6 +141,26 @@ definition {
 
 		task ("Then can see message no results found") {
 			TestrayFilter.assertNoResultsFound();
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify that can search for a field"
+	@priority = 5
+	test AdminCanSearchForField {
+		task ("When the user search field called link") {
+			TestrayFilter.clickFilter();
+
+			TestrayFilter.searchFilter(value = "Link");
+		}
+
+		task ("Then can see the field called link and don not see the field key") {
+			AssertElementPresent(
+				key_fieldLabel = "Link",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT");
+
+            AssertElementNotPresent(
+				key_fieldLabel = "Key",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT");
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -153,7 +153,7 @@ definition {
 			TestrayFilter.searchFilter(value = "Link");
 		}
 
-		task ("Then can see the field called link and don not see the field key") {
+		task ("Then can see the field called link and do not see the field key") {
 			AssertElementPresent(
 				key_fieldLabel = "Link",
 				locator1 = "TextInput#GENERIC_TEXT_INPUT");
@@ -207,6 +207,41 @@ definition {
 
 		task ("Then can see the team selected in the table") {
 			Testray.assertItemName(key_name = "Team 1");
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements using multiple filtering options"
+	@priority = 5
+	test AdminCanFilterRequirementsWithMultipleOptions {
+		task ("When the user filter a requirement with multiple options") {
+			TestrayFilter.clickFilter();
+
+			TestrayFilter.multiSelect(
+				header = "Team",
+				label = "Team",
+				listMultiSelect = "Team 1");
+
+			TestrayFilter.multiSelect(
+				header = "Component",
+				label = "Component",
+				listMultiSelect = "Component 1");
+
+			Type(
+				key_fieldLabel = "Summary",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
+				value1 = "Requirement 1");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see the multiple options in the table and do not see the requirement 2") {
+			TestrayRequirements.verifyRequirement(
+				linkTitle = "The front page of the internet",
+				requirementComponent = "Component 1",
+				requirementSummary = "Requirement 1",
+				requirementTeam = "Team 1");
+
+			Testray.assertItemNotPresent(key_name = "Requirement 2");
 		}
 	}
 

--- a/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
+++ b/modules/apps/site-initializer/site-initializer-testray/site-initializer-testray-test/src/testFunctional/tests/TestrayFiltersRequirementsAdministrator.testcase
@@ -19,36 +19,36 @@ definition {
 
 			User.firstLoginPG();
 
-			Testray.addTR2Site(siteName = ${testSiteName});
+			// Testray.addTR2Site(siteName = ${testSiteName});
 		}
 
-		task ("create all objects: projects, teams, components, requirements") {
-			JSONTestray.addProject(
-				projectDescription = "Project Description 1",
-				projectName = ${projectName});
+		// task ("create all objects: projects, teams, components, requirements") {
+		// 	JSONTestray.addProject(
+		// 		projectDescription = "Project Description 1",
+		// 		projectName = ${projectName});
 
-			JSONTestray.addTeam(
-				projectName = ${projectName},
-				teamName = ${teamName});
+		// 	JSONTestray.addTeam(
+		// 		projectName = ${projectName},
+		// 		teamName = ${teamName});
 
-			JSONTestray.addComponent(
-				componentName = ${componentName},
-				projectName = ${projectName},
-				teamName = ${teamName});
+		// 	JSONTestray.addComponent(
+		// 		componentName = ${componentName},
+		// 		projectName = ${projectName},
+		// 		teamName = ${teamName});
 
-            JSONTestray.addRequirement(
-				componentName = ${componentName},
-				linkTitle = "The front page of the internet",
-				projectName = ${projectName},
-				requirementName = "Requirement 1");
+        //     JSONTestray.addRequirement(
+		// 		componentName = ${componentName},
+		// 		linkTitle = "The front page of the internet",
+		// 		projectName = ${projectName},
+		// 		requirementName = "Requirement 1");
 
-              JSONTestray.addRequirement(
-				componentName = ${componentName},
-				linkTitle = "Page of the internet 2",
-                linkURL = "https://reddit.com",
-				projectName = ${projectName},
-				requirementName = "Requirement 2");
-		}
+        //       JSONTestray.addRequirement(
+		// 		componentName = ${componentName},
+		// 		linkTitle = "Page of the internet 2",
+        //         linkURL = "https://reddit.com",
+		// 		projectName = ${projectName},
+		// 		requirementName = "Requirement 2");
+		// }
 
 		task ("Go to the Requirements page") {
 			ApplicationsMenu.gotoSite(site = ${testSiteName});
@@ -63,21 +63,21 @@ definition {
 		}
 	}
 
-	tearDown {
-		var testPortalInstance = PropsUtil.get("test.portal.instance");
+	// tearDown {
+	// 	var testPortalInstance = PropsUtil.get("test.portal.instance");
 
-		JSONTestrayAPI.deleteObjectViaAPI(
-			object = "teams",
-			objectName = ${teamName});
+	// 	JSONTestrayAPI.deleteObjectViaAPI(
+	// 		object = "teams",
+	// 		objectName = ${teamName});
 
-		JSONTestrayAPI.deleteProject(projectName = ${projectName});
+	// 	JSONTestrayAPI.deleteProject(projectName = ${projectName});
 
-		Testray.testrayApisTearDown();
+	// 	Testray.testrayApisTearDown();
 
-		if (${testPortalInstance} == "true") {
-			PortalInstances.tearDownCP();
-		}
-	}
+	// 	if (${testPortalInstance} == "true") {
+	// 		PortalInstances.tearDownCP();
+	// 	}
+	// }
 
 	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by link"
 	@priority = 5
@@ -99,6 +99,27 @@ definition {
 				requirementComponent = "Component 1",
 				requirementSummary = "Requirement 1",
 				requirementTeam = "Team 1");
+
+			Testray.assertItemNotPresent(key_name = "Requirement 2");
+		}
+	}
+
+	@description = "Story ID: LPS-173519 | Test Summary: Verify if as an Administrator I should be able to filter requirements by summary"
+	@priority = 5
+	test AdminCanFilterRequirementsBySummary {
+		task ("When the user filter a requirement by summary") {
+			TestrayFilter.clickFilter();
+
+			Type(
+				key_fieldLabel = "Summary",
+				locator1 = "TextInput#GENERIC_TEXT_INPUT",
+				value1 = "Requirement 1");
+
+			Button.click(button = "Apply");
+		}
+
+		task ("Then can see the filters apply in the list by summary") {
+			Testray.assertItemName(key_name = "Requirement 1");
 
 			Testray.assertItemNotPresent(key_name = "Requirement 2");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -20,6 +20,11 @@
 	<td>//div[contains(@class,'dnd-table')]//div[normalize-space(text())='${key_itemName}']</td>
 	<td></td>
 </tr>
+<tr>
+	<td>DELETE_DATA_SET_MODAL_BODY</td>
+	<td>//div[@class='liferay-modal-body'][contains(text(),'Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>DELETE_DATA_SET_MODAL_BODY</td>
-	<td>//div[@class='liferay-modal-body'][contains(text(),'Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.')]</td>
+	<td>//div[@class='liferay-modal-body'][contains(text(),'${key_modalText}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -25,6 +25,11 @@
 	<td>//div[@class='liferay-modal-body'][contains(text(),'${key_modalText}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>VIEW_ENTRY_BUTTON</td>
+	<td>//div[contains(@class,'show')]//button[contains(.,'View')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -56,6 +56,28 @@ definition {
 
 	}
 
+	@description = "LPS-179521. Confirm that the dataset can be delete"
+	@priority = 5
+	test CanDeleteDataSet {
+		task ("When the user goes to add Datasets") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And the user deletes a dataset") {
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+
+			Button.clickDelete();
+		}
+
+		task ("Then The dataset is not present in the data set Admin page") {
+			AssertElementPresent(
+				locator1 = "Message#EMPTY_STATE_INFO",
+				value1 = "No Results Found");
+		}
+	}
+
 	@description = "Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
 	@priority = 3
 	test CannotExceed280Characters {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -66,7 +66,9 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+			FrontendDataSetAdmin.deleteDataSet(
+				entry = "Test Dataset",
+				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
 
 			Button.clickDelete();
 		}
@@ -186,7 +188,9 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+			FrontendDataSetAdmin.deleteDataSet(
+				entry = "Test Dataset",
+				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
 
 			Button.clickCancel();
 		}
@@ -208,7 +212,9 @@ definition {
 		}
 
 		task ("And When the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+			FrontendDataSetAdmin.deleteDataSet(
+				entry = "Test Dataset",
+				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
 		}
 
 		task ("And When the user clicks on the 'X' button in the modal") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -176,4 +176,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-179526. Confirm that the data set was not deleted after clicking CANCEL in the modal"
+	@priority = 5
+	test NotDeleteDatasetAfterCancel {
+		task ("When the user goes to add Datasets") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And the user deletes a dataset") {
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+
+			Button.clickCancel();
+		}
+
+		task ("Then The dataset is not present in the data set Admin page") {
+			AssertElementPresent(
+				key_itemName = "Test Dataset",
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -66,11 +66,7 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(
-				entry = "Test Dataset",
-				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
-
-			Button.clickDelete();
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
 		}
 
 		task ("Then The dataset is not present in the data set Admin page") {
@@ -80,7 +76,7 @@ definition {
 		}
 	}
 
-	@description = "Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
+	@description = "LPS-178779. Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
 	@priority = 3
 	test CannotExceed280Characters {
 		task ("When the user goes to add Datasets") {
@@ -103,6 +99,28 @@ definition {
 			AssertTextPresent(
 				locator1 = "Message#ERROR",
 				value1 = "Your request failed to complete.");
+		}
+	}
+
+	@description = "LPS-179768. Confirm that the options view and Delete is present and is visible after clicking the ellipsis button."
+	@priority = 3
+	test DeleteAndViewAreAvailable {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And opening the dropdown menu") {
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+		}
+
+		task ("Then Confirm that the options view and Delete is present and is visible") {
+			AssertElementPresent(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			AssertElementPresent(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
 		}
 	}
 
@@ -188,9 +206,15 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(
-				entry = "Test Dataset",
-				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			AssertElementPresent(
+				key_modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
+				locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 
 			Button.clickCancel();
 		}
@@ -212,9 +236,15 @@ definition {
 		}
 
 		task ("And When the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(
-				entry = "Test Dataset",
-				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			AssertElementPresent(
+				key_modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
+				locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 		}
 
 		task ("And When the user clicks on the 'X' button in the modal") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -198,4 +198,30 @@ definition {
 		}
 	}
 
+	@description = "LPS-179527. Confirm that the data set was not deleted after clicking clicks on the 'X' button in the modal"
+	@priority = 5
+	test NotDeleteDatasetAfterCloseButton {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And When the user deletes a dataset") {
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+		}
+
+		task ("And When the user clicks on the 'X' button in the modal") {
+			Click(
+				key_modalTitle = "Delete Dataset",
+				locator1 = "Button#CLOSE_MODAL");
+		}
+
+		task ("Then The dataset is present in the data set Admin page") {
+			AssertElementPresent(
+				key_itemName = "Test Dataset",
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+		}
+	}
+
 }


### PR DESCRIPTION
**Context**
As part of the dataset management feature, there is a need to delete datasets when they become unused, obsolete or not adequate for the purpose they were created. So the ability to delete unnecessary elements is an important requirement.

**Subtasks and tickets**
[FrontendDataSetViews#CanDeleteDataSet](https://issues.liferay.com/browse/LPS-179521)
[FrontendDataSetViews#NotDeleteDatasetAfterCancel](https://issues.liferay.com/browse/LPS-179526)
[FrontendDataSetViews#NotDeleteDatasetAfterCloseButton](https://issues.liferay.com/browse/LPS-179527)

**Story JIRA ticket**
https://issues.liferay.com/browse/LPS-178039