### PR TITLE
LPS-183949 | Update CannotUseCharactersInPaginationItems test's description

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/DatasetPagination.testcase
@@ -235,7 +235,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-183949. Confirm that pagination cannot have characters in pagination items field"
+	@description = "Blocked by LPS-183152. LPS-183949 Confirm that pagination cannot have characters in pagination items field"
 	@ignore = "true"
 	@priority = 4
 	test CannotUseCharactersInPaginationItems {


### PR DESCRIPTION
**Description**
Update CannotUseCharactersInPaginationItems test's description.

Implementation is still needed. We are skipping it now because of this [LPS-183152](https://issues.liferay.com/browse/LPS-183152) bug

**JIRA Link**
https://issues.liferay.com/browse/LPS-183949