### PR TITLE
LPS-179672 Add automations for Data Set and Client Extensions

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -204,6 +204,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SEARCH_COLUMN_AND_ROW</td>
+	<td>//div[contains(@class,'dnd-table')]//*[contains(string(),'${key_field}')]/../../..//div[contains(text(),'${key_color}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>SORT_FIELD</td>
 	<td>//button[contains(@class, "btn-sorting") and contains(text(), "${key_field}")]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -27,6 +27,27 @@ definition {
 		}
 	}
 
+	@description = "LPS-176807. Verify if is not possible to see an client extension deployed"
+	@priority = 4
+	test CannotSeeClientExtensionNotDeployed {
+		task ("When you access the Client Extension admin page") {
+			ApplicationsMenu.gotoPortlet(
+				category = "Custom Apps",
+				panel = "Applications",
+				portlet = "Client Extensions");
+		}
+
+		task ("Then the client extension is not present") {
+			AssertElementNotPresent(
+				key_tableEntryName = "Liferay Sample Frontend Data Set Cell Renderer",
+				locator1 = "ClientExtension#TABLE_ENTRY_NAME_REMOTE_TABLE");
+
+			AssertElementNotPresent(
+				key_tableEntryType = "Frontend Data Set Cell Renderer",
+				locator1 = "ClientExtension#TABLE_ENTRY_TYPE_REMOTE_TABLE");
+		}
+	}
+
 	@description = "LPS-176807. Verify if the Client Extension are visible when deploys"
 	@priority = 4
 	test CanViewDeployedFile {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -27,4 +27,32 @@ definition {
 		}
 	}
 
