### PR TITLE
LPS-188133 - Update npm-scripts to 48.1.0 for faster type generation

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -1,7 +1,7 @@
 {
 	"devDependencies": {
 		"@liferay/eslint-plugin": "1.4.0",
-		"@liferay/npm-scripts": "47.18.2",
+		"@liferay/npm-scripts": "48.1.0",
 		"@types/ckeditor4": "4.16.2",
 		"@types/codemirror": "^5.60.5",
 		"@types/react-router-dom": "^5.3.3",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1877,10 +1877,10 @@
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-"@liferay/npm-scripts@47.18.2":
-  version "47.18.2"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.18.2.tgz#2a8bac8f553fd99ae5b5ac8f6610b2bd2ac0840e"
-  integrity sha512-SQGjuPM2Tz4f79EXb+v/PjvWNVtU+rHjk2wmw8D4xLc3pArWc8LKDo8W5aLzvzefXaiZb2WYrTuAWojac5RURw==
+"@liferay/npm-scripts@48.1.0":
+  version "48.1.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-48.1.0.tgz#0c9066dddc5e81f2a9bf17684786d88b185f678f"
+  integrity sha512-AIVD7MAvM1ZT/AIpvLuKrpD6sDiRgNfrjwAg2b9fpDEXApNYPPpgtL57GGvwAqBXkKoiTPOGKJly8S+lolC8ww==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"

--- a/workspaces/package.json
+++ b/workspaces/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@liferay/eslint-plugin": "1.4.0",
-		"@liferay/npm-scripts": "47.18.1"
+		"@liferay/npm-scripts": "48.1.0"
 	},
 	"private": true,
 	"scripts": {

--- a/workspaces/yarn.lock
+++ b/workspaces/yarn.lock
@@ -1383,10 +1383,10 @@
     source-map "^0.7.3"
     webpack "^5.11.1"
 
-"@liferay/npm-scripts@47.18.1":
-  version "47.18.1"
-  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-47.18.1.tgz#b06c29d3a33c7839bb20c4ed1836948c80f99593"
-  integrity sha512-NBLW1Gu/fvJnVKYHAhua3Me0+Fj7c0zHxhfyA2qWRGwxje5Vbpo1BmLy0aO8KIweA3mYOL0zE3nbjW7kHGBB0Q==
+"@liferay/npm-scripts@48.1.0":
+  version "48.1.0"
+  resolved "https://registry.yarnpkg.com/@liferay/npm-scripts/-/npm-scripts-48.1.0.tgz#0c9066dddc5e81f2a9bf17684786d88b185f678f"
+  integrity sha512-AIVD7MAvM1ZT/AIpvLuKrpD6sDiRgNfrjwAg2b9fpDEXApNYPPpgtL57GGvwAqBXkKoiTPOGKJly8S+lolC8ww==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-188133