### PR TITLE
LPS-184908 Title field appears in wrong format when related

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -51,6 +51,26 @@ export function FrontendDataSet({
 	views,
 }: IFrontendDataSetProps): JSX.Element;
 
+export function DateTimeRenderer({
+	options,
+	value,
+}: DateTimeRendererProps): string;
+
+type DateTimeRendererProps = {
+	options?: {
+		format: {
+			day?: string;
+			hour?: string;
+			minute?: string;
+			month?: string;
+			second?: string;
+			timeZone?: string;
+			year?: string;
+		};
+	};
+	value: string;
+};
+
 type TDelta = {
 	href?: string;
 	label: number;

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@liferay/frontend-data-set-web": "*",
 		"data-engine-js-components-web": "*",
 		"dynamic-data-mapping-form-field-type": "*",
 		"frontend-js-web": "*"

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
@@ -78,6 +78,8 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 			GetterUtil.getLong(
 				ddmFormFieldRenderingContext.getProperty("objectEntryId"))
 		).put(
+			"objectFieldBusinessType", _getObjectFielTypeDate(ddmFormField)
+		).put(
 			"parameterObjectFieldName",
 			GetterUtil.getString(
 				ddmFormField.getProperty("parameterObjectFieldName"))
@@ -223,6 +225,23 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 				getValue(
 					GetterUtil.getString(
 						ddmFormField.getProperty("objectDefinitionId")))));
+	}
+
+	private String _getObjectFielTypeDate(DDMFormField ddmFormField) {
+		String objectFieldBusinessType = "";
+
+		ObjectDefinition objectDefinition = _getObjectDefinition(ddmFormField);
+
+		if ((objectDefinition != null) &&
+			(objectDefinition.getTitleObjectFieldId() > 0)) {
+
+			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+				objectDefinition.getTitleObjectFieldId());
+
+			objectFieldBusinessType = objectField.getBusinessType();
+		}
+
+		return objectFieldBusinessType;
 	}
 
 	private String _getValueKey(DDMFormField ddmFormField) {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributor.java
@@ -78,7 +78,7 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 			GetterUtil.getLong(
 				ddmFormFieldRenderingContext.getProperty("objectEntryId"))
 		).put(
-			"objectFieldBusinessType", _getObjectFielTypeDate(ddmFormField)
+			"objectFieldBusinessType", _getObjectFieldBusinessType(ddmFormField)
 		).put(
 			"parameterObjectFieldName",
 			GetterUtil.getString(
@@ -196,27 +196,20 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 			return labelKey;
 		}
 
-		ObjectDefinition objectDefinition = _getObjectDefinition(ddmFormField);
+		ObjectField objectField = _getObjectField(ddmFormField);
 
-		if ((objectDefinition != null) &&
-			(objectDefinition.getTitleObjectFieldId() > 0)) {
-
-			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
-				objectDefinition.getTitleObjectFieldId());
-
-			if (objectField != null) {
-				String objectFieldName = objectField.getName();
-
-				objectFieldName = StringUtil.replace(
-					objectFieldName, "createDate", "dateCreated");
-				objectFieldName = StringUtil.replace(
-					objectFieldName, "modifiedDate", "dateModified");
-
-				return objectFieldName;
-			}
+		if (objectField == null) {
+			return "id";
 		}
 
-		return "id";
+		String objectFieldName = objectField.getName();
+
+		objectFieldName = StringUtil.replace(
+			objectFieldName, "createDate", "dateCreated");
+		objectFieldName = StringUtil.replace(
+			objectFieldName, "modifiedDate", "dateModified");
+
+		return objectFieldName;
 	}
 
 	private ObjectDefinition _getObjectDefinition(DDMFormField ddmFormField) {
@@ -227,21 +220,27 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributor
 						ddmFormField.getProperty("objectDefinitionId")))));
 	}
 
