### PR TITLE
LPS 177876 - Add Ignore to CanBeAppliedToPageWhenClassicThemeNotAvailable Test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -55,6 +55,7 @@ definition {
 
 	@description = "Verify portal will apply different available page theme if classic theme not available"
 	@priority = 5
+	@ignore = "Ignored due to LPS-184319"
 	@refactordone
 	test CanBeAppliedToPageWhenClassicThemeNotAvailable {
 		property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/themesinfrastructure/Theme.testcase
@@ -54,8 +54,8 @@ definition {
 	}
 
 	@description = "Verify portal will apply different available page theme if classic theme not available"
-	@priority = 5
 	@ignore = "Ignored due to LPS-184319"
+	@priority = 5
 	@refactordone
 	test CanBeAppliedToPageWhenClassicThemeNotAvailable {
 		property portal.upstream = "true";


### PR DESCRIPTION
Add `@ignore` to `CanBeAppliedToPageWhenClassicThemeNotAvailable ` 

Depending on [LPS-184319](https://issues.liferay.com/browse/LPS-184319) to be done.