### PR TITLE
LPS-183733 Support actions in FDS OrderableTable

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/OrderableTable.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/OrderableTable.scss
@@ -8,6 +8,11 @@
 	.orderable-table.table-autofit td {
 		width: inherit;
 
+		&.actions-cell {
+			padding-right: 18px;
+			width: 0;
+		}
+
 		&.drag-handle-cell {
 			width: 0;
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
@@ -20,6 +20,11 @@ const API_URL = {
 	FDS_VIEWS: '/o/c/fdsviews',
 };
 
+const FUZZY_OPTIONS = {
+	post: '</strong>',
+	pre: '<strong>',
+};
+
 const OBJECT_RELATIONSHIP = {
 	FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship',
 	FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId',
@@ -40,4 +45,4 @@ const PAGINATION_PROPS = {
 	},
 };
 
-export {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS};
+export {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP, PAGINATION_PROPS};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -25,15 +25,15 @@ import fuzzy from 'fuzzy';
 import React, {useRef, useState} from 'react';
 
 import '../css/FDSEntries.scss';
-import {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS} from './Constants';
+import {
+	API_URL,
+	FUZZY_OPTIONS,
+	OBJECT_RELATIONSHIP,
+	PAGINATION_PROPS,
+} from './Constants';
 import {FDSViewType} from './FDSViews';
 import RequiredMark from './components/RequiredMark';
 import ValidationFeedback from './components/ValidationFeedback';
-
-const FUZZY_OPTIONS = {
-	post: '</strong>',
-	pre: '<strong>',
-};
 
 type FDSEntryType = {
 	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: Array<FDSViewType>;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -13,7 +13,9 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
 import ClayEmptyState from '@clayui/empty-state';
+import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
@@ -23,16 +25,19 @@ import React, {useEffect, useRef, useState} from 'react';
 import {DndProvider, useDrag, useDrop} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
+import {FUZZY_OPTIONS} from '../Constants';
 import Search from './Search';
 
 import '../../css/OrderableTable.scss';
 
-const FUZZY_OPTIONS = {
-	post: '</strong>',
-	pre: '<strong>',
-};
+interface Action {
+	icon: string;
+	label: string;
+	onClick: Function;
+}
 
-interface OrderableTableRowInterface {
+interface OrderableTableRowProps {
+	actions?: Array<Action>;
 	fields: Array<{
 		label: string;
 		name: string;
@@ -44,12 +49,13 @@ interface OrderableTableRowInterface {
 }
 
 const OrderableTableRow = ({
+	actions,
 	fields,
 	index,
 	item,
 	onOrderChange,
 	query,
-}: OrderableTableRowInterface) => {
+}: OrderableTableRowProps) => {
 	const tableRowRef = useRef<HTMLTableRowElement>(null);
 
 	const [{isDragging}, dragRef] = useDrag({
@@ -147,11 +153,52 @@ const OrderableTableRow = ({
 					</ClayTable.Cell>
 				);
 			})}
+
+			{actions && (
+				<ClayTable.Cell className="actions-cell">
+					<ClayDropDown
+						trigger={
+							<ClayButton
+								className="component-action"
+								displayType="unstyled"
+							>
+								<ClayIcon symbol="ellipsis-v" />
+
+								<span className="sr-only">
+									{Liferay.Language.get('actions')}
+								</span>
+							</ClayButton>
+						}
+					>
+						<ClayDropDown.ItemList>
+							{actions.map(({icon, label, onClick}) => (
+								<ClayDropDown.Item
+									key={label}
+									onClick={() =>
+										onClick({
+											item,
+										})
+									}
+								>
+									{icon && (
+										<span className="pr-2">
+											<ClayIcon symbol={icon} />
+										</span>
+									)}
+
+									{label}
+								</ClayDropDown.Item>
+							))}
+						</ClayDropDown.ItemList>
+					</ClayDropDown>
+				</ClayTable.Cell>
+			)}
 		</ClayTable.Row>
 	);
 };
 
-interface OrderableTableInterface {
+interface OrderableTableProps {
+	actions?: Array<Action>;
 	disableSave?: boolean;
 	fields: Array<{
 		label: string;
@@ -169,6 +216,7 @@ interface OrderableTableInterface {
 }
 
 const OrderableTable = ({
+	actions,
 	disableSave,
 	fields,
 	items: initialItems,
@@ -180,7 +228,7 @@ const OrderableTable = ({
 	onOrderChange,
 	onSaveButtonClick,
 	title,
-}: OrderableTableInterface) => {
+}: OrderableTableProps) => {
 	const [items, setItems] = useState(initialItems);
 	const [query, setQuery] = useState('');
 
@@ -257,6 +305,10 @@ const OrderableTable = ({
 										{field.label}
 									</ClayTable.Cell>
 								))}
+
+								{actions && (
+									<ClayTable.Cell className="actions-cell" />
+								)}
 							</ClayTable.Row>
 						</ClayTable.Head>
 
@@ -264,6 +316,7 @@ const OrderableTable = ({
 							<DndProvider backend={HTML5Backend}>
 								{items.map((item, index) => (
 									<OrderableTableRow
+										actions={actions}
 										fields={fields}
 										index={index}
 										item={item}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
@@ -19,6 +19,10 @@ declare const API_URL: {
 	FDS_FIELDS: string;
 	FDS_VIEWS: string;
 };
+declare const FUZZY_OPTIONS: {
+	post: string;
+	pre: string;
+};
 declare const OBJECT_RELATIONSHIP: {
 	readonly FDS_ENTRY_FDS_VIEW: 'fdsEntryFDSViewRelationship';
 	readonly FDS_ENTRY_FDS_VIEW_ID: 'r_fdsEntryFDSViewRelationship_c_fdsEntryId';
@@ -37,4 +41,4 @@ declare const PAGINATION_PROPS: {
 		initialDelta: number;
 	};
 };
-export {API_URL, OBJECT_RELATIONSHIP, PAGINATION_PROPS};
+export {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP, PAGINATION_PROPS};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -15,7 +15,13 @@
 /// <reference types="react" />
 
 import '../../css/OrderableTable.scss';
-interface OrderableTableInterface {
+interface Action {
+	icon: string;
+	label: string;
+	onClick: Function;
+}
+interface OrderableTableProps {
+	actions?: Array<Action>;
 	disableSave?: boolean;
 	fields: Array<{
 		label: string;
@@ -32,6 +38,7 @@ interface OrderableTableInterface {
 	title: string;
 }
 declare const OrderableTable: ({
+	actions,
 	disableSave,
 	fields,
 	items: initialItems,
@@ -43,5 +50,5 @@ declare const OrderableTable: ({
 	onOrderChange,
 	onSaveButtonClick,
 	title,
-}: OrderableTableInterface) => JSX.Element;
+}: OrderableTableProps) => JSX.Element;
 export default OrderableTable;


### PR DESCRIPTION
### References

- [LPS-183733 Support actions in FDS OrderableTable](https://issues.liferay.com/browse/LPS-183733)

### What is the goal of this PR?

I started working on editing of FDS Fields, and adding this support is the first step. I'm splitting this from the rest of the story, as it is required for other stories, such as [Delete and reorder FDS Filters for a Dataset View](https://issues.liferay.com/browse/LPS-176188) cc @thektan

Technical notes:
- I set props of action item to `icon`, `label` and `onClick`. We may extend these later on. These are the only ones I need at the moment.
- As sidequests, we're moving fuzzy constants to common file, and renaming some friendly interfaces.

### What does it look like?

This is not quite what it looks like after this PR, the PR just extends API. This is after I added a WIP item for edit:
![screen](https://user-images.githubusercontent.com/5435511/236435957-24d1f427-2d52-4156-8364-7ee25a21e004.png)
