### PR TITLE
LPS-185909 Empty values ​​in "On after add" and "On after update" actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IClientExtensionCellRenderer} from './api';
 import '../css/FDSView.scss';
 import {FDSViewType} from './FDSViews';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IFDSViewSectionInterface} from '../FDSView';
 declare const Details: ({
 	fdsView,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IFDSViewSectionInterface} from '../FDSView';
 import '../../css/FDSEntries.scss';
 declare const Fields: ({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Sorting.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Sorting.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {IFDSViewSectionInterface} from '../FDSView';
 declare const Sorting: ({
 	fdsView,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DefaultRenderer.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DefaultRenderer.tsx
@@ -63,7 +63,11 @@ const DefaultRenderer: React.FC<{
 	options: DefaultRendererOptions;
 	value: DefaultRendererValue;
 }> = ({options, value}) => {
-	if (typeof value === 'number' || typeof value === 'string') {
+	if (
+		typeof value === 'number' ||
+		typeof value === 'string' ||
+		React.isValidElement(value)
+	) {
 		return <Wrapper options={options}>{value}</Wrapper>;
 	}
 


### PR DESCRIPTION
### References

- [LPS-185909 Empty values ​​in "On after add" and "On after update" actions](https://issues.liferay.com/browse/LPS-185909)
- Caused by https://github.com/liferay-frontend/liferay-portal/pull/3362

### What is the goal of this PR?

A regression bugfix. The intent in the task that caused the issue was to make the component more robust to invalid inputs, to make it show empty cell instead of breaking. I did not cover one case of a valid input, when value is a React element. This PR fixes it.

This case is only possible when FDS is used as a controlled component. Normally, values are taken from data JSON, built in backend. I guess you can technically build a valid React element object in backend, but that's extremely unlikely, and definitely not something we are doing in DXP.

### What does it look like?

#### Before PR

See movie in JIRA ticket.

#### After PR

![screen](https://github.com/liferay-frontend/liferay-portal/assets/5435511/946eb70a-08fe-403e-a612-2fb9408cdaeb)


### Steps to reproduce

See steps in JIRA ticket.