### PR TITLE
LPS-180893 | Automation for FrontendDataSetViews#CanDeleteView

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -52,6 +52,20 @@ definition {
 		Button.clickDelete();
 	}
 
+	macro deleteDataSetView {
+		Click(
+			key_name = ${viewName},
+			locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
+
+		ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+		AssertElementPresent(
+			key_modalText = "Deleting a dataset view is an action that cannot be reversed. The content will be deleted and some dataset fragments may not be displayed.",
+			locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
+
+		Button.clickDelete();
+	}
+
 	macro searchProvider {
 		Click(
 			dropdownLabel = "Choose an Option",

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -18,6 +18,26 @@ definition {
 		PortletEntry.save();
 	}
 
+	macro createDataSetView {
+		Click(
+			key_entry = ${dataSetName},
+			locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+		Click(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
+
+		LexiconEntry.gotoAdd();
+
+		Type(
+			locator1 = "TextInput#NAME",
+			value1 = ${key_name});
+
+		Type(
+			locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+			value1 = ${description});
+
+		PortletEntry.save();
+	}
+
 	macro deleteDataSet {
 		Click(
 			key_entry = ${entry},

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -35,9 +35,27 @@
 	<td>//div[@class='liferay-modal-body'][contains(text(),'${key_modalText}')]</td>
 	<td></td>
 </tr>
+
+<!--DATA SET VIEWS-->
+
 <tr>
 	<td>VIEW_ENTRY_BUTTON</td>
 	<td>//div[contains(@class,'show')]//button[contains(.,'View')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>NEW_DATA_SET_VIEW_DESCRIPTION</td>
+	<td>//div[@class='form-group']//input[contains(@id,'fdsViewDesctiptionInput')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>NUMBER_OF_VIEWS</td>
+	<td>//div[contains(@class,'dnd-table')]//div[normalize-space(text())='Views']/../../../..//span[contains(@class,'count') and contains(.,'${numberOfViews}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>DATA_SET_VIEW_ENTRY_KEBAB_MENU</td>
+	<td>//div[contains(@class,'justify-content-center') and contains(.,'${key_name}')]/..//div[contains(@class,'d-flex')]//button[contains(@class,'dropdown-toggle')]//*[contains(@class,'lexicon-icon-ellipsis-v')]</td>
 	<td></td>
 </tr>
 </tbody>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetViews.testcase
@@ -146,6 +146,42 @@ definition {
 		}
 	}
 
+	@description = "LPS-180893. Confirm that a dataset view can be deleted"
+	@priority = 5
+	test CanDeleteView {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And Add a new view") {
+			FrontendDataSetAdmin.createDataSetView(
+				dataSetName = "Test Dataset",
+				description = "Description Test",
+				key_name = "View Test");
+		}
+
+		task ("And the user deletes a View created") {
+			FrontendDataSetAdmin.deleteDataSetView(viewName = "View Test");
+		}
+
+		task ("Then Confirm that the Success message should appear") {
+			Alert.viewSuccessMessage();
+		}
+
+		task ("And The dataset View is not present in the data set Admin page") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Object",
+				panel = "Control Panel",
+				portlet = "Datasets");
+
+			AssertElementPresent(
+				locator1 = "FrontendDataSetAdmin#NUMBER_OF_VIEWS",
+				numberOfViews = 0);
+		}
+	}
+
 	@description = "LPS-178779. Confirm the error message that appears when the user tries to create a dataset view with more than 280 characters in the name field"
 	@priority = 3
 	test CannotExceed280Characters {


### PR DESCRIPTION
**Description**
- Given access to the Datasets admin page
- When The user goes to add a new Dataset
- And Add a new view
- And the user deletes a View created
- Then Confirm that the Success message should appear
- And The dataset View is not present in the data set Admin page

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-180893