### PR TITLE
LPS-181347|Automation FDSViews#CanAssertNameFieldIsTrunkedIfExceedCharacters

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -34,6 +34,32 @@ definition {
 		}
 	}
 
+	@description = "LPS-181347. Confirm that field is trunked if exceed 100 characters"
+	@priority = 4
+	test CanAssertNameFieldIsTrunkedIfExceedCharacters {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Clicking add button, and a user types a name that is more than 100 characters until 280 characters, and Filling the description field with 'Test Description', and Clicking Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
+		}
+
+		task ("Then confirm the name value will be trunked") {
+			AssertElementPresent(
+				entryName = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 	@description = "LPS-180898. Confirm that the user can cancel deletion when clicking close (X) button"
 	@priority = 3
 	test CanCancelDeletionOnCloseButton {


### PR DESCRIPTION
**Description**

**Given** access to Datasets admin page

**And** Add a Dataset

**When** go to the View page of the dataset created.

**And** Clicking add button

**And** a user types a name that is more than 100 characters until 280 characters

**And** Filling the description field with "Test Description" 

**And** Clicking Save button

**Then** confirm the name value will be trunked

**Link JIRA** 
https://issues.liferay.com/browse/LPS-181347