### PR TITLE
LPS-187488 - getPathControlPanelSpritemap should return the spritemap from the admin-theme

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
@@ -1507,11 +1507,10 @@ public class ThemeDisplay
 			cdnBaseURL + themeStaticResourcePath +
 				colorScheme.getColorSchemeImagesPath());
 
-		String claySpritemapPath = StringBundler.concat(
-			cdnBaseURL, themeStaticResourcePath, theme.getImagesPath(),
-			"/clay/icons.svg");
+		String adminThemeClaySpritemapPath =
+			cdnBaseURL + "/o/admin-theme/images/clay/icons.svg";
 
-		setPathControlPanelSpritemap(claySpritemapPath);
+		setPathControlPanelSpritemap(adminThemeClaySpritemapPath);
 
 		String dynamicResourcesHost = getCDNDynamicResourcesHost();
 
@@ -1546,7 +1545,12 @@ public class ThemeDisplay
 			setPathThemeRoot(themeStaticResourcePath + rootPath);
 		}
 
+		String claySpritemapPath = StringBundler.concat(
+			cdnBaseURL, themeStaticResourcePath, theme.getImagesPath(),
+			"/clay/icons.svg");
+
 		setPathThemeSpritemap(claySpritemapPath);
+
 		setPathThemeTemplates(
 			cdnBaseURL + themeStaticResourcePath + theme.getTemplatesPath());
 	}


### PR DESCRIPTION
Rather than just referencing the clay spritemap, this updates it so that we ensure the returned path is always from the 
admin-theme.