-	private String _getObjectFielTypeDate(DDMFormField ddmFormField) {
-		String objectFieldBusinessType = "";
-
+	private ObjectField _getObjectField(DDMFormField ddmFormField) {
 		ObjectDefinition objectDefinition = _getObjectDefinition(ddmFormField);
 
 		if ((objectDefinition != null) &&
 			(objectDefinition.getTitleObjectFieldId() > 0)) {
 
-			ObjectField objectField = _objectFieldLocalService.fetchObjectField(
+			return _objectFieldLocalService.fetchObjectField(
 				objectDefinition.getTitleObjectFieldId());
-
-			objectFieldBusinessType = objectField.getBusinessType();
 		}
 
-		return objectFieldBusinessType;
+		return null;
+	}
+
+	private String _getObjectFieldBusinessType(DDMFormField ddmFormField) {
+		ObjectField objectField = _getObjectField(ddmFormField);
+
+		if (objectField == null) {
+			return null;
+		}
+
+		return objectField.getBusinessType();
 	}
 
 	private String _getValueKey(DDMFormField ddmFormField) {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ObjectRelationship/ObjectRelationship.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ObjectRelationship/ObjectRelationship.tsx
@@ -15,6 +15,7 @@
 import ClayAutocomplete from '@clayui/autocomplete';
 import ClayDropDown from '@clayui/drop-down';
 import {useDebounce} from '@clayui/shared';
+import {DateTimeRenderer} from '@liferay/frontend-data-set-web';
 import {
 	FORM_EVENT_TYPES,
 	useForm,
@@ -27,17 +28,6 @@ import React, {useEffect, useRef, useState} from 'react';
 type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
-
-function dateStructure(date: string): string {
-	const dateObj = new Date(date);
-	const day = dateObj.getUTCDate();
-	const month = dateObj.getUTCMonth() + 1;
-	const year = dateObj.getUTCFullYear();
-
-	return `${month.toString().padStart(2, '0')}-${day
-		.toString()
-		.padStart(2, '0')}-${year}`;
-}
 
 async function fetchOptions<T>(url: string) {
 	const response = await fetch(url, {
@@ -60,9 +50,17 @@ function getLabel<T extends ObjectMap<any>>(
 
 	if (typeof value !== 'object') {
 		if (objectFieldBusinessType === 'Date') {
-			const dateFormat = dateStructure(String(value));
-
-			return dateFormat;
+			return DateTimeRenderer({
+				options: {
+					format: {
+						day: 'numeric',
+						month: 'short',
+						timeZone: 'UTC',
+						year: 'numeric',
+					},
+				},
+				value: String(value),
+			});
 		}
 
 		return value ? String(value) : '';

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/tsconfig.json
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "58d9d31c39207e5d3171af37d86e33e8b14dcca0",
+	"@generated": "60d424e755eeadec21dfe83fc4a39738e48db308",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,6 +13,9 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
+			"@liferay/frontend-data-set-web": [
+				"../../frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts"
+			],
 			"data-engine-js-components-web": [
 				"../../data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/index.d.ts"
 			],
@@ -41,6 +44,9 @@
 		"../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../frontend-data-set/frontend-data-set-web"
+		},
 		{
 			"path": "../../data-engine/data-engine-js-components-web"
 		},

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/types/src/main/resources/META-INF/resources/ObjectRelationship/ObjectRelationship.d.ts
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/types/src/main/resources/META-INF/resources/ObjectRelationship/ObjectRelationship.d.ts
@@ -20,6 +20,7 @@ export default function ObjectRelationship({
 	labelKey,
 	name,
 	objectEntryId,
+	objectFieldBusinessType,
 	onBlur,
 	onChange,
 	onFocus,
@@ -38,6 +39,7 @@ interface IProps {
 	labelKey?: string;
 	name: string;
 	objectEntryId: string;
+	objectFieldBusinessType: string;
 	onBlur?: React.FocusEventHandler<HTMLInputElement>;
 	onChange: (event: {
 		target: {


### PR DESCRIPTION
Motivation
=======
Format the date when the user select the relationship.

Proposed Solution
========
Use the `DateTimeRenderer` function in [ObjectRelationship.tsx](https://github.com/liferay-objects/liferay-portal/pull/2192/commits/16f31631d670e973d1d2a8ed545a847af2de1666#diff-a4f1228058343fbc8a2f8fb014097d3a936e9617e6c8d7f1e96c06beb986cce5) to format the date. For this, we need to export the `DateFormatRenderer` in FDS in this [commit](https://github.com/liferay-objects/liferay-portal/pull/2192/commits/8400b698d343dd139cf3ff2eb0785494cf0655b5).


Commit to review
========
The [PR](https://github.com/liferay-objects/liferay-portal/pull/2192) has been approved for the object changes. Could you review just this [commit](https://github.com/liferay-objects/liferay-portal/pull/2192/commits/8400b698d343dd139cf3ff2eb0785494cf0655b5), please?

Screenshots
========
Before:
![screenshot-1686158133](https://github.com/liferay-frontend/liferay-portal/assets/48572495/531b2f1c-ecdb-4fa1-ad59-5c2cef9c3991)


After:
![screenshot-1686160512](https://github.com/liferay-frontend/liferay-portal/assets/48572495/5c954d58-28b7-4012-9fe3-40d811488f5d)


**Jira Ticket:** https://issues.liferay.com/browse/LPS-184908