### PR TITLE
LPS-184390 Prevents fields referencing other schemas from being available for selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -76,6 +76,10 @@ export async function getFields(fdsView: FDSViewType) {
 			return;
 		}
 
+		if (propertyValue.$ref) {
+			return;
+		}
+
 		fieldsArray.push({
 			format: properties[propertyKey].format || type,
 			label: propertyKey,


### PR DESCRIPTION
In this PR we are adding an extra condition in the way we get to openAPI schema fields in order to filter some of them out. This condition prevents composed fields (those having a reference to another schema) from being available for selection