### PR TITLE
LPS-181808 | Removed ignore from test and added on description the bug ticket that is causing quarantine

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/A11yTool.testcase
@@ -1,5 +1,5 @@
 @component-name = "portal-frontend-infrastructure"
-@description = "Quarantined due to test instability, will investigate in LPS-144125."
+@description = "Quarantined due to test instability, will investigate in LPS-144125/LPS-181924."
 definition {
 
 	property osgi.modules.includes = "frontend-js-a11y-sample-web,frontend-js-a11y-web";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtension.testcase
@@ -674,7 +674,6 @@ definition {
 	}
 
 	@description = "LPS-163525. Validate Client Extensions UI has a clear error message when all the mandatory fields are empty."
-	@ignore = "true"
 	@priority = 4
 	test HasMandatoryFieldErrorMessagesWhenEmpty {
 		task ("Given Add IFrame Client Extensions admin page") {


### PR DESCRIPTION
**Description**
These tests were either _ignored_ or on _quarantine_.
The test that was with ignore, was passing normally so I removed the ignore label.
- ClientExtension#HasMandatoryFieldErrorMessagesWhenEmpty
- FDSFilters#OneFilterCanBeRemoved

For the tests that were in quarantine, I added the bug ticket that is causing the error on the testcase description.

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-181808