### PR TITLE
LPS-186633 Scale image by adding height attribute

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -265,7 +265,14 @@
 						callback(imageSrc, selectedItem);
 					}
 					else {
-						let elementOuterHtml = '<img src="' + imageSrc + '">';
+						const editorContent = document.getElementById(
+							`${editor.id}_contents`
+						);
+
+						const editorContentHeight = editorContent.getBoundingClientRect()
+							.height;
+
+						let elementOuterHtml = `<img src="${imageSrc}" height="${editorContentHeight}">`;
 
 						if (instance._isEmptySelection(editor)) {
 							elementOuterHtml += '<br />';


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-186633

The issue is an image being uploaded into CKEditor does not get scaled to fit the editor. In order to fix this, I added the height attribute to the image being uploaded to scale it to the height of the editor.
Please let me know if there are any questions or comments about this.

Thank you!