### PR TITLE
[do not test yet] LPS-182301 Provide a Vertical Nav clay tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/constants/ClaySamplePortletKeys.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/constants/ClaySamplePortletKeys.java
@@ -38,4 +38,7 @@ public class ClaySamplePortletKeys {
 
 	public static final String TABS_DISPLAY_CONTEXT = "TABS_DISPLAY_CONTEXT";
 
+	public static final String VERTICAL_NAV_DISPLAY_CONTEXT =
+		"VERTICAL_NAV_DISPLAY_CONTEXT";
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleDisplayContext.java
@@ -110,6 +110,11 @@ public class ClaySampleDisplayContext {
 				tabsItem.setLabel("Tabs");
 				tabsItem.setPanelId("tabs");
 			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Vertical Nav");
+				tabsItem.setPanelId("vertical_nav");
+			}
 		).build();
 
 		return _tabsItems;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -96,7 +96,6 @@ public class VerticalNavDisplayContext {
 										5, verticalNavItem));
 								verticalNavItem.setExpanded(position == 2);
 							}
-
 						});
 
 					i++;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -46,6 +46,8 @@ public class VerticalNavDisplayContext {
 								"#" + integerWrapper.getValue());
 							verticalNavItem.setLabel(
 								"Item " + integerWrapper.getValue());
+							verticalNavItem.setId(
+								"id-" + integerWrapper.getValue());
 
 							if ((integerWrapper.getValue() % 2) == 0) {
 								verticalNavItem.setItems(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
+import com.liferay.portal.kernel.util.IntegerWrapper;
+
+import java.util.List;
+
+/**
+ * @author Eduardo Allegrini
+ */
+public class VerticalNavDisplayContext {
+
+	public List<VerticalNavItem> getVerticalNavItems() {
+		if (_verticalNavItems != null) {
+			return _verticalNavItems;
+		}
+
+		_verticalNavItems = new VerticalNavItemList() {
+			{
+				IntegerWrapper integerWrapper = new IntegerWrapper(1);
+
+				while (true) {
+					if (integerWrapper.getValue() == 8) {
+						break;
+					}
+
+					add(
+						verticalNavItem -> {
+							verticalNavItem.setHref(
+								"#" + integerWrapper.getValue());
+							verticalNavItem.setLabel(
+								"Page " + integerWrapper.getValue());
+						});
+
+					integerWrapper.increment();
+				}
+			}
+		};
+
+		return _verticalNavItems;
+	}
+
+	private List<VerticalNavItem> _verticalNavItems;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -52,9 +52,14 @@ public class VerticalNavDisplayContext {
 									_createVerticalNavItemsList(
 										integerWrapper.getValue(),
 										verticalNavItem));
+							}
 
-								verticalNavItem.setExpanded(
-									integerWrapper.getValue() == 4);
+							if (integerWrapper.getValue() == 4) {
+								verticalNavItem.setExpanded(true);
+							}
+
+							if (integerWrapper.getValue() == 3) {
+								verticalNavItem.setActive(true);
 							}
 						});
 
@@ -75,6 +80,7 @@ public class VerticalNavDisplayContext {
 
 				while (i < size) {
 					int position = i;
+
 					String suffix = "." + position;
 
 					add(
@@ -88,9 +94,9 @@ public class VerticalNavDisplayContext {
 								verticalNavItem.setItems(
 									_createVerticalNavItemsList(
 										5, verticalNavItem));
+								verticalNavItem.setExpanded(position == 2);
 							}
 
-							verticalNavItem.setExpanded(position == 2);
 						});
 
 					i++;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 /**
  * @author Eduardo Allegrini
+ * @author Daniel Sanz
  */
 public class VerticalNavDisplayContext {
 
@@ -44,7 +45,17 @@ public class VerticalNavDisplayContext {
 							verticalNavItem.setHref(
 								"#" + integerWrapper.getValue());
 							verticalNavItem.setLabel(
-								"Page " + integerWrapper.getValue());
+								"Item " + integerWrapper.getValue());
+
+							if ((integerWrapper.getValue() % 2) == 0) {
+								verticalNavItem.setItems(
+									_createVerticalNavItemsList(
+										integerWrapper.getValue(),
+										verticalNavItem));
+
+								verticalNavItem.setExpanded(
+									integerWrapper.getValue() == 4);
+							}
 						});
 
 					integerWrapper.increment();
