### PR TITLE
LPS-183948 | Automation for DatasetPagination

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -31,7 +31,7 @@ definition {
 				key_name = "View Test");
 		}
 
-		task ("When goes to Fields Tab") {
+		task ("When goes to Pagination Tab") {
 			FrontendDataSetAdmin.goToTab(
 				dataSetViewName = "View Test",
 				tabName = "Pagination");
@@ -83,9 +83,8 @@ definition {
 	test CanAssertDefaultValues {
 		task ("Then the default values for Pagination items will be 4, 8, 20, 40, 60, separated by commas") {
 			AssertElementPresent(
-				key_fieldName = "List of Items per Page",
 				key_fieldValue = "4, 8, 20, 40, 60",
-				locator1 = "Translation#TARGET_LANGUAGE_TEXT_BOX_FIELD");
+				locator1 = "FrontendDataSetAdmin#PAGINATION_TEXT_BOX");
 		}
 
 		task ("And The default value for the Default Value field is 20") {
@@ -227,12 +226,33 @@ definition {
 	}
 
 	@description = "LPS-183940. Confirm that error appears when pagination item is blank"
-	@ignore = "true"
 	@priority = 5
 	test ErrorAppearsWhenPaginationItemBlank {
+		task ("The user leaves the field Pagination Items empty") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = "");
 
-		// TODO LPS-183940 ErrorAppearsWhenPaginationItemBlank pending implementation
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
 
+		task ("Assert Save button is disabled") {
+			PRMMDFRequest.viewDisabledButton(buttonName = "Save");
+		}
+
+		task ("Then an error message appears") {
+			AssertElementPresent(
+				key_errorMessage = "This field is required.",
+				locator1 = "FrontendDataSetAdmin#VIEW_ERROR_MESSAGE");
+		}
+
+		task ("The field will be populated with the default values for Pagination items 4, 8, 20, 40, 60, separated by commas") {
+			Refresh();
+
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+
+			AssertElementPresent(
+				key_fieldValue = "4, 8, 20, 40, 60",
+				locator1 = "FrontendDataSetAdmin#PAGINATION_TEXT_BOX");
+		}
 	}
 
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -84,13 +84,13 @@ definition {
 		task ("Then the default values for Pagination items will be 4, 8, 20, 40, 60, separated by commas") {
 			AssertElementPresent(
 				key_fieldValue = "4, 8, 20, 40, 60",
-				locator1 = "FrontendDataSetAdmin#PAGINATION_TEXT_BOX");
+				locator1 = "FrontendDataSetAdmin#PAGINATION_LIST_OF_ITEMS");
 		}
 
 		task ("And The default value for the Default Value field is 20") {
 			AssertElementPresent(
-				key_keyName = 20,
-				locator1 = "Picklist#DISABLE_PICKLIST_KEY");
+				key_defaultValue = 20,
+				locator1 = "FrontendDataSetAdmin#PAGINATION_DEFAULT_ITEMS");
 		}
 	}
 
@@ -150,12 +150,25 @@ definition {
 	}
 
 	@description = "LPS-183941. Confirm the pagination can be created with one pagination item"
-	@ignore = "true"
 	@priority = 5
 	test CanCreateWithOnePaginationItem {
+		task ("Only one item is written in the pagination items") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = 10);
+		}
 
-		// TODO LPS-183941 CanCreateWithOnePaginationItem pending implementation
+		task ("The same item is placed in the default value field") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = 10);
 
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
+
+		task ("Saves") {
+			Button.clickSave();
+		}
+
+		task ("Then a success alert appears.") {
+			Alert.viewSuccessMessage();
+		}
 	}
 
 	@description = "LPS-183943. Confirm that pagination cannot exceed 25 pagination items"
@@ -251,7 +264,7 @@ definition {
 
 			AssertElementPresent(
 				key_fieldValue = "4, 8, 20, 40, 60",
-				locator1 = "FrontendDataSetAdmin#PAGINATION_TEXT_BOX");
+				locator1 = "FrontendDataSetAdmin#PAGINATION_LIST_OF_ITEMS");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -152,12 +152,19 @@ definition {
 	}
 
 	@description = "LPS-183948. Confirm that pagination cannot have characters in default value field"
-	@ignore = "true"
 	@priority = 4
 	test CannotUseCharactersInDefaultValueField {
+		task ("The user fills in the default value field some characters") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = "a");
 
-		// TODO LPS-183948 CannotUseCharactersInDefaultValueField pending implementation
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
 
+		task ("Then the user is not allowed to type characters in the Default value field") {
+			AssertElementPresent(
+				key_errorMessage = "This field is required.",
+				locator1 = "FrontendDataSetAdmin#VIEW_ERROR_MESSAGE");
+		}
 	}
 
 	@description = "LPS-183949. Confirm that pagination cannot have characters in pagination items field"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -172,12 +172,27 @@ definition {
 	}
 
 	@description = "LPS-183943. Confirm that pagination cannot exceed 25 pagination items"
