### PR TITLE
LPS-183502 LPS-18665 Enable sorting by create date in the list of Datasets + Add ignore to CanChangePaginationInAdminPage.

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -809,18 +809,22 @@ const FDSEntries = ({
 						contentRenderer: 'actionLink',
 						fieldName: 'label',
 						label: Liferay.Language.get('name'),
+						sortable: true,
 					},
 					{
 						fieldName: 'restApplication',
 						label: Liferay.Language.get('rest-application'),
+						sortable: true,
 					},
 					{
 						fieldName: 'restSchema',
 						label: Liferay.Language.get('rest-schema'),
+						sortable: true,
 					},
 					{
 						fieldName: 'restEndpoint',
 						label: Liferay.Language.get('rest-endpoint'),
+						sortable: true,
 					},
 					{
 						contentRenderer: 'viewsCount',
@@ -831,6 +835,7 @@ const FDSEntries = ({
 						contentRenderer: 'dateTime',
 						fieldName: 'dateModified',
 						label: Liferay.Language.get('modified-date'),
+						sortable: true,
 					},
 				],
 			},

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -861,6 +861,7 @@ const FDSEntries = ({
 						onClick: onDeleteClick,
 					},
 				]}
+				sorting={[{direction: 'desc', key: 'dateCreated'}]}
 				style="fluid"
 				views={views}
 				{...PAGINATION_PROPS}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/datamanagment/FDSEntry.testcase
@@ -31,7 +31,8 @@ definition {
 		}
 	}
 
-	@description = "LPS-175990. Confirm that the user can change the pagination on the dataset admin page"
+	@description = "Blocked by LPS-187299. Confirm that the user can change the pagination on the dataset admin page"
+	@ignore = "true"
 	@priority = 4
 	test CanChangePaginationInAdminPage {
 		task ("Given create 6 data sets") {


### PR DESCRIPTION
Ignoring LocalFile.FDSEntry#CanChangePaginationInAdminPage while the fix is made [LPS-187299](https://issues.liferay.com/browse/LPS-187299)

Original PR: https://github.com/liferay-frontend/liferay-portal/pull/3407

----
**Story:** https://issues.liferay.com/browse/LPS-183502
**Subtask:** https://issues.liferay.com/browse/LPS-186653

In the Datasets Table:
- Default sorts by create date
- Allows columns to be sortable (excluding the "Views" column)

### Demo

https://github.com/liferay-frontend/liferay-portal/assets/4496722/945ff048-ee56-47c6-a2b2-60bf42c8f94f