### PR TITLE
LPS-182096 Implement saving of FDS View Fields v2

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -20,11 +20,15 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Collections;
 import java.util.List;
 
 import javax.portlet.PortletRequest;
+import javax.portlet.ResourceURL;
 
 /**
  * @author Marko Cikos
@@ -95,6 +99,21 @@ public class FDSViewsDisplayContext {
 		}
 
 		return jsonArray;
+	}
+
+	public String getSaveFDSFieldsURL() {
+		ThemeDisplay themeDisplay = (ThemeDisplay)_portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ResourceURL resourceURL =
+			(ResourceURL)PortalUtil.getControlPanelPortletURL(
+				_portletRequest, themeDisplay.getScopeGroup(),
+				FDSViewsPortletKeys.FDS_VIEWS, 0, 0,
+				PortletRequest.RESOURCE_PHASE);
+
+		resourceURL.setResourceID("/frontend_data_set_views/save_fds_fields");
+
+		return resourceURL.toString();
 	}
 
 	private final PortletRequest _portletRequest;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -18,7 +18,7 @@ import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortle
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -77,9 +77,8 @@ public class SaveFDSFieldsMVCResourceCommand
 		for (int i = 0; i < creationDataJSONArray.length(); i++) {
 			JSONObject jsonObject = creationDataJSONArray.getJSONObject(i);
 
-			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
-				themeDisplay.getUserId(), 0,
-				objectDefinition.getObjectDefinitionId(),
+			ObjectEntry objectEntry = _objectEntryService.addObjectEntry(
+				0, objectDefinition.getObjectDefinitionId(),
 				HashMapBuilder.<String, Serializable>put(
 					"label", String.valueOf(jsonObject.get("name"))
 				).put(
@@ -107,7 +106,7 @@ public class SaveFDSFieldsMVCResourceCommand
 			resourceRequest, "deletionIds");
 
 		for (long id : deletionIds) {
-			_objectEntryLocalService.deleteObjectEntry(id);
+			_objectEntryService.deleteObjectEntry(id);
 		}
 
 		JSONPortletResponseUtil.writeJSON(
@@ -121,6 +120,6 @@ public class SaveFDSFieldsMVCResourceCommand
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
 
 	@Reference
-	private ObjectEntryLocalService _objectEntryLocalService;
+	private ObjectEntryService _objectEntryService;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.data.set.views.web.internal.portlet.action;
+
+import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.Serializable;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + FDSViewsPortletKeys.FDS_VIEWS,
+		"mvc.command.name=/frontend_data_set_views/save_fds_fields"
+	},
+	service = MVCResourceCommand.class
+)
+public class SaveFDSFieldsMVCResourceCommand
+	extends BaseTransactionalMVCResourceCommand {
+
+	@Override
+	protected void doTransactionalCommand(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String creationData = ParamUtil.getString(
+			resourceRequest, "creationData");
+
+		JSONArray creationDataJSONArray = _jsonFactory.createJSONArray(
+			creationData);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				themeDisplay.getCompanyId(), "C_FDSField");
+
+		String fdsViewId = ParamUtil.getString(resourceRequest, "fdsViewId");
+
+		JSONArray createdJSONArray = _jsonFactory.createJSONArray();
+
+		for (int i = 0; i < creationDataJSONArray.length(); i++) {
+			JSONObject jsonObject = creationDataJSONArray.getJSONObject(i);
+
+			ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+				themeDisplay.getUserId(), 0,
+				objectDefinition.getObjectDefinitionId(),
+				HashMapBuilder.<String, Serializable>put(
+					"label", String.valueOf(jsonObject.get("name"))
+				).put(
+					"name", String.valueOf(jsonObject.get("name"))
+				).put(
+					"r_fdsViewFDSFieldRelationship_c_fdsViewId", fdsViewId
+				).put(
+					"renderer", "default"
+				).put(
+					"sortable", true
+				).put(
+					"type", String.valueOf(jsonObject.get("type"))
+				).build(),
+				new ServiceContext());
+
+			JSONObject createdJSONObject = _jsonFactory.createJSONObject(
+				objectEntry.getValues());
+
+			createdJSONObject.put("id", objectEntry.getObjectEntryId());
+
+			createdJSONArray.put(createdJSONObject);
+		}
+
+		long[] deletionIds = ParamUtil.getLongValues(
+			resourceRequest, "deletionIds");
+
+		for (long id : deletionIds) {
+			_objectEntryLocalService.deleteObjectEntry(id);
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, createdJSONArray);
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
@@ -34,6 +34,8 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsViewLabel"));
 			"fdsViewsURL", fdsViewsURL
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()
+		).put(
+			"saveFDSFieldsURL", fdsViewsDisplayContext.getSaveFDSFieldsURL()
 		).build()
 	%>'
 />

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -49,15 +49,22 @@ interface FDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 
 interface FDSViewInterface {
 	fdsViewId: string;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 
-const FDSView = ({fdsViewId, fdsViewsURL, namespace}: FDSViewInterface) => {
+const FDSView = ({
+	fdsViewId,
+	fdsViewsURL,
+	namespace,
+	saveFDSFieldsURL,
+}: FDSViewInterface) => {
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
 	const [loading, setLoading] = useState(true);
@@ -120,6 +127,7 @@ const FDSView = ({fdsViewId, fdsViewsURL, namespace}: FDSViewInterface) => {
 						fdsView={fdsView}
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
+						saveFDSFieldsURL={saveFDSFieldsURL}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -20,16 +20,19 @@ interface FDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 interface FDSViewInterface {
 	fdsViewId: string;
 	fdsViewsURL: string;
 	namespace: string;
+	saveFDSFieldsURL: string;
 }
 declare const FDSView: ({
 	fdsViewId,
 	fdsViewsURL,
 	namespace,
+	saveFDSFieldsURL,
 }: FDSViewInterface) => JSX.Element;
 export {FDSViewSectionInterface};
 export default FDSView;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
@@ -18,5 +18,7 @@ import {FDSViewSectionInterface} from '../FDSView';
 declare const Fields: ({
 	fdsView,
 	fdsViewsURL,
+	namespace,
+	saveFDSFieldsURL,
 }: FDSViewSectionInterface) => JSX.Element;
 export default Fields;


### PR DESCRIPTION
### References

- [LPS-182096 Implement saving of FDS View Fields](https://issues.liferay.com/browse/LPS-182096)
- A followup on https://github.com/liferay-frontend/liferay-portal/pull/3288

### What is the goal of this PR?

We are changing from local to remote service for creation and deletion of fields, based on https://github.com/brianchandotcom/liferay-portal/pull/134399#issuecomment-1537435374

This is the only place in the module where we are using a standard resource request. All other interactions are with REST endpoints created by Objects, so we are using their default permissions behaviors. I made a few tests to double-check this:
- Admins can CRUD everything, including objects created by other admins.
- Non-admins get `403 User must have ADD_OBJECT_ENTRY permission`, if they try to use API directly.

We may want to expand this in the future, but I believe that's good enough behavior for now. 

/cc @dsanz 
