### PR TITLE
LPS-183938 | Automation for DatasetPagination#CanAssertDefaultValues

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -158,6 +158,18 @@ definition {
 		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet&p_p_lifecycle=0&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_mvcPath=%2Ffds_views.jsp&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_fdsEntryId=${datasetEntryId}");
 	}
 
+	macro goToFieldTabs {
+		Click(
+			key_name = ${dataSetViewName},
+			locator1 = "FrontendDataSetAdmin#DATA_SET_VIEW_ENTRY_KEBAB_MENU");
+
+		Click(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
+
+		Click(
+			locator1 = "FrontendDataSetAdmin#VIEWS_FIELD_TABS",
+			navTab = ${navTab});
+	}
+
 	macro goToViews {
 		Click(
 			key_entry = ${dataSetName},

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -78,6 +78,11 @@
 	<td>//div[contains(@class,"justify-content-center autofit-col autofit-col-expand") and contains(.,'${key_itemName}')]</td>
 	<td></td>
 </tr>
+<tr>
+	<td>VIEWS_FIELD_TABS</td>
+	<td>//li[@class='nav-item']//button[contains(@class,'nav-link')]//*[contains(@class, 'navbar') and (text()='${navTab}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -58,12 +58,20 @@ definition {
 	}
 
 	@description = "LPS-183938. Confirm the default values for 'Pagination Items' and 'Default Value' fields"
-	@ignore = "true"
 	@priority = 4
 	test CanAssertDefaultValues {
+		task ("Then the default values for Pagination items will be 4, 8, 20, 40, 60, separated by commas") {
+			AssertElementPresent(
+				key_fieldName = "List of Items per Page",
+				key_fieldValue = "4, 8, 20, 40, 60",
+				locator1 = "Translation#TARGET_LANGUAGE_TEXT_BOX_FIELD");
+		}
 
-		// TODO LPS-183938 CanAssertDefaultValues pending implementation
-
+		task ("And The default value for the Default Value field is 20") {
+			AssertElementPresent(
+				key_keyName = 20,
+				locator1 = "Picklist#DISABLE_PICKLIST_KEY");
+		}
 	}
 
 	@description = "LPS-183950. Confirm that pagination creation can be cancelled when clicking on cancel button"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -12,6 +12,30 @@ definition {
 		TestCase.setUpPortalInstance();
 
 		User.firstLoginPG();
+
+		task ("Given access to the Datasets admin page") {
+			FrontendDataSetAdmin.goToDatasetAdminPage();
+		}
+
+		task ("The user goes to add a new Dataset") {
+			FrontendDataSetAdmin.createDataSet(
+				key_name = "Test Dataset",
+				key_type = "/c/fdsentries");
+		}
+
+		task ("Add a new view") {
+			FrontendDataSetAdmin.goToViews(dataSetName = "Test Dataset");
+
+			FrontendDataSetAdmin.createDataSetView(
+				description = "Test Description",
+				key_name = "View Test");
+		}
+
+		task ("When goes to Fields Tab") {
+			FrontendDataSetAdmin.goToFieldTabs(
+				dataSetViewName = "View Test",
+				navTab = "Pagination");
+		}
 	}
 
 	tearDown {


### PR DESCRIPTION
**Description**
> Given access to the Datasets admin page
> And The user goes to add a new Dataset
> And Add a new view
> When goes to Fields Tab.
> Then the default values for Pagination items will be 4, 8, 20, 40, 60, separated by commas
> And The default value for the Default Value field is 20

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-183938