### PR TITLE
LPS-168553 Update acorn version to fix vulnerability

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -6,7 +6,7 @@
 		"@types/codemirror": "^5.60.5",
 		"@types/react-router-dom": "^5.3.3",
 		"@types/warning": "^3.0.0",
-		"acorn": "7.1.0",
+		"acorn": "7.1.1",
 		"alloy-ui": "^3.1.0-deprecated.40",
 		"babel-plugin-incremental-dom": "3.4.0",
 		"compass-mixins": "0.12.10",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -2883,10 +2883,10 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
 
-acorn@7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.0.tgz#949d36f2c292535da602283586c2477c57eb2d6c"
-  integrity sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
+acorn@7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 acorn@^6.0.1, acorn@^6.0.4, acorn@^6.2.1:
   version "6.4.0"


### PR DESCRIPTION
This PR fixes a security vulnerability due to an old version of the `acorn` dependency

`gradlew formatSource` after the change

![vul2](https://user-images.githubusercontent.com/46778114/232530950-40c65e41-7b72-4928-9a5e-3dff2a393348.jpg)
