### PR TITLE
[TECHNICAL SUPPORT] LPS-181552 portlet topper should not be displayed, not just the title

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -117,8 +117,6 @@ body.portlet {
 	}
 
 	.portlet-topper {
-		.portlet-title-default {
-			display: none !important;
-		}
+		display: none !important;
 	}
 }


### PR DESCRIPTION
Hey,
[LPS-181552](https://issues.liferay.com/browse/LPS-181552),

Based on the answer from [PTR-3736](https://issues.liferay.com/browse/PTR-3736), the user should not be able to interact with the widgets, when toggle control is off.
This is a follow up PR as [LPS-177707](https://issues.liferay.com/browse/LPS-177707) did not resolve the issue fully, the portlet topper is still clickable, hence the user is able to move the widgets.

Please review my changes