### PR TITLE
LPS-181346 | Automation FDSViews#CanAssertPaginationOnFDSViewsPage

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -1,5 +1,13 @@
 definition {
 
+	macro assertDataSetView {
+		for (var key_dataSetViewName : list ${key_dataSetViewNameList}) {
+			AssertElementPresent(
+				entryName = ${key_dataSetViewName},
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 	macro changePagination {
 		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
 
@@ -19,17 +27,34 @@ definition {
 	}
 
 	macro createDataSetView {
-		LexiconEntry.gotoAdd();
+		if (isSet(key_dataSetViewNameList)) {
+			for (var key_dataSetViewName : list ${key_dataSetViewNameList}) {
+				LexiconEntry.gotoAdd();
 
-		Type(
-			locator1 = "TextInput#NAME",
-			value1 = ${key_name});
+				Type(
+					locator1 = "TextInput#NAME",
+					value1 = ${key_dataSetViewName});
 
-		Type(
-			locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
-			value1 = ${description});
+				Type(
+					locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+					value1 = ${description});
 
-		PortletEntry.save();
+				PortletEntry.save();
+			}
+		}
+		else {
+			LexiconEntry.gotoAdd();
+
+			Type(
+				locator1 = "TextInput#NAME",
+				value1 = ${key_name});
+
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = ${description});
+
+			PortletEntry.save();
+		}
 	}
 
 	macro deleteAllDatasetEntries {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -66,6 +66,44 @@ definition {
 		}
 	}
 
+	@description = "LPS-181348. Confirm that a dataset view can be deleted"
+	@priority = 5
+	test AssertNumberOfCharactersExceededInNameField {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Clicking add button") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("And a user types a name that is more than 280 characters") {
+			Type(
+				locator1 = "TextInput#NAME",
+				value1 = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.");
+		}
+
+		task ("And Filling the description field with 'Test Description'") {
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = "Test Description");
+		}
+
+		task ("And Clicking Save button") {
+			Button.clickSave();
+		}
+
+		task ("Then confirm the error alert is present") {
+			Alert.viewErrorMessage(errorMessage = "Error:Your request failed to complete");
+		}
+	}
+
 	@description = "LPS-181346. Confirm that pagination works right on views page"
 	@priority = 3
 	test CanAssertPaginationOnFDSViewsPage {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -82,8 +82,7 @@ definition {
 		task ("And Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Test Description",
-				key_name = "View Test",
-				reps = "1,2,3,4,5,6");
+				key_dataSetViewNameList = "View Test 1,View Test 2,View Test 3,View Test 4,View Test 5,View Test 6");
 		}
 
 		task ("And changing the page to 4 entries.") {
@@ -91,11 +90,7 @@ definition {
 		}
 
 		task ("Then confirm that only 4 entries are displayed") {
-			for (var num : list "1,2,3,4") {
-				AssertElementPresent(
-					entryName = "View Test ${num}",
-					locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
-			}
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test 1,View Test 2,View Test 3,View Test 4");
 
 			Pagination.viewResults(results = "Showing 1 to 4 of 6 entries.");
 		}
@@ -105,11 +100,7 @@ definition {
 		}
 
 		task ("Then 2 entries are displayed") {
-			for (var num : list "5,6") {
-				AssertElementPresent(
-					entryName = "View Test ${num}",
-					locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
-			}
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test 5,View Test 6");
 
 			Pagination.viewResults(results = "Showing 5 to 6 of 6 entries.");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -184,6 +184,32 @@ definition {
 		}
 	}
 
+	@description = "LPS-181341. Confirm that The user can create a view with no description"
+	@priority = 4
+	test CanCreateViewWithNoDescription {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When going to the Dataset View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Clicking add button, And Filling the name with 'View Test', And Clicking the Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "",
+				key_name = "View Test");
+		}
+
+		task ("Then Confirm Data set view was created") {
+			AssertElementPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 	@description = "LPS-180893. Confirm that a dataset view can be deleted"
 	@priority = 5
 	test CanDeleteView {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -216,4 +216,40 @@ definition {
 		}
 	}
 
+	@description = "LPS-181351. Confirm that the user can search a view by its name"
+	@priority = 4
+	test CanSearchViewByName {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Adding a new view called 'View Test' and the description field with 'Test Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test");
+		}
+
+		task ("And Adding a new view called 'Bob Test' and the description field with 'Bob Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Bob Description",
+				key_name = "Bob Test");
+		}
+
+		task ("And type 'View Test' in the search bar and click enter") {
+			Search.searchCP(searchTerm = "View Test");
+		}
+
+		task ("Then the corresponding view is displayed") {
+			AssertElementPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -180,9 +180,7 @@ definition {
 		}
 
 		task ("Then The dataset is present in the data set Admin page") {
-			AssertElementPresent(
-				entryName = "View Test",
-				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -32,40 +32,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-180896 Confirm that the dataset view deletion is recoverable"
-	@priority = 5
-	test CanCancelDeletionOnCancelButton {
-		task ("The user goes to add a new Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Test Dataset",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("And Add a new view") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
-
-			FrontendDataSetAdmin.createDataSetView(
-				description = "Description Test",
-				key_name = "View Test");
-		}
-
-		task ("And select delete and in the modal, click the cancel button") {
-			Click(
-				key_name = "View Test",
-				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
-
-			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
-
-			Button.clickCancel();
-		}
-
-		task ("Then the dataset View is not deleted") {
-			AssertElementPresent(
-				key_itemName = "View Test",
-				locator1 = "FrontendDataSetAdmin#NAME_OF_VIEWS");
-		}
-	}
-
 	@description = "LPS-181348. Confirm that a dataset view can be deleted"
 	@priority = 5
 	test AssertNumberOfCharactersExceededInNameField {
@@ -144,6 +110,40 @@ definition {
 		}
 	}
 
+	@description = "LPS-180896 Confirm that the dataset view deletion is recoverable"
+	@priority = 5
+	test CanCancelDeletionOnCancelButton {
+		task ("The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("And Add a new view") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
+
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Description Test",
+				key_name = "View Test");
+		}
+
+		task ("And select delete and in the modal, click the cancel button") {
+			Click(
+				key_name = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
+
+			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
+
+			Button.clickCancel();
+		}
+
+		task ("Then the dataset View is not deleted") {
+			AssertElementPresent(
+				key_itemName = "View Test",
+				locator1 = "FrontendDataSetAdmin#NAME_OF_VIEWS");
+		}
+	}
+
 	@description = "LPS-180898. Confirm that the user can cancel deletion when clicking close (X) button"
 	@priority = 3
 	test CanCancelDeletionOnCloseButton {
@@ -181,6 +181,42 @@ definition {
 
 		task ("Then The dataset is present in the data set Admin page") {
 			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test");
+		}
+	}
+
+	@description = "LPS-181342. Confirm that the user can cancel a view criation by clicking on cancel button"
+	@priority = 5
+	test CanCancelViewCreationOnCancelButton {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Filling the name with 'View Test") {
+			LexiconEntry.gotoAdd();
+
+			Type(
+				locator1 = "TextInput#NAME",
+				value1 = "Test Description");
+
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = "View Test");
+		}
+
+		task ("And Clicking Cancel button") {
+			Button.clickCancel();
+		}
+
+		task ("Then Confirm that the View was not created") {
+			AssertElementNotPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
 		}
 	}
 
@@ -273,42 +309,6 @@ definition {
 
 		task ("Then the corresponding view is displayed") {
 			AssertElementPresent(
-				entryName = "View Test",
-				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
-		}
-	}
-
-	@description = "LPS-181342. Confirm that the user can cancel a view criation by clicking on cancel button"
-	@priority = 5
-	test CanCancelViewCreationOnCancelButton {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Filling the name with 'View Test") {
-			LexiconEntry.gotoAdd();
-
-			Type(
-				locator1 = "TextInput#NAME",
-				value1 = "Test Description");
-
-			Type(
-				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
-				value1 = "View Test");
-		}
-
-		task ("And Clicking Cancel button") {
-			Button.clickCancel();
-		}
-
-		task ("Then Confirm that the View was not created") {
-			AssertElementNotPresent(
 				entryName = "View Test",
 				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -252,4 +252,40 @@ definition {
 		}
 	}
 
+	@description = "LPS-181342. Confirm that the user can cancel a view criation by clicking on cancel button"
+	@priority = 5
+	test CanCancelViewCreationOnCancelButton {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Filling the name with 'View Test") {
+			LexiconEntry.gotoAdd();
+
+			Type(
+				locator1 = "TextInput#NAME",
+				value1 = "Test Description");
+
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = "View Test");
+		}
+
+		task ("And Clicking Cancel button") {
+			Button.clickCancel();
+		}
+
+		task ("Then Confirm that the View was not created") {
+			AssertElementNotPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -66,6 +66,55 @@ definition {
 		}
 	}
 
+	@description = "LPS-181346. Confirm that pagination works right on views page"
+	@priority = 3
+	test CanAssertPaginationOnFDSViewsPage {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test",
+				reps = "1,2,3,4,5,6");
+		}
+
+		task ("And changing the page to 4 entries.") {
+			FrontendDataSetAdmin.changePagination(itemsPerPage = "4 Items");
+		}
+
+		task ("Then confirm that only 4 entries are displayed") {
+			for (var num : list "1,2,3,4") {
+				AssertElementPresent(
+					entryName = "View Test ${num}",
+					locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+			}
+
+			Pagination.viewResults(results = "Showing 1 to 4 of 6 entries.");
+		}
+
+		task ("When to switch to page 2") {
+			Click(locator1 = "Pagination#NEXT_LINK");
+		}
+
+		task ("Then 2 entries are displayed") {
+			for (var num : list "5,6") {
+				AssertElementPresent(
+					entryName = "View Test ${num}",
+					locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+			}
+
+			Pagination.viewResults(results = "Showing 5 to 6 of 6 entries.");
+		}
+	}
+
 	@description = "LPS-180898. Confirm that the user can cancel deletion when clicking close (X) button"
 	@priority = 3
 	test CanCancelDeletionOnCloseButton {


### PR DESCRIPTION
**Description**
Automation for FDSViews#CanAssertPaginationOnFDSViewsPage - LPS-181346
Automation for FDSViews#AssertNumberOfCharactersExceededInNameField - LPS-181348 (already checked)
Automation for FDSViews#CanSearchViewByName - LPS-181351
Automation FDSViews#CanCancelViewCreationOnCancelButton - LPS-181342
Automation for FDSViews#CanCreateViewWithNoDescription - LPS-181341

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-181346
https://issues.liferay.com/browse/LPS-181348
https://issues.liferay.com/browse/LPS-181351
https://issues.liferay.com/browse/LPS-181342
https://issues.liferay.com/browse/LPS-181341