### PR TITLE
LPS-181572 LPS-184797 Add link to titles in the "Dataset" and "Dataset View" tables

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -17,6 +17,7 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
 import ClayModal from '@clayui/modal';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
@@ -732,13 +733,17 @@ const FDSEntries = ({
 		],
 	};
 
-	const onViewClick = ({itemData}: {itemData: FDSEntryType}) => {
+	const getViewURL = (itemData: FDSEntryType) => {
 		const url = new URL(fdsViewsURL);
 
 		url.searchParams.set(`${namespace}fdsEntryId`, itemData.id);
 		url.searchParams.set(`${namespace}fdsEntryLabel`, itemData.label);
 
-		navigate(url);
+		return url;
+	};
+
+	const onViewClick = ({itemData}: {itemData: FDSEntryType}) => {
+		navigate(getViewURL(itemData));
 	};
 
 	const onDeleteClick = ({
@@ -794,13 +799,27 @@ const FDSEntries = ({
 		});
 	};
 
+	const NameRenderer = ({itemData}: {itemData: FDSEntryType}) => {
+		return (
+			<div className="table-list-title">
+				<ClayLink href={getViewURL(itemData).toString()}>
+					{itemData.label}
+				</ClayLink>
+			</div>
+		);
+	};
+
 	const views = [
 		{
 			contentRenderer: 'table',
 			name: 'table',
 			schema: {
 				fields: [
-					{fieldName: 'label', label: Liferay.Language.get('name')},
+					{
+						contentRenderer: 'name',
+						fieldName: 'label',
+						label: Liferay.Language.get('name'),
+					},
 					{
 						fieldName: 'restApplication',
 						label: Liferay.Language.get('rest-application'),
@@ -834,6 +853,7 @@ const FDSEntries = ({
 				apiURL={`${API_URL.FDS_ENTRIES}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`}
 				creationMenu={creationMenu}
 				customDataRenderers={{
+					name: NameRenderer,
 					viewsCount: ViewsCountRenderer,
 				}}
 				id={`${namespace}FDSEntries`}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -17,7 +17,6 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
-import ClayLink from '@clayui/link';
 import ClayModal from '@clayui/modal';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
@@ -799,16 +798,6 @@ const FDSEntries = ({
 		});
 	};
 
-	const NameRenderer = ({itemData}: {itemData: FDSEntryType}) => {
-		return (
-			<div className="table-list-title">
-				<ClayLink href={getViewURL(itemData).toString()}>
-					{itemData.label}
-				</ClayLink>
-			</div>
-		);
-	};
-
 	const views = [
 		{
 			contentRenderer: 'table',
@@ -816,7 +805,8 @@ const FDSEntries = ({
 			schema: {
 				fields: [
 					{
-						contentRenderer: 'name',
+						actionId: 'view',
+						contentRenderer: 'actionLink',
 						fieldName: 'label',
 						label: Liferay.Language.get('name'),
 					},
@@ -853,12 +843,14 @@ const FDSEntries = ({
 				apiURL={`${API_URL.FDS_ENTRIES}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`}
 				creationMenu={creationMenu}
 				customDataRenderers={{
-					name: NameRenderer,
 					viewsCount: ViewsCountRenderer,
 				}}
 				id={`${namespace}FDSEntries`}
 				itemsActions={[
 					{
+						data: {
+							id: 'view',
+						},
 						icon: 'view',
 						label: Liferay.Language.get('view'),
 						onClick: onViewClick,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -14,6 +14,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import ClayLink from '@clayui/link';
 import ClayModal from '@clayui/modal';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
@@ -204,7 +205,7 @@ const FDSViews = ({
 	fdsViewURL,
 	namespace,
 }: IFDSViewsInterface) => {
-	const onViewClick = ({itemData}: {itemData: FDSViewType}) => {
+	const getViewURL = (itemData: FDSViewType) => {
 		const url = new URL(fdsViewURL);
 
 		url.searchParams.set(`${namespace}fdsEntryId`, fdsEntryId);
@@ -212,7 +213,11 @@ const FDSViews = ({
 		url.searchParams.set(`${namespace}fdsViewId`, itemData.id);
 		url.searchParams.set(`${namespace}fdsViewLabel`, itemData.label);
 
-		navigate(url);
+		return url;
+	};
+
+	const onViewClick = ({itemData}: {itemData: FDSViewType}) => {
+		navigate(getViewURL(itemData));
 	};
 
 	const onDeleteClick = ({
@@ -292,6 +297,16 @@ const FDSViews = ({
 		],
 	};
 
+	const TitleRenderer = ({itemData}: {itemData: FDSViewType}) => {
+		return (
+			<div className="table-list-title">
+				<ClayLink href={getViewURL(itemData).toString()}>
+					{itemData.label}
+				</ClayLink>
+			</div>
+		);
+	};
+
 	const views = [
 		{
 			contentRenderer: 'list',
@@ -300,6 +315,7 @@ const FDSViews = ({
 				description: 'description',
 				symbol: 'symbol',
 				title: 'label',
+				titleRenderer: TitleRenderer,
 			},
 		},
 	];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -16,7 +16,10 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayLink from '@clayui/link';
 import ClayModal from '@clayui/modal';
-import {FrontendDataSet} from '@liferay/frontend-data-set-web';
+import {
+	FrontendDataSet,
+	InternalRenderer,
+} from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
 import {fetch, navigate, openModal, openToast} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
@@ -315,7 +318,12 @@ const FDSViews = ({
 				description: 'description',
 				symbol: 'symbol',
 				title: 'label',
-				titleRenderer: TitleRenderer,
+				titleRenderer: {
+					component: TitleRenderer,
+					label: Liferay.Language.get('title'),
+					name: 'title',
+					type: 'internal',
+				} as InternalRenderer,
 			},
 		},
 	];

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
@@ -96,9 +96,14 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 			else if (currentAction.onClick) {
 				event.preventDefault();
 
-				event.target.setAttribute('onClick', currentAction.onClick);
-				event.target.onclick();
-				event.target.removeAttribute('onClick');
+				if (typeof currentAction.onClick === 'function') {
+					currentAction.onClick({itemData});
+				}
+				else {
+					event.target.setAttribute('onClick', currentAction.onClick);
+					event.target.onclick();
+					event.target.removeAttribute('onClick');
+				}
 			}
 		};
 
@@ -170,7 +175,7 @@ ActionLinkRenderer.propTypes = {
 			href: PropTypes.string,
 			icon: PropTypes.string,
 			method: PropTypes.oneOf(['delete', 'get', 'patch', 'post']),
-			onClick: PropTypes.string,
+			onClick: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
 			size: PropTypes.string,
 			target: PropTypes.oneOf([
 				'modal',

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -145,3 +145,5 @@ export {
 	INTERNAL_CELL_RENDERERS as FDS_INTERNAL_CELL_RENDERERS,
 	InternalCellRenderer as FDSInternalCellRenderer,
 } from './cell_renderers/InternalCellRenderer';
+
+export {InternalRenderer} from './utils/renderer';

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/renderer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/renderer.ts
@@ -131,3 +131,10 @@ function getModuleAndSymbolNames(url: string): [string, string] {
 
 	return [moduleName, symbolName];
 }
+
+export interface InternalRenderer extends Renderer {
+	component: React.ComponentType<any>;
+	label: string;
+	name: string;
+	type: 'internal';
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -61,7 +61,19 @@ const ListItem = ({item, schema}) => {
 
 	const [menuActive, setMenuActive] = useState(false);
 
-	const {description, image, sticker, symbol, title} = schema;
+	const {description, image, sticker, symbol, title, titleRenderer} = schema;
+
+	const TitleRenderer = titleRenderer;
+
+	const renderTitle = (item) => {
+		if (titleRenderer) {
+			return <TitleRenderer itemData={item} />
+		}
+
+		if (title) {
+			return <ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>
+		}
+	}
 
 	return (
 		<ClayList.Item
@@ -109,9 +121,7 @@ const ListItem = ({item, schema}) => {
 			)}
 
 			<ClayList.ItemField className="justify-content-center" expand>
-				{title && (
-					<ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>
-				)}
+				{renderTitle(item)}
 
 				{description && (
 					<ClayList.ItemText>{item[description]}</ClayList.ItemText>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -63,17 +63,17 @@ const ListItem = ({item, schema}) => {
 
 	const {description, image, sticker, symbol, title, titleRenderer} = schema;
 
-	const TitleRenderer = titleRenderer;
+	const TitleRendererComponent = titleRenderer.component;
 
 	const renderTitle = (item) => {
 		if (titleRenderer) {
-			return <TitleRenderer itemData={item} />
+			return <TitleRendererComponent itemData={item} />;
 		}
 
 		if (title) {
-			return <ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>
+			return <ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>;
 		}
-	}
+	};
 
 	return (
 		<ClayList.Item

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -49,6 +49,20 @@ const List = ({items, schema}) => {
 	);
 };
 
+const Title = ({item, title, titleRenderer}) => {
+	const TitleRendererComponent = titleRenderer.component;
+
+	if (TitleRendererComponent) {
+		return <TitleRendererComponent itemData={item} />;
+	}
+
+	if (title) {
+		return <ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>;
+	}
+
+	return null;
+};
+
 const ListItem = ({item, schema}) => {
 	const {
 		itemsActions,
@@ -62,18 +76,6 @@ const ListItem = ({item, schema}) => {
 	const [menuActive, setMenuActive] = useState(false);
 
 	const {description, image, sticker, symbol, title, titleRenderer} = schema;
-
-	const TitleRendererComponent = titleRenderer.component;
-
-	const renderTitle = (item) => {
-		if (titleRenderer) {
-			return <TitleRendererComponent itemData={item} />;
-		}
-
-		if (title) {
-			return <ClayList.ItemTitle>{item[title]}</ClayList.ItemTitle>;
-		}
-	};
 
 	return (
 		<ClayList.Item
@@ -121,7 +123,11 @@ const ListItem = ({item, schema}) => {
 			)}
 
 			<ClayList.ItemField className="justify-content-center" expand>
-				{renderTitle(item)}
+				<Title
+					item={item}
+					title={title}
+					titleRenderer={titleRenderer}
+				/>
 
 				{description && (
 					<ClayList.ItemText>{item[description]}</ClayList.ItemText>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/utils/renderer.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/utils/renderer.d.ts
@@ -30,3 +30,9 @@ export declare function getCellRendererByURL(
 	url: string,
 	type: 'clientExtension' | 'internal'
 ): Promise<CellRenderer>;
+export interface InternalRenderer extends Renderer {
+	component: React.ComponentType<any>;
+	label: string;
+	name: string;
+	type: 'internal';
+}


### PR DESCRIPTION
**Story:** https://issues.liferay.com/browse/LPS-181572
**Subtask:** https://issues.liferay.com/browse/LPS-184797

### What is the goal of this PR?

- Adds links to the name in the Datasets and Dataset Views tables

**Technical Notes:**
- Maybe I missed something, but I didn't see a way to edit the link in the `actionLink` content renderer so I added a custom `NameRenderer` component.
- `NameRenderer` is inside the main `FDSEntries` component to have access to `namespace`.
- ⚠️ **Change in `frontend-data-set-web` module:** The `list` content renderer didn't have any implementation for adding a link to the title so I added a `titleRenderer` property to allow any component to be passed for more flexibility. 

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/4496722/40ee7fba-3545-48f5-a080-3e1646121b11

