### PR TITLE
LPS-188020 Handle ETag correctly in LanguageFilter

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.servlet.filters.language;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -21,17 +22,24 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletApp;
 import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
 import com.liferay.portal.kernel.servlet.BufferCacheServletResponse;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
+import java.util.NoSuchElementException;
 import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.portlet.PortletConfig;
 
@@ -39,6 +47,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -66,6 +75,8 @@ public class LanguageFilter extends BasePortalFilter {
 			return;
 		}
 
+		_eTags.clear();
+
 		_portletConfig = PortletConfigFactoryUtil.create(
 			portlets.get(0), filterConfig.getServletContext());
 	}
@@ -76,11 +87,23 @@ public class LanguageFilter extends BasePortalFilter {
 			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
 
+		String eTagKey = _getETagKey(httpServletRequest);
+
+		String ifNoneMatch = httpServletRequest.getHeader(
+			HttpHeaders.IF_NONE_MATCH);
+
+		if ((ifNoneMatch != null) && ifNoneMatch.equals(_eTags.get(eTagKey))) {
+			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+
+			return;
+		}
+
 		BufferCacheServletResponse bufferCacheServletResponse =
 			new BufferCacheServletResponse(httpServletResponse);
 
 		processFilter(
-			LanguageFilter.class.getName(), httpServletRequest,
+			LanguageFilter.class.getName(),
+			new NoCacheHttpServletRequestWrapper(httpServletRequest),
 			bufferCacheServletResponse, filterChain);
 
 		if (_log.isDebugEnabled()) {
@@ -93,6 +116,17 @@ public class LanguageFilter extends BasePortalFilter {
 		String content = bufferCacheServletResponse.getString();
 
 		content = translateResponse(httpServletRequest, content);
+
+		httpServletResponse.setHeader(
+			HttpHeaders.CACHE_CONTROL, "private, no-cache");
+
+		String eTag =
+			StringPool.QUOTE + DigesterUtil.digest("SHA-1", content) +
+				StringPool.QUOTE;
+
+		_eTags.put(eTagKey, eTag);
+
+		httpServletResponse.setHeader(HttpHeaders.ETAG, eTag);
 
 		ServletResponseUtil.write(httpServletResponse, content);
 	}
@@ -119,8 +153,115 @@ public class LanguageFilter extends BasePortalFilter {
 			locale, content);
 	}
 
+	private String _getETagKey(HttpServletRequest httpServletRequest) {
+		return LanguageUtil.getLanguageId(httpServletRequest) +
+			StringPool.POUND + httpServletRequest.getRequestURI();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(LanguageFilter.class);
 
+	private final ConcurrentHashMap<String, String> _eTags =
+		new ConcurrentHashMap<>();
 	private PortletConfig _portletConfig;
+
+	private static class NoCacheHttpServletRequestWrapper
+		extends HttpServletRequestWrapper {
+
+		public NoCacheHttpServletRequestWrapper(
+			HttpServletRequest httpServletRequest) {
+
+			super(httpServletRequest);
+
+			_httpServletRequest = httpServletRequest;
+		}
+
+		public long getDateHeader(String name) {
+			if (StringUtil.equalsIgnoreCase(name, "If-Modified-Since") ||
+				StringUtil.equalsIgnoreCase(name, "If-None-Match")) {
+
+				return -1;
+			}
+
+			return _httpServletRequest.getDateHeader(name);
+		}
+
+		public String getHeader(String name) {
+			if (StringUtil.equalsIgnoreCase(name, "If-Modified-Since") ||
+				StringUtil.equalsIgnoreCase(name, "If-None-Match")) {
+
+				return null;
+			}
+
+			return _httpServletRequest.getHeader(name);
+		}
+
+		public Enumeration<String> getHeaderNames() {
+			List<String> headerNames = new ArrayList<>();
+
+			Enumeration<String> headerNamesEnumeration =
+				_httpServletRequest.getHeaderNames();
+
+			while (headerNamesEnumeration.hasMoreElements()) {
+				String name = headerNamesEnumeration.nextElement();
+
+				if (StringUtil.equalsIgnoreCase(name, "If-Modified-Since") ||
+					StringUtil.equalsIgnoreCase(name, "If-None-Match")) {
+
+					continue;
+				}
+
+				headerNames.add(headerNamesEnumeration.nextElement());
+			}
+
+			return new Enumeration<String>() {
+
+				@Override
+				public boolean hasMoreElements() {
+					if (_nextIndex < headerNames.size()) {
+						return true;
+					}
+
+					return false;
+				}
+
+				@Override
+				public String nextElement() {
+					if (!hasMoreElements()) {
+						throw new NoSuchElementException();
+					}
+
+					_nextIndex++;
+
+					return headerNames.get(_nextIndex - 1);
+				}
+
+				private int _nextIndex;
+
+			};
+		}
+
+		public Enumeration<String> getHeaders(String name) {
+			if (StringUtil.equalsIgnoreCase(name, "If-Modified-Since") ||
+				StringUtil.equalsIgnoreCase(name, "If-None-Match")) {
+
+				return null;
+			}
+
+			return _httpServletRequest.getHeaders(name);
+		}
+
+		public int getIntHeader(String name) {
+			if (StringUtil.equalsIgnoreCase(name, "If-Modified-Since") ||
+				StringUtil.equalsIgnoreCase(name, "If-None-Match")) {
+
+				return -1;
+			}
+
+			return _httpServletRequest.getIntHeader(name);
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+
+	}
 
 }


### PR DESCRIPTION
We need to modify the ETag returned by the delegate filter chain because we are modifying the content.

Also, instead of caching the responses we cache ETags in a map indexed by (file path, language id). This way, if the ETag sent from the browser matches the latest one sent by the server (for a given path and language) we return SC_NOT_MODIFIED. This way, we maintain the browser cache valid until the server restarts.

Note also that, in case the server restarts and nothing has changed, only the first client accessing a JS will be penalized by a cache invalidation because, after that, the same ETag we used in the previous server restart will be cached and all subsequent clients will get a SC_NOT_MODIFIED again.