### PR TITLE
LPS-189459 Move Pagination component to the end of the array

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -38,14 +38,6 @@ let NAVIGATION_BAR_ITEMS = [
 		Component: Fields,
 		label: Liferay.Language.get('fields'),
 	},
-	{
-		Component: Sorting,
-		label: Liferay.Language.get('sorting'),
-	},
-	{
-		Component: Pagination,
-		label: Liferay.Language.get('pagination'),
-	},
 ];
 
 if (Liferay.FeatureFlags['LPS-188645']) {
@@ -61,6 +53,14 @@ if (Liferay.FeatureFlags['LPS-188645']) {
 		},
 	];
 }
+
+NAVIGATION_BAR_ITEMS = [
+	...NAVIGATION_BAR_ITEMS,
+	{
+		Component: Pagination,
+		label: Liferay.Language.get('pagination'),
+	},
+];
 
 interface IFDSViewSectionInterface {
 	fdsClientExtensionCellRenderers: IClientExtensionCellRenderer[];


### PR DESCRIPTION
In this PR we're changing the way we compute the tabs in the data set manager app depending on the  `LPS-188645` FF. Now,  turning FF on/off keeps the desired order of tabs.