### PR TITLE
LPS-180302 Create a sample-workspace project for the cell renderer

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/CustomizedTableFDSView.java
@@ -26,7 +26,6 @@ import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
@@ -84,19 +83,36 @@ public class CustomizedTableFDSView extends BaseTableFDSView {
 						Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS),
 						null);
 
+				// Try to use the first instance registered from the UI that is found
+
 				for (FDSCellRendererCET fdsCellRendererCET :
 						fdsCellRendererCETs) {
 
-					if (Objects.equals(
-							fdsCellRendererCET.getName(LocaleUtil.ENGLISH),
-							"fds-cell-renderer")) {
-
+					if (!fdsCellRendererCET.isReadOnly()) {
 						moduleName =
 							"default from " + fdsCellRendererCET.getURL();
 
 						break;
 					}
 				}
+
+				// Try to use the sample-workspace instance if none created from the UI was found
+
+				if (moduleName == null) {
+					for (FDSCellRendererCET fdsCellRendererCET :
+							fdsCellRendererCETs) {
+
+						if (Objects.equals(
+								fdsCellRendererCET.getExternalReferenceCode(),
+								"LXC:liferay-sample-fds-cell-renderer")) {
+
+							moduleName =
+								"default from " + fdsCellRendererCET.getURL();
+						}
+					}
+				}
+
+				// Use the built-in AMD provided sample as a last resort
 
 				if (moduleName == null) {
 					moduleName = _npmResolver.resolveModuleName(

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/.gitignore
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/.gitignore
@@ -1,0 +1,5 @@
+/.liferay.json
+/node_modules
+
+/build
+/dist

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/.npmignore
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/.npmignore
@@ -1,0 +1,1 @@
+.liferay.json

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/client-extension.yaml
@@ -1,5 +1,6 @@
 assemble:
     - from: build
+      include: index.js
       into: static
 liferay-sample-fds-cell-renderer:
     name: Liferay Sample Frontend Data Set Cell Renderer

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/client-extension.yaml
@@ -1,3 +1,7 @@
-liferay-sample-global-css:
+assemble:
+    - from: build
+      into: static
+liferay-sample-fds-cell-renderer:
     name: Liferay Sample Frontend Data Set Cell Renderer
     type: fdsCellRenderer
+    url: index.js

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/liferay.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/liferay.json
@@ -1,0 +1,7 @@
+{
+	"build": {
+		"options": {
+		},
+		"type": "fdsCellRenderer"
+	}
+}

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/package.json
@@ -1,0 +1,16 @@
+{
+	"dependencies": {
+		"@liferay/dxp-7.4": "*",
+		"@liferay/js-api": "0.2.0-pre.0"
+	},
+	"description": "Liferay Sample Frontend Data Set Cell Renderer",
+	"main": "./src/index.tsx",
+	"name": "liferay-sample-fds-cell-renderer",
+	"scripts": {
+		"build": "liferay build",
+		"clean": "liferay clean",
+		"deploy": "liferay deploy",
+		"start": "liferay start"
+	},
+	"version": "1.0.0"
+}

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/src/index.tsx
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/src/index.tsx
@@ -1,0 +1,14 @@
+import type {FDSCellRenderer} from '@liferay/js-api/data-set';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const fdsCellRenderer: FDSCellRenderer = ({value}) => {
+	const element = document.createElement('div');
+
+	ReactDOM.render(<>{value == 'Green' ? '🍏' : value}</>, element);
+
+	return element;
+};
+
+export default fdsCellRenderer;

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/tsconfig.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"jsx": "react",
+		"lib": ["DOM", "ES2020"],
+		"module": "ES2020",
+		"moduleResolution": "node",
+		"outDir": "./build",
+		"resolveJsonModule": true,
+		"sourceMap": false,
+		"target": "ES2020"
+	},
+	"include": ["./src/**/*"]
+}
+


### PR DESCRIPTION
This creates a sample FDS Cell Renderer CX in the sample-workspace.

Additionally it changes the way we detect it (for testing purposes) in `frontend-data-set-sample-web`, so that we can demo things more easily. The algorithm now goes like this:

1. When rendering the customized view in `frontend-data-set-sample-web`, the first FDS cell renderer CX instance that is found and has been registered from the UI is used.
    1. This makes showing live development possible
    2. If you have more than one FDS cell renderer CXs registered from the UI the selection will be random, so make sure you only have one :-P
2. If no FDS cell renderer has been configured from the UI, a CX deployed from workspace with name `liferay-sample-fds-cell-renderer` will be used if found. This lets you build and deploy the sample FDS cell renderer and see it in action.
3. In any other case, the old built-in cell renderer is used.

----

If you deploy the extension and it works you should see green apples 🍏 instead of the word `Green` in the `frontend-data-set-sample-web` table:

![image](https://user-images.githubusercontent.com/3273630/229042986-e69754d4-fc3c-4ca2-b6bf-3dae7edb69f0.png)
