### PR TITLE
LPS-176658 avoiding multiple session_click requests on fieldset show/hide action

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
@@ -24,21 +24,21 @@
 	<aui:script sandbox="<%= true %>" use="aui-base,liferay-store">
 		var storeTask = A.debounce(Liferay.Store, 100);
 
-		function onFieldsetShow(event) {
-			if (event.panel.getAttribute('id') === '<%= id %>Content') {
-				var task = {};
-
-				task['<%= id %>'] = false;
-
-				storeTask(task);
-			}
-		}
-
 		function onFieldsetHide(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
 				task['<%= id %>'] = true;
+
+				storeTask(task);
+			}
+		}
+
+		function onFieldsetShow(event) {
+			if (event.panel.getAttribute('id') === '<%= id %>Content') {
+				var task = {};
+
+				task['<%= id %>'] = false;
 
 				storeTask(task);
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
@@ -24,7 +24,7 @@
 	<aui:script sandbox="<%= true %>" use="aui-base,liferay-store">
 		var storeTask = A.debounce(Liferay.Store, 100);
 
-		Liferay.on('liferay.collapse.show', (event) => {
+		function onFieldsetShow(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -32,9 +32,9 @@
 
 				storeTask(task);
 			}
-		});
+		}
 
-		Liferay.on('liferay.collapse.hide', (event) => {
+		function onFieldsetHide(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -42,6 +42,16 @@
 
 				storeTask(task);
 			}
-		});
+		}
+
+		function onStartNavigate() {
+			Liferay.detach('liferay.collapse.hide', onFieldsetHide);
+			Liferay.detach('liferay.collapse.show', onFieldsetShow);
+			Liferay.detach('startNavigate', onStartNavigate);
+		}
+
+		Liferay.on('liferay.collapse.hide', onFieldsetHide);
+		Liferay.on('liferay.collapse.show', onFieldsetShow);
+		Liferay.on('startNavigate', onStartNavigate);
 	</aui:script>
 </c:if>

--- a/portal-web/docroot/html/taglib/aui/fieldset/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/end.jsp
@@ -24,21 +24,21 @@
 	<aui:script sandbox="<%= true %>" use="aui-base,liferay-store">
 		var storeTask = A.debounce(Liferay.Store, 100);
 
-		function onFieldsetShow(event) {
-			if (event.panel.getAttribute('id') === '<%= id %>Content') {
-				var task = {};
-
-				task['<%= id %>'] = false;
-
-				storeTask(task);
-			}
-		}
-
 		function onFieldsetHide(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
 				task['<%= id %>'] = true;
+
+				storeTask(task);
+			}
+		}
+
+		function onFieldsetShow(event) {
+			if (event.panel.getAttribute('id') === '<%= id %>Content') {
+				var task = {};
+
+				task['<%= id %>'] = false;
 
 				storeTask(task);
 			}

--- a/portal-web/docroot/html/taglib/aui/fieldset/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/end.jsp
@@ -24,7 +24,7 @@
 	<aui:script sandbox="<%= true %>" use="aui-base,liferay-store">
 		var storeTask = A.debounce(Liferay.Store, 100);
 
-		Liferay.on('liferay.collapse.show', function(event) {
+		function onFieldsetShow(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -32,9 +32,9 @@
 
 				storeTask(task);
 			}
-		});
+		}
 
-		Liferay.on('liferay.collapse.hide', function(event) {
+		function onFieldsetHide(event) {
 			if (event.panel.getAttribute('id') === '<%= id %>Content') {
 				var task = {};
 
@@ -42,6 +42,16 @@
 
 				storeTask(task);
 			}
-		});
+		}
+
+		function onStartNavigate() {
+			Liferay.detach('liferay.collapse.hide', onFieldsetHide);
+			Liferay.detach('liferay.collapse.show', onFieldsetShow);
+			Liferay.detach('startNavigate', onStartNavigate);
+		}
+
+		Liferay.on('liferay.collapse.hide', onFieldsetHide);
+		Liferay.on('liferay.collapse.show', onFieldsetShow);
+		Liferay.on('startNavigate', onStartNavigate);
 	</aui:script>
 </c:if>


### PR DESCRIPTION
Hi! I was working on the LIMA bug [LPS-176658](https://issues.liferay.com/browse/LPS-176658) and I realized that the source of the problem was that multiple `session_click` requests were being sent when showing/hiding fieldsets. I found that a similar problem was already solved in issue [LPS-167672](https://issues.liferay.com/browse/LPS-167672) with the element `panel` (see PR #2841). So what I've done is to apply the same solution to the element `fieldset` and it is working. Please check if you agree with the solution.

### Steps to reproduce the problem

 1. Go to "Product menu" -> "Content & Data" -> "Knowledge Base"
 2. Add an KB Article, and before saving do the following...
 3. Open the Console window of your browser (F12 in most browsers on windows and linux) and select the network monitor
 4. Clear the network tab
 5. Click on any section of the right Properties panel to expand or collapse, for instance click on the "Display Page" section title
 6. You'll see a single network request to `/c/portal/session_click` with payload like "_com_liferay_knowledge_base_web_portlet_AdminPortlet_display-page=false&p_auth=PJ5IZGzQ"
 7. Save the KB Article
 8. Edit the KB Article
 9. Repeat steps 3-5
 10. Observe, that there are now 2 requests
 11. Close the KB Article and repeat 8+9 - you'll see 3 requests
 12. Close the KB Article and repeat 8+9 - you'll see 4 requests

NOTE:
The section "Display Page" works with element `<liferay-frontend:fieldset>`. The problem also occurs with section "Basic Information" which uses the element `<aui:fieldset>`.
