### PR TITLE
LPS-182763 Add sheet classes only if not in a pop up

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/EditFormBodyTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/EditFormBodyTag.java
@@ -66,13 +66,14 @@ public class EditFormBodyTag extends IncludeTag {
 		EditFormTag editFormTag = (EditFormTag)findAncestorWithClass(
 			this, EditFormTag.class);
 
-		String cssClass = "sheet";
+		if ((editFormTag != null) && !editFormTag.isFluid() &&
+			!themeDisplay.isStatePopUp()) {
 
-		if ((editFormTag != null) && !editFormTag.isFluid()) {
-			cssClass = "sheet sheet-lg";
+			jspWriter.write("<div class=\"sheet sheet-lg\">");
 		}
-
-		jspWriter.write("<div class=\"" + cssClass + "\">");
+		else {
+			jspWriter.write("<div class=\"c-pt-3 c-px-3\">");
+		}
 
 		return EVAL_BODY_INCLUDE;
 	}


### PR DESCRIPTION
Motivation
=======
[Link to story or ticket](https://issues.liferay.com/browse/LPS-182763)

Proposed Solution
========
Check `!themeDisplay.isStatePopUp() `to add sheet styles to de form content.

Steps to Verify:
----------------

1. Navigation to Design->Fragments
2. In fragment sets click on the three dots icon -> Import
3. Check the form styles
