### PR TITLE
HR_209 If the sidebar menu is a link, the page title should change after activating the link

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
@@ -119,6 +119,20 @@ PortletURLBuilder.create(
 		<div class="<%= (screenNavigationEntries.size() > 1) ? containerCssClass : fullContainerCssClass %>">
 
 			<%
+			String selectedScreenNavigationEntryLabel = selectedScreenNavigationEntry.getLabel(themeDisplay.getLocale());
+
+			if (Validator.isNotNull(selectedScreenNavigationEntryLabel)) {
+				PortalUtil.addPageSubtitle(selectedScreenNavigationEntryLabel, request);
+			}
+
+			if (selectedScreenNavigationCategory != null) {
+				String selectedScreenNavigationCategoryLabel = selectedScreenNavigationCategory.getLabel(themeDisplay.getLocale());
+
+				if (Validator.isNotNull(selectedScreenNavigationCategoryLabel)) {
+					PortalUtil.addPageSubtitle(selectedScreenNavigationCategoryLabel, request);
+				}
+			}
+
 			selectedScreenNavigationEntry.render(request, PipingServletResponseFactory.createPipingServletResponse(pageContext));
 			%>
 

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/LayoutSEOLinkManagerImpl.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/LayoutSEOLinkManagerImpl.java
@@ -21,7 +21,6 @@ import com.liferay.layout.seo.kernel.LayoutSEOLink;
 import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
 import com.liferay.layout.seo.model.LayoutSEOEntry;
 import com.liferay.layout.seo.service.LayoutSEOEntryLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -236,7 +235,7 @@ public class LayoutSEOLinkManagerImpl implements LayoutSEOLinkManager {
 		}
 
 		return _merge(
-			subtitleListMergeable.mergeToString(StringPool.SPACE),
+			subtitleListMergeable.mergeToString(_SEPARATOR),
 			_getTitle(layout, titleListMergeable, locale));
 	}
 
@@ -291,15 +290,17 @@ public class LayoutSEOLinkManagerImpl implements LayoutSEOLinkManager {
 		}
 
 		if (titleListMergeable != null) {
-			return titleListMergeable.mergeToString(StringPool.SPACE);
+			return titleListMergeable.mergeToString(_SEPARATOR);
 		}
 
 		return layout.getHTMLTitle(_language.getLanguageId(locale));
 	}
 
 	private String _merge(String... strings) {
-		return StringUtil.merge(strings, " - ");
+		return StringUtil.merge(strings, _SEPARATOR);
 	}
