### PR TITLE
LPS-181353 | Add FDSViews automation tests

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -118,7 +118,7 @@ definition {
 
 	macro editView {
 		Click(
-			key_name = "${key_OldName}",
+			key_name = ${key_oldName},
 			locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
 
 		MenuItem.click(menuItem = "View");
@@ -126,15 +126,15 @@ definition {
 		Type(
 			key_type = "Name",
 			locator1 = "FrontendDataSetAdmin#EDIT_DATA_SET_VIEW",
-			value1 = ${key_NewName});
-		
+			value1 = ${key_newName});
+
 		Type(
 			key_type = "Description",
 			locator1 = "FrontendDataSetAdmin#EDIT_DATA_SET_VIEW",
-			value1 = ${key_NewDescription});
+			value1 = ${key_newDescription});
 
 		PortletEntry.save();
-		
+
 		Navigator.gotoBack();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -8,6 +8,14 @@ definition {
 		}
 	}
 
+	macro assertDataSetViewDescription {
+		for (var key_dataSetViewDescription : list ${key_dataSetViewDescriptionList}) {
+			AssertElementPresent(
+				key_description = ${key_dataSetViewDescription},
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_DESCRIPTION");
+		}
+	}
+
 	macro changePagination {
 		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
 
@@ -106,6 +114,28 @@ definition {
 			locator1 = "FrontendDataSetAdmin#DELETE_DATA_SET_MODAL_BODY");
 
 		Button.clickDelete();
+	}
+
+	macro editView {
+		Click(
+			key_name = "${key_OldName}",
+			locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
+
+		MenuItem.click(menuItem = "View");
+
+		Type(
+			key_type = "Name",
+			locator1 = "FrontendDataSetAdmin#EDIT_DATA_SET_VIEW",
+			value1 = ${key_NewName});
+		
+		Type(
+			key_type = "Description",
+			locator1 = "FrontendDataSetAdmin#EDIT_DATA_SET_VIEW",
+			value1 = ${key_NewDescription});
+
+		PortletEntry.save();
+		
+		Navigator.gotoBack();
 	}
 
 	macro goToDatasetAdminPage {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -64,6 +64,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DATA_SET_VIEW_DESCRIPTION</td>
+	<td>//li[contains(@class,'list-group-item')]//div[contains(@class,'justify-content-center')]//p[(@class="list-group-text") and contains (.,'${key_description}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>EDIT_DATA_SET_VIEW</td>
+	<td>//div[contains(@class,"sheet-section")]//div[contains(@class,"form-group") and contains (.,'${key_type}')]//input[contains(@class,"form-control")]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>NAME_OF_VIEWS</td>
 	<td>//div[contains(@class,"justify-content-center autofit-col autofit-col-expand") and contains(.,'${key_itemName}')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -67,6 +67,58 @@ definition {
 		}
 	}
 
+	@description = "LPS-181349. Confirm that description field is trunked if exceed 100 characters"
+	@priority = 4
+	test AssertNumberOfCharactersInDescriptionField {
+		task ("When go to add View with name View Test and description with 150 characters") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor accumsan luctus. Praesent feugiat nibh a lectus hendrerit lobortis. Donec blandit.",
+				key_name = "View Test");
+		}
+
+		task ("Then confirm the description value will be trunked") {
+			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor accumsan luctus. Praesent feugiat nibh a lectus hendrerit lobortis. Donec blandit.");
+		}
+	}
+
+	@description = "LPS-181347. Confirm that field is trunked if exceed 100 characters"
+	@priority = 4
+	test CanAssertNameFieldIsTrunkedIfExceedCharacters {
+		task ("When Clicking add button, and a user types a name that is more than 100 characters until 280 characters, and Filling the description field with 'Test Description', and Clicking Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
+		}
+
+		task ("Then confirm the name value will be trunked") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
+		}
+	}
+
+	@description = "LPS-181340. Confirm that the name field is required for creating a view"
+	@priority = 5
+	test CanAssertNameIsRequired {
+		task ("When Clicking add button") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("And Filling the description field with 'Test Description'") {
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = "Test Description");
+		}
+
+		task ("And When Click the Save button") {
+			PortletEntry.save();
+		}
+
+		task ("Then Confirm that 'This field is required' alert messages are present in the provider field") {
+			AssertTextPresent(
+				locator1 = "Message#ERROR",
+				value1 = "This field is required.");
+		}
+	}
+
 	@description = "LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
 	@priority = 5
 	test CanAssertPagination {
@@ -96,20 +148,6 @@ definition {
 
 		task ("Then Confirm that only one page is displayed") {
 			Pagination.viewResults(results = "Showing 1 to 4 of 4 entries.");
-		}
-	}
-	
-	@description = "LPS-181349. Confirm that description field is trunked if exceed 100 characters"
-	@priority = 4
-	test AssertNumberOfCharactersInDescriptionField {
-		task ("When go to add View with name View Test and description with 150 characters") {
-			FrontendDataSetAdmin.createDataSetView(
-				description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor accumsan luctus. Praesent feugiat nibh a lectus hendrerit lobortis. Donec blandit.",
-				key_name = "View Test");
-		}
-
-		task ("Then confirm the description value will be trunked") {
-			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor accumsan luctus. Praesent feugiat nibh a lectus hendrerit lobortis. Donec blandit.");
 		}
 	}
 
@@ -305,31 +343,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-181353. Confirm that the user can search a view by its description"
-	@priority = 4
-	test CanSearchViewByDescription {
-		task ("When Adding a new view called 'View Test' and the description field with 'Test Description', And Clicking Save button") {
-			FrontendDataSetAdmin.createDataSetView(
-				description = "Test Description",
-				key_name = "View Test");
-		}
-
-		task ("And Adding a new view called 'Bob Test' and the description field with 'Bob Description'") {
-			FrontendDataSetAdmin.createDataSetView(
-				description = "Bob Description",
-				key_name = "Bob Test");
-		}
-
-		task ("And type 'Bob Description' in the search bar and click enter.") {
-			Search.searchCP(searchTerm = "Bob Description");
-		}
-
-		task ("Then the corresponding view is displayed") {
-			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Bob Test");
-
-		}
-	}
-
 	@description = "LPS-181344. Assert that the user can edit or delet view"
 	@priority = 5
 	test CanEditOrDeleteView {
@@ -363,15 +376,39 @@ definition {
 
 		task ("When we edit the name and description of a view ") {
 			FrontendDataSetAdmin.editView(
-				key_OldName = "View Test",
-				key_NewName = "View Test edited",
-				key_NewDescription = "Test Description edited");
+				key_newDescription = "Test Description edited",
+				key_newName = "View Test edited",
+				key_oldName = "View Test");
 		}
 
 		task ("Then The dataset is present in the data set Admin page") {
 			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test edited");
 
 			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Test Description edited");
+		}
+	}
+
+	@description = "LPS-181353. Confirm that the user can search a view by its description"
+	@priority = 4
+	test CanSearchViewByDescription {
+		task ("When Adding a new view called 'View Test' and the description field with 'Test Description', And Clicking Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test");
+		}
+
+		task ("And Adding a new view called 'Bob Test' and the description field with 'Bob Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Bob Description",
+				key_name = "Bob Test");
+		}
+
+		task ("And type 'Bob Description' in the search bar and click enter.") {
+			Search.searchCP(searchTerm = "Bob Description");
+		}
+
+		task ("Then the corresponding view is displayed") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Bob Test");
 		}
 	}
 
