### PR TITLE
LPS-183542 | Add @ignore on some FDS tests that are failing

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
@@ -288,7 +288,8 @@ definition {
 		}
 	}
 
-	@description = "LPS-179056. Confirm that the user can create a data set entry with special chatacters"
+	@description = "Ignored due to LPS-183512 | LPS-179056. Confirm that the user can create a data set entry with special chatacters"
+	@ignore = "true"
 	@priority = 5
 	test WithSpecialCharacters {
 		task ("When Create a DataSet") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -119,7 +119,8 @@ definition {
 		}
 	}
 
-	@description = "LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
+	@description = "Ignored due to LPS-183521 | LPS-180899 Confirm that when adding several views, pagination is displayed correctly when placing as 4 items"
+	@ignore = "true"
 	@priority = 5
 	test CanAssertPagination {
 		task ("And Adding a 6 view called 'View Test 1', 'View Test 2'... and Filling the description field with 'Test Description'") {
@@ -438,7 +439,8 @@ definition {
 		}
 	}
 
-	@description = "LPS-180895  Confirm that the view was really deleted"
+	@description = "Ignored due to LPS-183521 | LPS-180895  Confirm that the view was really deleted"
+	@ignore = "true"
 	@priority = 5
 	test CanUpdateNumberOfViews {
 		task ("When Add a new view") {
@@ -480,7 +482,8 @@ definition {
 		}
 	}
 
-	@description = "LPS-181350. Confirm that special characters are confirmed in the display name on the page "
+	@description = "Ignored due to LPS-183521 and LPS-183512 | LPS-181350. Confirm that special characters are confirmed in the display name on the page "
+	@ignore = "true"
 	@priority = 4
 	test CanUseSpecialCharactersInNameField {
 		task ("When Clicking add button, and Filling the Name field with, and Clicking Save button") {


### PR DESCRIPTION
**Description**
Add @ignore on some FDS tests that are failing.

> FDSViews#CanAssertPagination 
> FDSViews#CanUpdateNumberOfViews
> FDSViews#CanUseSpecialCharactersInNameField
> FDSEntry#WithSpecialCharacters

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-183542