### PR TITLE
LPS-173302 Error - OpenIdConnectSessionValidationFilter

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
@@ -159,24 +159,26 @@ public abstract class BaseBuiltInJSModuleServlet extends HttpServlet {
 		if (inputStream == null) {
 			String moduleName = resourceDescriptor.getPackagePath();
 
-			if (extension.equals("map")) {
-				JSModule jsModule = jsPackage.getJSModule(
-					moduleName.substring(0, moduleName.length() - 7));
+			if (moduleName != null) {
+				if (extension.equals("map")) {
+					JSModule jsModule = jsPackage.getJSModule(
+						moduleName.substring(0, moduleName.length() - 7));
 
-				if (jsModule != null) {
-					inputStream = jsModule.getSourceMapInputStream();
+					if (jsModule != null) {
+						inputStream = jsModule.getSourceMapInputStream();
+					}
 				}
-			}
-			else {
-				if (extension.equals("js")) {
-					moduleName = moduleName.substring(
-						0, moduleName.length() - 3);
-				}
+				else {
+					if (extension.equals("js")) {
+						moduleName = moduleName.substring(
+							0, moduleName.length() - 3);
+					}
 
-				JSModule jsModule = jsPackage.getJSModule(moduleName);
+					JSModule jsModule = jsPackage.getJSModule(moduleName);
 
-				if (jsModule != null) {
-					inputStream = jsModule.getInputStream();
+					if (jsModule != null) {
+						inputStream = jsModule.getInputStream();
+					}
 				}
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/npm/builtin/BaseBuiltInJSModuleServlet.java
@@ -181,6 +181,11 @@ public abstract class BaseBuiltInJSModuleServlet extends HttpServlet {
 					}
 				}
 			}
+			else {
+				if (_log.isDebugEnabled()) {
+					_log.debug("moduleName value is null");
+				}
+			}
 		}
 
 		if (inputStream == null) {


### PR DESCRIPTION
Previous PR: #3240 

Context
=======
Hi guys, this PR contains the solution to [LPS-173302](https://issues.liferay.com/browse/LPS-173302) wich fixes the [LPP-47683](https://issues.liferay.com/browse/LPP-47683). The SRE team has observed several errors in the VALE project (LXC) that are causing performance issues, and this PR solves one of these issues. Unfortunately we have no steps to reproduce this error. The solution was created based on stacktrace (You can find it on LPS ticket). I would like your review to know if this change can be merged on master.

Proposed Solution
========
I added a check to prevent the moduleName variable from being used if it is null. As commented in the PR #3240, a debug log was added to see when the moduleName is null.