### PR TITLE
LPS-169279 Fix accessibility problems with JAWS and hidden legend

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/end.jsp
@@ -21,7 +21,7 @@
 			</c:if>
 
 			<c:if test="<%= Validator.isNotNull(onSubmit) %>">
-				</fieldset>
+				</div>
 			</c:if>
 		</div>
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
@@ -27,8 +27,7 @@ String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 
 		<div class="panel-group panel-group-flush">
 			<c:if test="<%= Validator.isNotNull(onSubmit) %>">
-				<fieldset class="input-container" disabled="disabled">
-					<legend class="sr-only"><%= HtmlUtil.escape(portletDisplay.getTitle()) %></legend>
+				<div aria-label="<%= HtmlUtil.escape(portletDisplay.getTitle()) %>" class="input-container" role="group">
 			</c:if>
 
 			<aui:input name="formDate" type="hidden" value="<%= System.currentTimeMillis() %>" />


### PR DESCRIPTION
Motivation
=======
JAWS read the hidden legend as a navigable element
[Link to story or ticket](https://issues.liferay.com/browse/LPS-169279)

Proposed Solution
========
We have replaced the `<fieldset>` element with `<div role=“group”>` , removed the legend element and added an aria-label to the `<div role=“group”>` with the text that the legend had.

Steps to Verify:
----------------
1. Navigate to Site Builder->Pages and add a page
2. Navigation to Global templates
3. Add a new Global template
4. Input the page name
5. Use jaws
6. Using the arrow key to traverse the add page dialog box
