### PR TITLE
LPS-172402 LPS-183983 FDS Sorting Tab - Display "ascending" and "descending" labels

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/OrderableTable.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/OrderableTable.scss
@@ -5,16 +5,19 @@
 		text-align: center;
 	}
 
-	.orderable-table.table-autofit td {
-		width: inherit;
+	.orderable-table.table-autofit {
+		td,
+		th {
+			width: inherit;
 
-		&.actions-cell {
-			padding-right: 18px;
-			width: 0;
-		}
+			&.actions-cell {
+				padding-right: 18px;
+				width: 0;
+			}
 
-		&.drag-handle-cell {
-			width: 0;
+			&.drag-handle-cell {
+				width: 0;
+			}
 		}
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -134,6 +134,7 @@ const OrderableTableRow = ({
 						item.label || Liferay.Language.get('item')
 					)}
 					displayType={null}
+					size="sm"
 					symbol="drag"
 				/>
 			</ClayTable.Cell>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -36,12 +36,19 @@ interface Action {
 	onClick: Function;
 }
 
+interface ContentRendererProps {
+	item: any;
+}
+
+interface Field {
+	contentRenderer?: React.FC<ContentRendererProps>;
+	label: string;
+	name: string;
+}
+
 interface OrderableTableRowProps {
 	actions?: Array<Action>;
-	fields: Array<{
-		label: string;
-		name: string;
-	}>;
+	fields: Array<Field>;
 	index: number;
 	item: any;
 	onOrderChange: Function;
@@ -131,6 +138,18 @@ const OrderableTableRow = ({
 			</ClayTable.Cell>
 
 			{fields.map((field) => {
+				if (field.contentRenderer) {
+					const ContentRenderer = field.contentRenderer as React.FC<
+						ContentRendererProps
+					>;
+
+					return (
+						<ClayTable.Cell key={field.name}>
+							<ContentRenderer item={item} />
+						</ClayTable.Cell>
+					);
+				}
+
 				const itemFieldValue = String(item[field.name]);
 
 				const fuzzyMatch = fuzzy.match(
@@ -200,10 +219,7 @@ const OrderableTableRow = ({
 interface OrderableTableProps {
 	actions?: Array<Action>;
 	disableSave?: boolean;
-	fields: Array<{
-		label: string;
-		name: string;
-	}>;
+	fields: Array<Field>;
 	items: Array<any>;
 	noItemsButtonLabel: string;
 	noItemsDescription: string;
@@ -242,9 +258,13 @@ const OrderableTable = ({
 		setItems(
 			query
 				? initialItems.filter((item) =>
-						fields.some((field) =>
-							String(item[field.name]).match(regexp)
-						)
+						fields.some((field) => {
+							if (field.contentRenderer) {
+								return false;
+							}
+
+							return String(item[field.name]).match(regexp);
+						})
 				  ) || []
 				: initialItems
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -263,13 +263,9 @@ const OrderableTable = ({
 		setItems(
 			query
 				? initialItems.filter((item) =>
-						fields.some((field) => {
-							if (field.contentRenderer) {
-								return false;
-							}
-
-							return String(item[field.name]).match(regexp);
-						})
+						fields.some((field) =>
+							String(item[field.name]).match(regexp)
+						)
 				  ) || []
 				: initialItems
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -42,6 +42,7 @@ interface ContentRendererProps {
 
 interface Field {
 	contentRenderer?: React.FC<ContentRendererProps>;
+	headingTitle?: boolean;
 	label: string;
 	name: string;
 }
@@ -159,7 +160,10 @@ const OrderableTableRow = ({
 				);
 
 				return (
-					<ClayTable.Cell key={field.name}>
+					<ClayTable.Cell
+						headingTitle={field.headingTitle}
+						key={field.name}
+					>
 						{fuzzyMatch ? (
 							<span
 								dangerouslySetInnerHTML={{

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -321,7 +321,10 @@ const OrderableTable = ({
 								<ClayTable.Cell className="drag-handle-cell" />
 
 								{fields.map((field) => (
-									<ClayTable.Cell key={field.name}>
+									<ClayTable.Cell
+										headingCell
+										key={field.name}
+									>
 										{field.label}
 									</ClayTable.Cell>
 								))}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -28,6 +28,10 @@ import {getFields} from '../api';
 import OrderableTable from '../components/OrderableTable';
 import RequiredMark from '../components/RequiredMark';
 
+interface ContentRendererProps {
+	item: FDSSort;
+}
+
 interface Field {
 	format: string;
 	label: string;
@@ -77,6 +81,16 @@ function alertSuccess() {
 		type: 'success',
 	});
 }
+
+const SortingDirectionContentRenderer = ({item}: ContentRendererProps) => {
+	return (
+		<span>
+			{item.sortingDirection === SORTING_DIRECTION.ASCENDING.value
+				? SORTING_DIRECTION.ASCENDING.label
+				: SORTING_DIRECTION.DESCENDING.label}
+		</span>
+	);
+};
 
 const AddFDSSortModalContent = ({
 	closeModal,
@@ -327,6 +341,7 @@ const Sorting = ({fdsView, fdsViewsURL}: FDSViewSectionInterface) => {
 								name: 'fieldName',
 							},
 							{
+								contentRenderer: SortingDirectionContentRenderer,
 								label: Liferay.Language.get('value'),
 								name: 'sortingDirection',
 							},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -337,6 +337,7 @@ const Sorting = ({fdsView, fdsViewsURL}: FDSViewSectionInterface) => {
 						disableSave={!newFDSSortsOrder.length}
 						fields={[
 							{
+								headingTitle: true,
 								label: Liferay.Language.get('name'),
 								name: 'fieldName',
 							},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -12,21 +12,26 @@
  * details.
  */
 
-/// <reference types="react" />
-
+import React from 'react';
 import '../../css/OrderableTable.scss';
 interface Action {
 	icon: string;
 	label: string;
 	onClick: Function;
 }
+interface ContentRendererProps {
+	item: any;
+}
+interface Field {
+	contentRenderer?: React.FC<ContentRendererProps>;
+	headingTitle?: boolean;
+	label: string;
+	name: string;
+}
 interface OrderableTableProps {
 	actions?: Array<Action>;
 	disableSave?: boolean;
-	fields: Array<{
-		label: string;
-		name: string;
-	}>;
+	fields: Array<Field>;
 	items: Array<any>;
 	noItemsButtonLabel: string;
 	noItemsDescription: string;


### PR DESCRIPTION
**Story:** https://issues.liferay.com/browse/LPS-172402
**Subtask:** https://issues.liferay.com/browse/LPS-183983

### What is the goal of this PR?

- In the Sorting tab table, the value displays as "Ascending"/"Descending" instead of the stored `asc`/`desc` value.
- Changes to `OrderableTable` component:
  - New `contentRenderer` property in `fields` to add a custom renderer for a cell
  - New `headingTitle` property in `fields` to style as title cell
  - Styled the heading row as bold
  - Made the drag handle button smaller so the rows wouldn't have too much height

### What does it look like?

![Screenshot 2023-05-08 at 7 36 08 PM](https://user-images.githubusercontent.com/4496722/236984038-ebee876e-8cd4-4a91-961b-0e25eaf3f1de.png)
