### PR TITLE
LCD 27832

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-frontend-2/assets/Header.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-frontend-2/assets/Header.js
@@ -12,7 +12,8 @@
  * details.
  */
 
-import {upperCase} from './shared-utils';
+// eslint-disable-next-line @liferay/import-extensions
+import {upperCase} from './shared-utils.js';
 
 class HeaderWebComponent extends HTMLElement {
 	constructor() {


### PR DESCRIPTION
hey @bryceosterhaus  - there was a linting change done here https://github.com/liferay-frontend/liferay-portal/commit/200b1524da4ab3b4911206dffc4821988b8ec981#diff-64eef832fb0e9eec874e68091ed3eeb078167214def2403bc4cee96e21f1341e (removing .js) from the import that breaks this sample from rendering. 

I get a 404: 

```
WARN  [http-nio-8080-exec-2][code_jsp:157] {code="404", msg="ProxyServlet: /o/liferay-sample-etc-frontend-2/shared-utils", uri=/o/liferay-sample-etc-frontend-2/shared-utils}
```

I changed this back and disabled the eslint rule - is there any other way to fix this? 


cc: @gamerson