### PR TITLE
[TS] LPS-180053 Add a null check to _imageAlt to prevent the NPE in PortlettRequestDispatcherImpl which causes web content template portlet failure

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/StickerTag.java
@@ -195,7 +195,11 @@ public class StickerTag extends BaseContainerTag {
 		}
 		else if (Validator.isNotNull(_imageSrc)) {
 			jspWriter.write("<img alt=\"");
-			jspWriter.write(_imageAlt);
+
+			if (Validator.isNotNull(_imageAlt)) {
+				jspWriter.write(_imageAlt);
+			}
+
 			jspWriter.write("\" class=\"sticker-img\" src=\"");
 			jspWriter.write(_imageSrc);
 			jspWriter.write("\" />");


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-180053

This issue is only reproducible on a JBOSS/Wildfly bundle.

Issue:
The web content template portlet is unavailable, user cannot see the templates. It happens because of a nullPointerException in PortlettRequestDispatcherImpl, which is caused by a missing _imageAlt. (if you set the log level to DEBUG for PortletRequestDispatcherImpl class, you'll see a NPE)

https://user-images.githubusercontent.com/97447507/231758745-d09b19da-376a-4231-880c-f599afd88968.mp4

Solution:
Based on Fabian Bouché's suggestion I added a null check to _imageAlt, which solved the issue:

https://user-images.githubusercontent.com/97447507/231757891-087c5a9c-e433-41a8-8914-207703a4d6d8.mp4

I tested it on master in my local environment on JBOSS bundle, and the result can be seen in the above video.

Best regards,
Évi