### PR TITLE
LPS-181341 | Automation FDSViews#CanCreateViewWithNoDescription

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -108,6 +108,32 @@ definition {
 		}
 	}
 
+	@description = "LPS-181341. Confirm that The user can create a view with no description"
+	@priority = 4
+	test CanCreateViewWithNoDescription {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When going to the Dataset View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Clicking add button, And Filling the name with 'View Test', And Clicking the Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "",
+				key_name = "View Test");
+		}
+
+		task ("Then Confirm Data set view was created") {
+			AssertElementPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 	@description = "LPS-180893. Confirm that a dataset view can be deleted"
 	@priority = 5
 	test CanDeleteView {


### PR DESCRIPTION
**Description**
- Given access to Datasets admin page
- And Add a Dataset
- When going to the Dataset View page of the dataset created.
- And Clicking add button
- And Filling the Name field with "View Test"
- And Click the Save button
- Then Confirm Data set view was created

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-181341