### PR TITLE
LPS-187763 Dataset fragment uses the selected cell renderer

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -14,7 +14,6 @@
 
 package com.liferay.frontend.data.set.views.web.internal.fragment.renderer;
 
-import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.FDSCellRendererCET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.fragment.model.FragmentEntryLink;
@@ -51,7 +50,6 @@ import java.io.PrintWriter;
 import java.io.Writer;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -336,27 +334,17 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 								fdsFieldProperties.get("rendererType"));
 
 							if (rendererType.equals("clientExtension")) {
-								List<FDSCellRendererCET> fdsCellRendererCETs =
-									(List)_cetManager.getCETs(
-										fragmentEntryLink.getCompanyId(), null,
-										ClientExtensionEntryConstants.
-											TYPE_FDS_CELL_RENDERER,
-										Pagination.of(
-											QueryUtil.ALL_POS,
-											QueryUtil.ALL_POS),
-										null);
+								FDSCellRendererCET fdsCellRendererCET =
+									(FDSCellRendererCET)_cetManager.getCET(
+										fragmentEntryLink.getCompanyId(),
+										String.valueOf(
+											fdsFieldProperties.get(
+												"renderer")));
 
-								for (FDSCellRendererCET fdsCellRendererCET :
-										fdsCellRendererCETs) {
-
-									if (!fdsCellRendererCET.isReadOnly()) {
-										clientExtension = true;
-										moduleName =
-											fdsCellRendererCET.getURL();
-
-										break;
-									}
-								}
+								clientExtension = true;
+								moduleName =
+									"default from " +
+										fdsCellRendererCET.getURL();
 							}
 
 							return JSONUtil.put(
@@ -365,7 +353,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 									fdsFieldProperties.get("renderer"))
 							).put(
 								"contentRendererClientExtension",
-								(boolean)clientExtension
+								clientExtension
 							).put(
 								"contentRendererModuleURL", moduleName
 							).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -30,6 +30,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -52,6 +53,7 @@ import java.io.Writer;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -327,35 +329,13 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 							Map<String, Object> fdsFieldProperties =
 								fdsField.getProperties();
 
-							boolean clientExtension = false;
-							String moduleName = null;
+							JSONObject jsonObject =
+								_jsonFactory.createJSONObject();
 
-							String rendererType = String.valueOf(
-								fdsFieldProperties.get("rendererType"));
-
-							if (rendererType.equals("clientExtension")) {
-								FDSCellRendererCET fdsCellRendererCET =
-									(FDSCellRendererCET)_cetManager.getCET(
-										fragmentEntryLink.getCompanyId(),
-										String.valueOf(
-											fdsFieldProperties.get(
-												"renderer")));
-
-								clientExtension = true;
-								moduleName =
-									"default from " +
-										fdsCellRendererCET.getURL();
-							}
-
-							return JSONUtil.put(
+							jsonObject.put(
 								"contentRenderer",
 								String.valueOf(
 									fdsFieldProperties.get("renderer"))
-							).put(
-								"contentRendererClientExtension",
-								clientExtension
-							).put(
-								"contentRendererModuleURL", moduleName
 							).put(
 								"fieldName",
 								String.valueOf(fdsFieldProperties.get("name"))
@@ -363,11 +343,33 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 								"label",
 								String.valueOf(fdsFieldProperties.get("label"))
 							).put(
-								"rendererType", rendererType
-							).put(
 								"sortable",
 								(boolean)fdsFieldProperties.get("sortable")
 							);
+
+							String rendererType = String.valueOf(
+								fdsFieldProperties.get("rendererType"));
+
+							if (Objects.equals(
+									rendererType, "clientExtension")) {
+
+								FDSCellRendererCET fdsCellRendererCET =
+									(FDSCellRendererCET)_cetManager.getCET(
+										fragmentEntryLink.getCompanyId(),
+										String.valueOf(
+											fdsFieldProperties.get(
+												"renderer")));
+
+								jsonObject.put(
+									"contentRendererClientExtension", true
+								).put(
+									"contentRendererModuleURL",
+									"default from " +
+										fdsCellRendererCET.getURL()
+								);
+							}
+
+							return jsonObject;
 						}))
 			));
 	}
