### PR TITLE
LPS-185226 | Automation for Automation DatasetsFields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -65,6 +65,12 @@ definition {
 			value1 = ${paginationItems});
 	}
 
+	macro checkFields {
+		Check.checkNotVisible(
+			checkboxName = ${checkboxName},
+			locator1 = "Checkbox#ANY_CHECKBOX");
+	}
+
 	macro createDataSet {
 		if (isSet(key_name)) {
 			var key_datasetNameList = ${key_name};

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -40,6 +40,13 @@ definition {
 		}
 	}
 
+	macro assertFieldsOnTable {
+		AssertElementPresent(
+			key_position = ${key_position},
+			keyName = ${keyName},
+			locator1 = "FrontendDataSetAdmin#FIELDS_TABLE");
+	}
+
 	macro changePagination {
 		Click(locator1 = "FrontendDataSetAdmin#ITEMS_PER_PAGE_SELECT");
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -92,8 +92,18 @@
 	<td></td>
 </tr>
 <tr>
+	<td>FIELDS_TABLE</td>
+	<td>//table[contains(@class,'table-list')]//tr[@class='orderable-table-row'][${key_position}]//*[contains(text(),'${keyName}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>MODAL_SEARCH</td>
 	<td>//div[contains(@class,'modal')]//*[contains(@class, 'input-group-item')]//*[@placeholder="Search"]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>FIELDS_DRAG_DOTS_ICON</td>
+	<td>//table[contains(@class,'table-list')]//tr[@class='orderable-table-row']//td[@class="drag-handle-cell"]//button[@aria-label="Drag ${key_nameField}"]</td>
 	<td></td>
 </tr>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -97,12 +97,25 @@ definition {
 	}
 
 	@description = "LPS-185226. Confirm that the user can add a field"
-	@ignore = "true"
 	@priority = 5
 	test CanAddField {
+		task ("And clicks on Add Fields button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185226 CanAddField pending implementation
+		task ("And checks id field") {
+			FrontendDataSetAdmin.checkFields(checkboxName = "id");
+		}
 
+		task ("And clicks on Save button") {
+			Button.clickSave();
+		}
+
+		task ("Then the added fields are shown on Fields tab page") {
+			FrontendDataSetAdmin.assertFieldsOnTable(
+				key_position = 1,
+				keyName = "id");
+		}
 	}
 
 	@description = "LPS-185230. Confirm that the user can cancel adding a field by clicking on cancel button."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -185,9 +185,7 @@ definition {
 		}
 
 		task ("And select all the fields.") {
-			Check.checkNotVisible(
-				checkboxName = "",
-				locator1 = "Checkbox#ANY_CHECKBOX");
+			FrontendDataSetAdmin.checkFields(checkboxName = "");
 		}
 
 		task ("Then Confirm all fields are checked ") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -174,12 +174,40 @@ definition {
 	}
 
 	@description = "LPS-185228. Confirm that a field is not added after checking and unchecking it."
-	@ignore = "true"
 	@priority = 5
 	test CannotAddFieldAfterUncheckingIt {
+		task ("And clicks on plus button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185228 CannotAddFieldAfterUncheckingIt pending implementation
+		task ("And checks id and label fields") {
+			FrontendDataSetAdmin.checkFields(checkboxName = "id");
 
+			FrontendDataSetAdmin.checkFields(checkboxName = "label");
+		}
+
+		task ("And unchecks id field") {
+			Uncheck.uncheckNotVisible(
+				checkboxName = "id",
+				locator1 = "Checkbox#ANY_CHECKBOX");
+		}
+
+		task ("And clicks on Save button") {
+			Button.clickSave();
+		}
+
+		task ("Then label field should appear on Fields tab page") {
+			FrontendDataSetAdmin.assertFieldsOnTable(
+				key_position = 1,
+				keyName = "label");
+		}
+
+		task ("And id should not appear on Fields tab page") {
+			AssertElementNotPresent(
+				key_position = 1,
+				keyName = "id",
+				locator1 = "FrontendDataSetAdmin#FIELDS_TABLE");
+		}
 	}
 
 	@description = "LPS-179282. Confirm that the search bar returns works as expected"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -137,12 +137,44 @@ definition {
 	}
 
 	@description = "LPS-185229. Confirm that the user can change the field's order on Fields tab page."
-	@ignore = "true"
 	@priority = 4
 	test CanChangeFieldOrder {
+		task ("And clicks on plus button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185229 CanChangeFieldOrder pending implementation
+		task ("And checks id and label fields") {
+			FrontendDataSetAdmin.checkFields(checkboxName = "id");
 
+			FrontendDataSetAdmin.checkFields(checkboxName = "label");
+		}
+
+		task ("And clicks on Save button") {
+			Button.clickSave();
+		}
+
+		task ("And clicks on a field drag dots icon related id field ") {
+			Click.clickAt(
+				key_nameField = "id",
+				locator1 = "FrontendDataSetAdmin#FIELDS_DRAG_DOTS_ICON");
+		}
+
+		task ("Then the user can move the id field below the label field") {
+			DragAndDrop.javaScriptDragAndDropToBottom(
+				key_nameField = "id",
+				key_position = 2,
+				keyName = "label",
+				locator1 = "FrontendDataSetAdmin#FIELDS_DRAG_DOTS_ICON",
+				locator2 = "FrontendDataSetAdmin#FIELDS_TABLE");
+
+			FrontendDataSetAdmin.assertFieldsOnTable(
+				key_position = 1,
+				keyName = "label");
+
+			FrontendDataSetAdmin.assertFieldsOnTable(
+				key_position = 2,
+				keyName = "id");
+		}
 	}
 
 	@description = "LPS-179282. Confirm that the user can check and uncheck all the fields"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -229,12 +229,21 @@ definition {
 	}
 
 	@description = "LPS-185227. Confirm that the user can search a specific field when adding fields."
-	@ignore = "true"
 	@priority = 4
 	test CanSearchFieldOnAddFieldsModal {
+		task ("And clicks on Add Fields button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185227 CanSearchFieldOnAddFieldsModal pending implementation
+		task ("And types 'label' on modal search bar") {
+			FrontendDataSetAdmin.searchField(searchTerm = "label");
+		}
 
+		task ("Then 'label' field should appear on Add Fields modal") {
+			AssertElementPresent(
+				key_name = "label",
+				locator1 = "FrontendDataSetAdmin#FIELDS_ITEM");
+		}
 	}
 
 	@description = "LPS-185231. Confirm that the user can search a specific field on field's search bar."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -293,17 +293,11 @@ definition {
 		}
 
 		task ("And Check three options (creator,id ,name)") {
-			Check.checkNotVisible(
-				checkboxName = "creator",
-				locator1 = "Checkbox#ANY_CHECKBOX");
+			FrontendDataSetAdmin.checkFields(checkboxName = "creator");
 
-			Check.checkNotVisible(
-				checkboxName = "id",
-				locator1 = "Checkbox#ANY_CHECKBOX");
+			FrontendDataSetAdmin.checkFields(checkboxName = "id");
 
-			Check.checkNotVisible(
-				checkboxName = "name",
-				locator1 = "Checkbox#ANY_CHECKBOX");
+			FrontendDataSetAdmin.checkFields(checkboxName = "name");
 		}
 
 		task ("Then Confirm that the fields are checked ") {


### PR DESCRIPTION
**Description**
Add 4 automations for DatasetsFields testcase

**JIRA Tickets**
DatasetsFields#CanAddField ([LPS-185226](https://issues.liferay.com/browse/LPS-185226))
DatasetsFields#CanSearchFieldOnAddFieldsModal ([LPS-185227](https://issues.liferay.com/browse/LPS-185227))
DatasetsFields#CannotAddFieldAfterUncheckingIt ([LPS-185228](https://issues.liferay.com/browse/LPS-185228))
DatasetsFields#CanChangeFieldOrder ([LPS-185229](https://issues.liferay.com/browse/LPS-185229))