### PR TITLE
LPS-185230 | Automation for DatasetsFields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -258,7 +258,7 @@ definition {
 		Click(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
 	}
 
-	macro searchField {
+	macro searchFieldInModal {
 		WaitForElementPresent(locator1 = "FrontendDataSetAdmin#MODAL_SEARCH");
 
 		AssertElementPresent(locator1 = "Icon#BASIC_SEARCH");

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testFunctional/macros/FrontendDataSetAdmin.macro
@@ -258,6 +258,16 @@ definition {
 		Click(locator1 = "FrontendDataSetAdmin#VIEW_ENTRY_BUTTON");
 	}
 
+	macro searchField {
+		WaitForElementPresent(locator1 = "FrontendDataSetAdmin#FIELDS_TAB_SEARCH");
+
+		AssertElementPresent(locator1 = "Icon#BASIC_SEARCH");
+
+		Type(
+			locator1 = "FrontendDataSetAdmin#FIELDS_TAB_SEARCH",
+			value1 = ${searchTerm});
+	}
+
 	macro searchFieldInModal {
 		WaitForElementPresent(locator1 = "FrontendDataSetAdmin#MODAL_SEARCH");
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -93,7 +93,7 @@
 </tr>
 <tr>
 	<td>FIELDS_TABLE</td>
-	<td>//table[contains(@class,'table-list')]//tr[@class='orderable-table-row'][${key_position}]//*[contains(text(),'${keyName}')]</td>
+	<td>//table[contains(@class,'table-list')]//tr[@class='orderable-table-row'][${key_position}]//*[contains(.,'${keyName}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSetAdmin.path
@@ -102,6 +102,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>FIELDS_TAB_SEARCH</td>
+	<td>//li[contains(@class,'nav-item')]//*[contains(@class, 'input-group-item')]//*[@placeholder="Search"]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>FIELDS_DRAG_DOTS_ICON</td>
 	<td>//table[contains(@class,'table-list')]//tr[@class='orderable-table-row']//td[@class="drag-handle-cell"]//button[@aria-label="Drag ${key_nameField}"]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/Datasets.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/Datasets.testcase
@@ -1,0 +1,72 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property custom.properties = "feature.flag.LPS-164563=true";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Dataset";
+	property testray.main.component.name = "Frontend Dataset";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given creating a Data Set via API") {
+			FrontendDataSetAdmin.goToDatasetAdminPage();
+
+			FrontendDataSetAdmin.createDatasetEntryViaAPI(
+				datasetName = "Dataset Fields Test",
+				restApplication = "/headless-admin-taxonomy/v1.0",
+				restEndpoint = "/",
+				restSchema = "TaxonomyCategory");
+		}
+
+		task ("And a dataset view created via api") {
+			FrontendDataSetAdmin.createFDSViewViaAPI(
+				datasetName = "Dataset Fields Test",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Fields Test");
+		}
+
+		task ("When go to the View page of the dataset created.") {
+			FrontendDataSetAdmin.goToSpecificViewPage(
+				datasetName = "Dataset Fields Test",
+				key_viewName = "View Fields Test");
+		}
+
+		task ("When goes to Fields Tab.") {
+			FrontendDataSetAdmin.goToTab(tabName = "Fields");
+		}
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		FrontendDataSetAdmin.deleteAllDatasetEntries();
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@description = "LPS-185233. Confirm that composed fields (refrencing another schema) are not available for selection."
+	@priority = 4
+	test AssertComposedFieldsNotAvailableForSelection {
+		task ("And clicks on plus button") {
+			LexiconEntry.gotoAdd();
+		}
+
+		task ("Then Composed fields (refrencing another schema), are not available for selection") {
+			AssertElementNotPresent(
+				key_name = "parentTaxonomyCategory",
+				locator1 = "FrontendDataSetAdmin#FIELDS_ITEM");
+
+			AssertElementNotPresent(
+				key_name = "parentTaxonomyVocabulary",
+				locator1 = "FrontendDataSetAdmin#FIELDS_ITEM");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -119,12 +119,25 @@ definition {
 	}
 
 	@description = "LPS-185230. Confirm that the user can cancel adding a field by clicking on cancel button."
-	@ignore = "true"
 	@priority = 4
 	test CanCancelAddingOnCancelButton {
+		task ("And clicks on Add Fields button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185230 CanCancelAddingOnCancelButton pending implementation
+		task ("And checks id field") {
+			FrontendDataSetAdmin.checkFields(checkboxName = "id");
+		}
 
+		task ("And clicks on Cancel button") {
+			Button.clickCancel();
+		}
+
+		task ("Then there's no fields on Fields tab page") {
+			AssertElementPresent(
+				key_text = "Add Fields",
+				locator1 = "Button#ANY");
+		}
 	}
 
 	@description = "LPS-185232. Confirm that the user can cancel adding a field by clicking on modal's close (X) button."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -276,7 +276,7 @@ definition {
 		}
 
 		task ("And type Account in the search bar and click enter") {
-			FrontendDataSetAdmin.searchField(searchTerm = "name");
+			FrontendDataSetAdmin.searchFieldInModal(searchTerm = "name");
 		}
 
 		task ("Then the corresponding option is the just displayed") {
@@ -294,7 +294,7 @@ definition {
 		}
 
 		task ("And types 'label' on modal search bar") {
-			FrontendDataSetAdmin.searchField(searchTerm = "label");
+			FrontendDataSetAdmin.searchFieldInModal(searchTerm = "label");
 		}
 
 		task ("Then 'label' field should appear on Add Fields modal") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -305,12 +305,35 @@ definition {
 	}
 
 	@description = "LPS-185231. Confirm that the user can search a specific field on field's search bar."
-	@ignore = "true"
 	@priority = 4
 	test CanSearchFieldOnFieldsSearchBar {
+		task ("And clicks on plus button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185231 CanSearchFieldOnFieldsSearchBar pending implementation
+		task ("And checks id and label fields") {
+			FrontendDataSetAdmin.checkFields(checkboxName = "id");
 
+			FrontendDataSetAdmin.checkFields(checkboxName = "label");
+		}
+
+		task ("And clicks on Save button") {
+			Button.clickSave();
+		}
+
+		task ("And types id on Fields search bar") {
+			FrontendDataSetAdmin.searchField(searchTerm = "id");
+		}
+
+		task ("And clicks on search icon") {
+			Click(locator1 = "AppBuilder#SEARCH_BUTTON");
+		}
+
+		task ("Then only id field should appear on Fields page") {
+			FrontendDataSetAdmin.assertFieldsOnTable(
+				key_position = 1,
+				keyName = "id");
+		}
 	}
 
 	@description = "LPS-179282. Confirm that the user can check and uncheck the fields"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -51,15 +51,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-185233. Confirm that composed fields (refrencing another schema) are not available for selection."
-	@ignore = "true"
-	@priority = 4
-	test AssertComposedFieldsNotAvailableForSelection {
-
-		// TODO LPS-185233 AssertComposedFieldsNotAvailableForSelection pending implementation
-
-	}
-
 	@description = "LPS-179282. Confirm that metadata fields are not present for the user "
 	@priority = 3
 	test AssertNotPresentMetadataFields {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetsFields.testcase
@@ -141,12 +141,27 @@ definition {
 	}
 
 	@description = "LPS-185232. Confirm that the user can cancel adding a field by clicking on modal's close (X) button."
-	@ignore = "true"
 	@priority = 4
 	test CanCancelAddingOnCloseButton {
+		task ("And clicks on plus button") {
+			LexiconEntry.gotoAdd();
+		}
 
-		// TODO LPS-185232 CanCancelAddingOnCloseButton pending implementation
+		task ("And checks creator field") {
+			FrontendDataSetAdmin.checkFields(checkboxName = "creator");
+		}
 
+		task ("And clicks on X icon of the modal") {
+			Click(
+				key_modalTitle = "Add Fields",
+				locator1 = "Button#CLOSE_MODAL");
+		}
+
+		task ("Then the modal is closed / And the changes are not saved") {
+			AssertElementPresent(
+				key_text = "Add Fields",
+				locator1 = "Button#ANY");
+		}
 	}
 
 	@description = "LPS-185229. Confirm that the user can change the field's order on Fields tab page."


### PR DESCRIPTION
**Description**
Add 4 automations for DatasetsFields testcase

**JIRA Tickets**
DatasetsFields#CanCancelAddingOnCancelButton ([LPS-185230](https://issues.liferay.com/browse/LPS-185230))
DatasetsFields#CanSearchFieldOnFieldsSearchBar ([LPS-185231](https://issues.liferay.com/browse/LPS-185231))
DatasetsFields#CanCancelAddingOnCloseButton ([LPS-185232](https://issues.liferay.com/browse/LPS-185232))
DatasetsFields#AssertComposedFieldsNotAvailableForSelection ([LPS-185233](https://issues.liferay.com/browse/LPS-185233))