### PR TITLE
LPS-179284 Add REST context path to FDS Entry

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import javax.portlet.PortletRequest;
 
@@ -35,10 +36,11 @@ import javax.portlet.PortletRequest;
 public class FDSViewsDisplayContext {
 
 	public FDSViewsDisplayContext(
-		PortletRequest portletRequest,
+		PortletRequest portletRequest, Map<String, String> openapiResourcePaths,
 		ServiceTrackerList<FDSHeadlessResource> serviceTrackerList) {
 
 		_portletRequest = portletRequest;
+		_openapiResourcePaths = openapiResourcePaths;
 		_serviceTrackerList = serviceTrackerList;
 	}
 
@@ -104,16 +106,24 @@ public class FDSViewsDisplayContext {
 			Comparator.comparing(FDSHeadlessResource::getBundleLabel));
 
 		fdsHeadlessResources.sort(
-			Comparator.comparing(FDSHeadlessResource::getName));
+			Comparator.comparing(FDSHeadlessResource::getSchema));
 
 		for (FDSHeadlessResource fdsHeadlessResource : fdsHeadlessResources) {
+			String schema = fdsHeadlessResource.getSchema();
+
+			boolean objectResource = schema.startsWith("ObjectEntry");
+
 			jsonArray.put(
 				JSONUtil.put(
 					"bundleLabel", fdsHeadlessResource.getBundleLabel()
 				).put(
-					"entityClassName", fdsHeadlessResource.getEntityClassName()
+					"objectResource", objectResource
 				).put(
-					"name", _getName(fdsHeadlessResource)
+					"openapiResourcePath",
+					_openapiResourcePaths.get(
+						fdsHeadlessResource.getOsgiJaxrsApplicationSelect())
+				).put(
+					"schema", _getSchema(fdsHeadlessResource, objectResource)
 				).put(
 					"version", fdsHeadlessResource.getVersion()
 				));
@@ -122,20 +132,23 @@ public class FDSViewsDisplayContext {
 		return jsonArray;
 	}
 
-	private String _getName(FDSHeadlessResource fdsHeadlessResource) {
-		String name = fdsHeadlessResource.getName();
+	private String _getSchema(
+		FDSHeadlessResource fdsHeadlessResource, boolean objectResource) {
 
-		if (name.startsWith("ObjectEntry")) {
-			String[] nameParts = StringUtil.split(name, "#C_");
+		String schema = fdsHeadlessResource.getSchema();
 
-			if (nameParts.length == 2) {
-				return nameParts[1];
+		if (objectResource) {
+			String[] schemaParts = StringUtil.split(schema, "#C_");
+
+			if (schemaParts.length == 2) {
+				return schemaParts[1];
 			}
 		}
 
-		return name;
+		return schema;
 	}
 
+	private final Map<String, String> _openapiResourcePaths;
 	private final PortletRequest _portletRequest;
 	private final ServiceTrackerList<FDSHeadlessResource> _serviceTrackerList;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -32,17 +32,24 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.IOException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.portlet.Portlet;
 import javax.portlet.PortletException;
@@ -109,7 +116,8 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		renderRequest.setAttribute(
 			FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
-			new FDSViewsDisplayContext(renderRequest, _serviceTrackerList));
+			new FDSViewsDisplayContext(
+				renderRequest, _openapiResourcePaths, _serviceTrackerList));
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
@@ -141,7 +149,15 @@ public class FDSViewsPortlet extends MVCPortlet {
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						"entityClassName", "entityClassName", true)));
+						_language.get(locale, "provider"), "provider", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						"restContextPath", "restContextPath", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						"schema", "schema", true)));
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			userId, fdsEntryObjectDefinition.getObjectDefinitionId());
@@ -184,6 +200,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 		FDSViewsPortlet.class);
 
 	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
 	private Language _language;
 
 	@Reference
@@ -192,6 +211,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 	@Reference
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
+	private final Map<String, String> _openapiResourcePaths = new HashMap<>();
 	private ServiceTrackerList<FDSHeadlessResource> _serviceTrackerList;
 
 	private class FDSHeadlessResourceServiceTrackerCustomizer
