### PR TITLE
LPS-183945 | Automation for DatasetPagination

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -46,6 +46,14 @@ definition {
 		MenuItem.click(menuItem = ${itemsPerPage});
 	}
 
+	macro changePaginationItems {
+		Type(
+			locator1 = "FrontendDataSetAdmin#PAGINATION_LIST_OF_ITEMS",
+			value1 = ${paginationItems});
+	}
+
+	}
+
 	macro createDataSet {
 		if (isSet(key_name)) {
 			var key_datasetNameList = ${key_name};

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -46,12 +46,16 @@ definition {
 		MenuItem.click(menuItem = ${itemsPerPage});
 	}
 
+	macro changePaginationDefaultItems {
+		Type(
+			locator1 = "FrontendDataSetAdmin#PAGINATION_DEFAULT_ITEMS",
+			value1 = ${defaultPagination});
+	}
+
 	macro changePaginationItems {
 		Type(
 			locator1 = "FrontendDataSetAdmin#PAGINATION_LIST_OF_ITEMS",
 			value1 = ${paginationItems});
-	}
-
 	}
 
 	macro createDataSet {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -96,6 +96,24 @@
 	<td>//div[contains(@class,'modal')]//*[contains(@class, 'input-group-item')]//*[@placeholder="Search"]</td>
 	<td></td>
 </tr>
+
+<!-- DATA SET PAGINATION -->
+
+<tr>
+	<td>VIEW_ERROR_MESSAGE</td>
+	<td>//div[contains(@class,'has-error')]//div[contains(@class,'form-feedback-item') and contains(.,'${key_errorMessage}')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>PAGINATION_LIST_OF_ITEMS</td>
+	<td>//div[contains(@class,'form-group')]//textarea[contains(@id,'ViewListOfItemsPerPage')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>PAGINATION_DEFAULT_ITEMS</td>
+	<td>//div[contains(@class,'form-group')]//input[contains(@id,'ViewDefaultItemsPerPage')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -101,7 +101,7 @@
 
 <tr>
 	<td>VIEW_ERROR_MESSAGE</td>
-	<td>//div[contains(@class,'has-error')]//div[contains(@class,'form-feedback-item') and contains(.,'${key_errorMessage}')]</td>
+	<td>//div[contains(@class,'has-error')]//div[contains(@class,'form-feedback-item') and (text()='${key_errorMessage}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -105,12 +105,23 @@ definition {
 	}
 
 	@description = "LPS-183947. Confirm that pagination can be created"
-	@ignore = "true"
 	@priority = 5
 	test CanCreatePagination {
+		task ("And the user fills in the pagination items field") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = "10, 20, 30, 40");
+		}
 
-		// TODO LPS-183947 CanCreatePagination pending implementation
+		task ("And fills the default value field") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = 10);
+		}
 
+		task ("And saves") {
+			Button.clickSave();
+		}
+
+		task ("Then a success alert appears.") {
+			Alert.viewSuccessMessage();
+		}
 	}
 
 	@description = "LPS-183941. Confirm the pagination can be created with one pagination item"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -159,12 +159,27 @@ definition {
 	}
 
 	@description = "LPS-183946. Confirm that the default value cannot be different from some of the pagination items"
-	@ignore = "true"
 	@priority = 4
 	test DefaultValueCannotDivergeFromPaginationItems {
+		task ("And the user fills the pagination items field") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = "10, 20, 30, 40");
+		}
 
-		// TODO LPS-183946 DefaultValueCannotDivergeFromPaginationItems pending implementation
+		task ("And fills the default value field with a different number of one of the numbers written in the Pagination items field") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = 4);
 
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
+
+		task ("Assert Save button is disabled") {
+			PRMMDFRequest.viewDisabledButton(buttonName = "Save");
+		}
+
+		task ("Then an error message appears") {
+			AssertElementPresent(
+				key_errorMessage = "The default value must exist in the list of items per page.",
+				locator1 = "FrontendDataSetAdmin#VIEW_ERROR_MESSAGE");
+		}
 	}
 
 	@description = "LPS-183940. Confirm that error appears when pagination item is blank"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -49,12 +49,33 @@ definition {
 	}
 
 	@description = "LPS-183945. Confirm that pagination requires a default value"
-	@ignore = "true"
 	@priority = 4
 	test CanAssertDefaultValueIsRequired {
+		task ("And the user leaves the field Default Value empty") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = "");
 
-		// TODO LPS-183945 CanAssertDefaultValueIsRequired pending implementation
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
 
+		task ("Assert Save button is disabled") {
+			PRMMDFRequest.viewDisabledButton(buttonName = "Save");
+		}
+
+		task ("Then an error message appears") {
+			AssertElementPresent(
+				key_errorMessage = "This field is required.",
+				locator1 = "FrontendDataSetAdmin#VIEW_ERROR_MESSAGE");
+		}
+
+		task ("And the field will be populated with the default value for Default value: 20	") {
+			Refresh();
+
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+
+			AssertElementPresent(
+				key_fieldValue = 20,
+				locator1 = "FrontendDataSetAdmin#PAGINATION_DEFAULT_ITEMS");
+		}
 	}
 
 	@description = "LPS-183938. Confirm the default values for 'Pagination Items' and 'Default Value' fields"


### PR DESCRIPTION
**Description**
Automation for
DatasetPagination#CanAssertDefaultValueIsRequired ([LPS-183945](https://issues.liferay.com/browse/LPS-183945))
DatasetPagination#DefaultValueCannotDivergeFromPaginationItems ([LPS-183946](https://issues.liferay.com/browse/LPS-183946))
DatasetPagination#CanCreatePagination ([LPS-183947](https://issues.liferay.com/browse/LPS-183947))

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-183945