-	@ignore = "true"
 	@priority = 5
 	test CannotExceed25PaginationItems {
+		task ("The user writes 26 items in the pagination items field //Pagination Items: 1,2,3,…,26") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26");
+		}
 
-		// TODO LPS-183943 CannotExceed25PaginationItems pending implementation
+		task ("Fills the default value field") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = 10);
 
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
+
+		task ("Assert Save button is disabled") {
+			PRMMDFRequest.viewDisabledButton(buttonName = "Save");
+		}
+
+		task ("Then an error message appears") {
+			AssertElementPresent(
+				key_errorMessage = "This field contains more than 25 elements.",
+				locator1 = "FrontendDataSetAdmin#VIEW_ERROR_MESSAGE");
+		}
 	}
 
 	@description = "LPS-183944. Confirm that pagination cannot exceed 1000 items per page"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -20,7 +20,7 @@ definition {
 		task ("The user goes to add a new Dataset") {
 			FrontendDataSetAdmin.createDataSet(
 				key_name = "Test Dataset",
-				key_type = "/c/fdsviews");
+				key_type = "/c/fdsentries");
 		}
 
 		task ("Add a new view") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -20,7 +20,7 @@ definition {
 		task ("The user goes to add a new Dataset") {
 			FrontendDataSetAdmin.createDataSet(
 				key_name = "Test Dataset",
-				key_type = "/c/fdsentries");
+				key_type = "/c/fdsviews");
 		}
 
 		task ("Add a new view") {
@@ -196,12 +196,27 @@ definition {
 	}
 
 	@description = "LPS-183944. Confirm that pagination cannot exceed 1000 items per page"
-	@ignore = "true"
 	@priority = 5
 	test CannotExceed1000ItemsPerPage {
+		task ("The user fills the pagination items field") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = "10, 100, 1000, 1001");
+		}
 
-		// TODO LPS-183944 CannotExceed1000ItemsPerPage pending implementation
+		task ("Fills the default value field") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = 1001);
 
+			FrontendDataSetAdmin.goToTab(tabName = "Pagination");
+		}
+
+		task ("Assert Save button is disabled") {
+			PRMMDFRequest.viewDisabledButton(buttonName = "Save");
+		}
+
+		task ("Then an error message appears") {
+			AssertElementPresent(
+				key_errorMessage = "This field contains an invalid number. Only positive numbers between 1 and 1000 are allowed.",
+				locator1 = "FrontendDataSetAdmin#VIEW_ERROR_MESSAGE");
+		}
 	}
 
 	@description = "LPS-183948. Confirm that pagination cannot have characters in default value field"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -96,12 +96,38 @@ definition {
 	}
 
 	@description = "LPS-183950. Confirm that pagination creation can be cancelled when clicking on cancel button"
-	@ignore = "true"
 	@priority = 5
 	test CanCancelPaginationCreationOnCancelButton {
+		task ("And the user fills in the pagination items field") {
+			FrontendDataSetAdmin.changePaginationItems(paginationItems = "10, 20, 30, 40");
+		}
 
-		// TODO LPS-183950 CanCancelPaginationCreationOnCancelButton pending implementation
+		task ("And fills the default value field") {
+			FrontendDataSetAdmin.changePaginationDefaultItems(defaultPagination = 10);
+		}
 
+		task ("And Click on the Cancel button") {
+			Button.clickCancel();
+		}
+
+		task ("Then a success alert not appears") {
+			VerifyElementNotPresent(locator1 = "Message#SUCCESS_DISMISSIBLE");
+		}
+
+		task ("And the items set are not saved") {
+			FrontendDataSetAdmin.goToTab(
+				dataSetViewName = "View Test",
+				tabName = "Pagination");
+
+			AssertElementPresent(
+				key_fieldName = "List of Items per Page",
+				key_fieldValue = "4, 8, 20, 40, 60",
+				locator1 = "Translation#TARGET_LANGUAGE_TEXT_BOX_FIELD");
+
+			AssertElementPresent(
+				key_keyName = 20,
+				locator1 = "Picklist#DISABLE_PICKLIST_KEY");
+		}
 	}
 
 	@description = "LPS-183947. Confirm that pagination can be created"


### PR DESCRIPTION
**Description**
Automation for
DatasetPagination#CannotUseCharactersInDefaultValueField ([LPS-183948](https://issues.liferay.com/browse/LPS-183948))
DatasetPagination#CanCancelPaginationCreationOnCancelButton ([LPS-183950](https://issues.liferay.com/browse/LPS-183950))
DatasetPagination#ErrorAppearsWhenPaginationItemBlank ([LPS-183940](https://issues.liferay.com/browse/LPS-183940))
DatasetPagination#CanCreateWithOnePaginationItem ([LPS-183941](https://issues.liferay.com/browse/LPS-183941))
DatasetPagination#CannotExceed25PaginationItems ([LPS-183943](https://issues.liferay.com/browse/LPS-183943))
DatasetPagination#CannotExceed1000ItemsPerPage ([LPS-183944](https://issues.liferay.com/browse/LPS-183944))

**JIRA Ticket**
https://issues.liferay.com/browse/LPS-183948