### PR TITLE
LPS-185464 Allow FDS Filters to be set with `null` value

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -151,19 +151,23 @@ const FrontendDataSet = ({
 			...initialActiveView,
 		};
 
-		const filters = initialFilters.map((filter) => {
-			const preloadedData = filter.preloadedData;
+		const filters = initialFilters
+			? initialFilters.map((filter) => {
+					const preloadedData = filter.preloadedData;
 
-			if (preloadedData) {
-				filter.active = true;
-				filter.selectedData = preloadedData;
+					if (preloadedData) {
+						filter.active = true;
+						filter.selectedData = preloadedData;
 
-				filter.odataFilterString = getOdataFilterString(filter);
-				filter.selectedItemsLabel = getFilterSelectedItemsLabel(filter);
-			}
+						filter.odataFilterString = getOdataFilterString(filter);
+						filter.selectedItemsLabel = getFilterSelectedItemsLabel(
+							filter
+						);
+					}
 
-			return filter;
-		});
+					return filter;
+			  })
+			: [];
 
 		const paginationDelta =
 			showPagination &&
@@ -836,7 +840,6 @@ const FrontendDataSet = ({
 FrontendDataSet.defaultProps = {
 	bulkActions: [],
 	customViews: '{}',
-	filters: [],
 	inlineEditingSettings: null,
 	items: null,
 	itemsActions: null,


### PR DESCRIPTION
### References

- [LPS-185464 Fix all the things](https://issues.liferay.com/browse/LPS-185464)

### What is the goal of this PR?

This issue came up during development of FDS fragments, and it is not the first time I'm seeing it. The problem is that if we are setting a default through `defaultProps`, or a React default on a prop, it will end up overridden with a `null` value set in backend or parent component. As it works fine with `undefined` or an empty array, what we previously did is omitted setting the prop, or made sure backend sets an empty array as default. This ended up being proven bad approach, as it keeps resulting in bugs. So, in this PR, we are allowing setting of `null` value, with the behavior equal to `undefined` and `[]`.

### What does it look like?

No changes in UI.
