### PR TITLE
LPS-178039 | Story Automation - Delete FDS Entry

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -18,6 +18,16 @@ definition {
 		PortletEntry.save();
 	}
 
+	macro deleteDataSet {
+		Click(
+			key_entry = ${entry},
+			locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+		AssertElementPresent(locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+	}
+
 	macro searchProvider {
 		Click(
 			dropdownLabel = "Choose an Option",
@@ -36,12 +46,6 @@ definition {
 		Click(
 			locator1 = "FrontendDataSet#SELECT_TYPE_PROVIDER",
 			value1 = ${key_type});
-	}
-
-	macro changePagination {
-		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
-
-		MenuItem.click(menuItem = ${itemsPerPage});
 	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -38,4 +38,10 @@ definition {
 			value1 = ${key_type});
 	}
 
+	macro changePagination {
+		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
+
+		MenuItem.click(menuItem = ${itemsPerPage});
+	}
+
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -25,7 +25,9 @@ definition {
 
 		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
 
-		AssertElementPresent(locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+		AssertElementPresent(
+			key_modalText = ${modalText},
+			locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 	}
 
 	macro searchProvider {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -26,8 +26,10 @@ definition {
 		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
 
 		AssertElementPresent(
-			key_modalText = ${modalText},
+			key_modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
 			locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+
+		Button.clickDelete();
 	}
 
 	macro searchProvider {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -20,6 +20,11 @@
 	<td>//div[contains(@class,'dnd-table')]//div[normalize-space(text())='${key_itemName}']</td>
 	<td></td>
 </tr>
+<tr>
+	<td>DELETE_DATA_SET_MODAL_BODY</td>
+	<td>//div[@class='liferay-modal-body'][contains(text(),'Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -22,7 +22,7 @@
 </tr>
 <tr>
 	<td>DELETE_DATA_SET_MODAL_BODY</td>
-	<td>//div[@class='liferay-modal-body'][contains(text(),'Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.')]</td>
+	<td>//div[@class='liferay-modal-body'][contains(text(),'${key_modalText}')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -25,6 +25,11 @@
 	<td>//div[@class='liferay-modal-body'][contains(text(),'${key_modalText}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>VIEW_ENTRY_BUTTON</td>
+	<td>//div[contains(@class,'show')]//button[contains(.,'View')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -56,6 +56,28 @@ definition {
 
 	}
 
+	@description = "LPS-179521. Confirm that the dataset can be delete"
+	@priority = 5
+	test CanDeleteDataSet {
+		task ("When the user goes to add Datasets") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And the user deletes a dataset") {
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+
+			Button.clickDelete();
+		}
+
+		task ("Then The dataset is not present in the data set Admin page") {
+			AssertElementPresent(
+				locator1 = "Message#EMPTY_STATE_INFO",
+				value1 = "No Results Found");
+		}
+	}
+
 	@description = "Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
 	@priority = 3
 	test CannotExceed280Characters {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -66,7 +66,9 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+			FrontendDataSetAdmin.deleteDataSet(
+				entry = "Test Dataset",
+				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
 
 			Button.clickDelete();
 		}
@@ -186,7 +188,9 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+			FrontendDataSetAdmin.deleteDataSet(
+				entry = "Test Dataset",
+				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
 
 			Button.clickCancel();
 		}
@@ -208,7 +212,9 @@ definition {
 		}
 
 		task ("And When the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+			FrontendDataSetAdmin.deleteDataSet(
+				entry = "Test Dataset",
+				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
 		}
 
 		task ("And When the user clicks on the 'X' button in the modal") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -176,4 +176,26 @@ definition {
 		}
 	}
 
+	@description = "LPS-179526. Confirm that the data set was not deleted after clicking CANCEL in the modal"
+	@priority = 5
+	test NotDeleteDatasetAfterCancel {
+		task ("When the user goes to add Datasets") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And the user deletes a dataset") {
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+
+			Button.clickCancel();
+		}
+
+		task ("Then The dataset is not present in the data set Admin page") {
+			AssertElementPresent(
+				key_itemName = "Test Dataset",
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -66,11 +66,7 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(
-				entry = "Test Dataset",
-				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
-
-			Button.clickDelete();
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
 		}
 
 		task ("Then The dataset is not present in the data set Admin page") {
@@ -80,7 +76,7 @@ definition {
 		}
 	}
 
-	@description = "Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
+	@description = "LPS-178779. Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
 	@priority = 3
 	test CannotExceed280Characters {
 		task ("When the user goes to add Datasets") {
@@ -103,6 +99,28 @@ definition {
 			AssertTextPresent(
 				locator1 = "Message#ERROR",
 				value1 = "Your request failed to complete.");
+		}
+	}
+
+	@description = "LPS-179768. Confirm that the options view and Delete is present and is visible after clicking the ellipsis button."
+	@priority = 3
+	test DeleteAndViewAreAvailable {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And opening the dropdown menu") {
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+		}
+
+		task ("Then Confirm that the options view and Delete is present and is visible") {
+			AssertElementPresent(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			AssertElementPresent(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
 		}
 	}
 
@@ -188,9 +206,15 @@ definition {
 		}
 
 		task ("And the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(
-				entry = "Test Dataset",
-				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			AssertElementPresent(
+				key_modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
+				locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 
 			Button.clickCancel();
 		}
@@ -212,9 +236,15 @@ definition {
 		}
 
 		task ("And When the user deletes a dataset") {
-			FrontendDataSetAdmin.deleteDataSet(
-				entry = "Test Dataset",
-				modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.");
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			AssertElementPresent(
+				key_modalText = "Deleting a dataset is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
+				locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 		}
 
 		task ("And When the user clicks on the 'X' button in the modal") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -198,4 +198,30 @@ definition {
 		}
 	}
 
+	@description = "LPS-179527. Confirm that the data set was not deleted after clicking clicks on the 'X' button in the modal"
+	@priority = 5
+	test NotDeleteDatasetAfterCloseButton {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And When the user deletes a dataset") {
+			FrontendDataSetAdmin.deleteDataSet(entry = "Test Dataset");
+		}
+
+		task ("And When the user clicks on the 'X' button in the modal") {
+			Click(
+				key_modalTitle = "Delete Dataset",
+				locator1 = "Button#CLOSE_MODAL");
+		}
+
+		task ("Then The dataset is present in the data set Admin page") {
+			AssertElementPresent(
+				key_itemName = "Test Dataset",
+				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
+		}
+	}
+
 }


### PR DESCRIPTION
Context
As part of the dataset management feature, there is a need to delete datasets when they become unused, obsolete or not adequate for the purpose they were created. So the ability to delete unnecessary elements is an important requirement.

Subtasks and tickets
[FrontendDataSetViews#CanDeleteDataSet](https://issues.liferay.com/browse/LPS-179521)
[FrontendDataSetViews#NotDeleteDatasetAfterCancel](https://issues.liferay.com/browse/LPS-179526)
[FrontendDataSetViews#NotDeleteDatasetAfterCloseButton](https://issues.liferay.com/browse/LPS-179527)
[FrontendDataSetViews#DeleteAndViewAreAvailable](https://issues.liferay.com/browse/LPS-179768)

Story JIRA ticket
https://issues.liferay.com/browse/LPS-178039