### PR TITLE
LPS-186244 - Account selector doesn't work when impersonating a buyer user

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/fetch.es.js
@@ -38,7 +38,7 @@ export default function defaultFetch(resource, init = {}) {
 				resource = resourceLocation;
 			}
 			else {
-				resource = {...resource, url: resourceLocation};
+				resource = new URL(resourceLocation);
 			}
 		}
 
@@ -64,7 +64,7 @@ export default function defaultFetch(resource, init = {}) {
 				resource = resourceLocation;
 			}
 			else {
-				resource = {...resource, url: resourceLocation};
+				resource = new URL(resourceLocation);
 			}
 		}
 	}


### PR DESCRIPTION
Related Issue: [LPS-186244](https://issues.liferay.com/browse/LPS-186244)

The problem is that the "..." operator was overwriting the "resource" parameter, instead of just adding/updating the "url" property.