### PR TITLE
COMMERCE-11590 - Account selector doesn't work when impersonating a buyer user

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
@@ -64,7 +64,7 @@ export default function defaultFetch(resource, init = {}) {
 				resource = resourceLocation;
 			}
 			else {
-				resource = {...resource, url: resourceLocation};
+				resource.url = resourceLocation;
 			}
 		}
 	}


### PR DESCRIPTION
Related Issue: [COMMERCE-11590](https://issues.liferay.com/browse/COMMERCE-11590)

The problem is that the "..." operator was overwriting the "resource" parameter, instead of just adding/updating the "url" property.