+
+	private static final String _SEPARATOR = " - ";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutSEOLinkManagerImpl.class);

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerPageTitleTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/test/LayoutSEOLinkManagerPageTitleTest.java
@@ -18,7 +18,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
@@ -113,7 +112,7 @@ public class LayoutSEOLinkManagerPageTitleTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				subtitleListMergeable.mergeToString(StringPool.SPACE), " - ",
+				subtitleListMergeable.mergeToString(" - "), " - ",
 				layoutPrototypeTitle, " - ", companyName),
 			_layoutSEOLinkManager.getFullPageTitle(
 				_layout, null, null, null, subtitleListMergeable, companyName,
@@ -146,7 +145,7 @@ public class LayoutSEOLinkManagerPageTitleTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				subtitleListMergeable.mergeToString(StringPool.SPACE), " - ",
+				subtitleListMergeable.mergeToString(" - "), " - ",
 				_layout.getTitle(), " - ", _group.getName(), " - ",
 				companyName),
 			_layoutSEOLinkManager.getFullPageTitle(
@@ -167,7 +166,7 @@ public class LayoutSEOLinkManagerPageTitleTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				titleListMergeable.mergeToString(StringPool.SPACE), " - ",
+				titleListMergeable.mergeToString(" - "), " - ",
 				_group.getName(), " - ", companyName),
 			_layoutSEOLinkManager.getFullPageTitle(
 				_layout, null, null, titleListMergeable, null, companyName,
@@ -192,8 +191,8 @@ public class LayoutSEOLinkManagerPageTitleTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				subtitleListMergeable.mergeToString(StringPool.SPACE), " - ",
-				titleListMergeable.mergeToString(StringPool.SPACE), " - ",
+				subtitleListMergeable.mergeToString(" - "), " - ",
+				titleListMergeable.mergeToString(" - "), " - ",
 				_group.getName(), " - ", companyName),
 			_layoutSEOLinkManager.getFullPageTitle(
 				_layout, null, null, titleListMergeable, subtitleListMergeable,

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details.
+configuring=Configuring
 confirm=Confirm
 confirm-object-definition-name=Confirm Object Definition Name
 confirm-password=Confirm Password

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=تكوين ما إذا كانت خطوة السداد مع الخروج وفقًا لشروط التسليم ستُعرض أثناء السداد مع الخروج أم لا.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=تكوين ما إذا كانت خطوة السداد مع الخروج وفقًا لشروط الدفع ستُعرض أثناء السداد مع الخروج أم لا.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=تكوين ما إذا يتم إظهار رقم أمر الشراء أم إخفائه في تفاصيل الأمر المرسل والمعلق.
+configuring=Configuring (Automatic Copy)
 confirm=تأكيد
 confirm-object-definition-name=تأكيد اسم تعريف الكائن
 confirm-password=أكّد كلمة السر

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Потвърждение
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Потвърждение на парола

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configura si es mostra el pas de finalització de compra de les condicions d'entrega durant la finalització de la compra.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configura si es mostra el pas de la comprovació dels termes de pagament durant la finalització de la compra.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configura si el número de comanda de compra es mostra o s'oculta en els detalls de les comandes realitzades i pendents.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmeu
 confirm-object-definition-name=Confirma el nom de la definició de l'objecte
 confirm-password=Confirmeu la contrasenya

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Potvrdit
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Potvrzení hesla

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirm (Automatic Copy)
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirm adgangskode

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Legt fest, ob der Schritt Lieferbedingungen während dem Auschecken angezeigt werden soll.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Legt fest, ob der Schritt Zahlungsbedingungen während dem Auschecken angezeigt werden soll.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Legt fest, ob die Bestellnummer in den erteilten und ausstehenden Bestelldetails angezeigt oder ausgeblendet wird.
+configuring=Configuring (Automatic Copy)
 confirm=Bestätigen
 confirm-object-definition-name=Name der Objektdefinition bestätigen
 confirm-password=Kennwort bestätigen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Επιβεβαίωση
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Επιβεβαίωση κωδικού πρόσβασης

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details.
+configuring=Configuring
 confirm=Confirm
 confirm-object-definition-name=Confirm Object Definition Name
 confirm-password=Confirm Password

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirm (Automatic Copy)
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirm Password (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirm (Automatic Copy)
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirm Password (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configura si se muestra el paso de finalización de compra de condiciones de entrega al finalizar la compra.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configure si se muestra el paso de finalización de compra de las condiciones de pago al finalizar la compra.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Establece si el número del pedido de compra se muestra u oculta en los detalles de pedidos realizados y pendientes.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirmar nombre de definición del objeto
 confirm-password=Confirmar la contraseña

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configura si se muestra el paso de finalización de compra de condiciones de entrega al finalizar la compra.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configure si se muestra el paso de finalización de compra de las condiciones de pago al finalizar la compra.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Establece si el número del pedido de compra se muestra u oculta en los detalles de pedidos realizados y pendientes.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirmar nombre de definición del objeto
 confirm-password=Confirmar la contraseña

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configura si se muestra el paso de finalización de compra de condiciones de entrega al finalizar la compra.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configure si se muestra el paso de finalización de compra de las condiciones de pago al finalizar la compra.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Establece si el número del pedido de compra se muestra u oculta en los detalles de pedidos realizados y pendientes.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirmar nombre de definición del objeto
 confirm-password=Confirmar la contraseña

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configura si se muestra el paso de finalización de compra de condiciones de entrega al finalizar la compra.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configure si se muestra el paso de finalización de compra de las condiciones de pago al finalizar la compra.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Establece si el número del pedido de compra se muestra u oculta en los detalles de pedidos realizados y pendientes.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirmar nombre de definición del objeto
 confirm-password=Confirmar la contraseña

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Kinnita
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Kinnita salasõna

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Berretsi
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Berretsi pasahitza

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=تایید
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=تایید کلمه عبور

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Määrittää näytetäänkö toimitusehtojen kassavaihe ostoksen viimeistelyn aikana.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Määrittää näytetäänkö maksuehtojen kassavaihe ostoksen viimeistelyn aikana.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Määrittää näytetäänkö ostotilauksen numero vai piilotetaanko se jätettyjen ja odottavien tilausten tiedoissa.
+configuring=Configuring (Automatic Copy)
 confirm=Vahvista
 confirm-object-definition-name=Vahvista objektin määritelmän nimi
 confirm-password=Varmista salasana

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configure si l'étape de paiement des conditions de livraison est affichée lors du paiement.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configure si l'étape des conditions de paiement est affichée lors du paiement.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configure si le numéro de bon de commande est affiché ou masqué dans les détails de la commande passée et en attente.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmez
 confirm-object-definition-name=Confirmer le nom de la définition d'objet
 confirm-password=Confirmer le mot de passe

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirmez
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirmer le mot de passe

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirmar a contraseña

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=पुष्टि करें
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=पासवर्ड की पुष्टि करें

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Potvrdi
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Potvrdi lozinku

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Konfigurálja, hogy a pénztárnál megjelenjenek-e kiszállítás feltételei a fizetési folyamat lépéseként.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Konfigurálja. hogy a fizetésnél megjelenjen-e a fizetési feltételek lépése.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Konfigurálja, hogy a megrendelő száma megjelenjen vagy rejtve maradjon az elküldött és a függőben lévő megrendelések adatai közt.
+configuring=Configuring (Automatic Copy)
 confirm=Megerősít
 confirm-object-definition-name=Objektumdefiníció nevének a megerősítése
 confirm-password=Jelszó megerősítése

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Konfirmasi
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Konfirmasi Password

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -3894,6 +3894,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Conferma
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Conferma la password

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=אמת
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=לאמת סיסמא

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=チェックアウト時に配送条件のチェックアウト手順を表示するかどうかを構成します。
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=チェックアウト時に支払条件のチェックアウト手順を表示するかどうかを構成します。
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=注文済みおよび保留中の注文の詳細で、発注書番号を表示するかどうかを設定できます。
+configuring=Configuring (Automatic Copy)
 confirm=確認する
 confirm-object-definition-name=オブジェクト定義名の確認
 confirm-password=パスワードの再確認

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirm (Automatic Copy)
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirm Password (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=결제 중간에 배송 약관 단계를 보여줄 지 설정합니다.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=결제 도중 결제 약관 화면을 보여줄지 설정합니다.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=결제 완료 혹은 결제 대기 주문 상세에서 구매 번호를 노출할지 설정합니다.
+configuring=Configuring (Automatic Copy)
 confirm=확인하십시요
 confirm-object-definition-name=객체 정의 이름 확인
 confirm-password=암호를 확인하십시요

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=ຮັບຮອງ
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=ຢັ້ງຢຶນລະຫັດຜ່ານ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Patvirtinti (Automatic Translation)
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Patvirtinti slaptažodį (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Mengesahkan (Automatic Translation)
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Sah Kata Laluan (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Bekreft
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Bekreft passord

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configureert of de verzendingsvoorwaarden voor de afrekenstap getoond wordt tijdens het afrekenen.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configureert of de betalingsvoorwaarden voor de afrekenstap getoond wordt tijdens het afrekenen.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configureert of het koopordernummer wordt weergegeven of verborgen in de details van geplaatste bestellingen en bestellingen in behandeling.
+configuring=Configuring (Automatic Copy)
 confirm=Bevestigen
 confirm-object-definition-name=Naam objectdefinitie bevestigen
 confirm-password=Wachtwoord bevestigen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Bevestigen
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Wachtwoord bevestigen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Potwierdź
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Potwierdź hasło

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configura se a etapa de finalização de compra dos termos de entrega é exibida durante a finalização de compra.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configura se a etapa de finalização de compra dos termos de pagamento é exibida durante a finalização de compra.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configura quando o número de pedido da compra é exibido ou ocultado nos detalhes do pedido, realizado e pendente.
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirmar nome de definição de objeto
 confirm-password=Confirmar senha

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirmar
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirmar Senha

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Confirmă
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Confirmă Parola

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Подтвердить
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Подтверждение пароля

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Potvrdiť
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Potvrdiť heslo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Potrdi
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Potrdi geslo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Потврди
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Потврда Лозинке

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Potvrdi
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Potvrda Lozinke

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Konfigurerar om betalningssteget i leveransvillkoren visas vid betalning.
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Konfigurerar om betalningssteget i betalningsvillkoren visas vid betalning.
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Konfigurerar om köpets ordernummer visas eller döljs i placerade och väntande orderuppgifter.
+configuring=Configuring (Automatic Copy)
 confirm=Bekräfta
 confirm-object-definition-name=Bekräfta definitionsnamn av objekt
 confirm-password=Bekräfta lösenord

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=உறுதி
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=கடவுச்சொல் உறுதிசெய்

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=ตั้งค่าว่าจะแสดงขั้นตอนการชำระเงินตามเงื่อนไขการจัดส่งระหว่างการชำระเงินหรือไม่
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=ตั้งค่าว่าจะแสดงขั้นตอนการชำระเงินตามเงื่อนไขการจ่ายเงินระหว่างชำระเงินหรือไม่
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=ตั้งค่าว่าจะแสดงหรือซ่อนหมายเลขคำสั่งซื่้อสำหรับคำสั่งซื้อที่ซื้อและรอดำเนินการรายละเอียดคำสั่งซื้อ
+configuring=Configuring (Automatic Copy)
 confirm=ยืนยัน
 confirm-object-definition-name=ยืนยันชื่อคำจำกัดความออบเจ็ค
 confirm-password=ยืนยันรหัสผ่าน

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Doğrula
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Şifreyi Doğrula

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Підтвердити
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Підтвердження паролю

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=Xác nhận
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=Xác nhận lại mật khẩu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=配置在结账期间是否显示交货条款结账步骤。
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=配置是否在结账期间显示付款条款结账步骤。
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=配置在已下达和待定订单详细信息中显示还是隐藏采购单编号。
+configuring=Configuring (Automatic Copy)
 confirm=确认
 confirm-object-definition-name=确认对象定义名称
 confirm-password=确认密码

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -3895,6 +3895,7 @@ configures-whether-an-shipping-price-of-zero-is-shown-during-the-shipping-method
 configures-whether-the-delivery-terms-checkout-step-is-shown-during-checkout=Configures whether the delivery terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-payment-terms-checkout-step-is-shown-during-checkout=Configures whether the payment terms checkout step is shown during checkout. (Automatic Copy)
 configures-whether-the-purchase-order-number-is-shown-or-hidden-in-placed-and-pending-order-details=Configures whether the purchase order number is shown or hidden in placed and pending order details. (Automatic Copy)
+configuring=Configuring (Automatic Copy)
 confirm=確認
 confirm-object-definition-name=Confirm Object Definition Name (Automatic Copy)
 confirm-password=確認密碼


### PR DESCRIPTION
Reference: https://issues.liferay.com/browse/LPS-169101

In this PR, we are:
 * Turning screen navigation tag into a page subtitle contributor, so that the screen navigation `entry` and `category` labels are added to the page subtitle using portal API. 
 * Using the same `-` character to separate page title and subtitle elements. This provides a nice hierarchical visual schema to present the page title in the browser
 * For the case where a page is being configured, in addition, a suffix "(Configuring)" is added to the title. This follows the existing mechanism we have for the page edition.
 
How to test this:

- Follow LPS instructions or just go to any page configuration (press cog icon near to page in the control menu)
- Navigate through sections 
- Assert page title contains screen navigation entries and categories separated by dashes, before the original page title. For this case, you should see `(Configuring)` at the end of the page title
- For other cases, like object definition admin, just assert page title contains screen navigation entries and categories separated by dashes 

Other notes:
 * This solution does not guarantee screen navigation `entry` and `category` will show up in the page title as some widget might take over the responsibility of setting the full page title (e.g. user management)
 * Some screen navigation categories and entries are not well defined, so resulting page titles might look repetitive as both category and entry have the same value. This is technically not an issue in the page title composition mechanism but rather in the way screen navigation categories and entries are named/translated. That shall be addressed in separate tickets.
 * Page translation is another case where we'd like to apply the page title pattern, but I've left it out till we validate this

cc @ethib137 @marcoscv-work @edalgrin 