### PR TITLE
LPS-183959 Fix url of client extensions help text

### DIFF
--- a/learn-resources/client-extension-web.json
+++ b/learn-resources/client-extension-web.json
@@ -8,13 +8,13 @@
 	"learn-custom-element": {
 		"en_US": {
 			"message": "Learn more about custom element client extensions.",
-			"url": "https://learn.liferay.com/dxp/latest/en/building-applications/client-extensions/browser-based-client-extensions/understanding-custom-element-and-iframe-client-extensions.html#using-the-custom-element-type"
+			"url": "https://learn.liferay.com/dxp/latest/en/building-applications/client-extensions/front-end-client-extensions/understanding-custom-element-and-iframe-client-extensions.html#using-the-custom-element-type"
 		}
 	},
 	"learn-iframe": {
 		"en_US": {
 			"message": "Learn more about IFrame client extensions.",
-			"url": "https://learn.liferay.com/dxp/latest/en/building-applications/client-extensions/browser-based-client-extensions/understanding-custom-element-and-iframe-client-extensions.html#using-the-iframe-type"
+			"url": "https://learn.liferay.com/dxp/latest/en/building-applications/client-extensions/front-end-client-extensions/understanding-custom-element-and-iframe-client-extensions.html#using-the-iframe-type"
 		}
 	}
 }


### PR DESCRIPTION
This PR update the URL of the client extensions help text

---
BEFORE
https://learn.liferay.com/en/w/dxp/building-applications/client-extensions/browser-based-client-extensions/understanding-custom-element-and-iframe-client-extensions#using-the-custom-element-type
NOW
https://learn.liferay.com/w/dxp/building-applications/client-extensions/front-end-client-extensions/understanding-custom-element-and-iframe-client-extensions#using-the-custom-element-type