### PR TITLE
LPS-183521 | Fix to solve Ci problem of not deleting Data Set Views

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsAPI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsAPI.testcase
@@ -17,11 +17,10 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
+		FrontendDataSetAdmin.deleteAllDatasetEntries();
+
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();
-		}
-		else {
-			FrontendDataSetAdmin.deleteAllDatasetEntries();
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
@@ -24,11 +24,10 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
+		FrontendDataSetAdmin.deleteAllDatasetEntries();
+
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();
-		}
-		else {
-			FrontendDataSetAdmin.deleteAllDatasetEntries();
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -31,11 +31,10 @@ definition {
 	tearDown {
 		var testPortalInstance = PropsUtil.get("test.portal.instance");
 
+		FrontendDataSetAdmin.deleteAllDatasetEntries();
+
 		if (${testPortalInstance} == "true") {
 			PortalInstances.tearDownCP();
-		}
-		else {
-			FrontendDataSetAdmin.deleteAllDatasetEntries();
 		}
 	}
 


### PR DESCRIPTION
**Description**
Fixes to solve Ci problem of not deleting Data Set Views
- adding deleteAllDatasetEntries macro on setUp to solve the CI's problem of starting with some dataset entries already created
- changing the name "Test Dataset" to 'Dataset Test' because on setup the dataset name is 'Dataset Test'

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-183521