@@ -377,6 +379,9 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
+
+	@Reference
+	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -30,7 +30,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -329,10 +328,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 							Map<String, Object> fdsFieldProperties =
 								fdsField.getProperties();
 
-							JSONObject jsonObject =
-								_jsonFactory.createJSONObject();
-
-							jsonObject.put(
+							JSONObject jsonObject = JSONUtil.put(
 								"contentRenderer",
 								String.valueOf(
 									fdsFieldProperties.get("renderer"))
@@ -379,9 +375,6 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private Language _language;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -82,7 +82,7 @@ const getRendererLabel = ({
 		return (
 			renderer.name === rendererName ||
 			renderer.label === rendererName ||
-			renderer.erc
+			renderer.erc === rendererName
 		);
 	})[0];
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -74,16 +74,30 @@ const getRendererLabel = ({
 	cetRenderers?: FDSClientExtensionCellRenderer[];
 	rendererName: string;
 }): string => {
-	const AVAILABLE_CELL_RENDERERS = [
-		...FDS_INTERNAL_CELL_RENDERERS,
-		...cetRenderers,
-	];
+	let clientExtensionRenderer;
 
-	const renderer = AVAILABLE_CELL_RENDERERS.filter((renderer: any) => {
-		return renderer.name === rendererName || renderer.erc === rendererName;
-	})[0];
+	const internalRenderer = FDS_INTERNAL_CELL_RENDERERS.find(
+		(renderer: FDSInternalCellRenderer) => {
+			return renderer.name === rendererName;
+		}
+	);
 
-	return renderer?.label || renderer?.name || rendererName;
+	if (internalRenderer?.label) {
+		return internalRenderer.label;
+	}
+	else {
+		clientExtensionRenderer = cetRenderers.find(
+			(renderer: FDSClientExtensionCellRenderer) => {
+				return renderer.erc === rendererName;
+			}
+		);
+
+		if (clientExtensionRenderer?.name) {
+			return clientExtensionRenderer.name;
+		}
+
+		return rendererName;
+	}
 };
 
 interface IRendererLabelCellRendererComponentProps {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -67,12 +67,6 @@ interface ISaveFDSFieldsModalContentProps {
 	saveFDSFieldsURL: string;
 }
 
-interface IContentRendererProps {
-	cetRenderers?: FDSClientExtensionCellRenderer[];
-	item: IFDSField;
-	query: string;
-}
-
 const getRendererLabel = ({
 	cetRenderers = [],
 	rendererName,
@@ -92,11 +86,17 @@ const getRendererLabel = ({
 	return renderer?.label || renderer?.name || rendererName;
 };
 
-const CellRendererComponent = ({
+interface IRendererLabelCellRendererComponentProps {
+	cetRenderers?: FDSClientExtensionCellRenderer[];
+	item: IFDSField;
+	query: string;
+}
+
+const RendererLabelCellRendererComponent = ({
 	cetRenderers = [],
 	item,
 	query,
-}: IContentRendererProps) => {
+}: IRendererLabelCellRendererComponentProps) => {
 	const itemFieldValue = getRendererLabel({
 		cetRenderers,
 		rendererName: item.renderer,
@@ -905,7 +905,7 @@ const Fields = ({
 						{
 							contentRenderer: {
 								component: ({item, query}) => (
-									<CellRendererComponent
+									<RendererLabelCellRendererComponent
 										cetRenderers={
 											fdsClientExtensionCellRenderers
 										}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -593,7 +593,13 @@ const Fields = ({
 
 		const responseJSON = await response.json();
 
-		const storedFDSFields = responseJSON?.items;
+		const storedFDSFields = responseJSON?.items.map(
+			(field: IFDSField): IFDSField => {
+				field.renderer = getRendererLabel(field.renderer);
+
+				return field;
+			}
+		);
 
 		if (!storedFDSFields) {
 			openToast({
@@ -637,13 +643,7 @@ const Fields = ({
 
 			fdsFieldsOrderRef.current = orderedFDSFieldIds.join(',');
 
-			const nextOrderedFDSFields = orderedFDSFields.map((field) => {
-				field.renderer = getRendererLabel(field.renderer);
-
-				return field;
-			});
-
-			setFDSFields(nextOrderedFDSFields);
+			setFDSFields(orderedFDSFields);
 		}
 		else {
 			fdsFieldsOrderRef.current = storedFDSFields

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -72,7 +72,7 @@ const getRendererLabel = ({
 }: {
 	cetRenderers?: FDSClientExtensionCellRenderer[];
 	rendererName: string;
-}) => {
+}): string => {
 	const AVAILABLE_CELL_RENDERERS = [
 		...FDS_INTERNAL_CELL_RENDERERS,
 		...cetRenderers,
@@ -81,12 +81,11 @@ const getRendererLabel = ({
 	const renderer = AVAILABLE_CELL_RENDERERS.filter((renderer: any) => {
 		return (
 			renderer.name === rendererName ||
-			renderer.label === rendererName ||
 			renderer.erc === rendererName
 		);
 	})[0];
 
-	return renderer.label || renderer.name;
+	return renderer?.label || renderer?.name || rendererName;
 };
 
 const SaveFDSFieldsModalContent = ({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -66,9 +66,11 @@ interface ISaveFDSFieldsModalContentProps {
 }
 
 const getRendererLabel = (rendererName: string) => {
-	return FDS_INTERNAL_CELL_RENDERERS.filter(renderer => {
-		return (renderer.name === rendererName || renderer.label === rendererName)
-	})[0].label!
+	return FDS_INTERNAL_CELL_RENDERERS.filter((renderer) => {
+		return (
+			renderer.name === rendererName || renderer.label === rendererName
+		);
+	})[0].label!;
 };
 
 const SaveFDSFieldsModalContent = ({
@@ -400,7 +402,7 @@ const EditFDSFieldModalContent = ({
 		});
 		const editedFDSField: any = {
 			...editedFDSFieldResponse,
-			renderer: getRendererLabel(editedFDSFieldResponse.renderer)
+			renderer: getRendererLabel(editedFDSFieldResponse.renderer),
 		};
 		onSave({editedFDSField});
 	};
@@ -635,8 +637,9 @@ const Fields = ({
 
 			fdsFieldsOrderRef.current = orderedFDSFieldIds.join(',');
 
-			const nextOrderedFDSFields = orderedFDSFields.map(field => {
+			const nextOrderedFDSFields = orderedFDSFields.map((field) => {
 				field.renderer = getRendererLabel(field.renderer);
+
 				return field;
 			});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -225,7 +225,7 @@ definition {
 
 			DataSetAdmin.assertFieldsOnTable(
 				key_position = 1,
-				keyName = "default");
+				keyName = "Default");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -323,7 +323,7 @@ definition {
 		task ("Then assert the "Default" is present from the column Cell Renderer") {
 			AssertElementPresent(
 				key_tableColumn = "Cell Renderer",
-				key_tableRow = "default",
+				key_tableRow = "Default",
 				locator1 = "DataSet#FIELDS_TABLE_AND_ROW");
 		}
 


### PR DESCRIPTION
[LPS Story 181549](https://liferay.atlassian.net/browse/LPS-181549) & [Technical Task](https://liferay.atlassian.net/browse/LPS-187763)

### Goal
When the Data Set fragment is used in a page, it should use the cell renderers defined in the Data Set configuration, using internal or client extensions cell renderers.

### Changes

- Update Fields component to save & display correct cell renderer values
- Update Data Set fragment to retrieve client extension renderer module if available

[Screencast from 2023-06-20 10-59-10.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/c67191b3-9ab7-4ef4-9494-69011ddfd600)
