### PR TITLE
LPS-183641 Click on any action item on FDS Views page throws an error

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -17,8 +17,9 @@ import {ClayCheckbox, ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useContext} from 'react';
+import React, {useContext, useState} from 'react';
 
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import Actions from '../../actions/Actions';
@@ -58,10 +59,17 @@ const ListItem = ({item, schema}) => {
 		selectionType,
 	} = useContext(FrontendDataSetContext);
 
+	const [menuActive, setMenuActive] = useState(false);
+
 	const {description, image, sticker, symbol, title} = schema;
 
 	return (
-		<ClayList.Item flex>
+		<ClayList.Item
+			className={classNames({
+				'menu-active': menuActive,
+			})}
+			flex
+		>
 			{selectable && (
 				<ClayList.ItemField className="justify-content-center">
 					{selectionType === 'single' ? (
@@ -116,6 +124,8 @@ const ListItem = ({item, schema}) => {
 						actions={itemsActions || item.actionDropdownItems}
 						itemData={item}
 						itemId={item[selectedItemsKey]}
+						menuActive={menuActive}
+						onMenuActiveChange={setMenuActive}
 					/>
 				)}
 			</ClayList.ItemField>


### PR DESCRIPTION
### References

- [LPS-183641 Click on any action item on FDS Views page throws an error](https://issues.liferay.com/browse/LPS-183641)

### What is the goal of this PR?

I noticed this error while working on fields saving. We [changed API](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.js#L295-L296) of `Actions` component when we implemented quick actions, but we didn't apply this change to the `list` content renderer.

### What does it look like?

This is the error before PR. After PR, there is no error.

https://user-images.githubusercontent.com/5435511/236231644-2b6d18c2-4ab5-49c9-b07e-b2da312077da.mp4