### PR TITLE
LPS-186761 FDS list view breaks if title component is not set

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -50,7 +50,7 @@ const List = ({items, schema}) => {
 };
 
 const Title = ({item, title, titleRenderer}) => {
-	const TitleRendererComponent = titleRenderer.component;
+	const TitleRendererComponent = titleRenderer?.component;
 
 	if (TitleRendererComponent) {
 		return <TitleRendererComponent itemData={item} />;


### PR DESCRIPTION
### References

- [LPS-186761 FDS list view breaks if title component is not set](https://issues.liferay.com/browse/LPS-186761)
- Regression fix, caused by  https://github.com/liferay-frontend/liferay-portal/pull/3379

### What is the goal of this PR?

Regression bugfix.

@thektan I stumbled upon this bug by accident, when checking a feature in commerce. Feel free to make a quick review.

Note - if we had TS, this would not happen! :disappointed: 

### What does it look like?

#### Before PR

https://github.com/liferay-frontend/liferay-portal/assets/5435511/17f0777d-3bb9-4d28-9a23-154e9254bafc


#### After PR
No error.

### Steps to reproduce

1. Create an order in commerce.
2. Add or edit shipping or billing address.