### PR TITLE
LPS-188028 Improve clay vertical tag

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -91,6 +91,8 @@ public class VerticalNavDisplayContext {
 								parent.get("href") + suffix);
 							verticalNavItem.setLabel(
 								parent.get("label") + suffix);
+							verticalNavItem.setId(
+								parent.get("id") + suffix);
 
 							if (size == 4) {
 								verticalNavItem.setItems(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/VerticalNavDisplayContext.java
@@ -17,6 +17,7 @@ package com.liferay.frontend.taglib.clay.sample.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.portal.kernel.util.IntegerWrapper;
+import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.List;
 
@@ -25,6 +26,10 @@ import java.util.List;
  * @author Daniel Sanz
  */
 public class VerticalNavDisplayContext {
+
+	public List<String> getVerticalNavDefaultExpandedKeys() {
+		return ListUtil.fromArray("id-2", "id-6");
+	}
 
 	public List<VerticalNavItem> getVerticalNavItems() {
 		if (_verticalNavItems != null) {
@@ -91,8 +96,7 @@ public class VerticalNavDisplayContext {
 								parent.get("href") + suffix);
 							verticalNavItem.setLabel(
 								parent.get("label") + suffix);
-							verticalNavItem.setId(
-								parent.get("id") + suffix);
+							verticalNavItem.setId(parent.get("id") + suffix);
 
 							if (size == 4) {
 								verticalNavItem.setItems(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/vertical_nav.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/vertical_nav.jsp
@@ -31,3 +31,55 @@
 		/>
 	</clay:col>
 </clay:row>
+
+<h3>LARGE VERTICAL NAV</h3>
+
+<clay:row
+	cssClass="mb-3"
+>
+	<clay:col>
+		<clay:vertical-nav
+			large="<%= true %>"
+			verticalNavItems="<%= verticalNavDisplayContext.getVerticalNavItems() %>"
+		/>
+	</clay:col>
+</clay:row>
+
+<h3>DECORATED VERTICAL NAV</h3>
+
+<clay:row
+	cssClass="mb-3"
+>
+	<clay:col>
+		<clay:vertical-nav
+			decorated="<%= true %>"
+			verticalNavItems="<%= verticalNavDisplayContext.getVerticalNavItems() %>"
+		/>
+	</clay:col>
+</clay:row>
+
+<h3>PREDEFINED ACTIVE VERTICAL NAV</h3>
+
+<clay:row
+	cssClass="mb-3"
+>
+	<clay:col>
+		<clay:vertical-nav
+			active="id-1"
+			verticalNavItems="<%= verticalNavDisplayContext.getVerticalNavItems() %>"
+		/>
+	</clay:col>
+</clay:row>
+
+<h3>PREDEFINED EXPANDED VERTICAL NAV</h3>
+
+<clay:row
+	cssClass="mb-3"
+>
+	<clay:col>
+		<clay:vertical-nav
+			defaultExpandedKeys="<%= verticalNavDisplayContext.getVerticalNavDefaultExpandedKeys() %>"
+			verticalNavItems="<%= verticalNavDisplayContext.getVerticalNavItems() %>"
+		/>
+	</clay:col>
+</clay:row>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 13.7.1
+Bundle-Version: 13.8.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -83,5 +83,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "13.7.1"
+	"version": "13.8.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -53,6 +54,18 @@ public class VerticalNavTag extends BaseContainerTag {
 		return _decorated;
 	}
 
+	public List<String> getDefaultExpandedKeys() {
+		if (_defaultExpandedKeys != null) {
+			return _defaultExpandedKeys;
+		}
+
+		List<String> defaultExpandedKeys = new ArrayList<>();
+
+		_computeDefaultExpandedKeys(defaultExpandedKeys, getVerticalNavItems());
+
+		return defaultExpandedKeys;
+	}
+
 	public boolean getLarge() {
 		return _large;
 	}
@@ -69,6 +82,10 @@ public class VerticalNavTag extends BaseContainerTag {
 		_decorated = decorated;
 	}
 
+	public void setDefaultExpandedKeys(List<String> defaultExpandedKeys) {
+		_defaultExpandedKeys = defaultExpandedKeys;
+	}
+
 	public void setLarge(boolean large) {
 		_large = large;
 	}
@@ -83,6 +100,7 @@ public class VerticalNavTag extends BaseContainerTag {
 
 		_active = null;
 		_decorated = false;
+		_defaultExpandedKeys = null;
 		_large = false;
 		_verticalNavItems = null;
 	}
@@ -96,6 +114,7 @@ public class VerticalNavTag extends BaseContainerTag {
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
 		props.put("active", getActive());
 		props.put("decorated", _decorated);
+		props.put("defaultExpandedKeys", getDefaultExpandedKeys());
 		props.put("large", _large);
 		props.put("items", _verticalNavItems);
 
@@ -130,6 +149,30 @@ public class VerticalNavTag extends BaseContainerTag {
 		jspWriter.write("</div>");
 
 		return EVAL_BODY_INCLUDE;
+	}
+
+	private void _computeDefaultExpandedKeys(
+		List<String> defaultExpandedKeys,
+		List<VerticalNavItem> verticalNavItems) {
+
+		for (VerticalNavItem verticalNavItem : verticalNavItems) {
+			VerticalNavItemList items =
+				(VerticalNavItemList)verticalNavItem.get("items");
+
+			Boolean expanded = (Boolean)verticalNavItem.get("expanded");
+
+			if (expanded == null) {
+				expanded = Boolean.FALSE;
+			}
+
+			if (expanded) {
+				defaultExpandedKeys.add((String)verticalNavItem.get("id"));
+			}
+
+			if (items != null) {
+				_computeDefaultExpandedKeys(defaultExpandedKeys, items);
+			}
+		}
 	}
 
 	private String _getActiveVerticalNavItemKey(
@@ -195,6 +238,11 @@ public class VerticalNavTag extends BaseContainerTag {
 
 			if (expanded == null) {
 				expanded = Boolean.FALSE;
+
+				if (_defaultExpandedKeys != null) {
+					expanded = _defaultExpandedKeys.contains(
+						(String)verticalNavItem.get("id"));
+				}
 			}
 
 			String href = (String)verticalNavItem.get("href");
@@ -275,6 +323,7 @@ public class VerticalNavTag extends BaseContainerTag {
 
 	private String _active;
 	private boolean _decorated;
+	private List<String> _defaultExpandedKeys;
 	private boolean _large;
 	private List<VerticalNavItem> _verticalNavItems;
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -178,14 +178,13 @@ public class VerticalNavTag extends BaseContainerTag {
 				jspWriter.write(" role=\"button\" tabindex=\"-1\">");
 			}
 			else {
-				jspWriter.write("<a class=\"nav-link ");
-				jspWriter.write(" role=\"menuitem\" tabindex=\"-1\"");
+				jspWriter.write("<a class=\"nav-link");
 
 				if (active) {
 					jspWriter.write(" active");
 				}
 
-				jspWriter.write(" href=\"");
+				jspWriter.write("\" role=\"menuitem\" tabindex=\"-1\" href=\"");
 				jspWriter.write((String)verticalNavItem.get("href"));
 				jspWriter.write("\">");
 			}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -41,6 +41,14 @@ public class VerticalNavTag extends BaseContainerTag {
 		return super.doStartTag();
 	}
 
+	public String getActive() {
+		if (_active != null) {
+			return _active;
+		}
+
+		return _getActiveVerticalNavItemKey(getVerticalNavItems());
+	}
+
 	public boolean getDecorated() {
 		return _decorated;
 	}
@@ -51,6 +59,10 @@ public class VerticalNavTag extends BaseContainerTag {
 
 	public List<VerticalNavItem> getVerticalNavItems() {
 		return _verticalNavItems;
+	}
+
+	public void setActive(String active) {
+		_active = active;
 	}
 
 	public void setDecorated(boolean decorated) {
@@ -69,6 +81,7 @@ public class VerticalNavTag extends BaseContainerTag {
 	protected void cleanUp() {
 		super.cleanUp();
 
+		_active = null;
 		_decorated = false;
 		_large = false;
 		_verticalNavItems = null;
@@ -81,6 +94,7 @@ public class VerticalNavTag extends BaseContainerTag {
 
 	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
+		props.put("active", getActive());
 		props.put("decorated", _decorated);
 		props.put("large", _large);
 		props.put("items", _verticalNavItems);
@@ -118,6 +132,35 @@ public class VerticalNavTag extends BaseContainerTag {
 		return EVAL_BODY_INCLUDE;
 	}
 
+	private String _getActiveVerticalNavItemKey(
+		List<VerticalNavItem> verticalNavItems) {
+
+		for (VerticalNavItem verticalNavItem : verticalNavItems) {
+			VerticalNavItemList items =
+				(VerticalNavItemList)verticalNavItem.get("items");
+
+			Boolean active = (Boolean)verticalNavItem.get("active");
+
+			if (active == null) {
+				active = Boolean.FALSE;
+			}
+
+			if (active) {
+				return (String)verticalNavItem.get("id");
+			}
+
+			if (items != null) {
+				String activeKey = _getActiveVerticalNavItemKey(items);
+
+				if (activeKey != null) {
+					return activeKey;
+				}
+			}
+		}
+
+		return null;
+	}
+
 	private void _renderVerticalNavItems(
 			JspWriter jspWriter, List<VerticalNavItem> verticalNavItems,
 			int depth)
@@ -142,6 +185,10 @@ public class VerticalNavTag extends BaseContainerTag {
 
 			if (active == null) {
 				active = Boolean.FALSE;
+
+				if (_active != null) {
+					active = _active.equals(verticalNavItem.get("id"));
+				}
 			}
 
 			Boolean expanded = (Boolean)verticalNavItem.get("expanded");
@@ -226,6 +273,7 @@ public class VerticalNavTag extends BaseContainerTag {
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:vertical_nav:";
 
+	private String _active;
 	private boolean _decorated;
 	private boolean _large;
 	private List<VerticalNavItem> _verticalNavItems;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -224,24 +224,30 @@ public class VerticalNavTag extends BaseContainerTag {
 			VerticalNavItemList items =
 				(VerticalNavItemList)verticalNavItem.get("items");
 
-			Boolean active = (Boolean)verticalNavItem.get("active");
+			Boolean active;
 
-			if (active == null) {
-				active = Boolean.FALSE;
+			if (_active != null) {
+				active = _active.equals(verticalNavItem.get("id"));
+			}
+			else {
+				active = (Boolean)verticalNavItem.get("active");
 
-				if (_active != null) {
-					active = _active.equals(verticalNavItem.get("id"));
+				if (active == null) {
+					active = Boolean.FALSE;
 				}
 			}
 
-			Boolean expanded = (Boolean)verticalNavItem.get("expanded");
+			Boolean expanded;
 
-			if (expanded == null) {
-				expanded = Boolean.FALSE;
+			if (_defaultExpandedKeys != null) {
+				expanded = _defaultExpandedKeys.contains(
+					(String)verticalNavItem.get("id"));
+			}
+			else {
+				expanded = (Boolean)verticalNavItem.get("expanded");
 
-				if (_defaultExpandedKeys != null) {
-					expanded = _defaultExpandedKeys.contains(
-						(String)verticalNavItem.get("id"));
+				if (expanded == null) {
+					expanded = Boolean.FALSE;
 				}
 			}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -112,7 +112,12 @@ public class VerticalNavTag extends BaseContainerTag {
 
 	@Override
 	protected Map<String, Object> prepareProps(Map<String, Object> props) {
-		props.put("active", getActive());
+		String active = getActive();
+
+		if (active != null) {
+			props.put("active", getActive());
+		}
+
 		props.put("decorated", _decorated);
 		props.put("defaultExpandedKeys", getDefaultExpandedKeys());
 		props.put("large", _large);
@@ -166,7 +171,11 @@ public class VerticalNavTag extends BaseContainerTag {
 			}
 
 			if (expanded) {
-				defaultExpandedKeys.add((String)verticalNavItem.get("id"));
+				String itemId = (String)verticalNavItem.get("id");
+
+				if (itemId != null) {
+					defaultExpandedKeys.add(itemId);
+				}
 			}
 
 			if (items != null) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -3058,6 +3058,12 @@
 		<body-content>empty</body-content>
 		<attribute>
 			<description></description>
+			<name>active</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>decorated</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -3070,6 +3070,12 @@
 		</attribute>
 		<attribute>
 			<description></description>
+			<name>defaultExpandedKeys</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<description></description>
 			<name>large</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -22,6 +22,7 @@ export default function VerticalNav({
 	componentId: _componentId,
 	cssClass,
 	decorated,
+	defaultExpandedKeys,
 	items,
 	large,
 	locale: _locale,
@@ -36,6 +37,7 @@ export default function VerticalNav({
 			active={active}
 			className={cssClass}
 			decorated={decorated}
+			defaultExpandedKeys={defaultExpandedKeys}
 			items={items}
 			large={large}
 			triggerLabel={triggerLabel}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -37,7 +37,7 @@ export default function VerticalNav({
 			active={active}
 			className={cssClass}
 			decorated={decorated}
-			defaultExpandedKeys={defaultExpandedKeys}
+			defaultExpandedKeys={new Set(defaultExpandedKeys)}
 			items={items}
 			large={large}
 			triggerLabel={triggerLabel}
@@ -45,6 +45,7 @@ export default function VerticalNav({
 		>
 			{(item) => (
 				<ClayVerticalNav.Item
+					active={active ? active === item.id : item.active}
 					href={item.href}
 					items={item.items}
 					key={item.id}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 7.6.0
+version 7.7.0


### PR DESCRIPTION
Followup pull for https://github.com/liferay-frontend/liferay-portal/pull/3475 where
* We compute `active` and `defaultExpandedKeys` props in dedicated methods, rather than while rendering
* We give priority to tag attributes vs item properties for `active` and `defaultExpandedKeys`. We do that in the getters.

Other notes:
* Decorated variant keeps failing, probably due to a clay issue. This does not prevent this pull to pass, we can work on this later on
* I left out the [grouping commit](https://github.com/liferay-frontend/liferay-portal/pull/3475/commits/218a56c2c0c7c2bb7986a00989de255f780666c1) for now as we want to merge this today

cc @markocikos @edalgrin 