### PR TITLE
[TECHNICAL SUPPORT] LPS-181292 Description field overrides localisation

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -282,6 +282,21 @@ name = HtmlUtil.escapeJS(name);
 			},
 		</c:if>
 
+		<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+			onChangeCallback: function () {
+				var ckEditor = CKEDITOR.instances['<%= name %>'];
+				var dirty = ckEditor.checkDirty();
+
+				if (dirty) {
+					window['<%= HtmlUtil.escapeJS(onChangeMethod) %>'](
+						window['<%= name %>'].getHTML()
+					);
+
+					ckEditor.resetDirty();
+				}
+			},
+		</c:if>
+
 		<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
 			onFocusCallback: function () {
 				window['<%= HtmlUtil.escapeJS(onFocusMethod) %>'](
@@ -549,6 +564,25 @@ name = HtmlUtil.escapeJS(name);
 				);
 			</c:if>
 
+			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+				var contentChangeHandle = setInterval(() => {
+					try {
+						window['<%= name %>'].onChangeCallback();
+					}
+					catch (e) {}
+				}, 300);
+
+				var clearContentChangeHandle = function (event) {
+					if (event.portletId === '<%= portletId %>') {
+						clearInterval(contentChangeHandle);
+
+						Liferay.detach('destroyPortlet', clearContentChangeHandle);
+					}
+				};
+
+				Liferay.on('destroyPortlet', clearContentChangeHandle);
+			</c:if>
+
 			<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
 				CKEDITOR.instances['<%= name %>'].on(
 					'focus',
@@ -597,14 +631,6 @@ name = HtmlUtil.escapeJS(name);
 				);
 			</c:if>
 		});
-
-		<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-			ckEditor.on('change', (event) => {
-				window['<%= HtmlUtil.escapeJS(onChangeMethod) %>'](
-					window['<%= name %>'].getHTML()
-				);
-			});
-		</c:if>
 
 		ckEditor.on('dataReady', (event) => {
 			if (instancePendingData !== null) {


### PR DESCRIPTION
Hey,

issue: [LPS-181292](https://issues.liferay.com/browse/LPS-181292),
caused by: [LPS-144199](https://issues.liferay.com/browse/LPS-144199)

The original issue described in [LPS-144199](https://issues.liferay.com/browse/LPS-144199) did not require this commit that I am about to revert. The root cause of this issue is a race condition, where the default change event from ckeditor is handled after we already changed the selectedLanguageId of the inputLocalized field. This results setting the previous locale's data to the newly selected one, thus corrupting existing locales or even new ones.
https://github.com/liferay/liferay-portal/blob/master/portal-web/docroot/html/taglib/ui/input_localized/page.jsp#L48-L54

Please review my changes.

Thanks,