### PR TITLE
LPS-167705 Collapsible fieldsets should announce on screen readers co…

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
@@ -25,7 +25,7 @@ String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 		<div class="sheet <%= fluid ? StringPool.BLANK : "sheet-lg" %>">
 	</c:if>
 
-		<div class="panel-group panel-group-flush">
+		<div aria-orientation="vertical" class="panel-group panel-group-flush" role="tablist">
 			<c:if test="<%= Validator.isNotNull(onSubmit) %>">
 				<div aria-label="<%= HtmlUtil.escape(portletDisplay.getTitle()) %>" class="input-container" role="group">
 			</c:if>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -43,11 +43,7 @@ else if (collapsible) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
-					<legend class="sr-only">
-						<%= header %>
-					</legend>
-
-					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
+					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" id="<%= id %>Toggle" role="tab">
 						<span>
 							<%= header %>
 						</span>
@@ -71,5 +67,5 @@ else if (collapsible) {
 		</c:otherwise>
 	</c:choose>
 
-	<div class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
+	<div aria-labelledby="<%= id %>Toggle" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="tabpanel">
 		<div class="<%= collapsible ? "panel-body" : StringPool.BLANK %>">


### PR DESCRIPTION
…rrectly

https://issues.liferay.com/browse/LPS-167705

I couldn't find an easy way to get `aria-orientation="vertical"` and `role="tablist"` to print out only for collapsible fieldsets without touching every component that used this pattern. The good news is these attributes don't affect the screen reader readout when `collapsible="<%= false %>"`.

I got rid of the `legend` tag in collapsible panels since the `fieldset` is described by the title. `legend` is an optional element in `fieldset` according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset#technical_summary.