### PR TITLE
LPS-181351 | Automation for FDSViews#CanSearchViewByName

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -85,4 +85,40 @@ definition {
 
 	}
 
+	@description = "LPS-181351. Confirm that the user can search a view by its name"
+	@priority = 4
+	test CanSearchViewByName {
+		task ("And Add a Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Dataset Test",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
+		}
+
+		task ("And Adding a new view called 'View Test' and the description field with 'Test Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test");
+		}
+
+		task ("And Adding a new view called 'Bob Test' and the description field with 'Bob Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Bob Description",
+				key_name = "Bob Test");
+		}
+
+		task ("And type 'View Test' in the search bar and click enter") {
+			Search.searchCP(searchTerm = "View Test");
+		}
+
+		task ("Then the corresponding view is displayed") {
+			AssertElementPresent(
+				entryName = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+		}
+	}
+
 }


### PR DESCRIPTION
**Description**
- Given access to Datasets admin page
- And Add a Dataset
- When go to the View page of the dataset created.
- And Adding a new view called "View Test" and the description field with "Test Description"
- And Clicking Save button
- And Adding a new view called "Bob Test" and the description field with "Bob Description"
- And Clicking Save button
- And type "View Test" in the search bar and click enter
- Then the corresponding view is displayed

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-181351