@@ -53,6 +64,39 @@ public class VerticalNavDisplayContext {
 		};
 
 		return _verticalNavItems;
+	}
+
+	private VerticalNavItemList _createVerticalNavItemsList(
+		int size, VerticalNavItem parent) {
+
+		return new VerticalNavItemList() {
+			{
+				int i = 0;
+
+				while (i < size) {
+					int position = i;
+					String suffix = "." + position;
+
+					add(
+						verticalNavItem -> {
+							verticalNavItem.setHref(
+								parent.get("href") + suffix);
+							verticalNavItem.setLabel(
+								parent.get("label") + suffix);
+
+							if (size == 4) {
+								verticalNavItem.setItems(
+									_createVerticalNavItemsList(
+										5, verticalNavItem));
+							}
+
+							verticalNavItem.setExpanded(position == 2);
+						});
+
+					i++;
+				}
+			}
+		};
 	}
 
 	private List<VerticalNavItem> _verticalNavItems;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/ClaySamplePortlet.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/ClaySamplePortlet.java
@@ -21,6 +21,7 @@ import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.Drop
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.MultiselectDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext;
 import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.TabsDisplayContext;
+import com.liferay.frontend.taglib.clay.sample.web.internal.display.context.VerticalNavDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 
 import java.io.IOException;
@@ -81,6 +82,9 @@ public class ClaySamplePortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			ClaySamplePortletKeys.TABS_DISPLAY_CONTEXT,
 			new TabsDisplayContext());
+		renderRequest.setAttribute(
+			ClaySamplePortletKeys.VERTICAL_NAV_DISPLAY_CONTEXT,
+			new VerticalNavDisplayContext());
 
 		super.doDispatch(renderRequest, renderResponse);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -35,6 +35,7 @@ page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.contex
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.MultiselectDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.NavigationBarsDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.TabsDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.sample.web.internal.display.context.VerticalNavDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.PaginationBarDelta" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.PaginationBarLabels" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.SelectOption" %><%@
@@ -57,4 +58,5 @@ DropdownsDisplayContext dropdownsDisplayContext = (DropdownsDisplayContext)reque
 MultiselectDisplayContext multiselectDisplayContext = (MultiselectDisplayContext)request.getAttribute(ClaySamplePortletKeys.MULTISELECT_DISPLAY_CONTEXT);
 NavigationBarsDisplayContext navigationBarsDisplayContext = (NavigationBarsDisplayContext)request.getAttribute(ClaySamplePortletKeys.NAVIGATION_BARS_DISPLAY_CONTEXT);
 TabsDisplayContext tabsDisplayContext = (TabsDisplayContext)request.getAttribute(ClaySamplePortletKeys.TABS_DISPLAY_CONTEXT);
+VerticalNavDisplayContext verticalNavDisplayContext = (VerticalNavDisplayContext)request.getAttribute(ClaySamplePortletKeys.VERTICAL_NAV_DISPLAY_CONTEXT);
 %>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/vertical_nav.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/vertical_nav.jsp
