### PR TITLE
LPS-180895 | Automation for FDSViews#CanUpdateNumberOfViews + FDSViews#CanAssertPagination

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -50,7 +50,7 @@
 </tr>
 <tr>
 	<td>NUMBER_OF_VIEWS</td>
-	<td>//div[contains(@class,'dnd-table')]//div[normalize-space(text())='Views']/../../../..//span[contains(@class,'count') and contains(.,'${numberOfViews}')]</td>
+	<td>//div[contains(@class,'dnd-table')]//div[normalize-space(text())='Views']/../../../..//span[contains(@class,'badge') and contains(.,'${numberOfViews}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -344,6 +344,7 @@ definition {
 				entryName = "View Test",
 				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
 		}
+	}
 
 	@description = "LPS-180895  Confirm that the view was really deleted"
 	@priority = 5
@@ -368,7 +369,7 @@ definition {
 
 		task ("Then confirm that the views column shows 1 views") {
 			AssertElementPresent(
-				locator1 = "FrontendDataSetAdmin#NUMBER_ON_VIEWS",
+				locator1 = "FrontendDataSetAdmin#NUMBER_OF_VIEWS",
 				numberOfViews = 1);
 		}
 
@@ -393,7 +394,6 @@ definition {
 				locator1 = "FrontendDataSetAdmin#NUMBER_OF_VIEWS",
 				numberOfViews = 0);
 		}
-
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -344,6 +344,56 @@ definition {
 				entryName = "View Test",
 				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
 		}
+
+	@description = "LPS-180895  Confirm that the view was really deleted"
+	@priority = 5
+	test CanUpdateNumberOfViews {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("And Add a new view") {
+			FrontendDataSetAdmin.goToViews(key_entry = "Test Dataset");
+
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Description Test",
+				key_name = "View Test");
+		}
+
+		task ("And back to the Datasets admin page") {
+			Navigator.gotoBack();
+		}
+
+		task ("Then confirm that the views column shows 1 views") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSetAdmin#NUMBER_ON_VIEWS",
+				numberOfViews = 1);
+		}
+
+		task ("When go to View admin page") {
+			Click(
+				key_entry = "Test Dataset",
+				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
+
+			Click(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
+		}
+
+		task ("And the user deletes a View created") {
+			FrontendDataSetAdmin.deleteDataSetView(viewName = "View Test");
+		}
+
+		task ("And back to the Datasets admin page") {
+			Navigator.gotoBack();
+		}
+
+		task ("Then confirm that the views column shows 0 views") {
+			AssertElementPresent(
+				locator1 = "FrontendDataSetAdmin#NUMBER_OF_VIEWS",
+				numberOfViews = 0);
+		}
+
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -70,6 +70,48 @@ definition {
 		}
 	}
 
+	@description = "LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
+	@priority = 5
+	test CanAssertPagination {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_dataSetViewNameList = "View Test 1,View Test 2,View Test 3,View Test 4,View Test 5,View Test 6");
+		}
+
+		task ("And Change the pagination to 4 items") {
+			FrontendDataSetAdmin.changePagination(itemsPerPage = "4 Items");
+		}
+
+		task ("Then Confirm that 2 pages are shown") {
+			AssertElementPresent(locator1 = "Pagination#NEXT_LINK");
+
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test 1,View Test 2,View Test 3,View Test 4");
+
+			Pagination.viewResults(results = "Showing 1 to 4 of 6 entries.");
+		}
+
+		task ("When the user deletes two Views") {
+			FrontendDataSetAdmin.deleteDataSetView(viewName = "View Test 1");
+
+			FrontendDataSetAdmin.deleteDataSetView(viewName = "View Test 2");
+		}
+
+		task ("Then Confirm that only one page is displayed") {
+			Pagination.viewResults(results = "Showing 1 to 4 of 4 entries.");
+		}
+	}
+
 	@description = "LPS-181346. Confirm that pagination works right on views page"
 	@priority = 3
 	test CanAssertPaginationOnFDSViewsPage {
@@ -141,69 +183,6 @@ definition {
 			AssertElementPresent(
 				key_itemName = "View Test",
 				locator1 = "FrontendDataSetAdmin#NAME_OF_VIEWS");
-		}
-	}
-
-	@description = "LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
-	@priority = 5
-	test CanAssertPagination {
-		task ("When The user goes to add a new Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Test Dataset",
-				key_type = "Channel");
-		}
-
-		task ("And Add a 6 views") {
-			FrontendDataSetAdmin.createDataSetView(
-				dataSetName = "Test Dataset",
-				description = "Description Test",
-				key_name = "View Test 1");
-
-			FrontendDataSetAdmin.addDataSetView(
-				description = "Description Test",
-				key_name = "View Test 2");
-
-			FrontendDataSetAdmin.addDataSetView(
-				description = "Description Test",
-				key_name = "View Test 3");
-
-			FrontendDataSetAdmin.addDataSetView(
-				description = "Description Test",
-				key_name = "View Test 4");
-
-			FrontendDataSetAdmin.addDataSetView(
-				description = "Description Test",
-				key_name = "View Test 5");
-
-			FrontendDataSetAdmin.addDataSetView(
-				description = "Description Test",
-				key_name = "View Test 6");
-		}
-
-		task ("And Change the pagination to 4 items") {
-			FrontendDataSetAdmin.changePagination(itemsPerPage = "4 Items");
-		}
-
-		task ("Then Confirm that 2 pages are shown") {
-			AssertElementPresent(locator1 = "Pagination#NEXT_LINK");
-
-			for (var num : list "1,2,3,4") {
-				AssertElementPresent(
-					entryName = "View Test ${num}",
-					locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
-			}
-
-			Pagination.viewResults(results = "Showing 1 to 4 of 6 entries.");
-		}
-
-		task ("When the user deletes two Views") {
-			for (var num : list "1,2") {
-				FrontendDataSetAdmin.deleteDataSetView(viewName = "View Test");
-			}
-		}
-
-		task ("Then Confirm that only one page is displayed") {
-			Pagination.viewResults(results = "Showing 1 to 4 of 4 entries.");
 		}
 	}
 
