### PR TITLE
LPS-188818 - Keep pagination info when navigating tabs 

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -57,8 +57,8 @@ interface IFDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	onUpdateFDSView: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
-	updateFDSTabHandler: (data: FDSViewType) => void;
 }
 
 interface IFDSViewInterface {
@@ -79,10 +79,6 @@ const FDSView = ({
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
 	const [loading, setLoading] = useState(true);
-
-	const handleTabUpdate = (updatedViewData: FDSViewType): void => {
-		setFDSView({...fdsView, ...updatedViewData});
-	};
 
 	useEffect(() => {
 		const getFDSView = async () => {
@@ -145,8 +141,12 @@ const FDSView = ({
 						fdsView={fdsView}
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
+						onUpdateFDSView={(
+							updatedViewData: FDSViewType
+						): void => {
+							setFDSView({...fdsView, ...updatedViewData});
+						}}
 						saveFDSFieldsURL={saveFDSFieldsURL}
-						updateFDSTabHandler={handleTabUpdate}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -57,7 +57,7 @@ interface IFDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
-	onUpdateFDSView: (data: FDSViewType) => void;
+	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 }
 
@@ -141,7 +141,7 @@ const FDSView = ({
 						fdsView={fdsView}
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
-						onUpdateFDSView={(
+						onFDSViewUpdate={(
 							updatedViewData: FDSViewType
 						): void => {
 							setFDSView({...fdsView, ...updatedViewData});

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -58,6 +58,7 @@ interface IFDSViewSectionInterface {
 	fdsViewsURL: string;
 	namespace: string;
 	saveFDSFieldsURL: string;
+	updateFDSTabHandler: (data: FDSViewType) => void;
 }
 
 interface IFDSViewInterface {
@@ -78,6 +79,10 @@ const FDSView = ({
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
 	const [loading, setLoading] = useState(true);
+
+	const handleTabUpdate = (updatedViewData: FDSViewType): void => {
+		setFDSView({...fdsView, ...updatedViewData});
+	};
 
 	useEffect(() => {
 		const getFDSView = async () => {
@@ -141,6 +146,7 @@ const FDSView = ({
 						fdsViewsURL={fdsViewsURL}
 						namespace={namespace}
 						saveFDSFieldsURL={saveFDSFieldsURL}
+						updateFDSTabHandler={handleTabUpdate}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -27,7 +27,7 @@ const Details = ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	onUpdateFDSView,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface) => {
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
@@ -72,7 +72,7 @@ const Details = ({
 				);
 			}
 
-			onUpdateFDSView(responseJSON);
+			onFDSViewUpdate(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -27,7 +27,7 @@ const Details = ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	updateFDSTabHandler,
+	onUpdateFDSView,
 }: IFDSViewSectionInterface) => {
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
@@ -72,7 +72,7 @@ const Details = ({
 				);
 			}
 
-			updateFDSTabHandler(responseJSON);
+			onUpdateFDSView(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -27,6 +27,7 @@ const Details = ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	updateFDSTabHandler,
 }: IFDSViewSectionInterface) => {
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
@@ -70,6 +71,8 @@ const Details = ({
 					fdsViewLabelRef.current?.value ?? ''
 				);
 			}
+
+			updateFDSTabHandler(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
@@ -27,7 +27,7 @@ function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	updateFDSTabHandler,
+	onUpdateFDSView,
 }: IFDSViewSectionInterface) {
 	const [listOfItemsPerPage, setListOfItemsPerPage] = useState(
 		fdsView.listOfItemsPerPage
@@ -132,7 +132,7 @@ function Pagination({
 				),
 				type: 'success',
 			});
-			updateFDSTabHandler(responseJSON);
+			onUpdateFDSView(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
@@ -27,7 +27,7 @@ function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	onUpdateFDSView,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface) {
 	const [listOfItemsPerPage, setListOfItemsPerPage] = useState(
 		fdsView.listOfItemsPerPage
@@ -132,7 +132,7 @@ function Pagination({
 				),
 				type: 'success',
 			});
-			onUpdateFDSView(responseJSON);
+			onFDSViewUpdate(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
@@ -27,6 +27,7 @@ function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	updateFDSTabHandler,
 }: IFDSViewSectionInterface) {
 	const [listOfItemsPerPage, setListOfItemsPerPage] = useState(
 		fdsView.listOfItemsPerPage
@@ -132,6 +133,7 @@ function Pagination({
 				type: 'success',
 			});
 			setListOfItemsPerPage(itemsPerPage);
+			updateFDSTabHandler(responseJSON);
 		}
 		else {
 			openToast({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
@@ -132,7 +132,6 @@ function Pagination({
 				),
 				type: 'success',
 			});
-			setListOfItemsPerPage(itemsPerPage);
 			updateFDSTabHandler(responseJSON);
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -22,8 +22,8 @@ interface IFDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
+	onUpdateFDSView: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
-	updateFDSTabHandler: (data: FDSViewType) => void;
 }
 interface IFDSViewInterface {
 	fdsClientExtensionCellRenderers: IClientExtensionCellRenderer[];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -23,6 +23,7 @@ interface IFDSViewSectionInterface {
 	fdsViewsURL: string;
 	namespace: string;
 	saveFDSFieldsURL: string;
+	updateFDSTabHandler: (data: FDSViewType) => void;
 }
 interface IFDSViewInterface {
 	fdsClientExtensionCellRenderers: IClientExtensionCellRenderer[];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -22,7 +22,7 @@ interface IFDSViewSectionInterface {
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
 	namespace: string;
-	onUpdateFDSView: (data: FDSViewType) => void;
+	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 }
 interface IFDSViewInterface {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -19,6 +19,6 @@ declare const Details: ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	onUpdateFDSView,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface) => JSX.Element;
 export default Details;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -19,6 +19,6 @@ declare const Details: ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	updateFDSTabHandler,
+	onUpdateFDSView,
 }: IFDSViewSectionInterface) => JSX.Element;
 export default Details;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Details.d.ts
@@ -19,5 +19,6 @@ declare const Details: ({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	updateFDSTabHandler,
 }: IFDSViewSectionInterface) => JSX.Element;
 export default Details;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
@@ -19,6 +19,6 @@ declare function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	onUpdateFDSView,
+	onFDSViewUpdate,
 }: IFDSViewSectionInterface): JSX.Element;
 export default Pagination;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
@@ -19,6 +19,6 @@ declare function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
-	updateFDSTabHandler,
+	onUpdateFDSView,
 }: IFDSViewSectionInterface): JSX.Element;
 export default Pagination;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Pagination.d.ts
@@ -19,5 +19,6 @@ declare function Pagination({
 	fdsView,
 	fdsViewsURL,
 	namespace,
+	updateFDSTabHandler,
 }: IFDSViewSectionInterface): JSX.Element;
 export default Pagination;

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/test.properties
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/test.properties
@@ -11,7 +11,7 @@
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (testray.component.names == "Clay") OR \
         (\
-            (environment.acceptance == true) AND \
+            (environment.acceptance == true)
             (portal.acceptance == true) AND \
             (portal.upstream == true) AND \
             (\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/test.properties
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/test.properties
@@ -11,24 +11,26 @@
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (testray.component.names == "Clay") OR \
         (\
-            (test.class.method.name == "CommerceAccountSelector#CanCreateNewAccountInFlow") OR \
-            (test.class.method.name == "DMContentPages#CanCreateTagUsingAutocomplete")\
-        ) AND \
-        (\
-            (environment.acceptance == true) AND \
-            (portal.acceptance == true) AND \
-            (portal.upstream == true) AND \
             (\
-                (app.server.types == null) OR \
-                (app.server.types ~ "tomcat")\
+                (test.class.method.name == "CommerceAccountSelector#CanCreateNewAccountInFlow") OR \
+                (test.class.method.name == "DMContentPages#CanCreateTagUsingAutocomplete") OR \
             ) AND \
             (\
-                (database.types == null) OR \
-                (database.types ~ "mysql")\
-            ) AND \
-            (\
-                (operating.system.types == null) OR \
-                (operating.system.types ~ "centos")\
+                (environment.acceptance == true)
+                (portal.acceptance == true) AND \
+                (portal.upstream == true) AND \
+                (\
+                    (app.server.types == null) OR \
+                    (app.server.types ~ "tomcat")\
+                ) AND \
+                (\
+                    (database.types == null) OR \
+                    (database.types ~ "mysql")\
+                ) AND \
+                (\
+                    (operating.system.types == null) OR \
+                    (operating.system.types ~ "centos")\
+                )\
             )\
         )
 


### PR DESCRIPTION
### Problem
In the FDS View component the user could change information using the different tabs available. When a user changes the pagination info , save it, navigate to other tab and come back to the Pagination one, the old information is still visible.
The same problem occurs in the Details tab.

When the FDS View first render, it request the **general view** data, that is passed as a prop to the different tabs. To trigger a new data request the only dependency is the viewId, that it is something that does not change among the tabs, so whenever a user changes the tab, is loading stale **general view** data. This is also happening with the other tabs, but don't have relevant data to update the UI.

### Proposed solution
The parent FDS View passes an update function to the components that need to update the view after saving the data.
In the current PR, I'm only passing the callback to the Details and Pagination tabs, but could be passed to all of them to be consistent. 

### Before
[before.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/415b2f81-b2bc-4a76-a9f7-f4540c96046f)

### After
[after.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/a18ca721-df08-434a-9201-a4701776cea8)
