### PR TITLE
LPS-185943 Ensure links are distinguished from surrounding text

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -90,7 +90,7 @@
 					<div class="row">
 						<div class="col-md-12 text-center text-md-left">
 							<@liferay.language_format
-								arguments='<a class="text-white" href="http://www.liferay.com" rel="external">Liferay</a>'
+								arguments='<a class="text-decoration-underline text-white" href="http://www.liferay.com" rel="external">Liferay</a>'
 								key="powered-by-x"
 							/>
 						</div>


### PR DESCRIPTION
[Related](url) Issue: https://issues.liferay.com/browse/LPS-185943

This PR adds an underline to "Liferay" on the homepage (footer) of the classic theme (I guess it is an accessibility issue) as requested by the product designer Marcos Castro.
It does so by ~~adding a style attribute to the HTML element. I opted for not creating a class and adding it to the element because it would imply changing the CSS code for just one specific case.~~ adding an existing class (`text-decoration-underline`) as suggested by Matuzalem Teles.