### PR TITLE
LPS-169287 HR_322 Dynamic Loading spinner has no equivalent alt-text

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -247,11 +247,9 @@ const Modal = ({
 							>
 								{url && (
 									<>
-										{loading ? (
-											<ClayLoadingIndicator />
-										) : (
-											<StatusMessage />
-										)}
+										{loading && <ClayLoadingIndicator />}
+
+										<StatusMessage loading={loading} />
 
 										<Iframe
 											iframeBodyCssClass={
@@ -333,16 +331,18 @@ const Modal = ({
 	);
 };
 
-const StatusMessage = () => {
+const StatusMessage = ({loading}) => {
 	const [showMessage, setShowMessage] = useState(true);
 
 	useEffect(() => {
-		setTimeout(() => setShowMessage(false), 1000);
-	});
+		if (!loading) {
+			setTimeout(() => setShowMessage(false), 1000);
+		}
+	}, [loading]);
 
 	return showMessage ? (
 		<span className="sr-only" role="status">
-			{Liferay.Language.get('loaded')}
+			{!loading && Liferay.Language.get('loaded')}
 		</span>
 	) : null;
 };


### PR DESCRIPTION
Fixes https://issues.liferay.com/browse/LPS-169287

I'm sending this fix because JAWS is not reading correctly the status message. It's necessary to take into account the loading status inside the StatusMessage component to ensure that the screen reader reads the message.

cc @eltonccdantas 