### PR TITLE
LPS-188401 There are some dynamic attributes that can contain xss

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/servlet/taglib/BaseContainerTag.java
@@ -22,6 +22,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -442,8 +443,22 @@ public class BaseContainerTag extends AttributesTagSupport {
 	}
 
 	protected void writeDynamicAttributes() throws Exception {
+		Map<String, Object> escapedDynamicAttributes = new HashMap<>();
+		Map<String, Object> dynamicAttributes = getDynamicAttributes();
+
+		for (Map.Entry<String, Object> entry : dynamicAttributes.entrySet()) {
+			if (entry.getValue() instanceof String) {
+				escapedDynamicAttributes.put(
+					entry.getKey(),
+					HtmlUtil.escapeAttribute((String)entry.getValue()));
+			}
+			else {
+				escapedDynamicAttributes.put(entry.getKey(), entry.getValue());
+			}
+		}
+
 		String dynamicAttributesString = InlineUtil.buildDynamicAttributes(
-			getDynamicAttributes());
+			escapedDynamicAttributes);
 
 		if (!dynamicAttributesString.isEmpty()) {
 			JspWriter jspWriter = pageContext.getOut();


### PR DESCRIPTION
None of the dynamic attributes are escaped when calling the clay taglibs. We cannot escape them from the origin, since the react component already does this for us. We only need to escape those for the server side rendering that is performed in the tag.