### PR TITLE
LPS-177576 Allow users to rename a dataset

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -606,9 +606,7 @@ const AddFDSEntryModalContent = ({
 	return (
 		<>
 			<ClayModal.Header>
-				{rename
-					? Liferay.Language.get('rename-data-set')
-					: Liferay.Language.get('new-data-set')}
+				{Liferay.Language.get('new-data-set')}
 			</ClayModal.Header>
 
 			<ClayModal.Body>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -42,7 +42,12 @@ type FDSEntryType = {
 			href: string;
 			method: string;
 		};
+		update: {
+			href: string;
+			method: string;
+		};
 	};
+	externalReferenceCode: string;
 	id: string;
 	label: string;
 	restApplication: string;
@@ -798,6 +803,115 @@ const FDSEntries = ({
 		});
 	};
 
+	const RenameFDSEntryModalContent = ({
+		closeModal,
+		itemData,
+		loadData,
+		namespace,
+	}: {
+		closeModal: Function;
+		itemData: FDSEntryType;
+		loadData: Function;
+		namespace: string;
+	}) => {
+		const [fdsEntryNameValue, setFdsEntryNameValue] = useState('');
+
+		function saveFDSEntryRename() {
+			fetch(itemData.actions.update.href, {
+				body: JSON.stringify({
+					externalReferenceCode: itemData.externalReferenceCode,
+					label: fdsEntryNameValue,
+				}),
+				headers: {
+					'Accept': 'application/json',
+					'Content-Type': 'application/json',
+				},
+				method: itemData.actions.update.method,
+			})
+				.then(() => {
+					closeModal();
+
+					openToast({
+						message: Liferay.Language.get(
+							'your-request-completed-successfully'
+						),
+						type: 'success',
+					});
+
+					loadData();
+				})
+				.catch(() =>
+					openToast({
+						message: Liferay.Language.get(
+							'your-request-failed-to-complete'
+						),
+						type: 'danger',
+					})
+				);
+		}
+
+		return (
+			<>
+				<ClayModal.Header>
+					{Liferay.Language.get('rename-dataset')}
+				</ClayModal.Header>
+
+				<ClayModal.Body>
+					<ClayForm.Group>
+						<label htmlFor={`${namespace}fdsRenameInput`}>
+							{Liferay.Language.get('name')}
+						</label>
+
+						<ClayInput
+							id={`${namespace}fdsRenameInput`}
+							onChange={(event) =>
+								setFdsEntryNameValue(event.target.value)
+							}
+							type="text"
+							value={fdsEntryNameValue}
+						/>
+					</ClayForm.Group>
+				</ClayModal.Body>
+
+				<ClayModal.Footer
+					last={
+						<ClayButton.Group spaced>
+							<ClayButton onClick={saveFDSEntryRename}>
+								{Liferay.Language.get('save')}
+							</ClayButton>
+
+							<ClayButton
+								displayType="secondary"
+								onClick={() => closeModal()}
+							>
+								{Liferay.Language.get('cancel')}
+							</ClayButton>
+						</ClayButton.Group>
+					}
+				/>
+			</>
+		);
+	};
+
+	const onRenameClick = ({
+		itemData,
+		loadData,
+	}: {
+		itemData: FDSEntryType;
+		loadData: Function;
+	}) => {
+		openModal({
+			contentComponent: ({closeModal}: {closeModal: Function}) => (
+				<RenameFDSEntryModalContent
+					closeModal={closeModal}
+					itemData={itemData}
+					loadData={loadData}
+					namespace={namespace}
+				/>
+			),
+		});
+	};
+
 	const views = [
 		{
 			contentRenderer: 'table',
@@ -859,6 +973,11 @@ const FDSEntries = ({
 						icon: 'view',
 						label: Liferay.Language.get('view'),
 						onClick: onViewClick,
+					},
+					{
+						icon: 'pencil',
+						label: Liferay.Language.get('rename'),
+						onClick: onRenameClick,
 					},
 					{
 						icon: 'trash',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import '../css/FDSEntries.scss';
 import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -12,8 +12,6 @@
  * details.
  */
 
-/// <reference types="react" />
-
 import '../css/FDSEntries.scss';
 import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';
@@ -24,7 +22,12 @@ declare type FDSEntryType = {
 			href: string;
 			method: string;
 		};
+		update: {
+			href: string;
+			method: string;
+		};
 	};
+	externalReferenceCode: string;
 	id: string;
 	label: string;
 	restApplication: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
@@ -12,8 +12,6 @@
  * details.
  */
 
-/// <reference types="react" />
-
 import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSEntryType} from './FDSEntries';
 declare type FDSViewType = {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
@@ -12,6 +12,8 @@
  * details.
  */
 
+/// <reference types="react" />
+
 import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSEntryType} from './FDSEntries';
 declare type FDSViewType = {

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -13931,7 +13931,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename
 rename-collection=Rename Collection
 rename-column-label=Rename Column Label
-rename-dataset=Rename Dataset
+rename-data-set=Rename Data Set
 rename-display-page-template=Rename Display Page Template
 rename-fragment=Rename Fragment
 rename-group=Rename Group

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -13931,6 +13931,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename
 rename-collection=Rename Collection
 rename-column-label=Rename Column Label
+rename-dataset=Rename Dataset
 rename-display-page-template=Rename Display Page Template
 rename-fragment=Rename Fragment
 rename-group=Rename Group

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=إعادة تسمية
 rename-collection=تغيير اسم المجموعة
 rename-column-label=إعادة تسمية العمود
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=تغيير اسم قالب صفحة العرض
 rename-fragment=تسمية التجزئة
 rename-group=إعادة تسمية المجموعة

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=إعادة تسمية
 rename-collection=تغيير اسم المجموعة
 rename-column-label=إعادة تسمية العمود
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=تغيير اسم قالب صفحة العرض
 rename-fragment=تسمية التجزئة
 rename-group=إعادة تسمية المجموعة

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Преименуване
 rename-collection=Преименуване на колекция (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Преименуване на шаблон за показване на страница (Automatic Translation)
 rename-fragment=Преименуване на фрагмент (Automatic Translation)
 rename-group=Преименуване на група

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Преименуване
 rename-collection=Преименуване на колекция (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Преименуване на шаблон за показване на страница (Automatic Translation)
 rename-fragment=Преименуване на фрагмент (Automatic Translation)
 rename-group=Преименуване на група

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Canvia el nom
 rename-collection=Canvia el nom de la col·lecció
 rename-column-label=Canvia el nom de l'etiqueta de columna
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Canvia el nom de la plantilla de pàgina de visualització
 rename-fragment=Canvia el nom del fragment
 rename-group=Canvia el nom del grup

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Canvia el nom
 rename-collection=Canvia el nom de la col·lecció
 rename-column-label=Canvia el nom de l'etiqueta de columna
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Canvia el nom de la plantilla de pàgina de visualització
 rename-fragment=Canvia el nom del fragment
 rename-group=Canvia el nom del grup

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Přejmenovat
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Přejmenování šablony stránky zobrazení (Automatic Translation)
 rename-fragment=Přejmenovat fragment (Automatic Translation)
 rename-group=Přejmenovat skupinu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Přejmenovat
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Přejmenování šablony stránky zobrazení (Automatic Translation)
 rename-fragment=Přejmenovat fragment (Automatic Translation)
 rename-group=Přejmenovat skupinu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Omdøb samling (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Omdøb visningssideskabelon (Automatic Translation)
 rename-fragment=Omdøb fragment (Automatic Translation)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Omdøb samling (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Omdøb visningssideskabelon (Automatic Translation)
 rename-fragment=Omdøb fragment (Automatic Translation)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Umbenennen
 rename-collection=Sammlung umbenennen
 rename-column-label=Spaltenbeschriftung umbenennen
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Vorlage für die Anzeigeseite umbenennen
 rename-fragment=Fragment umbenennen
 rename-group=Gruppe umbenennen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Umbenennen
 rename-collection=Sammlung umbenennen
 rename-column-label=Spaltenbeschriftung umbenennen
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Vorlage für die Anzeigeseite umbenennen
 rename-fragment=Fragment umbenennen
 rename-group=Gruppe umbenennen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Μετονομασία
 rename-collection=Μετονομασία συλλογής (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Μετονομασία προτύπου σελίδας εμφάνισης (Automatic Translation)
 rename-fragment=Μετονομασία τμήματος (Automatic Translation)
 rename-group=Μετονομασία ομάδος

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Μετονομασία
 rename-collection=Μετονομασία συλλογής (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Μετονομασία προτύπου σελίδας εμφάνισης (Automatic Translation)
 rename-fragment=Μετονομασία τμήματος (Automatic Translation)
 rename-group=Μετονομασία ομάδος

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -13931,7 +13931,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename
 rename-collection=Rename Collection
 rename-column-label=Rename Column Label
-rename-dataset=Rename Dataset
+rename-data-set=Rename Data Set
 rename-display-page-template=Rename Display Page Template
 rename-fragment=Rename Fragment
 rename-group=Rename Group

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -13931,6 +13931,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename
 rename-collection=Rename Collection
 rename-column-label=Rename Column Label
+rename-dataset=Rename Dataset
 rename-display-page-template=Rename Display Page Template
 rename-fragment=Rename Fragment
 rename-group=Rename Group

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renombrar
 rename-collection=Cambiar nombre de la colección
 rename-column-label=Cambiar nombre de la etiqueta de columna
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Cambiar nombre de plantilla de página de visualización
 rename-fragment=Cambio de nombre de fragmento
 rename-group=Renombrar grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Nimeta ümber
 rename-collection=Nimeta kollektsioon ümber (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Kuvalehe malli ümbernimetamine (Automatic Translation)
 rename-fragment=Nimeta fragment ümber (Automatic Translation)
 rename-group=Nimeta grupp ümber

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Nimeta ümber
 rename-collection=Nimeta kollektsioon ümber (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Kuvalehe malli ümbernimetamine (Automatic Translation)
 rename-fragment=Nimeta fragment ümber (Automatic Translation)
 rename-group=Nimeta grupp ümber

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Berrizendatu
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Zatia berrizendatu
 rename-group=Berrizendatu multzoa

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Berrizendatu
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Zatia berrizendatu
 rename-group=Berrizendatu multzoa

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=تغییر نام
 rename-collection=مجموعه تغییر نام (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=تغییر نام صفحه نمایش الگو (Automatic Translation)
 rename-fragment=تغییر نام اجزا
 rename-group=تغییر نام گروه

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=تغییر نام
 rename-collection=مجموعه تغییر نام (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=تغییر نام صفحه نمایش الگو (Automatic Translation)
 rename-fragment=تغییر نام اجزا
 rename-group=تغییر نام گروه

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -13924,7 +13924,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Uudelleennimeä
 rename-collection=Nimeä Kokoelma Uudelleen
 rename-column-label=Nimeä sarakkeen tunniste uudelleen
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Uudelleennimeä Näyttösivumalli
 rename-fragment=Nimeä Sivunosa Uudelleen
 rename-group=Uudelleennimeä ryhmä

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -13924,6 +13924,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Uudelleennimeä
 rename-collection=Nimeä Kokoelma Uudelleen
 rename-column-label=Nimeä sarakkeen tunniste uudelleen
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Uudelleennimeä Näyttösivumalli
 rename-fragment=Nimeä Sivunosa Uudelleen
 rename-group=Uudelleennimeä ryhmä

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomer
 rename-collection=Renommer la collection
 rename-column-label=Renommer le libellé de la colonne
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Renommer le modèle de page d'affichage
 rename-fragment=Renommer le fragment
 rename-group=Renommer le groupe

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomer
 rename-collection=Renommer la collection
 rename-column-label=Renommer le libellé de la colonne
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Renommer le modèle de page d'affichage
 rename-fragment=Renommer le fragment
 rename-group=Renommer le groupe

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Retitrez
 rename-collection=Renommer la collection
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Renommer le modèle de page d'affichage
 rename-fragment=Renommer le fragment
 rename-group=Renommer le groupe

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Retitrez
 rename-collection=Renommer la collection
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Renommer le modèle de page d'affichage
 rename-fragment=Renommer le fragment
 rename-group=Renommer le groupe

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomear
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Renomear grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomear
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Renomear grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=रिनेम
 rename-collection=संग्रह का नाम बदलें
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=डिस्प्ले पेज टेम्पलेट का नाम बदलें (Automatic Translation)
 rename-fragment=टुकड़ा नाम बदलें (Automatic Translation)
 rename-group=ग्रूप को रिनेम करे

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=रिनेम
 rename-collection=संग्रह का नाम बदलें
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=डिस्प्ले पेज टेम्पलेट का नाम बदलें (Automatic Translation)
 rename-fragment=टुकड़ा नाम बदलें (Automatic Translation)
 rename-group=ग्रूप को रिनेम करे

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Preimenovati
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Preimenuj grupu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Preimenovati
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Preimenuj grupu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -13928,6 +13928,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Átnevezés
 rename-collection=Gyűjtemény átnevezése
 rename-column-label=Oszlop címkéjének átnevezése
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Megjelenítő-oldal sablon átnevezése
 rename-fragment=Töredék átnevezése
 rename-group=Csoport átnevezése

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -13928,7 +13928,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Átnevezés
 rename-collection=Gyűjtemény átnevezése
 rename-column-label=Oszlop címkéjének átnevezése
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Megjelenítő-oldal sablon átnevezése
 rename-fragment=Töredék átnevezése
 rename-group=Csoport átnevezése

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Ubah nama
 rename-collection=Ganti Nama Koleksi (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Mengganti Nama Templat Halaman Tampilan (Automatic Translation)
 rename-fragment=Ganti Nama Fragmen (Automatic Translation)
 rename-group=Ubah nama Grup

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Ubah nama
 rename-collection=Ganti Nama Koleksi (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Mengganti Nama Templat Halaman Tampilan (Automatic Translation)
 rename-fragment=Ganti Nama Fragmen (Automatic Translation)
 rename-group=Ubah nama Grup

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -13926,7 +13926,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rinomina
 rename-collection=Rinomina insieme (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Aggiungi template di pagina di visualizzazione
 rename-fragment=Rinomina frammento (Automatic Translation)
 rename-group=Rinomina il Gruppo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -13926,6 +13926,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rinomina
 rename-collection=Rinomina insieme (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Aggiungi template di pagina di visualizzazione
 rename-fragment=Rinomina frammento (Automatic Translation)
 rename-group=Rinomina il Gruppo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=שנה שם
 rename-collection=שנה שם אוסף (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=שינוי שם של תבנית דף תצוגה (Automatic Translation)
 rename-fragment=שנה את שם הקטע
 rename-group=שנה שם הקבוצה

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=שנה שם
 rename-collection=שנה שם אוסף (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=שינוי שם של תבנית דף תצוגה (Automatic Translation)
 rename-fragment=שנה את שם הקטע
 rename-group=שנה שם הקבוצה

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=名前を変更する
 rename-collection=コレクション名を変更
 rename-column-label=列のラベル名を変更
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=ディスプレイページテンプレート名を変更
 rename-fragment=フラグメント名を変更
 rename-group=グループ名の変更

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=名前を変更する
 rename-collection=コレクション名を変更
 rename-column-label=列のラベル名を変更
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=ディスプレイページテンプレート名を変更
 rename-fragment=フラグメント名を変更
 rename-group=グループ名の変更

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename (Automatic Copy)
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Rename Group (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -13931,6 +13931,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename
 rename-collection=Rename Collection
 rename-column-label=Rename Column Label
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template
 rename-fragment=Rename Fragment
 rename-group=Rename Group

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -13931,7 +13931,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Rename
 rename-collection=Rename Collection
 rename-column-label=Rename Column Label
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template
 rename-fragment=Rename Fragment
 rename-group=Rename Group

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=개명하십시오
 rename-collection=콜렉션 이름 변경
 rename-column-label=컬럼 라벨 이름 변경
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=디스플레이 페이지 템플릿 이름 변경
 rename-fragment=프래그먼트 이름 변경
 rename-group=그룹을 새 이름을 붙이십시요

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=개명하십시오
 rename-collection=콜렉션 이름 변경
 rename-column-label=컬럼 라벨 이름 변경
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=디스플레이 페이지 템플릿 이름 변경
 rename-fragment=프래그먼트 이름 변경
 rename-group=그룹을 새 이름을 붙이십시요

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=ປ່ຽນຊື່
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=ປ່ຽນຊື່​ກົມ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=ປ່ຽນຊື່
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=ປ່ຽນຊື່​ກົມ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Pervardyti (Automatic Translation)
 rename-collection=Pervardyti rinkinį (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Pervardyti rodomo puslapio šabloną (Automatic Translation)
 rename-fragment=Pervardyti fragmentą (Automatic Translation)
 rename-group=Pervardyti grupę (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Pervardyti (Automatic Translation)
 rename-collection=Pervardyti rinkinį (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Pervardyti rodomo puslapio šabloną (Automatic Translation)
 rename-fragment=Pervardyti fragmentą (Automatic Translation)
 rename-group=Pervardyti grupę (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Menamakan semula (Automatic Translation)
 rename-collection=Namakan Semula Koleksi (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Namakan Semula Templat Halaman Paparan (Automatic Translation)
 rename-fragment=Namakan Semula Serpihan (Automatic Translation)
 rename-group=Namakan Semula Kumpulan (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Menamakan semula (Automatic Translation)
 rename-collection=Namakan Semula Koleksi (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Namakan Semula Templat Halaman Paparan (Automatic Translation)
 rename-fragment=Namakan Semula Serpihan (Automatic Translation)
 rename-group=Namakan Semula Kumpulan (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Bytt navn
 rename-collection=Gi samling nytt navn
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Gi nytt navn til visningssidemal (Automatic Translation)
 rename-fragment=Gi fragmentet nytt navn
 rename-group=Bytt gruppenavn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Bytt navn
 rename-collection=Gi samling nytt navn
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Gi nytt navn til visningssidemal (Automatic Translation)
 rename-fragment=Gi fragmentet nytt navn
 rename-group=Bytt gruppenavn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -13928,7 +13928,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Hernoemen
 rename-collection=Collectie hernoemen
 rename-column-label=Kolomlabel hernoemen
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Weergavepaginasjabloon hernoemen
 rename-fragment=Fragment hernoemen
 rename-group=Groep hernoemen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -13928,6 +13928,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Hernoemen
 rename-collection=Collectie hernoemen
 rename-column-label=Kolomlabel hernoemen
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Weergavepaginasjabloon hernoemen
 rename-fragment=Fragment hernoemen
 rename-group=Groep hernoemen

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -13928,7 +13928,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Hernoem
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Hernoem groep

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -13928,6 +13928,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Hernoem
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Hernoem groep

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Zmień nazwę
 rename-collection=Zmień nazwę kolekcji (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Zmień nazwę szablonu strony wyświetlania (Automatic Translation)
 rename-fragment=Zmienianie nazwy fragmentu (Automatic Translation)
 rename-group=Zmień nazwę grupy

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Zmień nazwę
 rename-collection=Zmień nazwę kolekcji (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Zmień nazwę szablonu strony wyświetlania (Automatic Translation)
 rename-fragment=Zmienianie nazwy fragmentu (Automatic Translation)
 rename-group=Zmień nazwę grupy

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomear
 rename-collection=Renomear coleção
 rename-column-label=Renomear a etiqueta da coluna
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Renomear Modelo da Página de Exibição
 rename-fragment=Renomear fragmento
 rename-group=Renomear grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomear
 rename-collection=Renomear coleção
 rename-column-label=Renomear a etiqueta da coluna
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Renomear Modelo da Página de Exibição
 rename-fragment=Renomear fragmento
 rename-group=Renomear grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomear
 rename-collection=Coleção de renome (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Renomear modelo de página de exibição (Automatic Translation)
 rename-fragment=Rename Fragmento (Automatic Translation)
 rename-group=Renomear Grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Renomear
 rename-collection=Coleção de renome (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Renomear modelo de página de exibição (Automatic Translation)
 rename-fragment=Rename Fragmento (Automatic Translation)
 rename-group=Renomear Grupo

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Redenumeste
 rename-collection=Redenumire colecție (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Redenumire șablon pagină afișată (Automatic Translation)
 rename-fragment=Redenumire fragment (Automatic Translation)
 rename-group=Redenumeste Grup

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Redenumeste
 rename-collection=Redenumire colecție (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Redenumire șablon pagină afișată (Automatic Translation)
 rename-fragment=Redenumire fragment (Automatic Translation)
 rename-group=Redenumeste Grup

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Переименовать
 rename-collection=Переименовать коллекцию (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Переименовать шаблон страницы дисплея (Automatic Translation)
 rename-fragment=Переименовать фрагмент (Automatic Translation)
 rename-group=Переименовать Группу

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Переименовать
 rename-collection=Переименовать коллекцию (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Переименовать шаблон страницы дисплея (Automatic Translation)
 rename-fragment=Переименовать фрагмент (Automatic Translation)
 rename-group=Переименовать Группу

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Premenovať
 rename-collection=Premenovať kolekciu (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Premenovať šablónu zobrazenej strany (Automatic Translation)
 rename-fragment=Premenovať fragment (Automatic Translation)
 rename-group=Premenovať skupinu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Premenovať
 rename-collection=Premenovať kolekciu (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Premenovať šablónu zobrazenej strany (Automatic Translation)
 rename-fragment=Premenovať fragment (Automatic Translation)
 rename-group=Premenovať skupinu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Preimenuj
 rename-collection=Preimenuj zbirko (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Preimenuj predlogo strani za prikaz (Automatic Translation)
 rename-fragment=Preimenuj fragment (Automatic Translation)
 rename-group=Preimenuj skupino

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Preimenuj
 rename-collection=Preimenuj zbirko (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Preimenuj predlogo strani za prikaz (Automatic Translation)
 rename-fragment=Preimenuj fragment (Automatic Translation)
 rename-group=Preimenuj skupino

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Преименуј
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Преименуј Групу

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Преименуј
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Преименуј Групу

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Preimenuj
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Preimenuj Grupu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Preimenuj
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Rename Display Page Template (Automatic Copy)
 rename-fragment=Rename Fragment (Automatic Copy)
 rename-group=Preimenuj Grupu

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Byt namn
 rename-collection=Byt namn på samlingen
 rename-column-label=Byt namn på kolumnetikett
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Byt namn på mall för visningssida
 rename-fragment=Byt namn på fragment
 rename-group=Byt gruppnamn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Byt namn
 rename-collection=Byt namn på samlingen
 rename-column-label=Byt namn på kolumnetikett
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Byt namn på mall för visningssida
 rename-fragment=Byt namn på fragment
 rename-group=Byt gruppnamn

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=மறுபெயரிடு
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=டிஸ்ஃபிளே பேஜ் டெம்ப்ளேட்டை மாற்று
 rename-fragment=Fragment-ன் பெயர் மாற்று
 rename-group=குழு மறுபெயரிடு

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=மறுபெயரிடு
 rename-collection=Rename Collection (Automatic Copy)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=டிஸ்ஃபிளே பேஜ் டெம்ப்ளேட்டை மாற்று
 rename-fragment=Fragment-ன் பெயர் மாற்று
 rename-group=குழு மறுபெயரிடு

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=เปลี่ยนชื่อ
 rename-collection=รีเนมคอลเลคชั่น
 rename-column-label=เปลี่ยนชื่อคอลัมน์ลาเบล
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=เปลี่ยนชื่อเทมเพลตหน้าจอแสดงผล
 rename-fragment=เปลี่ยนชื่อชิ้นส่วน
 rename-group=เปลี่ยนชื่อกรุ๊ป

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=เปลี่ยนชื่อ
 rename-collection=รีเนมคอลเลคชั่น
 rename-column-label=เปลี่ยนชื่อคอลัมน์ลาเบล
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=เปลี่ยนชื่อเทมเพลตหน้าจอแสดงผล
 rename-fragment=เปลี่ยนชื่อชิ้นส่วน
 rename-group=เปลี่ยนชื่อกรุ๊ป

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Yeniden Adlandır
 rename-collection=Koleksiyonu Yeniden Adlandır (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Görüntüleme Sayfası Şablonsunu Yeniden Adlandır (Automatic Translation)
 rename-fragment=Parçayı Yeniden Adlandır (Automatic Translation)
 rename-group=Grubu Yeniden Adlandır

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Yeniden Adlandır
 rename-collection=Koleksiyonu Yeniden Adlandır (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Görüntüleme Sayfası Şablonsunu Yeniden Adlandır (Automatic Translation)
 rename-fragment=Parçayı Yeniden Adlandır (Automatic Translation)
 rename-group=Grubu Yeniden Adlandır

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Перейменувати
 rename-collection=Перейменувати збірку (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Перейменувати шаблон відображуваної сторінки (Automatic Translation)
 rename-fragment=Перейменувати фрагмент (Automatic Translation)
 rename-group=Перейменувати групу

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Перейменувати
 rename-collection=Перейменувати збірку (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Перейменувати шаблон відображуваної сторінки (Automatic Translation)
 rename-fragment=Перейменувати фрагмент (Automatic Translation)
 rename-group=Перейменувати групу

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -13925,7 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Đổi tên
 rename-collection=Đổi tên Bộ sưu tập (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=Đổi tên Mẫu Trang Hiển thị (Automatic Translation)
 rename-fragment=Đổi tên Đoạn (Automatic Translation)
 rename-group=Đổi tên nhóm

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -13925,6 +13925,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=Đổi tên
 rename-collection=Đổi tên Bộ sưu tập (Automatic Translation)
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=Đổi tên Mẫu Trang Hiển thị (Automatic Translation)
 rename-fragment=Đổi tên Đoạn (Automatic Translation)
 rename-group=Đổi tên nhóm

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -13927,7 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=重命名
 rename-collection=重命名集合
 rename-column-label=重命名列标签
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=重命名显示页模板
 rename-fragment=重命名片段
 rename-group=重命名组

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -13927,6 +13927,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=重命名
 rename-collection=重命名集合
 rename-column-label=重命名列标签
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=重命名显示页模板
 rename-fragment=重命名片段
 rename-group=重命名组

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -13926,7 +13926,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=更名
 rename-collection=變更集合的名稱
 rename-column-label=Rename Column Label (Automatic Copy)
-rename-dataset=Rename Dataset (Automatic Copy)
+rename-data-set=Rename Data Set (Automatic Copy)
 rename-display-page-template=重命名顯示頁範本
 rename-fragment=變更頁面片段名稱
 rename-group=群組更名

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -13926,6 +13926,7 @@ removing-this-site-connection-will-not-allow-the-site-to-consume-data-from-this-
 rename=更名
 rename-collection=變更集合的名稱
 rename-column-label=Rename Column Label (Automatic Copy)
+rename-dataset=Rename Dataset (Automatic Copy)
 rename-display-page-template=重命名顯示頁範本
 rename-fragment=變更頁面片段名稱
 rename-group=群組更名


### PR DESCRIPTION
Goal of this PR is to add the ability to rename a dataset entry.

We achieve this by adding a new `rename` action item, which when clicked opens a modal with an input that allows the user to enter a new value for the name of the dataset. 

## How it looks
<img width="1226" alt="image" src="https://github.com/liferay-frontend/liferay-portal/assets/24564752/10630e3a-d011-4aa0-8966-9a7de99f14d4">

## Concerns
- Should we add the current dataset name as a default value of the input?
- Should the modal be displayed in the center of the page, or closer to the top (as depicted in the screenshot) This is happening because the `html` element does not have the same height as the viewport
