### PR TITLE
LPS-168867 Remove expanded FDS table header attribute

### DIFF
--- a/modules/apps/commerce/commerce-catalog-web/src/main/java/com/liferay/commerce/catalog/web/internal/frontend/data/set/view/table/CommerceCatalogTableFDSView.java
+++ b/modules/apps/commerce/commerce-catalog-web/src/main/java/com/liferay/commerce/catalog/web/internal/frontend/data/set/view/table/CommerceCatalogTableFDSView.java
@@ -42,9 +42,8 @@ public class CommerceCatalogTableFDSView extends BaseTableFDSView {
 
 		return fdsTableSchemaBuilder.add(
 			"name", "name",
-			fdsTableSchemaField -> {
-				fdsTableSchemaField.setContentRenderer("actionLink");
-			}
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"actionLink")
 		).add(
 			"defaultLanguageId", "default-language"
 		).add(

--- a/modules/apps/commerce/commerce-catalog-web/src/main/java/com/liferay/commerce/catalog/web/internal/frontend/data/set/view/table/CommerceCatalogTableFDSView.java
+++ b/modules/apps/commerce/commerce-catalog-web/src/main/java/com/liferay/commerce/catalog/web/internal/frontend/data/set/view/table/CommerceCatalogTableFDSView.java
@@ -44,7 +44,6 @@ public class CommerceCatalogTableFDSView extends BaseTableFDSView {
 			"name", "name",
 			fdsTableSchemaField -> {
 				fdsTableSchemaField.setContentRenderer("actionLink");
-				fdsTableSchemaField.setExpand(true);
 			}
 		).add(
 			"defaultLanguageId", "default-language"

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
@@ -92,12 +92,6 @@ public class FDSTableSchemaField {
 		return this;
 	}
 
-	public FDSTableSchemaField setExpand(boolean expand) {
-		_expand = expand;
-
-		return this;
-	}
-
 	public FDSTableSchemaField setFieldName(String fieldName) {
 		_fieldName = fieldName;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/view/table/FDSTableSchemaField.java
@@ -52,10 +52,6 @@ public class FDSTableSchemaField {
 		return _contentRendererClientExtension;
 	}
 
-	public boolean isExpand() {
-		return _expand;
-	}
-
 	public boolean isLocalizeLabel() {
 		return _localizeLabel;
 	}
@@ -132,8 +128,6 @@ public class FDSTableSchemaField {
 		).put(
 			"contentRendererModuleURL", getContentRendererModuleURL()
 		).put(
-			"expand", isExpand()
-		).put(
 			"fieldName",
 			() -> {
 				String fieldName = getFieldName();
@@ -173,7 +167,6 @@ public class FDSTableSchemaField {
 	private String _contentRenderer;
 	private boolean _contentRendererClientExtension;
 	private String _contentRendererModuleURL;
-	private boolean _expand;
 	private String _fieldName;
 	private String _label;
 	private boolean _localizeLabel = true;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_dnd_table.scss
@@ -40,11 +40,6 @@
 	&.item-selector {
 		width: 1%;
 	}
-
-	&.expand {
-		min-width: 150px;
-		width: 20%;
-	}
 }
 
 .dnd-th {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHead.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHead.js
@@ -30,8 +30,6 @@ function TableHead({
 	selectedItemsValue,
 	selectionType,
 }) {
-	const expandableColumns = fields.some((field) => field.expand);
-
 	function handleCheckboxClick() {
 		if (selectedItemsValue.length === items.length) {
 			return selectItems([]);
@@ -71,11 +69,7 @@ function TableHead({
 				)}
 
 				{fields.map((field) => (
-					<TableHeadCell
-						{...field}
-						expandableColumns={expandableColumns}
-						key={field.label}
-					/>
+					<TableHeadCell {...field} key={field.label} />
 				))}
 
 				<DndTable.Cell
@@ -91,11 +85,7 @@ function TableHead({
 }
 
 TableHead.propTypes = {
-	fields: PropTypes.arrayOf(
-		PropTypes.shape({
-			expand: PropTypes.bool,
-		})
-	),
+	fields: PropTypes.array,
 	items: PropTypes.array,
 	schema: PropTypes.shape({
 		fields: PropTypes.any,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHeadCell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableHeadCell.js
@@ -24,7 +24,6 @@ import Cell from './dnd_table/Cell';
 
 function TableHeadCell({
 	contentRenderer,
-	expand,
 	fieldName,
 	hideColumnLabel,
 	label,
@@ -82,7 +81,6 @@ function TableHeadCell({
 				[`content-renderer-${contentRenderer}`]: contentRenderer,
 			})}
 			columnName={String(fieldName)}
-			expand={expand}
 			heading
 			resizable
 		>
@@ -124,8 +122,6 @@ function TableHeadCell({
 
 TableHeadCell.proptypes = {
 	contentRenderer: PropTypes.string,
-	expand: PropTypes.bool,
-	expandableColumns: PropTypes.bool,
 	fieldName: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.arrayOf(PropTypes.string),

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
@@ -21,7 +21,7 @@ import ViewsContext from '../../ViewsContext';
 import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
 import Context from './TableContext';
 
-function Cell({children, className, columnName, expand, heading, resizable}) {
+function Cell({children, className, columnName, heading, resizable}) {
 	const {
 		draggingAllowed,
 		draggingColumnName,
@@ -88,11 +88,7 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 
 	return (
 		<div
-			className={classNames(
-				heading ? 'dnd-th' : 'dnd-td',
-				expand && 'expand',
-				className
-			)}
+			className={classNames(heading ? 'dnd-th' : 'dnd-td', className)}
 			ref={cellRef}
 			style={{
 				width,
@@ -114,7 +110,6 @@ function Cell({children, className, columnName, expand, heading, resizable}) {
 }
 
 Cell.defaultProps = {
-	expand: false,
 	heading: false,
 	resizable: false,
 };
@@ -122,7 +117,6 @@ Cell.defaultProps = {
 Cell.propTypes = {
 	className: PropTypes.string,
 	columnName: PropTypes.string,
-	expand: PropTypes.bool,
 	heading: PropTypes.bool,
 	resizable: PropTypes.bool,
 };


### PR DESCRIPTION
[https://issues.liferay.com/browse/LPS-168867](https://issues.liferay.com/browse/LPS-168867)

- Remove CommerceCatalog usage of `setExpand()`
- Remove `expand` from FDSTableSchemaField
- Remove `expand` client-side usages in the React components
