### PR TITLE
LPS-185224 Enable editing of newly added FDS Fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -98,7 +98,11 @@ public class SaveFDSFieldsMVCResourceCommand
 			JSONObject jsonObject = _jsonFactory.createJSONObject(
 				objectEntry.getValues());
 
-			jsonObject.put("id", objectEntry.getObjectEntryId());
+			jsonObject.put(
+				"externalReferenceCode", objectEntry.getExternalReferenceCode()
+			).put(
+				"id", objectEntry.getObjectEntryId()
+			);
 
 			jsonArray.put(jsonObject);
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -145,7 +145,10 @@ const SaveFDSFieldsModalContent = ({
 		});
 
 		onSave({
-			createdFDSFields,
+			createdFDSFields: createdFDSFields.map((fdsField) => ({
+				...fdsField,
+				id: Number(fdsField.id),
+			})),
 			deletedFDSFieldsIds: deletionIds,
 		});
 	};


### PR DESCRIPTION
### References

- [LPS-185224 Enable editing of newly added FDS Fields](https://issues.liferay.com/browse/LPS-185224)

### What is the goal of this PR?

We are enabling editing of newly added item, by fixing two bugs:
- We need to return ERC of newly added item, because we are now using ERC endpoint
- `id`, a `Long`, is serialized as a string, so we need to transform it to a number before we can compare it.

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/5435511/47a3fe7a-b6ea-4cb9-8151-c126479174d8

### Steps to reproduce

1. Add `feature.flag.LPS-164563=true` to `portal-ext.properties`. This enables FDS Views Manager.
1. Add `feature.flag.LPS-161364=true` to `portal-ext.properties`. This enables Objects relationships nested fields, used by FDS Views Manager.
1. If you previously opened Datasets page, delete `FDS Entry` and `FDS View` on Global Menu > Control Panel > Object > Objects
1. Open Global Menu > Control Panel > Object > Datasets
1. Create a dataset, and a view for that dataset. Edit view.