### PR TITLE
LPS-186738 Check if modal is open before calling processClose

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -56,7 +56,11 @@ const Modal = ({
 	const [loading, setLoading] = useState(true);
 
 	const {observer, onOpenChange, open} = useModal({
-		onClose: () => processClose(),
+		onClose: () => {
+			if (open) {
+				processClose();
+			}
+		},
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
Hey there!

I found a bug while using `Liferay.Util.openModal` and here is the fix. To test this you can just paste `Liferay.Util.openModal({ url: '', onClose: () => alert('hey!') })` in the devtools, you will see that without the fix the callback is called indefinitely.