### PR TITLE
LPS-179380 Search bar does not work on the Dataset view page

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_views.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_views.jsp
@@ -27,8 +27,6 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsEntryLabel"));
 	module="js/FDSViews"
 	props='<%=
 		HashMapBuilder.<String, Object>put(
-			"fdsEntriesAPIURL", fdsViewsDisplayContext.getFDSEntriesAPIURL()
-		).put(
 			"fdsEntryId", ParamUtil.getString(request, "fdsEntryId")
 		).put(
 			"fdsEntryLabel", ParamUtil.getString(request, "fdsEntryLabel")

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
@@ -14,6 +14,7 @@
 
 const OBJECT_RELATIONSHIP = {
 	FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship',
+	FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId'
 } as const;
 
 const PAGINATION_PROPS = {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
@@ -14,7 +14,7 @@
 
 const OBJECT_RELATIONSHIP = {
 	FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship',
-	FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId'
+	FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId',
 } as const;
 
 const PAGINATION_PROPS = {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -183,7 +183,6 @@ const AddFDSViewModalContent = ({
 };
 
 interface IFDSViewsProps {
-	fdsEntriesAPIURL: string;
 	fdsEntryId: string;
 	fdsEntryLabel: string;
 	fdsViewURL: string;
@@ -192,7 +191,6 @@ interface IFDSViewsProps {
 }
 
 const FDSViews = ({
-	fdsEntriesAPIURL,
 	fdsEntryId,
 	fdsEntryLabel,
 	fdsViewURL,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -302,7 +302,7 @@ const FDSViews = ({
 
 	return (
 		<FrontendDataSet
-			apiURL={`${fdsEntriesAPIURL}/${fdsEntryId}/${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`}
+			apiURL={`${fdsViewsAPIURL}/?filter=(${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW_ID} eq '${fdsEntryId}')`}
 			creationMenu={creationMenu}
 			id={`${namespace}FDSViews`}
 			itemsActions={[

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
@@ -14,6 +14,7 @@
 
 declare const OBJECT_RELATIONSHIP: {
 	readonly FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship';
+	readonly FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId';
 };
 declare const PAGINATION_PROPS: {
 	pagination: {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
@@ -21,7 +21,6 @@ export declare type TFDSView = {
 	label: string;
 };
 interface IFDSViewsProps {
-	fdsEntriesAPIURL: string;
 	fdsEntryId: string;
 	fdsEntryLabel: string;
 	fdsViewURL: string;
@@ -29,7 +28,6 @@ interface IFDSViewsProps {
 	namespace: string;
 }
 declare const FDSViews: ({
-	fdsEntriesAPIURL,
 	fdsEntryId,
 	fdsEntryLabel,
 	fdsViewURL,


### PR DESCRIPTION
Reference: 
 - https://issues.liferay.com/browse/LPS-179380

In this PR we're changing the endpoint used to fetch related FDSViews from a given FDSEntry so that we can make search work. Before this PR, we were fetching the FDSViews from the FDSEntry endpoint as related objects. This endpoint does not support Search at this moment. 

Solution is to use the "proper" endpoint for the entity in question (FDSViews) but pre-filtered to just fetch the FDSViews associated to the current FDSEntry.