@@ -1,0 +1,33 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<blockquote>
+	<p>An alternative patterns that displays navigation items in a vertical menu.</p>
+</blockquote>
+
+<h3>DEFAULT VERTICAL NAV</h3>
+
+<clay:row
+	cssClass="mb-3"
+>
+	<clay:col>
+		<clay:vertical-nav
+			verticalNavItems="<%= verticalNavDisplayContext.getVerticalNavItems() %>"
+		/>
+	</clay:col>
+</clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -106,20 +107,52 @@ public class VerticalNavTag extends BaseContainerTag {
 
 		jspWriter.write("<div class=\"collapse menubar-collapse\">");
 
+		_renderVerticalNavItems(jspWriter, _verticalNavItems, 0);
+
+		jspWriter.write("</div>");
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private void _renderVerticalNavItems(
+			JspWriter jspWriter, List<VerticalNavItem> verticalNavItems,
+			int depth)
+		throws Exception {
+
 		jspWriter.write("<ul aria-orientation=\"vertical\" role=\"menubar\"");
 
-		jspWriter.write("class=\"nav nav-nested\">");
+		jspWriter.write("class=\"nav ");
 
-		for (VerticalNavItem verticalNavItem : _verticalNavItems) {
-			String label = (String)verticalNavItem.get("label");
+		if (depth == 0) {
+			jspWriter.write("nav-nested\">");
+		}
+		else {
+			jspWriter.write("nav-stacked\">");
+		}
+
+		for (VerticalNavItem verticalNavItem : verticalNavItems) {
+			VerticalNavItemList items =
+				(VerticalNavItemList)verticalNavItem.get("items");
+
+			Boolean expanded = (Boolean)verticalNavItem.get("expanded");
+
+			if (expanded == null) {
+				expanded = Boolean.FALSE;
+			}
+
+			String href = (String)verticalNavItem.get("href");
 
 			jspWriter.write("<li role=\"none\" class=\"nav-item\">");
 
-			jspWriter.write("<a class=\"nav-link collapse-icon collapsed btn ");
-			jspWriter.write("btn-unstyled\" aria-expanded=\"false\" ");
-			jspWriter.write("role=\"menuitem\" tabindex=\"-1\" href=\"");
+			jspWriter.write("<a class=\"nav-link collapse-icon");
+			if (!expanded) {
+				jspWriter.write(" collapsed");
+			}
+			jspWriter.write(" btn btn-unstyled\" aria-expanded=\"");
+			jspWriter.write(expanded.toString());
+			jspWriter.write("\" role=\"menuitem\" tabindex=\"-1\" href=\"");
 
-			if (Validator.isNotNull((String)verticalNavItem.get("href"))) {
+			if (Validator.isNotNull(href)) {
 				jspWriter.write((String)verticalNavItem.get("href"));
 			}
 			else {
@@ -127,16 +160,33 @@ public class VerticalNavTag extends BaseContainerTag {
 			}
 
 			jspWriter.write("\">");
-			jspWriter.write(label);
+			jspWriter.write((String)verticalNavItem.get("label"));
+
+			if (items != null) {
+				IconTag iconTag = new IconTag();
+
+				if (expanded) {
+					iconTag.setSymbol("caret-bottom");
+				}
+				else {
+					iconTag.setSymbol("caret-right");
+				}
+
+				jspWriter.write("<span class=\"collapse-icon-closed\">");
+				iconTag.doTag(pageContext);
+				jspWriter.write("</span>");
+			}
+
 			jspWriter.write("</a>");
+
+			if ((items != null) && expanded) {
+				_renderVerticalNavItems(jspWriter, items, depth++);
+			}
+
 			jspWriter.write("</li>");
 		}
 
 		jspWriter.write("</ul>");
-
-		jspWriter.write("</div>");
-
-		return EVAL_BODY_INCLUDE;
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:vertical_nav:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -134,6 +134,12 @@ public class VerticalNavTag extends BaseContainerTag {
 			VerticalNavItemList items =
 				(VerticalNavItemList)verticalNavItem.get("items");
 
+			Boolean active = (Boolean)verticalNavItem.get("active");
+
+			if (active == null) {
+				active = Boolean.FALSE;
+			}
+
 			Boolean expanded = (Boolean)verticalNavItem.get("expanded");
 
 			if (expanded == null) {
@@ -145,9 +151,15 @@ public class VerticalNavTag extends BaseContainerTag {
 			jspWriter.write("<li role=\"none\" class=\"nav-item\">");
 
 			jspWriter.write("<a class=\"nav-link collapse-icon");
+
 			if (!expanded) {
 				jspWriter.write(" collapsed");
 			}
+
+			if (active) {
+				jspWriter.write(" active");
+			}
+
 			jspWriter.write(" btn btn-unstyled\" aria-expanded=\"");
 			jspWriter.write(expanded.toString());
 			jspWriter.write("\" role=\"menuitem\" tabindex=\"-1\" href=\"");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -178,13 +178,14 @@ public class VerticalNavTag extends BaseContainerTag {
 				IconTag iconTag = new IconTag();
 
 				if (expanded) {
+					jspWriter.write("<span class=\"collapse-icon-open\">");
 					iconTag.setSymbol("caret-bottom");
 				}
 				else {
+					jspWriter.write("<span class=\"collapse-icon-closed\">");
 					iconTag.setSymbol("caret-right");
 				}
 
-				jspWriter.write("<span class=\"collapse-icon-closed\">");
 				iconTag.doTag(pageContext);
 				jspWriter.write("</span>");
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -75,6 +75,11 @@ public class VerticalNavTag extends BaseContainerTag {
 	}
 
 	@Override
+	protected String getHydratedModuleName() {
+		return "{VerticalNav} from frontend-taglib-clay";
+	}
+
+	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
 		props.put("decorated", _decorated);
 		props.put("large", _large);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib;
+
+import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+
+/**
+ * @author Eduardo Allegrini
+ * @author Daniel Sanz
+ */
+public class VerticalNavTag extends BaseContainerTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
+
+		setContainerElement("nav");
+
+		return super.doStartTag();
+	}
+
+	public boolean getDecorated() {
+		return _decorated;
+	}
+
+	public boolean getLarge() {
+		return _large;
+	}
+
+	public List<VerticalNavItem> getVerticalNavItems() {
+		return _verticalNavItems;
+	}
+
+	public void setDecorated(boolean decorated) {
+		_decorated = decorated;
+	}
+
+	public void setLarge(boolean large) {
+		_large = large;
+	}
+
+	public void setVerticalNavItems(List<VerticalNavItem> verticalNavItems) {
+		_verticalNavItems = verticalNavItems;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_decorated = false;
+		_large = false;
+		_verticalNavItems = null;
+	}
+
+	@Override
+	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("decorated", _decorated);
+		props.put("large", _large);
+		props.put("items", _verticalNavItems);
+
+		return super.prepareProps(props);
+	}
+
+	@Override
+	protected String processCssClasses(Set<String> cssClasses) {
+		cssClasses.add("menubar menubar-transparent");
+
+		if (_decorated) {
+			cssClasses.add("menubar-decorated");
+		}
+
+		cssClasses.add(
+			_large ? "menubar-vertical-expand-lg" :
+				"menubar-vertical-expand-md");
+
+		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected int processStartTag() throws Exception {
+		super.processStartTag();
+
+		JspWriter jspWriter = pageContext.getOut();
+
+		jspWriter.write("<div class=\"collapse menubar-collapse\">");
+
+		jspWriter.write("<ul aria-orientation=\"vertical\" role=\"menubar\"");
+
+		jspWriter.write("class=\"nav nav-nested\">");
+
+		for (VerticalNavItem verticalNavItem : _verticalNavItems) {
+			String label = (String)verticalNavItem.get("label");
+
+			jspWriter.write("<li role=\"none\" class=\"nav-item\">");
+
+			jspWriter.write("<a class=\"nav-link collapse-icon collapsed btn ");
+			jspWriter.write("btn-unstyled\" aria-expanded=\"false\" ");
+			jspWriter.write("role=\"menuitem\" tabindex=\"-1\" href=\"");
+
+			if (Validator.isNotNull((String)verticalNavItem.get("href"))) {
+				jspWriter.write((String)verticalNavItem.get("href"));
+			}
+			else {
+				jspWriter.write(CharPool.POUND);
+			}
+
+			jspWriter.write("\">");
+			jspWriter.write(label);
+			jspWriter.write("</a>");
+			jspWriter.write("</li>");
+		}
+
+		jspWriter.write("</ul>");
+
+		jspWriter.write("</div>");
+
+		return EVAL_BODY_INCLUDE;
+	}
+
+	private static final String _ATTRIBUTE_NAMESPACE = "clay:vertical_nav:";
+
+	private boolean _decorated;
+	private boolean _large;
+	private List<VerticalNavItem> _verticalNavItems;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -17,7 +17,6 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
-import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -148,30 +147,44 @@ public class VerticalNavTag extends BaseContainerTag {
 
 			String href = (String)verticalNavItem.get("href");
 
+			boolean button = false;
+
+			if ((items != null) || Validator.isNull(href)) {
+				button = true;
+			}
+
 			jspWriter.write("<li role=\"none\" class=\"nav-item\">");
 
-			jspWriter.write("<a class=\"nav-link collapse-icon");
+			if (button) {
+				jspWriter.write("<button class=\"nav-link collapse-icon");
 
-			if (!expanded) {
-				jspWriter.write(" collapsed");
-			}
+				if (!expanded) {
+					jspWriter.write(" collapsed");
+				}
 
-			if (active) {
-				jspWriter.write(" active");
-			}
+				if (active) {
+					jspWriter.write(" active");
+				}
 
-			jspWriter.write(" btn btn-unstyled\" aria-expanded=\"");
-			jspWriter.write(expanded.toString());
-			jspWriter.write("\" role=\"menuitem\" tabindex=\"-1\" href=\"");
-
-			if (Validator.isNotNull(href)) {
-				jspWriter.write((String)verticalNavItem.get("href"));
+				jspWriter.write(" btn btn-unstyled\" type=\"button\"");
+				jspWriter.write(" aria-expanded=\"");
+				jspWriter.write(expanded.toString());
+				jspWriter.write("\" aria-haspopup=\"true\"");
+				jspWriter.write(" role=\"button\" tabindex=\"-1\">");
 			}
 			else {
-				jspWriter.write(CharPool.POUND);
+				jspWriter.write("<a class=\"nav-link ");
+				jspWriter.write(" role=\"menuitem\" tabindex=\"-1\"");
+
+				if (active) {
+					jspWriter.write(" active");
+				}
+
+				jspWriter.write(" href=\"");
+				jspWriter.write((String)verticalNavItem.get("href"));
+				jspWriter.write("\">");
 			}
 
-			jspWriter.write("\">");
 			jspWriter.write((String)verticalNavItem.get("label"));
 
 			if (items != null) {
@@ -190,7 +203,12 @@ public class VerticalNavTag extends BaseContainerTag {
 				jspWriter.write("</span>");
 			}
 
-			jspWriter.write("</a>");
+			if (button) {
+				jspWriter.write("</button>");
+			}
+			else {
+				jspWriter.write("</a>");
+			}
 
 			if ((items != null) && expanded) {
 				_renderVerticalNavItems(jspWriter, items, depth++);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
@@ -25,6 +25,10 @@ public class VerticalNavItem extends NavigationItem {
 		put("expanded", expanded);
 	}
 
+	public void setId(String id) {
+		put("id", id);
+	}
+
 	public void setItems(List<VerticalNavItem> verticalNavItems) {
 		put("items", verticalNavItems);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+/**
+ * @author Eduardo Allegrini
+ */
+public class VerticalNavItem extends NavigationItem {
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
@@ -14,8 +14,19 @@
 
 package com.liferay.frontend.taglib.clay.servlet.taglib.util;
 
+import java.util.List;
+
 /**
  * @author Eduardo Allegrini
  */
 public class VerticalNavItem extends NavigationItem {
+
+	public void setExpanded(boolean expanded) {
+		put("expanded", expanded);
+	}
+
+	public void setItems(List<VerticalNavItem> verticalNavItems) {
+		put("items", verticalNavItems);
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItemList.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItemList.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeSupplier;
+
+import java.util.ArrayList;
+
+/**
+ * @author Eduardo Allegrini
+ */
+public class VerticalNavItemList extends ArrayList<VerticalNavItem> {
+
+	public static VerticalNavItemList of(
+		UnsafeSupplier<VerticalNavItem, Exception>... unsafeSuppliers) {
+
+		VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
+
+		for (UnsafeSupplier<VerticalNavItem, Exception> unsafeSupplier :
+				unsafeSuppliers) {
+
+			try {
+				VerticalNavItem verticalNavItem = unsafeSupplier.get();
+
+				if (verticalNavItem != null) {
+					verticalNavItemList.add(verticalNavItem);
+				}
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		}
+
+		return verticalNavItemList;
+	}
+
+	public static VerticalNavItemList of(VerticalNavItem... verticalNavItems) {
+		VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
+
+		for (VerticalNavItem verticalNavItem : verticalNavItems) {
+			if (verticalNavItem != null) {
+				verticalNavItemList.add(verticalNavItem);
+			}
+		}
+
+		return verticalNavItemList;
+	}
+
+	public void add(UnsafeConsumer<VerticalNavItem, Exception> unsafeConsumer) {
+		VerticalNavItem verticalNavItem = new VerticalNavItem();
+
+		try {
+			unsafeConsumer.accept(verticalNavItem);
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+
+		add(verticalNavItem);
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -3051,4 +3051,28 @@
 		</attribute>
 		<dynamic-attributes>true</dynamic-attributes>
 	</tag>
+	<tag>
+		<description></description>
+		<name>vertical-nav</name>
+		<tag-class>com.liferay.frontend.taglib.clay.servlet.taglib.VerticalNavTag</tag-class>
+		<body-content>empty</body-content>
+		<attribute>
+			<description></description>
+			<name>decorated</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>large</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
+			<name>verticalNavItems</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
 </taglib>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {VerticalNav as ClayVerticalNav} from '@clayui/core';
+import React from 'react';
+
+export default function VerticalNav({
+	activation,
+	active,
+	decorated,
+	items,
+	large,
+	triggerLabel,
+	additionalProps: _additionalProps,
+	componentId: _componentId,
+	cssClass,
+	locale: _locale,
+	portletId: _portletId,
+	portletNamespace: _portletNamespace,
+	...otherProps
+}) {
+	return (
+		<ClayVerticalNav
+			activation={activation}
+			active={active}
+			decorated={decorated}
+			items={items}
+			large={large}
+			triggerLabel={triggerLabel}
+			className={cssClass}
+			{...otherProps}
+		>
+			{(item) => (
+				<ClayVerticalNav.Item
+					href={item.href}
+					items={item.items}
+					key={item.id}
+				>
+					{item.label}
+				</ClayVerticalNav.Item>
+			)}
+		</ClayVerticalNav>
+	);
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/index.js
@@ -27,4 +27,5 @@ export {default as HorizontalCard} from './cards/HorizontalCard';
 export {default as NavigationCard} from './cards/NavigationCard';
 export {default as UserCard} from './cards/UserCard';
 export {default as VerticalCard} from './cards/VerticalCard';
+export {default as VerticalNav} from './VerticalNav';
 export {default as ManagementToolbar} from './management_toolbar/ManagementToolbar';


### PR DESCRIPTION
In this PR we are adding the <clay:vertical-nav> tag which brings clay vertical navigation to JSP-based UIs in DXP.

Current features:

- Supports a hierarchy of VerticalNavigationItems
- Supports expanded / collapsed items
- Supports active item
- Renders <a> or <button> accordingly
- React hydration

Missing:
- Vertical Navigation List builder classes
