### PR TITLE
LPS-181342 | Automation for FDSViews#CanCancelViewCreationOnCancelButton

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -76,6 +76,42 @@ definition {
 		}
 	}
 
+	@description = "LPS-181342. Confirm that the user can cancel a view criation by clicking on cancel button"
+	@priority = 5
+	test CanCancelViewCreationOnCancelButton {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Filling the name with 'View Test") {
+			LexiconEntry.gotoAdd();
+
+			Type(
+				locator1 = "TextInput#NAME",
+				value1 = "Test Description");
+
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = "View Test");
+		}
+
+		task ("And Clicking Cancel button") {
+			Button.clickCancel();
+		}
+
+		task ("Then Confirm that the View was not created") {
+			AssertElementNotPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 	@description = "LPS-180893. Confirm that a dataset view can be deleted"
 	@ignore = "true"
 	@priority = 5


### PR DESCRIPTION
**Description**
- Given access to Datasets admin page
- And Add a Dataset
- When go to the View page of the dataset created.
- And Filling the name with "View Test"
- And the description field with "Test Description"
- And Clicking Cancel button
- Then Confirm that the View was not created

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-181342