@@ -201,8 +221,49 @@ public class FDSViewsPortlet extends MVCPortlet {
 		public FDSHeadlessResource addingService(
 			ServiceReference<Object> serviceReference) {
 
+			String osgiJaxrsApplicationSelect =
+				(String)serviceReference.getProperty(
+					"osgi.jaxrs.application.select");
+
+			if (osgiJaxrsApplicationSelect == null) {
+				return null;
+			}
+
+			String openapiResourcePath = (String)serviceReference.getProperty(
+				"openapi.resource.path");
+
+			if (openapiResourcePath != null) {
+				_openapiResourcePaths.put(
+					osgiJaxrsApplicationSelect, openapiResourcePath);
+
+				return null;
+			}
+
+			String[] objectClass = (String[])serviceReference.getProperty(
+				"objectClass");
+
 			String entityClassName = (String)serviceReference.getProperty(
 				"entity.class.name");
+
+			if ((objectClass != null) && (objectClass.length == 1)) {
+				String objectClassName = objectClass[0];
+
+				if (objectClassName.endsWith("ObjectEntryResource")) {
+					String[] entityClassNameParts = StringUtil.split(
+						entityClassName, "#");
+
+					_openapiResourcePaths.put(
+						osgiJaxrsApplicationSelect,
+						_getObjectEntryRESTContextPath(
+							entityClassNameParts[1]));
+				}
+
+				if (objectClassName.endsWith(
+						"ObjectEntryRelatedObjectsResourceImpl")) {
+
+					return null;
+				}
+			}
 
 			if (entityClassName != null) {
 				String[] entityClassNameParts = StringUtil.split(
@@ -211,7 +272,8 @@ public class FDSViewsPortlet extends MVCPortlet {
 				Object object = _bundleContext.getService(serviceReference);
 
 				return new FDSHeadlessResource(
-					_getFDSHeadlessResourceBundleLabel(object), entityClassName,
+					_getFDSHeadlessResourceBundleLabel(object),
+					osgiJaxrsApplicationSelect,
 					entityClassNameParts[entityClassNameParts.length - 1],
 					entityClassNameParts[entityClassNameParts.length - 2].
 						replaceAll(StringPool.UNDERLINE, StringPool.PERIOD));
@@ -251,6 +313,25 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 			return bundleName.substring(
 				0, bundleName.lastIndexOf(StringPool.SPACE));
+		}
+
+		private String _getObjectEntryRESTContextPath(String name) {
+			List<ObjectDefinition> objectDefinitions = new ArrayList<>();
+
+			_companyLocalService.forEachCompanyId(
+				companyId -> objectDefinitions.addAll(
+					_objectDefinitionLocalService.getObjectDefinitions(
+						companyId, true, WorkflowConstants.STATUS_APPROVED)));
+
+			for (ObjectDefinition objectDefinition : objectDefinitions) {
+				String objectDefinitionName = objectDefinition.getName();
+
+				if (Objects.equals(objectDefinitionName, name)) {
+					return objectDefinition.getRESTContextPath();
+				}
+			}
+
+			return null;
 		}
 
 		private final BundleContext _bundleContext;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/resource/FDSHeadlessResource.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/resource/FDSHeadlessResource.java
@@ -20,12 +20,12 @@ package com.liferay.frontend.data.set.views.web.internal.resource;
 public class FDSHeadlessResource {
 
 	public FDSHeadlessResource(
-		String bundleLabel, String entityClassName, String name,
+		String bundleLabel, String osgiJaxrsApplicationSelect, String schema,
 		String version) {
 
 		_bundleLabel = bundleLabel;
-		_entityClassName = entityClassName;
-		_name = name;
+		_osgiJaxrsApplicationSelect = osgiJaxrsApplicationSelect;
+		_schema = schema;
 		_version = version;
 	}
 
@@ -33,12 +33,12 @@ public class FDSHeadlessResource {
 		return _bundleLabel;
 	}
 
-	public String getEntityClassName() {
-		return _entityClassName;
+	public String getOsgiJaxrsApplicationSelect() {
+		return _osgiJaxrsApplicationSelect;
 	}
 
-	public String getName() {
-		return _name;
+	public String getSchema() {
+		return _schema;
 	}
 
 	public String getVersion() {
@@ -46,8 +46,8 @@ public class FDSHeadlessResource {
 	}
 
 	private final String _bundleLabel;
-	private final String _entityClassName;
-	private final String _name;
+	private final String _osgiJaxrsApplicationSelect;
+	private final String _schema;
 	private final String _version;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -41,15 +41,17 @@ type TFDSEntry = {
 			method: string;
 		};
 	};
-	entityClassName: string;
 	id: string;
 	label: string;
+	restContextPath: string;
+	schema: string;
 };
 
 type THeadlessResource = {
 	bundleLabel: string;
-	entityClassName: string;
-	name: string;
+	objectResource: boolean;
+	openapiResourcePath: string;
+	schema: string;
 	version: string;
 };
 
@@ -62,9 +64,9 @@ const HeadlessResourceItem = ({
 	headlessResource,
 	query,
 }: IHeadlessResourceItemProps) => {
-	const fuzzyNameMatch = fuzzy.match(
+	const fuzzySchemaMatch = fuzzy.match(
 		query,
-		headlessResource.name,
+		headlessResource.schema,
 		FUZZY_OPTIONS
 	);
 
@@ -76,14 +78,14 @@ const HeadlessResourceItem = ({
 
 	return (
 		<ClayLayout.ContentRow className="headless-resource">
-			{fuzzyNameMatch ? (
+			{fuzzySchemaMatch ? (
 				<span
 					dangerouslySetInnerHTML={{
-						__html: fuzzyNameMatch.rendered,
+						__html: fuzzySchemaMatch.rendered,
 					}}
 				/>
 			) : (
-				<span>{headlessResource.name}</span>
+				<span>{headlessResource.schema}</span>
 			)}
 
 			<span className="context">
@@ -100,24 +102,6 @@ const HeadlessResourceItem = ({
 				{` ${headlessResource.version}`}
 			</span>
 		</ClayLayout.ContentRow>
-	);
-};
-
-interface IProviderRendererProps {
-	headlessResourcesMap: Map<String, THeadlessResource>;
-	itemData: TFDSEntry;
-}
-
-const ProviderRenderer: React.FC<IProviderRendererProps> = ({
-	headlessResourcesMap,
-	itemData,
-}: IProviderRendererProps) => {
-	const headlessResource = headlessResourcesMap.get(itemData.entityClassName);
-
-	return (
-		<>
-			{`${headlessResource?.name} (${headlessResource?.bundleLabel} ${headlessResource?.version})`}
-		</>
 	);
 };
 
@@ -159,9 +143,10 @@ const DropdownMenu = ({
 		setHeadlessResources(
 			query
 				? initialHeadlessResources.filter(
-						({bundleLabel, name}: THeadlessResource) => {
+						({bundleLabel, schema}: THeadlessResource) => {
 							return (
-								bundleLabel.match(regexp) || name.match(regexp)
+								bundleLabel.match(regexp) ||
+								schema.match(regexp)
 							);
 						}
 				  ) || []
@@ -180,7 +165,7 @@ const DropdownMenu = ({
 			<ClayDropDown.ItemList items={headlessResources} role="listbox">
 				{(item: THeadlessResource) => (
 					<ClayDropDown.Item
-						key={item.entityClassName}
+						key={`${item.openapiResourcePath}${item.version}${item.schema}`}
 						onClick={() => {
 							setSelectedHeadlessResource(item);
 
@@ -226,9 +211,35 @@ const AddFDSEntryModalContent = ({
 	const fdsEntryLabelRef = useRef<HTMLInputElement>(null);
 
 	const addFDSEntry = async () => {
+		if (!selectedHeadlessResource) {
+			return;
+		}
+
+		const {
+			bundleLabel,
+			objectResource,
+			openapiResourcePath,
+			schema,
+			version,
+		} = selectedHeadlessResource;
+
+		let path = `/o${openapiResourcePath}`;
+
+		if (!objectResource) {
+			const schemaParts = schema.split(/(?=[A-Z])/);
+
+			const lowerCaseSchemaParts = schemaParts.map((schemaPart) =>
+				schemaPart.toLowerCase()
+			);
+
+			path = `${path}/${version}/${lowerCaseSchemaParts.join('-')}s`;
+		}
+
 		const body = {
-			entityClassName: selectedHeadlessResource?.entityClassName,
 			label: fdsEntryLabelRef.current?.value,
+			provider: `${schema} (${bundleLabel} ${version})`,
+			restContextPath: path,
+			schema,
 		};
 
 		const response = await fetch(fdsEntriesAPIURL, {
@@ -422,15 +433,6 @@ const FDSEntries = ({
 	headlessResources,
 	namespace,
 }: IFDSEntriesProps) => {
-	const headlessResourcesMapRef = useRef<Map<string, THeadlessResource>>(
-		new Map(
-			headlessResources.map((headlessResource) => [
-				headlessResource.entityClassName,
-				headlessResource,
-			])
-		)
-	);
-
 	const creationMenu = {
 		primaryItems: [
 			{
@@ -526,7 +528,6 @@ const FDSEntries = ({
 				fields: [
 					{fieldName: 'label', label: Liferay.Language.get('name')},
 					{
-						contentRenderer: 'provider',
 						fieldName: 'provider',
 						label: Liferay.Language.get('provider'),
 					},
@@ -551,14 +552,6 @@ const FDSEntries = ({
 				apiURL={`${fdsEntriesAPIURL}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`}
 				creationMenu={creationMenu}
 				customDataRenderers={{
-					provider: ({itemData}: {itemData: TFDSEntry}) => (
-						<ProviderRenderer
-							headlessResourcesMap={
-								headlessResourcesMapRef.current
-							}
-							itemData={itemData}
-						/>
-					),
 					viewsCount: ViewsCountRenderer,
 				}}
 				id={`${namespace}FDSEntries`}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -17,8 +17,9 @@
 import '../css/FDSEntries.scss';
 declare type THeadlessResource = {
 	bundleLabel: string;
-	entityClassName: string;
-	name: string;
+	objectResource: boolean;
+	openapiResourcePath: string;
+	schema: string;
 	version: string;
 };
 interface IFDSEntriesProps {


### PR DESCRIPTION
### References

- [LPS-179284 Add REST context path to FDS Entry](https://issues.liferay.com/browse/LPS-179284)
- Fixes [LPS-178414 Search box returns wrong results](https://issues.liferay.com/browse/LPS-178414)

### What is the goal of this PR?

Goals of this PR:
- Add REST context path to FDS Entry
  - do this in a way that we support Object entries
- Scrap `entityClassName` as a unique identifier of a headless resource. It is not, that was causing LPS-178414.

:warning: There are a few quite ugly solutions in this PR. Viewer discretion is advised.

Technical notes:
- We are defining `restContextPath` as the final URL for FDS data endpoint.
  - `openapiResourcePath` is the path to the REST application. This follows convention in DXP.
- We are renaming headless resource `name` to `schema`. This follows OpenAPI naming convention.
- `openapiResourcePath` and  `entityClassName`/`schema` are wired over `osgi.jaxrs.application.select` property.
  - This is **not** true for Objects. For Objects, we need to find object definition and `getRESTContextPath` from it. 
- Another complication for Objects was that `entityClassName`, `version` and `bundle` are not unique, even when put together. This is because we have `ObjectEntryResource` and `ObjectEntryRelatedObjectsResource`. In this PR, we are explicitly discarding service reference of the relationship object. /cc @gabrielwas @guilhermedcamacho
- Regarding `entityClassName`, my initial intent was to replace it with a composite of properties from last point. In the end, I opted for alternative where I removed need for a unique identifier. I achieved this with adding `Provider` label to FDS Entry persistence. This way, we don't need to reconstruct headless resource from a complex custom identifier. Continuing with that approach ended up quickly growing in complexity.
- A challenge in this task was how to get from `schema` to relevant part of the REST context path. For example, `analytics-settings-rest` REST application has `CommerceChannel` schema. We can get that from `osgi.jaxrs.application.select` wiring in backend, or `components.schemas` wiring in OpenAPI frontend. But then, how do we get from `CommerceChannel` to  `commerce-channels` part of `/o/analytics-settings-rest/v1.0/commerce-channels`? I found no clean way of doing this, in either backend or frontend. In this PR, we are directly covering string, from `TitleCase` to `title-cases`, including `s` on the end. /cc @matijapetanjek @4lejandrito
- The fact that we are constructing the endpoint in correct format does not mean that this endpoint exists. In a followup task, it should be possible to filter out non-existing endpoints by comparing them to all paths in respective REST applications. 

/cc @pablo-agulla  

### What does it look like?
![screen](https://user-images.githubusercontent.com/5435511/228561096-28dfe67e-9456-482f-9d68-7dbb66f61b91.png)

https://user-images.githubusercontent.com/5435511/228561040-3ae26968-0ade-4d7c-a94c-4ba5314c1166.mp4
### Steps to reproduce

1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`. This enables FDS Views Manager.
1. Add `feature.flag.LPS-161364=true` to `portal-ext.properties`. This enables Objects relationships nested fields, used by FDS Views Manager.
1. :warning: If you previously opened Datasets page, drop database and create a new one. This PR changes persistence layer.
1. Start DXP
1. Open Global Menu > Control Panel > Object > Datasets
