### PR TITLE
LPS-181116 Implement display of the list of fields in FDS View Fields tab

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/drop-down": "3.92.0",
 		"@liferay/frontend-data-set-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"name": "@liferay/frontend-data-set-views-web",

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -39,10 +39,6 @@ public class FDSViewsDisplayContext {
 		_serviceTrackerList = serviceTrackerList;
 	}
 
-	public String getFDSEntriesAPIURL() {
-		return "/o/c/fdsentries";
-	}
-
 	public String getFDSEntriesURL() {
 		return PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(
@@ -51,10 +47,6 @@ public class FDSViewsDisplayContext {
 		).setMVCPath(
 			"/fds_entries.jsp"
 		).buildString();
-	}
-
-	public String getFDSViewsAPIURL() {
-		return "/o/c/fdsviews";
 	}
 
 	public String getFDSViewsURL() {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -181,6 +181,46 @@ public class FDSViewsPortlet extends MVCPortlet {
 			LocalizedMapUtil.getLocalizedMap("FDSEntry FDSView Relationship"),
 			"fdsEntryFDSViewRelationship",
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectDefinition fdsFieldObjectDefinition =
+			_objectDefinitionLocalService.addCustomObjectDefinition(
+				userId, false, false,
+				LocalizedMapUtil.getLocalizedMap("FDS Field"), "FDSField",
+				"300", null, LocalizedMapUtil.getLocalizedMap("FDS Fields"),
+				ObjectDefinitionConstants.SCOPE_COMPANY,
+				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+				Arrays.asList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "column-label"), "label", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "name"), "name", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "type"), "type", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "renderer"), "renderer", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
+						_language.get(locale, "sortable"), "sortable", true)));
+
+		_objectDefinitionLocalService.publishCustomObjectDefinition(
+			userId, fdsFieldObjectDefinition.getObjectDefinitionId());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+			fdsFieldObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap("FDSView FDSField Relationship"),
+			"fdsViewFDSFieldRelationship",
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/FDSView.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/FDSView.scss
@@ -1,0 +1,5 @@
+@import 'atlas-variables';
+
+html:not(#__):not(#___) .cadmin .fds-view-fields-modal .fields {
+	background-color: $gray-200;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_entries.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_entries.jsp
@@ -20,8 +20,6 @@
 	module="js/FDSEntries"
 	props='<%=
 		HashMapBuilder.<String, Object>put(
-			"fdsEntriesAPIURL", fdsViewsDisplayContext.getFDSEntriesAPIURL()
-		).put(
 			"fdsViewsURL", fdsViewsDisplayContext.getFDSViewsURL()
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
@@ -31,8 +31,6 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsViewLabel"));
 		HashMapBuilder.<String, Object>put(
 			"fdsViewId", ParamUtil.getString(request, "fdsViewId")
 		).put(
-			"fdsViewsAPIURL", fdsViewsDisplayContext.getFDSViewsAPIURL()
-		).put(
 			"fdsViewsURL", fdsViewsURL
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_views.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_views.jsp
@@ -31,8 +31,6 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsEntryLabel"));
 		).put(
 			"fdsEntryLabel", ParamUtil.getString(request, "fdsEntryLabel")
 		).put(
-			"fdsViewsAPIURL", fdsViewsDisplayContext.getFDSViewsAPIURL()
-		).put(
 			"fdsViewURL", fdsViewsDisplayContext.getFDSViewURL()
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
@@ -12,9 +12,16 @@
  * details.
  */
 
+const API_URL = {
+	FDS_ENTRIES: '/o/c/fdsentries',
+	FDS_FIELDS: '/o/c/fdsfields',
+	FDS_VIEWS: '/o/c/fdsviews',
+};
+
 const OBJECT_RELATIONSHIP = {
 	FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship',
 	FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId',
+	FDS_VIEW_FDS_FIELD: 'fdsViewFDSFieldRelationship',
 } as const;
 
 const PAGINATION_PROPS = {
@@ -24,4 +31,4 @@ const PAGINATION_PROPS = {
 	},
 };
 
-export {OBJECT_RELATIONSHIP, PAGINATION_PROPS};
+export {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -25,8 +25,8 @@ import fuzzy from 'fuzzy';
 import React, {useRef, useState} from 'react';
 
 import '../css/FDSEntries.scss';
-import {OBJECT_RELATIONSHIP, PAGINATION_PROPS} from './Constants';
-import {TFDSView} from './FDSViews';
+import {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS} from './Constants';
+import {FDSViewType} from './FDSViews';
 import RequiredMark from './RequiredMark';
 import ValidationFeedback from './ValidationFeedback';
 
@@ -36,7 +36,7 @@ const FUZZY_OPTIONS = {
 };
 
 type FDSEntryType = {
-	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: Array<TFDSView>;
+	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: Array<FDSViewType>;
 	actions: {
 		delete: {
 			href: string;
@@ -258,7 +258,6 @@ const RestEndpointDropdownMenu = ({
 
 interface AddFDSEntryModalContentInterface {
 	closeModal: Function;
-	fdsEntriesAPIURL: string;
 	loadData: Function;
 	namespace: string;
 	restApplications: Array<string>;
@@ -266,7 +265,6 @@ interface AddFDSEntryModalContentInterface {
 
 const AddFDSEntryModalContent = ({
 	closeModal,
-	fdsEntriesAPIURL,
 	loadData,
 	namespace,
 	restApplications,
@@ -316,7 +314,7 @@ const AddFDSEntryModalContent = ({
 			restSchema: selectedRESTSchema,
 		};
 
-		const response = await fetch(fdsEntriesAPIURL, {
+		const response = await fetch(API_URL.FDS_ENTRIES, {
 			body: JSON.stringify(body),
 			headers: {
 				'Accept': 'application/json',
@@ -700,14 +698,12 @@ const AddFDSEntryModalContent = ({
 };
 
 interface FDSEntriesInterface {
-	fdsEntriesAPIURL: string;
 	fdsViewsURL: string;
 	namespace: string;
 	restApplications: Array<string>;
 }
 
 const FDSEntries = ({
-	fdsEntriesAPIURL,
 	fdsViewsURL,
 	namespace,
 	restApplications,
@@ -725,7 +721,6 @@ const FDSEntries = ({
 						}) => (
 							<AddFDSEntryModalContent
 								closeModal={closeModal}
-								fdsEntriesAPIURL={fdsEntriesAPIURL}
 								loadData={loadData}
 								namespace={namespace}
 								restApplications={restApplications}
@@ -836,7 +831,7 @@ const FDSEntries = ({
 	return (
 		<div className="fds-entries">
 			<FrontendDataSet
-				apiURL={`${fdsEntriesAPIURL}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`}
+				apiURL={`${API_URL.FDS_ENTRIES}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`}
 				creationMenu={creationMenu}
 				customDataRenderers={{
 					viewsCount: ViewsCountRenderer,
@@ -862,4 +857,5 @@ const FDSEntries = ({
 	);
 };
 
+export {FDSEntryType};
 export default FDSEntries;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -18,40 +18,50 @@ import ClayNavigationBar from '@clayui/navigation-bar';
 import {fetch, openToast} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {TFDSView} from './FDSViews';
+import '../css/FDSView.scss';
+import {API_URL, OBJECT_RELATIONSHIP} from './Constants';
+import {FDSViewType} from './FDSViews';
 import Details from './fds_view/Details';
+import Fields from './fds_view/Fields';
 
 const NAVIGATION_BAR_ITEMS = [
 	{
 		Component: Details,
 		label: Liferay.Language.get('details'),
 	},
+	{
+		Component: Fields,
+		label: Liferay.Language.get('fields'),
+	},
 ];
 
-interface IFDSViewProps {
-	fdsViewId: string;
-	fdsViewsAPIURL: string;
+interface FDSViewSectionInterface {
+	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
 }
 
-const FDSView = ({
-	fdsViewId,
-	fdsViewsAPIURL,
-	fdsViewsURL,
-	namespace,
-}: IFDSViewProps) => {
+interface FDSViewInterface {
+	fdsViewId: string;
+	fdsViewsURL: string;
+	namespace: string;
+}
+
+const FDSView = ({fdsViewId, fdsViewsURL, namespace}: FDSViewInterface) => {
 	const [activeIndex, setActiveIndex] = useState(0);
-	const [fdsView, setFDSView] = useState<TFDSView>();
+	const [fdsView, setFDSView] = useState<FDSViewType>();
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
 		const getFDSView = async () => {
-			const response = await fetch(`${fdsViewsAPIURL}/${fdsViewId}`, {
-				headers: {
-					Accept: 'application/json',
-				},
-			});
+			const response = await fetch(
+				`${API_URL.FDS_VIEWS}/${fdsViewId}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`,
+				{
+					headers: {
+						Accept: 'application/json',
+					},
+				}
+			);
 
 			const responseJSON = await response.json();
 
@@ -71,7 +81,7 @@ const FDSView = ({
 		};
 
 		getFDSView();
-	}, [fdsViewId, fdsViewsAPIURL]);
+	}, [fdsViewId]);
 
 	const Content = NAVIGATION_BAR_ITEMS[activeIndex].Component;
 
@@ -98,7 +108,6 @@ const FDSView = ({
 				fdsView && (
 					<Content
 						fdsView={fdsView}
-						fdsViewsAPIURL={fdsViewsAPIURL}
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
 					/>
@@ -108,4 +117,5 @@ const FDSView = ({
 	);
 };
 
+export {FDSViewSectionInterface};
 export default FDSView;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -20,20 +20,20 @@ import classNames from 'classnames';
 import {fetch, navigate, openModal, openToast} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
-import '../css/FDSEntries.scss';
-import {OBJECT_RELATIONSHIP, PAGINATION_PROPS} from './Constants';
+import {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS} from './Constants';
+import {FDSEntryType} from './FDSEntries';
 import RequiredMark from './RequiredMark';
 
-export type TFDSView = {
+type FDSViewType = {
+	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: FDSEntryType;
 	description: string;
 	id: string;
 	label: string;
 };
 
-interface IAddFDSViewModalContentProps {
+interface AddFDSViewModalContentInterface {
 	closeModal: Function;
 	fdsEntryId: string;
-	fdsViewsAPIURL: string;
 	loadData: Function;
 	namespace: string;
 }
@@ -41,10 +41,9 @@ interface IAddFDSViewModalContentProps {
 const AddFDSViewModalContent = ({
 	closeModal,
 	fdsEntryId,
-	fdsViewsAPIURL,
 	loadData,
 	namespace,
-}: IAddFDSViewModalContentProps) => {
+}: AddFDSViewModalContentInterface) => {
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
 	const fdsViewDescriptionRef = useRef<HTMLInputElement>(null);
@@ -58,7 +57,7 @@ const AddFDSViewModalContent = ({
 			symbol: 'catalog',
 		};
 
-		const response = await fetch(fdsViewsAPIURL, {
+		const response = await fetch(API_URL.FDS_VIEWS, {
 			body: JSON.stringify(body),
 			headers: {
 				'Accept': 'application/json',
@@ -182,11 +181,10 @@ const AddFDSViewModalContent = ({
 	);
 };
 
-interface IFDSViewsProps {
+interface FDSViewsInterface {
 	fdsEntryId: string;
 	fdsEntryLabel: string;
 	fdsViewURL: string;
-	fdsViewsAPIURL: string;
 	namespace: string;
 }
 
@@ -194,10 +192,9 @@ const FDSViews = ({
 	fdsEntryId,
 	fdsEntryLabel,
 	fdsViewURL,
-	fdsViewsAPIURL,
 	namespace,
-}: IFDSViewsProps) => {
-	const onViewClick = ({itemData}: {itemData: TFDSView}) => {
+}: FDSViewsInterface) => {
+	const onViewClick = ({itemData}: {itemData: FDSViewType}) => {
 		const url = new URL(fdsViewURL);
 
 		url.searchParams.set(`${namespace}fdsEntryId`, fdsEntryId);
@@ -212,7 +209,7 @@ const FDSViews = ({
 		itemData,
 		loadData,
 	}: {
-		itemData: TFDSView;
+		itemData: FDSViewType;
 		loadData: Function;
 	}) => {
 		openModal({
@@ -232,7 +229,7 @@ const FDSViews = ({
 					onClick: ({processClose}: {processClose: Function}) => {
 						processClose();
 
-						fetch(`${fdsViewsAPIURL}/${itemData.id}`, {
+						fetch(`${API_URL.FDS_VIEWS}/${itemData.id}`, {
 							method: 'DELETE',
 						})
 							.then(() => {
@@ -275,7 +272,6 @@ const FDSViews = ({
 							<AddFDSViewModalContent
 								closeModal={closeModal}
 								fdsEntryId={fdsEntryId}
-								fdsViewsAPIURL={fdsViewsAPIURL}
 								loadData={loadData}
 								namespace={namespace}
 							/>
@@ -300,7 +296,7 @@ const FDSViews = ({
 
 	return (
 		<FrontendDataSet
-			apiURL={`${fdsViewsAPIURL}/?filter=(${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW_ID} eq '${fdsEntryId}')`}
+			apiURL={`${API_URL.FDS_VIEWS}/?filter=(${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW_ID} eq '${fdsEntryId}')`}
 			creationMenu={creationMenu}
 			id={`${namespace}FDSViews`}
 			itemsActions={[
@@ -322,4 +318,5 @@ const FDSViews = ({
 	);
 };
 
+export {FDSViewType};
 export default FDSViews;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -19,22 +19,15 @@ import classNames from 'classnames';
 import {fetch, navigate, openToast} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
-import {TFDSView} from '../FDSViews';
+import {API_URL} from '../Constants';
+import {FDSViewSectionInterface} from '../FDSView';
 import RequiredMark from '../RequiredMark';
-
-interface IDetailsProps {
-	fdsView: TFDSView;
-	fdsViewsAPIURL: string;
-	fdsViewsURL: string;
-	namespace: string;
-}
 
 const Details = ({
 	fdsView,
-	fdsViewsAPIURL,
 	fdsViewsURL,
 	namespace,
-}: IDetailsProps) => {
+}: FDSViewSectionInterface) => {
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
 	const fdsViewDescriptionRef = useRef<HTMLInputElement>(null);
@@ -46,7 +39,7 @@ const Details = ({
 			label: fdsViewLabelRef.current?.value,
 		};
 
-		const response = await fetch(`${fdsViewsAPIURL}/${fdsView.id}`, {
+		const response = await fetch(`${API_URL.FDS_VIEWS}/${fdsView.id}`, {
 			body: JSON.stringify(body),
 			headers: {
 				'Accept': 'application/json',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -1,0 +1,347 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {ClayCheckbox, ClayInput} from '@clayui/form';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import ClayModal from '@clayui/modal';
+import {FrontendDataSet} from '@liferay/frontend-data-set-web';
+import {ManagementToolbar} from 'frontend-js-components-web';
+import {fetch, openModal, openToast} from 'frontend-js-web';
+import React, {useEffect, useState} from 'react';
+
+import {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS} from '../Constants';
+import {FDSViewSectionInterface} from '../FDSView';
+import {FDSViewType} from '../FDSViews';
+
+interface AddFDSFieldsModalContentInterface {
+	closeModal: Function;
+	fdsView: FDSViewType;
+	loadData: Function;
+}
+
+type FieldType = {
+	name: string;
+	selected: boolean;
+	type: string;
+	visible: boolean;
+};
+
+const AddFDSFieldsModalContent = ({
+	closeModal,
+	fdsView,
+	loadData,
+}: AddFDSFieldsModalContentInterface) => {
+	const [fields, setFields] = useState<Array<FieldType> | null>(null);
+	const [query, setQuery] = useState('');
+
+	const onSearch = (query: string) => {
+		setQuery(query);
+
+		if (!fields) {
+			return;
+		}
+
+		const regexp = new RegExp(query, 'i');
+
+		setFields(
+			fields.map((field) => ({
+				...field,
+				visible: Boolean(field.name.match(regexp)),
+			}))
+		);
+	};
+
+	useEffect(() => {
+		const getFields = async () => {
+			const {restApplication, restSchema} = fdsView[
+				OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW
+			];
+
+			const response = await fetch(`/o${restApplication}/openapi.json`);
+
+			if (!response.ok) {
+				openToast({
+					message: Liferay.Language.get(
+						'your-request-failed-to-complete'
+					),
+					type: 'danger',
+				});
+
+				return null;
+			}
+
+			const responseJSON = await response.json();
+
+			const properties =
+				responseJSON?.components?.schemas[restSchema]?.properties;
+
+			if (!properties) {
+				openToast({
+					message: Liferay.Language.get(
+						'your-request-failed-to-complete'
+					),
+					type: 'danger',
+				});
+
+				return null;
+			}
+
+			const fieldsArray: Array<FieldType> = [];
+
+			const isObjectSchema =
+				responseJSON.components.schemas[restSchema].xml.name ===
+				'ObjectEntry';
+
+			Object.keys(properties).forEach((propertyKey) => {
+				const propertyValue = properties[propertyKey];
+
+				if (isObjectSchema && !propertyValue.extensions) {
+					return;
+				}
+
+				if (propertyKey === 'x-class-name') {
+					return;
+				}
+
+				const type = propertyValue.type;
+
+				if (type === 'object' || type === 'array') {
+					return;
+				}
+
+				fieldsArray.push({
+					name: propertyKey,
+					selected: false,
+					type,
+					visible: true,
+				});
+			});
+
+			setFields(fieldsArray);
+		};
+
+		getFields();
+	}, [fdsView]);
+
+	const isSelectAllChecked = () => {
+		if (!fields) {
+			return false;
+		}
+
+		const selectedFieldsCount =
+			fields.filter((field) => field.selected)?.length || 0;
+
+		return selectedFieldsCount === fields.length;
+	};
+
+	const isSelectAllIndeterminate = () => {
+		if (!fields) {
+			return false;
+		}
+
+		const selectedFieldsCount =
+			fields.filter((field) => field.selected)?.length || 0;
+
+		return selectedFieldsCount > 0 && selectedFieldsCount < fields.length;
+	};
+
+	const visibleFields = fields?.filter((field) => field.visible) ?? [];
+
+	return (
+		<div className="fds-view-fields-modal">
+			<ClayModal.Header>
+				{Liferay.Language.get('add-fields')}
+			</ClayModal.Header>
+
+			<ClayModal.Body>
+				{fields === null ? (
+					<ClayLoadingIndicator />
+				) : (
+					<>
+						<ManagementToolbar.Container>
+							<ManagementToolbar.ItemList expand>
+								<ManagementToolbar.Item className="pr-2">
+									<ClayCheckbox
+										checked={isSelectAllChecked()}
+										indeterminate={isSelectAllIndeterminate()}
+										onChange={({target: {checked}}) =>
+											setFields(
+												fields.map((field) => ({
+													...field,
+													selected: checked,
+												}))
+											)
+										}
+									/>
+								</ManagementToolbar.Item>
+
+								<ManagementToolbar.Item className="nav-item-expand">
+									<ClayInput.Group>
+										<ClayInput.GroupItem>
+											<ClayInput
+												insetAfter
+												onChange={(event) =>
+													onSearch(event.target.value)
+												}
+												placeholder={Liferay.Language.get(
+													'search'
+												)}
+												type="text"
+												value={query}
+											/>
+
+											<ClayInput.GroupInsetItem
+												after
+												tag="span"
+											>
+												<ClayButtonWithIcon
+													aria-label={Liferay.Language.get(
+														'search'
+													)}
+													displayType="unstyled"
+													symbol="search"
+												/>
+											</ClayInput.GroupInsetItem>
+										</ClayInput.GroupItem>
+									</ClayInput.Group>
+								</ManagementToolbar.Item>
+							</ManagementToolbar.ItemList>
+						</ManagementToolbar.Container>
+
+						<div className="fields pb-2 pt-2">
+							{visibleFields.length > 0 ? (
+								visibleFields.map(({name, selected}) => (
+									<div
+										className="pb-2 pl-3 pr-3 pt-2"
+										key={name}
+									>
+										<ClayCheckbox
+											checked={selected}
+											label={name}
+											onChange={({target: {checked}}) => {
+												setFields(
+													fields.map((field) =>
+														field.name === name
+															? {
+																	...field,
+																	selected: checked,
+															  }
+															: field
+													)
+												);
+											}}
+										/>
+									</div>
+								))
+							) : (
+								<div className="pb-2 pl-3 pr-3 pt-2 text-3">
+									{Liferay.Language.get('no-results-found')}
+								</div>
+							)}
+						</div>
+					</>
+				)}
+			</ClayModal.Body>
+
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							onClick={() => {
+								closeModal();
+
+								loadData();
+							}}
+						>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => closeModal()}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</div>
+	);
+};
+
+const Fields = ({fdsView, namespace}: FDSViewSectionInterface) => {
+	const creationMenu = {
+		primaryItems: [
+			{
+				label: Liferay.Language.get('new-dataset'),
+				onClick: ({loadData}: {loadData: Function}) =>
+					openModal({
+						contentComponent: ({
+							closeModal,
+						}: {
+							closeModal: Function;
+						}) => (
+							<AddFDSFieldsModalContent
+								closeModal={closeModal}
+								fdsView={fdsView}
+								loadData={loadData}
+							/>
+						),
+					}),
+			},
+		],
+	};
+
+	const views = [
+		{
+			contentRenderer: 'table',
+			name: 'table',
+			schema: {
+				fields: [
+					{fieldName: 'name', label: Liferay.Language.get('name')},
+					{
+						fieldName: 'label',
+						label: Liferay.Language.get('column-label'),
+					},
+					{
+						fieldName: 'type',
+						label: Liferay.Language.get('type'),
+					},
+					{
+						fieldName: 'renderer',
+						label: Liferay.Language.get('renderer'),
+					},
+					{
+						fieldName: 'sortable',
+						label: Liferay.Language.get('sortable'),
+					},
+				],
+			},
+		},
+	];
+
+	return (
+		<FrontendDataSet
+			apiURL={`${API_URL.FDS_FIELDS}?nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD}`}
+			creationMenu={creationMenu}
+			id={`${namespace}FDSFields`}
+			style="fluid"
+			views={views}
+			{...PAGINATION_PROPS}
+		/>
+	);
+};
+
+export default Fields;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/tsconfig.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "811127be1cb19a5546396809d55129c18d6b8cbd",
+	"@generated": "ecde8b5a59fa5b9d339534f649f9fbc538ae706a",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -15,6 +15,9 @@
 		"paths": {
 			"@liferay/frontend-data-set-web": [
 				"../frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts"
+			],
+			"frontend-js-components-web": [
+				"../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.d.ts"
 			],
 			"frontend-js-web": [
 				"../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
@@ -40,6 +43,9 @@
 	"references": [
 		{
 			"path": "../frontend-data-set-web"
+		},
+		{
+			"path": "../../frontend-js/frontend-js-components-web"
 		},
 		{
 			"path": "../../frontend-js/frontend-js-web"

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
@@ -12,9 +12,15 @@
  * details.
  */
 
+declare const API_URL: {
+	FDS_ENTRIES: string;
+	FDS_FIELDS: string;
+	FDS_VIEWS: string;
+};
 declare const OBJECT_RELATIONSHIP: {
 	readonly FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship';
 	readonly FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId';
+	readonly FDS_VIEW_FDS_FIELD: 'fdsViewFDSFieldRelationship';
 };
 declare const PAGINATION_PROPS: {
 	pagination: {
@@ -24,4 +30,4 @@ declare const PAGINATION_PROPS: {
 		initialDelta: number;
 	};
 };
-export {OBJECT_RELATIONSHIP, PAGINATION_PROPS};
+export {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -15,16 +15,31 @@
 /// <reference types="react" />
 
 import '../css/FDSEntries.scss';
+import {OBJECT_RELATIONSHIP} from './Constants';
+import {FDSViewType} from './FDSViews';
+declare type FDSEntryType = {
+	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: Array<FDSViewType>;
+	actions: {
+		delete: {
+			href: string;
+			method: string;
+		};
+	};
+	id: string;
+	label: string;
+	restApplication: string;
+	restEndpoint: string;
+	restSchema: string;
+};
 interface FDSEntriesInterface {
-	fdsEntriesAPIURL: string;
 	fdsViewsURL: string;
 	namespace: string;
 	restApplications: Array<string>;
 }
 declare const FDSEntries: ({
-	fdsEntriesAPIURL,
 	fdsViewsURL,
 	namespace,
 	restApplications,
 }: FDSEntriesInterface) => JSX.Element;
+export {FDSEntryType};
 export default FDSEntries;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -14,16 +14,22 @@
 
 /// <reference types="react" />
 
-interface IFDSViewProps {
+import '../css/FDSView.scss';
+import {FDSViewType} from './FDSViews';
+interface FDSViewSectionInterface {
+	fdsView: FDSViewType;
+	fdsViewsURL: string;
+	namespace: string;
+}
+interface FDSViewInterface {
 	fdsViewId: string;
-	fdsViewsAPIURL: string;
 	fdsViewsURL: string;
 	namespace: string;
 }
 declare const FDSView: ({
 	fdsViewId,
-	fdsViewsAPIURL,
 	fdsViewsURL,
 	namespace,
-}: IFDSViewProps) => JSX.Element;
+}: FDSViewInterface) => JSX.Element;
+export {FDSViewSectionInterface};
 export default FDSView;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -14,17 +14,10 @@
 
 /// <reference types="react" />
 
-import {TFDSView} from '../FDSViews';
-interface IDetailsProps {
-	fdsView: TFDSView;
-	fdsViewsAPIURL: string;
-	fdsViewsURL: string;
-	namespace: string;
-}
+import {FDSViewSectionInterface} from '../FDSView';
 declare const Details: ({
 	fdsView,
-	fdsViewsAPIURL,
 	fdsViewsURL,
 	namespace,
-}: IDetailsProps) => JSX.Element;
+}: FDSViewSectionInterface) => JSX.Element;
 export default Details;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
@@ -14,25 +14,9 @@
 
 /// <reference types="react" />
 
-import {OBJECT_RELATIONSHIP} from './Constants';
-import {FDSEntryType} from './FDSEntries';
-declare type FDSViewType = {
-	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: FDSEntryType;
-	description: string;
-	id: string;
-	label: string;
-};
-interface FDSViewsInterface {
-	fdsEntryId: string;
-	fdsEntryLabel: string;
-	fdsViewURL: string;
-	namespace: string;
-}
-declare const FDSViews: ({
-	fdsEntryId,
-	fdsEntryLabel,
-	fdsViewURL,
+import {FDSViewSectionInterface} from '../FDSView';
+declare const Fields: ({
+	fdsView,
 	namespace,
-}: FDSViewsInterface) => JSX.Element;
-export {FDSViewType};
-export default FDSViews;
+}: FDSViewSectionInterface) => JSX.Element;
+export default Fields;


### PR DESCRIPTION
### References

- [LPS-181116 Implement display of the list of fields in FDS View Fields tab](https://issues.liferay.com/browse/LPS-181116)
- [Mockups](https://www.figma.com/file/VTOLTBFe99y9kA7AY3TcNR/lps-165276-design-app-to-manage-datasets?node-id=1212-129807&t=O4mTLVakfJIDVQrk-0)

### What is the goal of this PR?

The main goal of this PR is to fetch list of fields for a given REST application and schema. 

Technical notes:
- We are making a OpenAPI REST application request and parsing response for given schema properties.
- Properties are in different format for Objects and other REST applications. In either case, there are some properties that do not match fields. Unfortunately, there is no explicit marker that a property is a field. Logic that we are applying is probably the ugliest part of this PR (see use of `extensions` property and removal of `x-class-name`). Hopefully, solution in this PR is temporary, and we get some better indication from origin later on. /cc @4lejandrito @gabrielwas
- We're doing a couple of side-quests:
  - renaming remaining types and interfaces
  - moving API URL definitions from backend to frontend
- We are preparing persistence for FDS Fields. It is not yet used, will be used in the next story.

/cc @ugeortiz

### What does it look like?

https://user-images.githubusercontent.com/5435511/232493024-4693b6bf-efc5-422b-b8ba-e5e863c19dcf.mp4

### Steps to reproduce
1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`. This enables FDS Views Manager.
1. Add `feature.flag.LPS-161364=true` to `portal-ext.properties`. This enables Objects relationships nested fields, used by FDS Views Manager.
1. If you previously opened Datasets page, delete `FDS Entry` and `FDS View` on Global Menu > Control Panel > Object > Objects
1. Open Global Menu > Control Panel > Object > Datasets