### PR TITLE
LPS-188505 Add JSP comment to remove whitespace and keep source format

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -334,21 +334,21 @@ if (fixedHeader) {
 							<td class="<%= columnClassName %>" colspan="<%= entry.getColspan() %>">
 								<c:choose>
 									<c:when test="<%= truncate %>">
-										<span class="text-truncate">
+										<span class="text-truncate"><%--
 
-											<%
-											entry.print(pageContext.getOut(), request, response);
-											%>
+											--%><%
+												entry.print(pageContext.getOut(), request, response);
+											%><%--
 
-										</span>
+										--%></span>
 									</c:when>
-									<c:otherwise>
+									<c:otherwise><%--
 
-										<%
-										entry.print(pageContext.getOut(), request, response);
-										%>
+										--%><%
+											entry.print(pageContext.getOut(), request, response);
+										%><%--
 
-									</c:otherwise>
+									--%></c:otherwise>
 								</c:choose>
 							</td>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-188505

The issue is that jsp has trailing and leading whitespaces due to the formatting. This can cause issue with customers that use "whitespace:pre-wrap" CSS style which will show the whitespaces and break format.
By adding comments, it will remove all the whitespaces and still maintain formatting.
Please let me know if there are any questions or comments about this.

Thank you!