### PR TITLE
LPS-181344 | Added new automation test FDSViews#CanEditOrDeleteView

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -68,6 +68,11 @@
 	<td>//div[contains(@class,"justify-content-center autofit-col autofit-col-expand") and contains(.,'${key_itemName}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>OPTIONS_IN_VIEW_ELLIPSIS</td>
+	<td>//ul[contains(@class,"list-unstyled")]//button[contains(@class,"dropdown-item") and contains(.,'${key_name}')]//span[contains(@class,"pr-2")]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -140,4 +140,38 @@ definition {
 		}
 	}
 
+	@description = "LPS-181344. Assert that the user can edit or delet view"
+	@priority = 5
+	test CanEditOrDeleteView {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created, and click save button") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
+
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Description Test",
+				key_name = "View Test");
+		}
+
+		task ("And Clicking the ellipsis button") {
+			Click(
+				key_name = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
+		}
+
+		task ("Then confirm the options Edit and Delete are visible") {
+			AssertElementPresent(
+				key_name = "View",
+				locator1 = "FrontendDataSetAdmin#OPTIONS_IN_VIEW_ELLIPSIS");
+
+			AssertElementPresent(
+				key_name = "Delete",
+				locator1 = "FrontendDataSetAdmin#OPTIONS_IN_VIEW_ELLIPSIS");
+		}
+	}
+
 }


### PR DESCRIPTION
Descriptiion:
New automation that visualizes/confirms the two options (View) and (Delete) in the VIEWS ellipses

Plan:
- Given access to Datasets admin page
- And Add a Dataset
- When go to the View page of the dataset created, and click save button
- And Clicking the ellipsis button
- Then confirm the options Edit and Delete are visible

JIRA Ticket:
https://issues.liferay.com/browse/LPS-181344