### PR TITLE
LPS-184321 | Update DataSet names (entries and views) that have comma in it

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
@@ -287,19 +287,18 @@ definition {
 		}
 	}
 
-	@description = "Ignored due to LPS-183512 | LPS-179056. Confirm that the user can create a data set entry with special chatacters"
-	@ignore = "true"
+	@description = "Needs refactor after LPS-183512 is fixed | LPS-179056. Confirm that the user can create a data set entry with special chatacters"
 	@priority = 5
 	test WithSpecialCharacters {
 		task ("When Create a DataSet") {
 			FrontendDataSetAdmin.createDataSet(
-				key_name = "Data Set ~!@#$%^&*(){}[],.<>/? name",
+				key_name = "Data Set ~!@#$%^&*(){}[].<>/? name",
 				key_type = "/c/fdsentries");
 		}
 
 		task ("Then confirm that the dataset is created and if the name is provided as expected") {
 			AssertElementPresent(
-				key_itemName = "Data Set ~!@#$%^&*(){}[],.<>/? name",
+				key_itemName = "Data Set ~!@#$%^&*(){}[].<>/? name",
 				locator1 = "FrontendDataSetAdmin#TABLE_CELL");
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
@@ -103,7 +103,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-178779. Confirm the error message that appears when the user tries to create a dataset entry with more than 280 characters in the name field"
+	@description = "Needs refactor after LPS-183512 is fixed | LPS-178779. Confirm the error message that appears when the user tries to create a dataset entry with more than 280 characters in the name field"
 	@priority = 3
 	test CannotExceed280Characters {
 		task ("When the user goes to add Datasets") {
@@ -111,7 +111,7 @@ definition {
 		}
 
 		task ("When a user types a name that is more than 280 characters") {
-			PortletEntry.inputName(name = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam fermentum, est sed varius porttitor, odio tortor commodo ligula, quis auctor nulla massa ut eros. Vestibulum in eros maximus quam gravida dapibus. Proin vitae mi diam. Duis iaculis, nisi quis pharetra varius, arcu eros bibendum turpis, nec posuere nibh arcu id orci.");
+			PortletEntry.inputName(name = "Lorem ipsum dolor sit amet consectetur adipiscing elit. Nam fermentum est sed varius porttitor odio tortor commodo ligula quis auctor nulla massa ut eros. Vestibulum in eros maximus quam gravida dapibus. Proin vitae mi diam. Duis iaculis nisi quis pharetra varius arcu eros bibendum turpis nec posuere nibh arcu id orci.");
 		}
 
 		task ("And choose the provider named Channel") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSViews.testcase
@@ -481,18 +481,17 @@ definition {
 		}
 	}
 
-	@description = "Ignored due to LPS-183521 and LPS-183512 | LPS-181350. Confirm that special characters are confirmed in the display name on the page "
-	@ignore = "true"
+	@description = "Needs refactor after LPS-183512 is fixed | LPS-181350 Confirm that special characters are confirmed in the display name on the page "
 	@priority = 4
 	test CanUseSpecialCharactersInNameField {
 		task ("When Clicking add button, and Filling the Name field with, and Clicking Save button") {
 			FrontendDataSetAdmin.createDataSetView(
 				description = "Test Description",
-				key_name = "View ~!@#$%^&*(){}[],.<>/? name");
+				key_name = "View ~!@#$%^&*(){}[].<>/? name");
 		}
 
 		task ("And Confirm the view name in View page as expected") {
-			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View ~!@#$%^&*(){}[],.<>/? name");
+			FrontendDataSetAdmin.assertDataSetView(key_dataSetViewNameList = "View ~!@#$%^&*(){}[].<>/? name");
 		}
 
 		task ("And Then Confirm the description is 'Test Description'") {


### PR DESCRIPTION
**Description**
Update DataSet names (entries and views) that have comma in it, by removing the comma and the ignore from the test

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-184321