@@ -440,44 +477,6 @@ definition {
 			AssertElementPresent(
 				locator1 = "FrontendDataSetAdmin#NUMBER_OF_VIEWS",
 				numberOfViews = 0);
-		}
-	}
-
-	@description = "LPS-181347. Confirm that field is trunked if exceed 100 characters"
-	@priority = 4
-	test CanAssertNameFieldIsTrunkedIfExceedCharacters {
-		task ("When Clicking add button, and a user types a name that is more than 100 characters until 280 characters, and Filling the description field with 'Test Description', and Clicking Save button") {
-			FrontendDataSetAdmin.createDataSetView(
-				description = "Test Description",
-				key_name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
-		}
-
-		task ("Then confirm the name value will be trunked") {
-			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
-		}
-	}
-
-	@description = "LPS-181340. Confirm that the name field is required for creating a view"
-	@priority = 5
-	test CanAssertNameIsRequired {
-		task ("When Clicking add button") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And Filling the description field with 'Test Description'") {
-			Type(
-				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
-				value1 = "Test Description");
-		}
-
-		task ("And When Click the Save button") {
-			PortletEntry.save();
-		}
-
-		task ("Then Confirm that 'This field is required' alert messages are present in the provider field") {
-			AssertTextPresent(
-				locator1 = "Message#ERROR",
-				value1 = "This field is required.");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -13,11 +13,18 @@ definition {
 
 		User.firstLoginPG();
 
-		task ("Given access Datasets admin page") {
-			ApplicationsMenu.gotoPortlet(
-				category = "Object",
-				panel = "Control Panel",
-				portlet = "Datasets");
+		task ("Given creating a Data Set via API") {
+			FrontendDataSetAdmin.goToDatasetAdminPage();
+
+			FrontendDataSetAdmin.createDatasetEntryViaAPI(
+				datasetName = "Dataset Test",
+				restApplication = "/c/fdsentries");
+
+			Refresh();
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
 		}
 	}
 
@@ -35,16 +42,6 @@ definition {
 	@description = "LPS-181348. Confirm that a dataset view can be deleted"
 	@priority = 5
 	test AssertNumberOfCharactersExceededInNameField {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
 		task ("And Clicking add button") {
 			LexiconEntry.gotoAdd();
 		}
@@ -73,16 +70,6 @@ definition {
 	@description = "LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
 	@priority = 5
 	test CanAssertPagination {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
 		task ("And Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Test Description",
@@ -111,21 +98,25 @@ definition {
 			Pagination.viewResults(results = "Showing 1 to 4 of 4 entries.");
 		}
 	}
+	
+	@description = "LPS-181349. Confirm that description field is trunked if exceed 100 characters"
+	@priority = 4
+	test AssertNumberOfCharactersInDescriptionField {
+		task ("When go to add View with name View Test and description with 150 characters") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor accumsan luctus. Praesent feugiat nibh a lectus hendrerit lobortis. Donec blandit.",
+				key_name = "View Test");
+		}
+
+		task ("Then confirm the description value will be trunked") {
+			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed auctor accumsan luctus. Praesent feugiat nibh a lectus hendrerit lobortis. Donec blandit.");
+		}
+	}
 
 	@description = "LPS-181346. Confirm that pagination works right on views page"
 	@priority = 3
 	test CanAssertPaginationOnFDSViewsPage {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
+		task ("When Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Test Description",
 				key_dataSetViewNameList = "View Test 1,View Test 2,View Test 3,View Test 4,View Test 5,View Test 6");
@@ -155,15 +146,7 @@ definition {
 	@description = "LPS-180896 Confirm that the dataset view deletion is recoverable"
 	@priority = 5
 	test CanCancelDeletionOnCancelButton {
-		task ("The user goes to add a new Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Test Dataset",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("And Add a new view") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
-
+		task ("When Add a new view") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Description Test",
 				key_name = "View Test");
@@ -189,15 +172,7 @@ definition {
 	@description = "LPS-180898. Confirm that the user can cancel deletion when clicking close (X) button"
 	@priority = 3
 	test CanCancelDeletionOnCloseButton {
-		task ("When The user goes to add a new Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Test Dataset",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("And Add a new view") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
-
+		task ("When Add a new view") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Description Test",
 				key_name = "View Test");
@@ -229,17 +204,7 @@ definition {
 	@description = "LPS-181342. Confirm that the user can cancel a view criation by clicking on cancel button"
 	@priority = 5
 	test CanCancelViewCreationOnCancelButton {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Filling the name with 'View Test") {
+		task ("When Add a view with the name 'View Test") {
 			LexiconEntry.gotoAdd();
 
 			Type(
@@ -262,76 +227,64 @@ definition {
 		}
 	}
 
+	@description = "LPS-181354. Confirm that the user can create more than one view"
+	@priority = 4
+	test CanCreateMultipleViews {
+		task ("When Adding a new view called "View Test" and the description field with "Test Description"") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test");
+		}
+
+		task ("And Adding a new view called "Bob Test" and the description field with "Bob Description"") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Bob Description",
+				key_name = "Bob Test");
+		}
+
+		task ("Then Assert that the 2 views are created") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test");
+
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Bob Test");
+		}
+	}
+
 	@description = "LPS-181339. Confirm that the user can create a view"
 	@priority = 5
 	test CanCreateView {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Filling the name with 'View Test' And Clicking Save button") {
+		task ("When Filling the name with 'View Test' And Clicking Save button") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Test Description",
 				key_name = "View Test");
 		}
 
 		task ("Then Confirm the view name in View page as expected") {
-			AssertElementPresent(
-				entryName = "View Test",
-				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test");
 		}
 
 		task ("And Confirm the description is 'Test Description'") {
-			AssertElementPresent(
-				locator1 = "FrontendDataSetAdmin#NAME_OF_VIEWS",
-				viewDescription = "Test Description");
+			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Test Description");
 		}
 	}
 
 	@description = "LPS-181341. Confirm that The user can create a view with no description"
 	@priority = 4
 	test CanCreateViewWithNoDescription {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When going to the Dataset View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Clicking add button, And Filling the name with 'View Test', And Clicking the Save button") {
+		task ("When Clicking add button, And Filling the name with 'View Test', And Clicking the Save button") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "",
 				key_name = "View Test");
 		}
 
 		task ("Then Confirm Data set view was created") {
-			AssertElementPresent(
-				entryName = "View Test",
-				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_NAME");
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test");
 		}
 	}
 
 	@description = "LPS-180893. Confirm that a dataset view can be deleted"
 	@priority = 5
 	test CanDeleteView {
-		task ("When The user goes to add a new Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Test Dataset",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("And Add a new view") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
-
+		task ("When Add a new view") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Description Test",
 				key_name = "View Test");
@@ -352,20 +305,80 @@ definition {
 		}
 	}
 
+	@description = "LPS-181353. Confirm that the user can search a view by its description"
+	@priority = 4
+	test CanSearchViewByDescription {
+		task ("When Adding a new view called 'View Test' and the description field with 'Test Description', And Clicking Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test");
+		}
+
+		task ("And Adding a new view called 'Bob Test' and the description field with 'Bob Description'") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Bob Description",
+				key_name = "Bob Test");
+		}
+
+		task ("And type 'Bob Description' in the search bar and click enter.") {
+			Search.searchCP(searchTerm = "Bob Description");
+		}
+
+		task ("Then the corresponding view is displayed") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Bob Test");
+
+		}
+	}
+
+	@description = "LPS-181344. Assert that the user can edit or delet view"
+	@priority = 5
+	test CanEditOrDeleteView {
+		task ("When go to the View page of the dataset created, and click save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Description Test",
+				key_name = "View Test");
+		}
+
+		task ("And Clicking the ellipsis button") {
+			Click(
+				key_name = "View Test",
+				locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
+		}
+
+		task ("Then confirm the options Edit and Delete are visible") {
+			MenuItem.viewVisible(menuItem = "View");
+
+			MenuItem.viewVisible(menuItem = "Delete");
+		}
+	}
+
+	@description = "LPS-181343. Confirm that the user can edit a view"
+	@priority = 5
+	test CanEditView {
+		task ("When go to the View page of the dataset created, and click save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Description Test",
+				key_name = "View Test");
+		}
+
+		task ("When we edit the name and description of a view ") {
+			FrontendDataSetAdmin.editView(
+				key_OldName = "View Test",
+				key_NewName = "View Test edited",
+				key_NewDescription = "Test Description edited");
+		}
+
+		task ("Then The dataset is present in the data set Admin page") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View Test edited");
+
+			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Test Description edited");
+		}
+	}
+
 	@description = "LPS-181351. Confirm that the user can search a view by its name"
 	@priority = 4
 	test CanSearchViewByName {
-		task ("And Add a Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Dataset Test",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("When go to the View page of the dataset created.") {
-			FrontendDataSetAdmin.goToViews(dataSetName = "Dataset Test");
-		}
-
-		task ("And Adding a new view called 'View Test' and the description field with 'Test Description'") {
+		task ("When Adding a new view called 'View Test' and the description field with 'Test Description'") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Test Description",
 				key_name = "View Test");
@@ -391,15 +404,7 @@ definition {
 	@description = "LPS-180895  Confirm that the view was really deleted"
 	@priority = 5
 	test CanUpdateNumberOfViews {
-		task ("When The user goes to add a new Dataset") {
-			FrontendDataSetAdmin.createDataSet(
-				key_name = "Test Dataset",
-				key_type = "/c/fdsentries");
-		}
-
-		task ("And Add a new view") {
-			FrontendDataSetAdmin.goToViews(key_entry = "Test Dataset");
-
+		task ("When Add a new view") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Description Test",
 				key_name = "View Test");
@@ -435,6 +440,62 @@ definition {
 			AssertElementPresent(
 				locator1 = "FrontendDataSetAdmin#NUMBER_OF_VIEWS",
 				numberOfViews = 0);
+		}
+	}
+
+	@description = "LPS-181347. Confirm that field is trunked if exceed 100 characters"
+	@priority = 4
+	test CanAssertNameFieldIsTrunkedIfExceedCharacters {
+		task ("When Clicking add button, and a user types a name that is more than 100 characters until 280 characters, and Filling the description field with 'Test Description', and Clicking Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
+		}
+
+		task ("Then confirm the name value will be trunked") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer non tincidunt ipsum. Quisque in justo a nibh sagittis auctor non at quam. Nulla facilisi. Donec feugiat, sapien at cursus orci aliquam.");
+		}
+	}
+
+	@description = "LPS-181340. Confirm that the name field is required for creating a view"
+	@priority = 5
+	test CanAssertNameIsRequired {
+		task ("When Clicking add button") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("And Filling the description field with 'Test Description'") {
+			Type(
+				locator1 = "FrontendDataSetAdmin#NEW_DATA_SET_VIEW_DESCRIPTION",
+				value1 = "Test Description");
+		}
+
+		task ("And When Click the Save button") {
+			PortletEntry.save();
+		}
+
+		task ("Then Confirm that 'This field is required' alert messages are present in the provider field") {
+			AssertTextPresent(
+				locator1 = "Message#ERROR",
+				value1 = "This field is required.");
+		}
+	}
+
+	@description = "LPS-181350. Confirm that special characters are confirmed in the display name on the page "
+	@priority = 4
+	test CanUseSpecialCharactersInNameField {
+		task ("When Clicking add button, and Filling the Name field with, and Clicking Save button") {
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View ~!@#$%^&*(){}[],.<>/? name");
+		}
+
+		task ("And Confirm the view name in View page as expected") {
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View ~!@#$%^&*(){}[],.<>/? name");
+		}
+
+		task ("And Then Confirm the description is 'Test Description'") {
+			FrontendDataSetAdmin.assertDataSetViewDescription(key_dataSetViewDescriptionList = "Test Description");
 		}
 	}
 


### PR DESCRIPTION
**Description**
Add FDSViews Tests
Automation for FDSViews#CanCreateView
Automation for FDSViews#CanAssertNameIsRequired
Automation for FDSViews#CanAssertNameFieldIsTrunkedIfExceedCharacters
Automation for FDSViews#CanUseSpecialCharactersInNameField
Automation for FDSViews#CanSearchViewByDescription


Tests Links 
https://issues.liferay.com/browse/LPS-181339
https://issues.liferay.com/browse/LPS-181340
https://issues.liferay.com/browse/LPS-181347
https://issues.liferay.com/browse/LPS-181350
https://issues.liferay.com/browse/LPS-181353

---

Description:
Added FDSViews tests 

Linked tests with respective tickets:
[FDSViews#CanEditOrDeleteView](https://issues.liferay.com/browse/LPS-181344)
[FDSViews#AssertNumberOfCharactersInDescriptionField
](https://issues.liferay.com/browse/LPS-181349)[FDSViews#CanEditView](https://issues.liferay.com/browse/LPS-181343)
[(FDSViews#CanCreateMultipleViews - already checked)
](https://issues.liferay.com/browse/LPS-181354)