### PR TITLE
LPS-167551 HR_53 After selecting the items and clicking on done button in the select test dialog, the focus should go to the updated content that is the Test edit box

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -146,9 +146,6 @@ function AssetVocabulariesCategoriesSelector({
 			height: '70vh',
 			iframeBodyCssClass: '',
 			multiple: true,
-			onClose: () => {
-				selectButtonRef.current?.focus();
-			},
 			onSelect: (selectedItems) => {
 				if (selectedItems) {
 					const newValues = Object.keys(selectedItems).reduce(

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -141,9 +141,6 @@ function AssetTagsSelector({
 			buttonAddLabel: Liferay.Language.get('done'),
 			getSelectedItemsOnly: false,
 			multiple: true,
-			onClose: () => {
-				selectButtonRef.current?.focus();
-			},
 			onSelect: (dialogSelectedItems) => {
 				if (!dialogSelectedItems?.length) {
 					return;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -54,12 +54,19 @@ const Modal = ({
 	zIndex,
 }) => {
 	const [loading, setLoading] = useState(true);
-	const [visible, setVisible] = useState(true);
+
+	const {observer, onOpenChange, open} = useModal({
+		onClose: () => processClose(),
+	});
+
+	useEffect(() => {
+		onOpenChange(true);
+	}, [onOpenChange]);
 
 	const eventHandlersRef = useRef([]);
 
 	const processClose = useCallback(() => {
-		setVisible(false);
+		onOpenChange(false);
 
 		document.body.classList.remove('modal-open');
 
@@ -74,11 +81,7 @@ const Modal = ({
 		if (onClose) {
 			onClose();
 		}
-	}, [eventHandlersRef, onClose]);
-
-	const {observer} = useModal({
-		onClose: () => processClose(),
-	});
+	}, [eventHandlersRef, onClose, onOpenChange]);
 
 	const onButtonClick = ({formId, onClick, type}) => {
 		const submitForm = (form) => {
@@ -201,7 +204,7 @@ const Modal = ({
 
 	return (
 		<>
-			{visible && (
+			{open && (
 				<ClayModal
 					center={center}
 					className={classNames('liferay-modal', className)}


### PR DESCRIPTION
It fixes https://issues.liferay.com/browse/LPS-169274

Hi guys! the first commit of this PR has already been reviewed from the Echo team, so only the second commit would need to be reviewed.

To focus on the trigger when the modal is closed, `visible` and `setVisible` has been replaced by `open` and `handleOpenModal`, which are provided by `useModal`, as shown in the [Modal example](https://clayui.com/docs/components/modal.html).
