### PR TITLE
LPS-185440 Add support for status in Screen Navigation taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 12.1.3
+Bundle-Version: 12.2.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.util

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -10,5 +10,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "12.1.3"
+	"version": "12.2.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationEntry.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationEntry.java
@@ -36,6 +36,14 @@ public interface ScreenNavigationEntry<T> {
 
 	public String getScreenNavigationKey();
 
+	public default String getStatusLabel(Locale locale, T context) {
+		return null;
+	}
+
+	public default String getStatusStyle(T context) {
+		return "secondary";
+	}
+
 	public default boolean isVisible(User user, T context) {
 		return true;
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
@@ -254,6 +254,9 @@ public class ScreenNavigationTag extends IncludeTag {
 			"liferay-frontend:screen-navigation:menubarCssClass",
 			_menubarCssClass);
 		httpServletRequest.setAttribute(
+			"liferay-frontend:screen-navigation:modelContext",
+			getModelContext());
+		httpServletRequest.setAttribute(
 			"liferay-frontend:screen-navigation:navCssClass", _navCssClass);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:screen-navigation:portletURL", _portletURL);

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
@@ -24,6 +24,7 @@ String headerContainerCssClass = (String)request.getAttribute("liferay-frontend:
 String id = (String)request.getAttribute("liferay-frontend:screen-navigation:id");
 boolean inverted = (boolean)request.getAttribute("liferay-frontend:screen-navigation:inverted");
 String menubarCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:menubarCssClass");
+Object modelContext = (Object)request.getAttribute("liferay-frontend:screen-navigation:modelContext");
 String navCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:navCssClass");
 PortletURL portletURL = (PortletURL)request.getAttribute("liferay-frontend:screen-navigation:portletURL");
 ScreenNavigationCategory selectedScreenNavigationCategory = (ScreenNavigationCategory)request.getAttribute("liferay-frontend:screen-navigation:selectedScreenNavigationCategory");
@@ -90,12 +91,13 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 
 							<%
 							for (ScreenNavigationEntry<Object> screenNavigationEntry : screenNavigationEntries) {
+								String statusLabel = screenNavigationEntry.getStatusLabel(themeDisplay.getLocale(), modelContext);
 							%>
 
 								<li class="nav-item">
 									<a
 										aria-current="<%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "page" : "false" %>"
-										class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %>"
+										class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(statusLabel) ? "align-items-center d-flex" : StringPool.BLANK %>"
 										href="<%=
 											PortletURLBuilder.create(
 												PortletURLUtil.clone(portletURL, liferayPortletResponse)
@@ -107,6 +109,14 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 										%>"
 									>
 										<%= screenNavigationEntry.getLabel(themeDisplay.getLocale()) %>
+
+										<c:if test="<%= Validator.isNotNull(statusLabel) %>">
+											<clay:label
+												cssClass="ml-2"
+												displayType="<%= screenNavigationEntry.getStatusStyle(modelContext) %>"
+												label="<%= statusLabel %>"
+											/>
+										</c:if>
 									</a>
 								</li>
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
@@ -95,15 +95,19 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 								<li class="nav-item">
 									<a
 										aria-current="<%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "page" : "false" %>"
-										class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %>" href="<%=
-PortletURLBuilder.create(
-									PortletURLUtil.clone(portletURL, liferayPortletResponse)
-								).setParameter(
-									"screenNavigationCategoryKey", screenNavigationEntry.getCategoryKey()
-								).setParameter(
-									"screenNavigationEntryKey", screenNavigationEntry.getEntryKey()
-								).buildPortletURL() %>"><%= screenNavigationEntry.getLabel(themeDisplay.getLocale()) %></a
+										class="nav-link <%= Objects.equals(selectedScreenNavigationEntry.getEntryKey(), screenNavigationEntry.getEntryKey()) ? "active" : StringPool.BLANK %>"
+										href="<%=
+											PortletURLBuilder.create(
+												PortletURLUtil.clone(portletURL, liferayPortletResponse)
+											).setParameter(
+												"screenNavigationCategoryKey", screenNavigationEntry.getCategoryKey()
+											).setParameter(
+												"screenNavigationEntryKey", screenNavigationEntry.getEntryKey()
+											).buildPortletURL()
+										%>"
 									>
+										<%= screenNavigationEntry.getLabel(themeDisplay.getLocale()) %>
+									</a>
 								</li>
 
 							<%

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 8.1.0
+version 8.2.0


### PR DESCRIPTION
Hi guys!

This PR adds support for status in Screen Navigation taglib entries. The solution is thought to be able to show something like this:

![image](https://github.com/liferay-frontend/liferay-portal/assets/2444936/7067036d-f78c-4b1a-a6f3-4694dd9de5a7)

I have added `T context` as param from both methods so on each implementation we are able to do some checks to add the status.

Could you please give me your feedback? Thanks a lot 😄

**LPS ticket:** https://issues.liferay.com/browse/LPS-185440