### PR TITLE
LPS-182969 Create React component to provide <liferay-learn:message> tag behavior

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.js
@@ -12,6 +12,11 @@
  * details.
  */
 
+export {
+	default as LearnMessage,
+	LearnResourcesContext,
+} from './learn_message/LearnMessage';
+
 export {default as Treeview} from './treeview/Treeview';
 
 export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -16,7 +16,26 @@ import ClayLink from '@clayui/link';
 import getCN from 'classnames';
 import React, {useContext} from 'react';
 
-export const LearnResourcesContext = React.createContext({});
+export const LearnResourcesContext = React.createContext<
+	Partial<ILearnResourceContext>
+>({});
+
+interface ILearnResourceLocaleItem {
+	message: string;
+	url?: string;
+}
+
+interface ILearnResourceKeyItem {
+	[locale: string]: ILearnResourceLocaleItem;
+}
+
+interface ILearnResourceItem {
+	[resourceKey: string]: ILearnResourceKeyItem;
+}
+
+interface ILearnResourceContext {
+	[learnResourceName: string]: ILearnResourceItem;
+}
 
 interface IProps {
 	className?: string;
@@ -62,7 +81,9 @@ export default function LearnMessage({
 	resourceKey,
 	...otherProps
 }: IProps) {
-	const learnResourcesContext: any = useContext(LearnResourcesContext);
+	const learnResourcesContext = useContext(
+		LearnResourcesContext
+	) as ILearnResourceContext;
 
 	const resourceKeyObject = learnResourcesContext[resource][resourceKey] || {
 		en_US: {},

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayLink from '@clayui/link';
+import getCN from 'classnames';
+import React, {useContext} from 'react';
+
+export const LearnResourcesContext = React.createContext({});
+
+interface IProps {
+	className?: string;
+
+	/**
+	 * The learn resource
+	 */
+	resource: string;
+
+	/**
+	 * The key to render.
+	 */
+	resourceKey: string;
+}
+
+/**
+ * This component is used to render links to Liferay Learn articles. The json
+ * object `learnResources` contains the messages and urls and is taken from
+ * liferay-portal/learn-resources.
+ *
+ * Use `LearnResourcesContext` to wrap the entire React App.
+ *
+ * Example use:
+ * <LearnResourcesContext.Provider value={learnResources}>
+ * 	<LearnMessage resourceKey="general" resource="portlet-configuration-web" />
+ * </LearnResourcesContext.Provider>
+ *
+ * Example of `learnResources`:
+ * {
+ * 	"portlet-configuration-web": { // Learn resource
+ *		"general": { // Resource key
+ *			"en_US": {
+ *				"message": "Tell me more",
+ *				"url": "https://learn.liferay.com/"
+ *			}
+ *		}
+ * 	}
+ * }
+ */
+export default function LearnMessage({
+	className = '',
+	resource,
+	resourceKey,
+	...otherProps
+}: IProps) {
+	const learnResourcesContext: any = useContext(LearnResourcesContext);
+
+	const resourceKeyObject = learnResourcesContext[resource][resourceKey] || {
+		en_US: {},
+	};
+
+	const learnMessageObject =
+		resourceKeyObject[Liferay.ThemeDisplay.getLanguageId()] ||
+		resourceKeyObject[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
+		resourceKeyObject[Object.keys(resourceKeyObject)[0]];
+
+	if (learnMessageObject.url) {
+		return (
+			<ClayLink
+				className={getCN('learn-message', className)}
+				href={learnMessageObject.url}
+				rel="noopener noreferrer"
+				target="_blank"
+				{...otherProps}
+			>
+				{learnMessageObject.message}
+			</ClayLink>
+		);
+	}
+
+	return <></>;
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -37,7 +37,9 @@ interface ILearnResourceContext {
 	[learnResourceName: string]: ILearnResourceItem;
 }
 
-interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+type ClayLinkProps = React.ComponentProps<typeof ClayLink>;
+
+interface IProps extends ClayLinkProps {
 	className?: string;
 
 	/**

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -87,7 +87,9 @@ export default function LearnMessage({
 		LearnResourcesContext
 	) as ILearnResourceContext;
 
-	const resourceKeyObject = learnResourcesContext[resource][resourceKey] || {
+	const resourceKeyObject = learnResourcesContext?.[resource]?.[
+		resourceKey
+	] || {
 		en_US: {},
 	};
 

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -37,7 +37,7 @@ interface ILearnResourceContext {
 	[learnResourceName: string]: ILearnResourceItem;
 }
 
-interface IProps {
+interface IProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
 	className?: string;
 
 	/**

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -58,7 +58,8 @@ interface IProps extends ClayLinkProps {
  * object `learnResources` contains the messages and urls and is taken from
  * liferay-portal/learn-resources.
  *
- * Use `LearnResourcesContext` to wrap the entire React App.
+ * Use `LearnResourcesContext` to wrap the entire React App and in the JSP use
+ * `LearnMessageUtil.getReactDataJSONObject` to get the required resources.
  *
  * Example use:
  * <LearnResourcesContext.Provider value={learnResources}>
@@ -87,11 +88,35 @@ export default function LearnMessage({
 		LearnResourcesContext
 	) as ILearnResourceContext;
 
+	if (
+		process.env.NODE_ENV === 'development' &&
+		!Object.keys(learnResourcesContext).length
+	) {
+		console.warn(
+			`Unable to render LearnMessage for resourceKey: '${resourceKey}'.`,
+			'Unable to find LearnResourcesContext.',
+			'To LearnMessage component must be wrapped with',
+			'<LearnResourcesContext.Provider value={learnResources}>',
+			'with the needed learnResources passed in using the Java method',
+			'LearnMessageUtil.getReactDataJSONObject("module-name").'
+		);
+	}
+
 	const resourceKeyObject = learnResourcesContext?.[resource]?.[
 		resourceKey
 	] || {
 		en_US: {},
 	};
+
+	if (
+		process.env.NODE_ENV === 'development' &&
+		!learnResourcesContext?.[resource]
+	) {
+		console.warn(
+			`Unable to render LearnMessage for resourceKey: '${resourceKey}'.`,
+			`Unable to find resource: '${resource}'`
+		);
+	}
 
 	const learnMessageObject =
 		resourceKeyObject[Liferay.ThemeDisplay.getLanguageId()] ||

--- a/modules/apps/frontend-js/frontend-js-components-web/test/learn_message/LearnMessage.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/learn_message/LearnMessage.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import LearnMessage, {
+	LearnResourcesContext,
+} from '../../src/main/resources/META-INF/resources/learn_message/LearnMessage';
+
+const MESSAGE = 'Learn more.';
+const URL =
+	'https://learn.liferay.com/dxp/latest/en/using-search/search-pages-and-widgets/search-bar-suggestions.html';
+
+const LEARN_RESOURCES_MOCK_DATA = {
+	'portal-search-web': {
+		'search-bar-suggestions': {
+			en_US: {
+				message: MESSAGE,
+				url: URL,
+			},
+		},
+	},
+};
+
+const LearnMessageWithContext = (props) => {
+	return (
+		<LearnResourcesContext.Provider value={LEARN_RESOURCES_MOCK_DATA}>
+			<LearnMessage {...props} />
+		</LearnResourcesContext.Provider>
+	);
+};
+
+describe('LearnMessage', () => {
+	it('displays the localized message string and url', () => {
+		const {getByText} = render(
+			<LearnMessageWithContext
+				resource="portal-search-web"
+				resourceKey="search-bar-suggestions"
+			/>
+		);
+
+		const element = getByText(MESSAGE);
+
+		expect(element).not.toBeNull();
+
+		expect(element.href).toEqual(URL);
+	});
+
+	it('displays nothing if LearnResourcesContext is missing', () => {
+		const {container} = render(
+			<LearnMessage
+				resource="portal-search-web"
+				resourceKey="search-bar-suggestions"
+			/>
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('displays nothing if resource and resourceKey props are not defined', () => {
+		const {container} = render(<LearnMessageWithContext />);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('displays nothing if resource is not defined', () => {
+		const {container} = render(
+			<LearnMessageWithContext resourceKey="search-bar-suggestions" />
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('displays nothing if resourceKey is not defined', () => {
+		const {container} = render(
+			<LearnMessageWithContext resource="portal-search-web" />
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/learn_message/LearnMessage.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/learn_message/LearnMessage.d.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+export declare const LearnResourcesContext: React.Context<{}>;
+interface IProps {
+	className?: string;
+
+	/**
+	 * The learn resource
+	 */
+	resource: string;
+
+	/**
+	 * The key to render.
+	 */
+	resourceKey: string;
+}
+
+/**
+ * This component is used to render links to Liferay Learn articles. The json
+ * object `learnResources` contains the messages and urls and is taken from
+ * liferay-portal/learn-resources.
+ *
+ * Use `LearnResourcesContext` to wrap the entire React App.
+ *
+ * Example use:
+ * <LearnResourcesContext.Provider value={learnResources}>
+ * 	<LearnMessage resourceKey="general" resource="portlet-configuration-web" />
+ * </LearnResourcesContext.Provider>
+ *
+ * Example of `learnResources`:
+ * {
+ * 	"portlet-configuration-web": { // Learn resource
+ *		"general": { // Resource key
+ *			"en_US": {
+ *				"message": "Tell me more",
+ *				"url": "https://learn.liferay.com/"
+ *			}
+ *		}
+ * 	}
+ * }
+ */
+export default function LearnMessage({
+	className,
+	resource,
+	resourceKey,
+	...otherProps
+}: IProps): JSX.Element;
+export {};

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/learn_message/LearnMessage.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/learn_message/LearnMessage.d.ts
@@ -12,9 +12,26 @@
  * details.
  */
 
+import ClayLink from '@clayui/link';
 import React from 'react';
-export declare const LearnResourcesContext: React.Context<{}>;
-interface IProps {
+export declare const LearnResourcesContext: React.Context<Partial<
+	ILearnResourceContext
+>>;
+interface ILearnResourceLocaleItem {
+	message: string;
+	url?: string;
+}
+interface ILearnResourceKeyItem {
+	[locale: string]: ILearnResourceLocaleItem;
+}
+interface ILearnResourceItem {
+	[resourceKey: string]: ILearnResourceKeyItem;
+}
+interface ILearnResourceContext {
+	[learnResourceName: string]: ILearnResourceItem;
+}
+declare type ClayLinkProps = React.ComponentProps<typeof ClayLink>;
+interface IProps extends ClayLinkProps {
 	className?: string;
 
 	/**
@@ -33,7 +50,8 @@ interface IProps {
  * object `learnResources` contains the messages and urls and is taken from
  * liferay-portal/learn-resources.
  *
- * Use `LearnResourcesContext` to wrap the entire React App.
+ * Use `LearnResourcesContext` to wrap the entire React App and in the JSP use
+ * `LearnMessageUtil.getReactDataJSONObject` to get the required resources.
  *
  * Example use:
  * <LearnResourcesContext.Provider value={learnResources}>

--- a/modules/apps/learn/learn-api/bnd.bnd
+++ b/modules/apps/learn/learn-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Learn API
 Bundle-SymbolicName: com.liferay.learn.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package: com.liferay.learn

--- a/modules/apps/learn/learn-api/build.gradle
+++ b/modules/apps/learn/learn-api/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
+++ b/modules/apps/learn/learn-api/src/main/java/com/liferay/learn/LearnMessageUtil.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -44,6 +45,24 @@ public class LearnMessageUtil {
 		JSONObject jsonObject = getJSONObject(resource);
 
 		return new LearnMessage(jsonObject, key, languageId);
+	}
+
+	public static JSONObject getReactDataJSONObject(String resource) {
+		JSONObject learnMessageJSONObject = getJSONObject(resource);
+
+		return JSONUtil.put(resource, learnMessageJSONObject);
+	}
+
+	public static JSONObject getReactDataJSONObject(String[] resources) {
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
+
+		for (String resource : resources) {
+			JSONObject learnMessageJSONObject = getJSONObject(resource);
+
+			jsonObject.put(resource, learnMessageJSONObject);
+		}
+
+		return jsonObject;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/learn/learn-api/src/main/resources/com/liferay/learn/packageinfo
+++ b/modules/apps/learn/learn-api/src/main/resources/com/liferay/learn/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-182969

Here's the initial solution that I ended up with. I attempted adding an additional context attribute to the `react:component` taglib, but it would almost be identical to the `props` taglib attribute so it like a cleaner approach to continue passing in values from `props`. 

**Example usage:**
JSP:
```
<react:component
	module='path/to/component'
	props='<%=
		HashMapBuilder.<String, Object>put(
			"learnResources", LearnMessageUtil.getReactDataJSONObject("search-experiences-web")
		).build()
	%>'
/>
```
React:
```
<LearnResourcesContext.Provider value={learnResources}>
	<LearnMessage
		resource='search-experiences-web'
		resourceKey='element-source'
	/>
</LearnResourcesContext.Provider>
```

For multiple resources, you'd pass in something like:
```
"learnResources", LearnMessageUtil.getReactDataJSONObject(new String[] {"portal-search-web", "search-experiences-web"})
```

Another idea I tried out was collecting resources within a `Liferay.LearnResources` object like `Liferay.FeatureFlags` but I wasn't able to figure out a good place to define which resources to load as well as prevent race conditions from happening.

I think the approach in this PR is good as a first step as it keeps the implementation straight-forward and easier to debug.