+	@description = "LPS-176807. Verify if the Client Extension are visible when deploys"
+	@priority = 4
+	test CanViewDeployedFile {
+		property osgi.modules.includes = "frontend-data-set-sample-web";
+
+		task ("When create a page") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+
+		task ("And Go to page edit page") {
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+
+			Click(locator1 = "Icon#PLUS");
+		}
+
+		task ("Then Confirm the client extension sample is located at Widgets > Samples") {
+			Click(
+				key_panel = "Sample",
+				locator1 = "Panel#PANEL");
+
+			AssertElementPresent(
+				key_remoteAppName = "Frontend Data Set Sample",
+				locator1 = "ClientExtension#APPLICATION_SEARCH_FIELD_WIDGET_SEARCH_REMOTE_APP");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -27,6 +27,53 @@ definition {
 		}
 	}
 
+	@description = "LPS-176807. Verify if the apple icon appears when file is deployed"
+	@priority = 4
+	test CanChangeFilterWithClientExtension {
+		property osgi.modules.includes = "frontend-data-set-sample-web";
+		property test.name.skip.portal.instance = "FrontendDataSetClientExtension#CanChangeFilterWithClientExtension";
+
+		task ("Given Sample FDS portlet deployed") {
+			FileInstall.deployFileOnServer(jarFile = "liferay-sample-fds-cell-renderer.zip");
+
+			WaitForConsoleTextPresent(value1 = "STARTED liferay-sample-fds-cell-renderer_1.0.0");
+		}
+
+		task ("When entering on a page which uses FDS") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+
+		task ("Then an apple emoji appears instead of the word green") {
+			Click(
+				key_sampleTab = "Customized",
+				locator1 = "FrontendDataSet#FDS_DATASET");
+
+			WaitForElementPresent(
+				assetType = "apple",
+				index = 1,
+				locator1 = "Fragment#CONTENT_DISPLAY_TEXT");
+
+			AssertElementPresent(
+				assetType = "apple",
+				index = 1,
+				locator1 = "Fragment#CONTENT_DISPLAY_TEXT");
+		}
+	}
+
 	@description = "LPS-176807. Verify if is not possible to see an client extension deployed"
 	@priority = 4
 	test CannotSeeClientExtensionNotDeployed {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -1,0 +1,30 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property custom.properties = "feature.flag.LPS-172904=true";
+	property portal.acceptance = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Frontend Data Set";
+	property testray.main.component.name = "Frontend Data Set";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		var testPortalInstance = PropsUtil.get("test.portal.instance");
+
+		if (${testPortalInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+		}
+	}
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -55,4 +55,36 @@ definition {
 		}
 	}
 
+	@description = "LPS-176807. Verify if filters are corretly displayed"
+	@priority = 4
+	test CanViewSpecificFilters {
+		property osgi.modules.includes = "frontend-data-set-sample-web";
+
+		task ("And entering on a page which uses FDS") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Frontend Data Set Test Page",
+				widgetName = "Frontend Data Set Sample");
+
+			Navigator.gotoPage(pageName = "Frontend Data Set Test Page");
+		}
+
+		task ("When Selecting the Customized tab") {
+			Click(
+				key_sampleTab = "Customized",
+				locator1 = "FrontendDataSet#FDS_DATASET");
+		}
+
+		task ("Then check that the user can see the word "Green" within the Color column") {
+			AssertElementPresent(
+				key_color = "Green",
+				key_field = "Color",
+				locator1 = "FrontendDataSet#SEARCH_COLUMN_AND_ROW");
+		}
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/Dockerfile
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/Dockerfile
@@ -1,0 +1,3 @@
+FROM liferay/caddy:latest
+
+COPY static/ /public_html/

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/LCP.json
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/LCP.json
@@ -1,0 +1,22 @@
+{
+	"cpu": 0.1,
+	"environments": {
+		"dev": {
+			"loadBalancer": {
+				"cdn": false,
+				"targetPort": 80
+			}
+		},
+		"infra": {
+			"deploy": false
+		}
+	},
+	"id": "liferaysamplefdscellrenderer",
+	"kind": "Deployment",
+	"loadBalancer": {
+		"cdn": true,
+		"targetPort": 80
+	},
+	"memory": 50,
+	"scale": 1
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/WEB-INF/liferay-plugin-package.properties
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/WEB-INF/liferay-plugin-package.properties
@@ -1,0 +1,2 @@
+#Fri Mar 31 08:31:05 CEST 2023
+Liferay-Client-Extension-Frontend=static/

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/liferay-sample-fds-cell-renderer.client-extension-config.json
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/liferay-sample-fds-cell-renderer.client-extension-config.json
@@ -1,0 +1,12 @@
+{
+  "com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-fds-cell-renderer" : {
+    "baseURL" : "${portalURL}/o/liferay-sample-fds-cell-renderer",
+    "description" : "",
+    "dxp.lxc.liferay.com.virtualInstanceId" : "default",
+    "name" : "Liferay Sample Frontend Data Set Cell Renderer",
+    "properties" : [ ],
+    "sourceCodeURL" : "",
+    "type" : "fdsCellRenderer",
+    "typeSettings" : [ "url=index.js" ]
+  }
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/static/index.js
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/dependencies/liferay-sample-fds-cell-renderer.zip/static/index.js
@@ -1,0 +1,53 @@
+import * as __WEBPACK_EXTERNAL_MODULE_react__ from "react";
+import * as __WEBPACK_EXTERNAL_MODULE_react_dom_7dac9eee__ from "react-dom";
+/******/ // The require scope
+/******/ var __webpack_require__ = {};
+/******/
+/************************************************************************/
+/******/ /* webpack/runtime/define property getters */
+/******/ (() => {
+/******/ 	// define getter functions for harmony exports
+/******/ 	__webpack_require__.d = (exports, definition) => {
+/******/ 		for(var key in definition) {
+/******/ 			if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+/******/ 				Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 			}
+/******/ 		}
+/******/ 	};
+/******/ })();
+/******/
+/******/ /* webpack/runtime/hasOwnProperty shorthand */
+/******/ (() => {
+/******/ 	__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ })();
+/******/
+/************************************************************************/
+var __webpack_exports__ = {};
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  "Z": () => (/* binding */ src)
+});
+
+;// CONCATENATED MODULE: external "react"
+var x = y => { var x = {}; __webpack_require__.d(x, y); return x; }
+var y = x => () => x
+const external_react_namespaceObject = x({ ["default"]: () => __WEBPACK_EXTERNAL_MODULE_react__["default"] });
+;// CONCATENATED MODULE: external "react-dom"
+var external_react_dom_x = y => { var x = {}; __webpack_require__.d(x, y); return x; }
+var external_react_dom_y = x => () => x
+const external_react_dom_namespaceObject = external_react_dom_x({ ["default"]: () => __WEBPACK_EXTERNAL_MODULE_react_dom_7dac9eee__["default"] });
+;// CONCATENATED MODULE: ./src/index.tsx
+
+
+const fdsCellRenderer = ({ value }) => {
+    const element = document.createElement('div');
+    const isGreen = value === 'Green';
+    if (isGreen) element.classList.add ("apple");
+    external_react_dom_namespaceObject["default"].render(external_react_namespaceObject["default"].createElement(external_react_namespaceObject["default"].Fragment, null, isGreen ? '🍏' : value), element);
+    return element;
+};
+/* harmony default export */ const src = (fdsCellRenderer);
+
+var __webpack_exports__default = __webpack_exports__.Z;
+export { __webpack_exports__default as default };


### PR DESCRIPTION
**Description:**
Add automations for edit option on Data Set Fields

**JIRA Ticket:**
https://liferay.atlassian.net/browse/LPS-179672


**Context about the problem with assert on apple emoji:**
I needed to add a @class in the @div from :apple_emoji: to differentiate from the others @divs. The reason is that apple emoji don't had anything to differentiate of others @divs on the same column. And considering that what was putted on code literally was one emoji, I couldn't test it on Poshi.
I asked from others devs how to do it, and this is the solution that I found.