### PR TITLE
LPS-185690 Avoid using :visible since it is not a valid CSS Selector

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -454,13 +454,21 @@ AUI.add(
 
 					const contentBox = instance._contentBox;
 
-					const visibleRows = contentBox.all('.lfr-form-row:visible');
+					const allRowsNodes = contentBox.all('.lfr-form-row')._nodes;
 
-					const visibleRowsSize = visibleRows.size();
+					const visibleRows = [];
 
-					let deleteRow = visibleRowsSize > 1;
+					for (let i = 0; i < allRowsNodes.length; i++) {
+						if (allRowsNodes[i].checkVisibility()) {
+							visibleRows.push(allRowsNodes[i]);
+						}
+					}
 
-					if (visibleRowsSize === 1) {
+					const visibleRowsLength = visibleRows.length;
+
+					let deleteRow = visibleRowsLength > 1;
+
+					if (visibleRowsLength === 1) {
 						instance.addRow(node);
 
 						deleteRow = true;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185690

The issue is that 'visible' is being passed to YUI used as a querySelectorAlly query which causes issue.
We need to check visibility one by one in order to resolve this.
Let me know if there are any questions or comments about this.

Thank you! 
