### PR TITLE
LPS-182096 Implement saving of FDS View Fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -20,11 +20,15 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Collections;
 import java.util.List;
 
 import javax.portlet.PortletRequest;
+import javax.portlet.ResourceURL;
 
 /**
  * @author Marko Cikos
@@ -95,6 +99,21 @@ public class FDSViewsDisplayContext {
 		}
 
 		return jsonArray;
+	}
+
+	public String getSaveFDSFieldsURL() {
+		ThemeDisplay themeDisplay = (ThemeDisplay)_portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceURL resourceURL =
+			(ResourceURL)PortalUtil.getControlPanelPortletURL(
+				_portletRequest, themeDisplay.getScopeGroup(),
+				FDSViewsPortletKeys.FDS_VIEWS, 0, 0,
+				PortletRequest.RESOURCE_PHASE);
+
+		resourceURL.setResourceID("/frontend_data_set_views/save_fds_fields");
+
+		return resourceURL.toString();
 	}
 
 	private final PortletRequest _portletRequest;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.views.web.internal.portlet.action;
+
+import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.Serializable;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + FDSViewsPortletKeys.FDS_VIEWS,
+		"mvc.command.name=/frontend_data_set_views/save_fds_fields"
+	},
+	service = MVCResourceCommand.class
+)
+public class SaveFDSFieldsMVCResourceCommand
+	extends BaseTransactionalMVCResourceCommand {
+
+	@Override
+	protected void doTransactionalCommand(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String creationData = ParamUtil.getString(
+			resourceRequest, "creationData");
+
+		JSONArray creationDataJSONArray = _jsonFactory.createJSONArray(
+			creationData);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				themeDisplay.getCompanyId(), "C_FDSField");
+
+		String fdsViewId = ParamUtil.getString(resourceRequest, "fdsViewId");
+
+		JSONArray createdJSONArray = _jsonFactory.createJSONArray();
+
+		for (int i = 0; i < creationDataJSONArray.length(); i++) {
+			JSONObject jsonObject = creationDataJSONArray.getJSONObject(i);
+
+			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+				themeDisplay.getUserId(), 0,
+				objectDefinition.getObjectDefinitionId(),
+				HashMapBuilder.<String, Serializable>put(
+					"label", String.valueOf(jsonObject.get("name"))
+				).put(
+					"name", String.valueOf(jsonObject.get("name"))
+				).put(
+					"r_fdsViewFDSFieldRelationship_c_fdsViewId", fdsViewId
+				).put(
+					"renderer", "default"
+				).put(
+					"sortable", true
+				).put(
+					"type", String.valueOf(jsonObject.get("type"))
+				).build(),
+				new ServiceContext());
+
+			JSONObject createdJSONObject = _jsonFactory.createJSONObject(
+				objectEntry.getValues());
+
+			createdJSONObject.put("id", objectEntry.getObjectEntryId());
+
+			createdJSONArray.put(createdJSONObject);
+		}
+
+		long[] deletionIds = ParamUtil.getLongValues(
+			resourceRequest, "deletionIds");
+
+		for (long id : deletionIds) {
+			_objectEntryLocalService.deleteObjectEntry(id);
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, createdJSONArray);
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
@@ -34,6 +34,8 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsViewLabel"));
 			"fdsViewsURL", fdsViewsURL
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()
+		).put(
+			"saveFDSFieldsURL", fdsViewsDisplayContext.getSaveFDSFieldsURL()
 		).build()
 	%>'
 />

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -49,15 +49,22 @@ interface FDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 
 interface FDSViewInterface {
 	fdsViewId: string;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 
-const FDSView = ({fdsViewId, fdsViewsURL, namespace}: FDSViewInterface) => {
+const FDSView = ({
+	fdsViewId,
+	fdsViewsURL,
+	namespace,
+	saveFDSFieldsURL,
+}: FDSViewInterface) => {
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
 	const [loading, setLoading] = useState(true);
@@ -120,6 +127,7 @@ const FDSView = ({fdsViewId, fdsViewsURL, namespace}: FDSViewInterface) => {
 						fdsView={fdsView}
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
+						saveFDSFieldsURL={saveFDSFieldsURL}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -20,16 +20,19 @@ interface FDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 interface FDSViewInterface {
 	fdsViewId: string;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 declare const FDSView: ({
 	fdsViewId,
 	fdsViewsURL,
 	namespace,
+	saveFDSFieldsURL,
 }: FDSViewInterface) => JSX.Element;
 export {FDSViewSectionInterface};
 export default FDSView;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
@@ -18,5 +18,7 @@ import {FDSViewSectionInterface} from '../FDSView';
 declare const Fields: ({
 	fdsView,
 	fdsViewsURL,
+	namespace,
+	saveFDSFieldsURL,
 }: FDSViewSectionInterface) => JSX.Element;
 export default Fields;


### PR DESCRIPTION
### References

- [LPS-182096 Implement saving of FDS View Fields](https://issues.liferay.com/browse/LPS-182096)

### What is the goal of this PR?

Saving of multiple selection of FDS Fields. We are creating entries for new selections and deleting entries for unselected.

Technical notes:
- We could not implement this behavior with existing Objects endpoints, not in a reasonable way. Instead, we are implementing this as a resource request. Some approaches we considered and discarded:
  - Invoking single save and delete endpoints multiple times. This would result in very poor performance and potential race condition bugs.
  - Using `batch` endpoint. This endpoint starts a process, instead of doing a transaction. This would complicate implementation, result in poor UX, and we still have multiple requests for creation and deletion.
  - Creating all fields along with FDS View, only updating selected status. This would solve multiple requests issue from previous point, as we are doing a single `batch` PATCH. But, we would still have complex implementation, poor UX, and now bad performance in terms of creation of potentially needless entries in database. It would severely limit or even block out intent to support nested fields in the future.
- I would love to see this kind of `synchronize` endpoint on Objects in the future @4lejandrito @gabrielwas @pablo-agulla

### What does it look like?

https://user-images.githubusercontent.com/5435511/235130411-98f553b7-f137-4815-b67f-1de99d5c9de5.mp4

### Steps to reproduce
1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`. This enables FDS Views Manager.
1. Add `feature.flag.LPS-161364=true` to `portal-ext.properties`. This enables Objects relationships nested fields, used by FDS Views Manager.
1. Open Global Menu > Control Panel > Object > Datasets
1. Create a dataset, create a view on it. Edit view.