@@ -283,32 +262,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-181341. Confirm that The user can create a view with no description"
-	@priority = 4
-	test CanCreateViewWithNoDescription {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When going to the Dataset View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Clicking add button, And Filling the name with 'View Test', And Clicking the Save button") {
-			FrontendDataSetAdmin.createDataSetView(
-				description = "",
-				key_name = "View Test");
-		}
-
-		task ("Then Confirm Data set view was created") {
-			AssertElementPresent(
-				entryName = "View Test",
-				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
-		}
-	}
-
 	@description = "LPS-181339. Confirm that the user can create a view"
 	@priority = 5
 	test CanCreateView {
@@ -338,6 +291,32 @@ definition {
 			AssertElementPresent(
 				locator1 = "FrontendDataSetAdmin#NAME_OF_VIEWS",
 				viewDescription = "Test Description");
+		}
+	}
+
+	@description = "LPS-181341. Confirm that The user can create a view with no description"
+	@priority = 4
+	test CanCreateViewWithNoDescription {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When going to the Dataset View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Clicking add button, And Filling the name with 'View Test', And Clicking the Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "",
+				key_name = "View Test");
+		}
+
+		task ("Then Confirm Data set view was created") {
+			AssertElementPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -144,6 +144,69 @@ definition {
 		}
 	}
 
+	@description = "LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
+	@priority = 5
+	test CanAssertPagination {
+		task ("When The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "Channel");
+		}
+
+		task ("And Add a 6 views") {
+			FrontendDataSetAdmin.createDataSetView(
+				dataSetName = "Test Dataset",
+				description = "Description Test",
+				key_name = "View Test 1");
+
+			FrontendDataSetAdmin.addDataSetView(
+				description = "Description Test",
+				key_name = "View Test 2");
+
+			FrontendDataSetAdmin.addDataSetView(
+				description = "Description Test",
+				key_name = "View Test 3");
+
+			FrontendDataSetAdmin.addDataSetView(
+				description = "Description Test",
+				key_name = "View Test 4");
+
+			FrontendDataSetAdmin.addDataSetView(
+				description = "Description Test",
+				key_name = "View Test 5");
+
+			FrontendDataSetAdmin.addDataSetView(
+				description = "Description Test",
+				key_name = "View Test 6");
+		}
+
+		task ("And Change the pagination to 4 items") {
+			FrontendDataSetAdmin.changePagination(itemsPerPage = "4 Items");
+		}
+
+		task ("Then Confirm that 2 pages are shown") {
+			AssertElementPresent(locator1 = "Pagination#NEXT_LINK");
+
+			for (var num : list "1,2,3,4") {
+				AssertElementPresent(
+					entryName = "View Test ${num}",
+					locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+			}
+
+			Pagination.viewResults(results = "Showing 1 to 4 of 6 entries.");
+		}
+
+		task ("When the user deletes two Views") {
+			for (var num : list "1,2") {
+				FrontendDataSetAdmin.deleteDataSetView(viewName = "View Test");
+			}
+		}
+
+		task ("Then Confirm that only one page is displayed") {
+			Pagination.viewResults(results = "Showing 1 to 4 of 4 entries.");
+		}
+	}
+
 	@description = "LPS-180898. Confirm that the user can cancel deletion when clicking close (X) button"
 	@priority = 3
 	test CanCancelDeletionOnCloseButton {


### PR DESCRIPTION
**Description**

- **Given** access to the Datasets admin page
- **When** The user goes to add a new Dataset
- **And** Add a new view
- **And** the user deletes a View created
- **And** back to the Datasets admin page
- **Then** confirm that the views column shows 0 views

**Jira ticket**
https://issues.liferay.com/browse/LPS-180895

--- 

**Description**

- **Given** access to the Datasets admin page 
- **When** The user goes to add a new Dataset
- **And** Add a 6 views
- **And** Change the pagination to 4 items
- **Then** Confirm that 2 pages are shown
- **When** the user deletes two Views
- **Then** Confirm that only one page is displayed

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-180899