### PR TITLE
LPS-187784 Support pagination in FDS fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -202,6 +203,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			).put(
 				"namespace", fragmentRendererContext.getFragmentElementId()
 			).put(
+				"pagination", _getPaginationJSONObject(fdsViewObjectEntry)
+			).put(
 				"style", "fluid"
 			).put(
 				"views",
@@ -249,6 +252,25 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		return defaultObjectEntryManager.getObjectEntry(
 			companyId, dtoConverterContext, externalReferenceCode,
 			objectDefinition, null);
+	}
+
+	private JSONObject _getPaginationJSONObject(ObjectEntry fdsViewObjectEntry)
+		throws Exception {
+
+		Map<String, Object> properties = fdsViewObjectEntry.getProperties();
+
+		return JSONUtil.put(
+			"deltas",
+			JSONUtil.toJSONArray(
+				StringUtil.split(
+					String.valueOf(properties.get("listOfItemsPerPage")),
+					StringPool.COMMA_AND_SPACE),
+				(String itemPerPage) -> JSONUtil.put(
+					"label", GetterUtil.getInteger(itemPerPage)))
+		).put(
+			"initialDelta",
+			String.valueOf(properties.get("defaultItemsPerPage"))
+		);
 	}
 
 	private Collection<ObjectEntry> _getRelatedObjectEntries(


### PR DESCRIPTION
### References

- [LPS-185986 Show the configured pagination options in the dataset fragment](https://issues.liferay.com/browse/LPS-185986)

### What is the goal of this PR?

Enabling pagination in FDS fragment. 

Notes:
- If pagination is not set in DS manager, FDS will show pagination with default settings (4, 8, 20, 40, 50; 20 selected).

### What does it look like?

![screen](https://github.com/liferay-frontend/liferay-portal/assets/5435511/36166ccb-a805-4d67-bc9d-d4e2534af886)

### Steps to reproduce

