### PR TITLE
LPS-186438 Show FDS View name instead of ID in fragment configuration selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -23,7 +23,9 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
@@ -197,6 +199,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_CLOB, true, false, null,
 						_language.get(locale, "sorts-order"), "fdsSortsOrder",
 						false)));
+
+		ObjectField labelObjectField = _objectFieldLocalService.getObjectField(
+			fdsViewObjectDefinition.getObjectDefinitionId(), "label");
+
+		_objectDefinitionLocalService.updateTitleObjectFieldId(
+			fdsViewObjectDefinition.getObjectDefinitionId(),
+			labelObjectField.getObjectFieldId());
 
 		_objectDefinitionLocalService.publishCustomObjectDefinition(
 			userId, fdsViewObjectDefinition.getObjectDefinitionId());
@@ -385,6 +394,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
 
 	@Reference
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;


### PR DESCRIPTION
### References

- [LPS-172403 Create a fragment to show a dataset view](https://issues.liferay.com/browse/LPS-172403)
- [mockups](https://www.figma.com/file/9dL05nj2eXEM4dRIiPC2cP/lps-172443-design-fragment-to-expose-datasets?type=design&node-id=353-257097&t=wgUpCssXzu0EHdSD-0)

### What is the goal of this PR?

In fragment configuration, selected entity is presented as its title field. In objects, we can set which fields is a title field by setting `titleObjectFieldIs`. By default, this is the `id` field. In this PR, we are setting it to be the `label` field. Unfortunately, there is no API to set this as a part of `addCustomObjectDefinition()`, but we can set it separately, with `ObjectDefinitionLocalService`.

### What does it look like?

![screen](https://github.com/liferay-frontend/liferay-portal/assets/5435511/011f7d99-4b8f-4b8b-9642-e5836065b141)

