### PR TITLE
LPS-182920 | Solve LPS-182920 by avoiding null iframe

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -333,11 +333,13 @@ name = HtmlUtil.escapeJS(name);
 		if (ckEditor) {
 			var iframe = ckEditor.one('iframe');
 
-			iframe.attr(
-				'aria-labelledby',
-				'<%= namespace %>Aria ' +
-					iframe._node.attributes['aria-describedby'].value
-			);
+			if (iframe) {
+				iframe.attr(
+					'aria-labelledby',
+					'<%= namespace %>Aria ' +
+						iframe._node.attributes['aria-describedby'].value
+				);
+			}
 
 			addAUIClass(iframe);
 


### PR DESCRIPTION
**How to reproduce the bug**:

1. Go to Message Boards
2. Click on the three upper dots 
3. Configuration
4. Message Added Emails
5. Click on source in ckEditor 

This also happens in Blogs and Web Content so it seems to be in all configuration of the mails

**Jira Ticket**: https://issues.liferay.com/browse/LPS-182920