### PR TITLE
Accessibility: LPS-177006 Add label when searchValue is null

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -113,7 +113,9 @@ const ResultsBar = ({
 								? Liferay.Language.get('clear-x-result-for-x')
 								: Liferay.Language.get('clear-x-results-for-x'),
 							itemsTotal,
-							searchValue
+							searchValue !== null
+								? searchValue
+								: filterLabelItems?.map((item) => item.label)
 						)}
 						className="component-link tbar-link"
 						onClick={(event) => {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177006

The aria-label contains null when the filtered by Mine. To resolve this, we must check to see if `searchValue `is null and then use the filter label.
Please let me know if there are any questions or comments about this.

Thank you!