### PR TITLE
LPS-189049 Turn data set app data model into system objects

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewItemSelectorDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewItemSelectorDisplayContext.java
@@ -37,7 +37,7 @@ public class FDSViewItemSelectorDisplayContext {
 	public String getClassName() {
 		ObjectDefinition objectDefinition =
 			ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-				_themeDisplay.getCompanyId(), "C_FDSView");
+				_themeDisplay.getCompanyId(), "FDSView");
 
 		if (objectDefinition != null) {
 			return objectDefinition.getClassName();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -142,7 +142,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 			ObjectDefinition fdsViewObjectDefinition =
 				_objectDefinitionLocalService.fetchObjectDefinition(
-					fragmentEntryLink.getCompanyId(), "C_FDSView");
+					fragmentEntryLink.getCompanyId(), "FDSView");
 
 			if (externalReferenceCode != StringPool.BLANK) {
 				fdsViewObjectEntry = _getObjectEntry(
@@ -206,7 +206,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 		ObjectDefinition fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				fragmentEntryLink.getCompanyId(), "C_FDSEntry");
+				fragmentEntryLink.getCompanyId(), "FDSEntry");
 
 		ObjectEntry fdsEntryObjectEntry = _getObjectEntry(
 			fragmentEntryLink.getCompanyId(), fdsEntryObjectEntryERC,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -125,7 +125,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				userId, "FDSEntry", "FDSEntry", false,
+				"FDSEntry", userId, "FDSEntry", "FDSEntry", false,
 				LocalizedMapUtil.getLocalizedMap("FDS Entry"), true, "FDSEntry",
 				null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Entries"),
@@ -157,7 +157,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsViewObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				userId, "FDSView", "FDSView", false,
+				"FDSView", userId, "FDSView", "FDSView", false,
 				LocalizedMapUtil.getLocalizedMap("FDS View"), true, "FDSView",
 				null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Views"),
@@ -223,7 +223,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsFieldObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				userId, "FDSField", "FDSField", false,
+				"FDSField", userId, "FDSField", "FDSField", false,
 				LocalizedMapUtil.getLocalizedMap("FDS Field"), true, "FDSField",
 				null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Fields"),
@@ -269,9 +269,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsDateFilterObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				userId, "FDSDateFilter", "FDSDateFilter", false,
-				LocalizedMapUtil.getLocalizedMap("FDS Date Filter"), true,
-				"FDSDateFilter", null, null, null, null,
+				"FDSDateFilter", userId, "FDSDateFilter", "FDSDateFilter",
+				false, LocalizedMapUtil.getLocalizedMap("FDS Date Filter"),
+				true, "FDSDateFilter", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Date Filters"),
 				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
 				WorkflowConstants.STATUS_DRAFT,
@@ -311,7 +311,8 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsDynamicFilterObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				userId, "FDSDynamicFilter", "FDSDynamicFilter", false,
+				"FDSDynamicFilter", userId, "FDSDynamicFilter",
+				"FDSDynamicFilter", false,
 				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filter"), true,
 				"FDSDynamicFilter", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filters"),
@@ -359,7 +360,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsSortObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				userId, "FDSSort", "FDSSort", false,
+				"FDSSort", userId, "FDSSort", "FDSSort", false,
 				LocalizedMapUtil.getLocalizedMap("FDS Sort"), true, "FDSSort",
 				"300", null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Sorts"),

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.io.IOException;
@@ -116,19 +117,20 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				companyId, "C_FDSEntry");
+				companyId, "FDSEntry");
 
 		if (fdsEntryObjectDefinition != null) {
 			return;
 		}
 
 		fdsEntryObjectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				userId, false, false,
-				LocalizedMapUtil.getLocalizedMap("FDS Entry"), "FDSEntry",
-				"100", null, LocalizedMapUtil.getLocalizedMap("FDS Entries"),
-				true, ObjectDefinitionConstants.SCOPE_COMPANY,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				userId, "FDSEntry", "FDSEntry", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Entry"), true, "FDSEntry",
+				null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Entries"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
 				Arrays.asList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -150,16 +152,17 @@ public class FDSViewsPortlet extends MVCPortlet {
 						_language.get(locale, "rest-schema"), "restSchema",
 						true)));
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsEntryObjectDefinition.getObjectDefinitionId());
 
 		ObjectDefinition fdsViewObjectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				userId, false, false,
-				LocalizedMapUtil.getLocalizedMap("FDS View"), "FDSView", "200",
-				null, LocalizedMapUtil.getLocalizedMap("FDS Views"), true,
-				ObjectDefinitionConstants.SCOPE_COMPANY,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				userId, "FDSView", "FDSView", false,
+				LocalizedMapUtil.getLocalizedMap("FDS View"), true, "FDSView",
+				null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Views"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
 				Arrays.asList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -207,7 +210,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 			fdsViewObjectDefinition.getObjectDefinitionId(),
 			labelObjectField.getObjectFieldId());
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsViewObjectDefinition.getObjectDefinitionId());
 
 		_objectRelationshipLocalService.addObjectRelationship(
@@ -219,12 +222,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectDefinition fdsFieldObjectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				userId, false, false,
-				LocalizedMapUtil.getLocalizedMap("FDS Field"), "FDSField",
-				"300", null, LocalizedMapUtil.getLocalizedMap("FDS Fields"),
-				true, ObjectDefinitionConstants.SCOPE_COMPANY,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				userId, "FDSField", "FDSField", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Field"), true, "FDSField",
+				null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Fields"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
 				Arrays.asList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -252,7 +256,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
 						_language.get(locale, "sortable"), "sortable", true)));
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsFieldObjectDefinition.getObjectDefinitionId());
 
 		_objectRelationshipLocalService.addObjectRelationship(
@@ -264,13 +268,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectDefinition fdsDateFilterObjectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				userId, false, false,
-				LocalizedMapUtil.getLocalizedMap("FDS Date Filter"),
-				"FDSDateFilter", "300", null,
-				LocalizedMapUtil.getLocalizedMap("FDS Date Filters"), true,
-				ObjectDefinitionConstants.SCOPE_COMPANY,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				userId, "FDSDateFilter", "FDSDateFilter", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Date Filter"), true,
+				"FDSDateFilter", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Date Filters"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
 				Arrays.asList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_DATE,
@@ -293,7 +297,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(locale, "type"), "type", false)));
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsDateFilterObjectDefinition.getObjectDefinitionId());
 
 		_objectRelationshipLocalService.addObjectRelationship(
@@ -306,13 +310,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectDefinition fdsDynamicFilterObjectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				userId, false, false,
-				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filter"),
-				"FDSDynamicFilter", "300", null,
-				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filters"), true,
-				ObjectDefinitionConstants.SCOPE_COMPANY,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				userId, "FDSDynamicFilter", "FDSDynamicFilter", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filter"), true,
+				"FDSDynamicFilter", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filters"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
 				Arrays.asList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -341,7 +345,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 						_language.get(locale, "preselected-values"),
 						"preselectedValues", false)));
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsDynamicFilterObjectDefinition.getObjectDefinitionId());
 
 		_objectRelationshipLocalService.addObjectRelationship(
@@ -354,12 +358,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
 		ObjectDefinition fdsSortObjectDefinition =
-			_objectDefinitionLocalService.addCustomObjectDefinition(
-				userId, false, false,
-				LocalizedMapUtil.getLocalizedMap("FDS Sort"), "FDSSort", "300",
-				null, LocalizedMapUtil.getLocalizedMap("FDS Sorts"), true,
-				ObjectDefinitionConstants.SCOPE_COMPANY,
-				ObjectDefinitionConstants.STORAGE_TYPE_DEFAULT,
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				userId, "FDSSort", "FDSSort", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Sort"), true, "FDSSort",
+				"300", null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Sorts"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
 				Arrays.asList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -371,7 +376,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 						_language.get(locale, "sorting"), "sortingDirection",
 						true)));
 
-		_objectDefinitionLocalService.publishCustomObjectDefinition(
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsSortObjectDefinition.getObjectDefinitionId());
 
 		_objectRelationshipLocalService.addObjectRelationship(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -64,7 +64,7 @@ public class SaveFDSFieldsMVCResourceCommand
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.fetchObjectDefinition(
-				themeDisplay.getCompanyId(), "C_FDSField");
+				themeDisplay.getCompanyId(), "FDSField");
 
 		String fdsViewId = ParamUtil.getString(resourceRequest, "fdsViewId");
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
@@ -13,12 +13,12 @@
  */
 
 const API_URL = {
-	FDS_DATE_FILTERS: '/o/c/fdsdatefilters',
-	FDS_DYNAMIC_FILTERS: '/o/c/fdsdynamicfilters',
-	FDS_ENTRIES: '/o/c/fdsentries',
-	FDS_FIELDS: '/o/c/fdsfields',
-	FDS_SORTS: '/o/c/fdssorts',
-	FDS_VIEWS: '/o/c/fdsviews',
+	FDS_DATE_FILTERS: '/o/data-set-manager/date-filters',
+	FDS_DYNAMIC_FILTERS: '/o/data-set-manager/dynamic-filters',
+	FDS_ENTRIES: '/o/data-set-manager/entries',
+	FDS_FIELDS: '/o/data-set-manager/fields',
+	FDS_SORTS: '/o/data-set-manager/sorts',
+	FDS_VIEWS: '/o/data-set-manager/views',
 };
 
 const FUZZY_OPTIONS = {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/definition/util/ObjectDefinitionUtil.java
@@ -74,6 +74,18 @@ public class ObjectDefinitionUtil {
 			"APISort", "/headless-builder/sorts"
 		).put(
 			"Bookmark", "/bookmarks"
+		).put(
+			"FDSDateFilter", "/data-set-manager/date-filters"
+		).put(
+			"FDSDynamicFilter", "/data-set-manager/dynamic-filters"
+		).put(
+			"FDSEntry", "/data-set-manager/entries"
+		).put(
+			"FDSField", "/data-set-manager/fields"
+		).put(
+			"FDSSort", "/data-set-manager/sorts"
+		).put(
+			"FDSView", "/data-set-manager/views"
 		).build();
 	private static final Map<String, String>
 		_allowedUnmodifiableSystemObjectDefinitionNames = HashMapBuilder.put(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
@@ -126,7 +126,7 @@ definition {
 	}
 
 	macro createDataSetEntryViaAPI {
-		if (${restApplication} == "/c/fdsentries") {
+		if (${restApplication} == "/data-set-manager/entries") {
 			var restSchema = "FDSEntry";
 			var restEndpoint = "/";
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/JSONDataSet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/JSONDataSet.macro
@@ -1,6 +1,5 @@
 definition {
 
-	@summary = "This calls the JSON WS API to add a DataSet"
 	macro _createDataSetEntry {
 		Variables.assertDefined(parameterList = "${dataSetName},${restApplication},${restEndpoint},${restSchema}");
 
@@ -78,7 +77,6 @@ definition {
 		}
 	}
 
-	@summary = "This calls the JSON WS API to delete all data sets"
 	macro _deleteFDSEntry {
 		var portalURL = JSONCompany.getPortalURL();
 
@@ -109,7 +107,6 @@ definition {
 		}
 	}
 
-	@summary = "This calls the JSON WS API to delete all data set views"
 	macro _deleteFDSViews {
 		var portalURL = JSONCompany.getPortalURL();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/JSONDataSet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/JSONDataSet.macro
@@ -15,7 +15,7 @@ definition {
 		}
 
 		var curl = '''
-			${portalURL}/o/c/fdsentries \
+			${portalURL}/o/data-set-manager/entries \
 				-u ${userEmailAddress}:${userPassword} \
 				-H accept: application/json \
 				-H Content-Type: application/json \
@@ -57,7 +57,7 @@ definition {
 
 		if (${dataSetEntryId} != "") {
 			var curl = '''
-				${portalURL}/o/c/fdsviews \
+				${portalURL}/o/data-set-manager/views \
 					-u ${userEmailAddress}:${userPassword} \
 					-H accept: application/json \
 					-H Content-Type: application/json \
@@ -97,7 +97,7 @@ definition {
 		if (${dataSetEntriesIdList} != "") {
 			for (var dataSetEntryId : list ${dataSetEntriesIdList}) {
 				var curl = '''
-					${portalURL}/o/c/fdsentries/${dataSetEntryId} \
+					${portalURL}/o/data-set-manager/entries/${dataSetEntryId} \
 						-u ${userEmailAddress}:${userPassword}
 				''';
 
@@ -128,7 +128,7 @@ definition {
 		if (${dataSetViewsIdList} != "") {
 			for (var dataSetViewsIds : list ${dataSetViewsIdList}) {
 				var curl = '''
-					${portalURL}/o/c/fdsviews/${dataSetViewsIds} \
+					${portalURL}/o/data-set-manager/views/${dataSetViewsIds} \
 						-u ${userEmailAddress}:${userPassword}
 				''';
 
@@ -154,7 +154,7 @@ definition {
 		}
 
 		var curl = '''
-			${portalURL}/o/c/fdsentries \
+			${portalURL}/o/data-set-manager/entries \
 				-u ${userEmailAddress}:${userPassword}
 		''';
 
@@ -180,7 +180,7 @@ definition {
 		}
 
 		var curl = '''
-			${portalURL}/o/c/fdsentries \
+			${portalURL}/o/data-set-manager/entries \
 				-u ${userEmailAddress}:${userPassword}
 		''';
 
@@ -210,7 +210,7 @@ definition {
 		}
 
 		var curl = '''
-			${portalURL}/o/c/fdsviews \
+			${portalURL}/o/data-set-manager/views \
 				-u ${userEmailAddress}:${userPassword}
 		''';
 		var dataSetViewsIds = "";
@@ -241,7 +241,7 @@ definition {
 		}
 
 		var curl = '''
-			${portalURL}/o/c/fdsviews \
+			${portalURL}/o/data-set-manager/views \
 				-u ${userEmailAddress}:${userPassword}
 		''';
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSet.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSet.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSet.testcase
@@ -38,7 +38,7 @@ definition {
 		task ("Given create 6 data sets") {
 			DataSetAdmin.createDataSet(
 				key_dataSetNameList = "Test Data Set 1,Test Data Set 2,Test Data Set 3,Test Data Set 4,Test Data Set 5,Test Data Set 6",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("When changing the page to 4 entries") {
@@ -68,7 +68,7 @@ definition {
 		task ("When Create a DataSet ") {
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("Then Confirm the name as expected") {
@@ -79,7 +79,7 @@ definition {
 
 		task ("And Confirm the Provider as expected") {
 			AssertElementPresent(
-				key_itemName = "/c/fdsentries",
+				key_itemName = "/data-set-manager/entries",
 				locator1 = "DataSet#TABLE_CELL");
 		}
 	}
@@ -90,7 +90,7 @@ definition {
 		task ("When the user goes to add data sets") {
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("And the user deletes a data set") {
@@ -148,7 +148,7 @@ definition {
 		}
 
 		task ("And choose the provider named Channel") {
-			DataSetAdmin.selectProvider(key_type = "/c/fdsentries");
+			DataSetAdmin.selectProvider(key_type = "/data-set-manager/entries");
 		}
 
 		task ("And clicking on the Save button") {
@@ -174,13 +174,13 @@ definition {
 		task ("And search for a known uniquely named headless provider") {
 			DataSetAdmin.searchProvider(
 				dropdownLabel = "Choose an Option",
-				key_provider = "/c/fdsentries");
+				key_provider = "/data-set-manager/entries");
 		}
 
 		task ("Then the suggested list is updated to have only 1 result for the search, and Then the suggested list contains the uniquely named headless provider") {
 			AssertElementPresent(
 				locator1 = "CommerceWidget#TAG_FACET_COMPACT_LAYOUT",
-				tagName = "/c/fdsentries");
+				tagName = "/data-set-manager/entries");
 		}
 	}
 
@@ -206,7 +206,7 @@ definition {
 		task ("When The user goes to add a new data set") {
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("And opening the dropdown menu") {
@@ -229,8 +229,8 @@ definition {
 			LexiconEntry.gotoAdd();
 		}
 
-		task ("And choose the Provider called /c/fdsentries") {
-			DataSetAdmin.selectProvider(key_type = "/c/fdsentries");
+		task ("And choose the Provider called /data-set-manager/entries") {
+			DataSetAdmin.selectProvider(key_type = "/data-set-manager/entries");
 		}
 
 		task ("And clicking on the Save button") {
@@ -277,8 +277,8 @@ definition {
 			PortletEntry.inputName(name = "Test Data Set");
 		}
 
-		task ("And choose the Provider called /c/fdsentries ") {
-			DataSetAdmin.selectProvider(key_type = "/c/fdsentries");
+		task ("And choose the Provider called /data-set-manager/entries ") {
+			DataSetAdmin.selectProvider(key_type = "/data-set-manager/entries");
 		}
 
 		task ("And clicking on the Cancel button ") {
@@ -300,7 +300,7 @@ definition {
 		task ("When the user goes to add data sets") {
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("And the user deletes a data set") {
@@ -330,7 +330,7 @@ definition {
 		task ("When The user goes to add a new data set") {
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("And When the user deletes a data set") {
@@ -364,7 +364,7 @@ definition {
 		task ("When Create a DataSet") {
 			DataSetAdmin.createDataSet(
 				key_name = "Data Set ~!@#$%^&*(){}[].<>/? name",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("Then confirm that the data set is created and if the name is provided as expected") {
@@ -375,7 +375,7 @@ definition {
 
 		task ("And Then Confirm the Provider as expected") {
 			AssertElementPresent(
-				key_itemName = "/c/fdsentries",
+				key_itemName = "/data-set-manager/entries",
 				locator1 = "DataSet#TABLE_CELL");
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetApi.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetApi.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetApi.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetApi.testcase
@@ -32,7 +32,7 @@ definition {
 
 			DataSetAdmin.createDataSetEntryViaAPI(
 				dataSetName = "Data Set Test",
-				restApplication = "/c/fdsentries");
+				restApplication = "/data-set-manager/entries");
 		}
 
 		task ("and given access to the Data Sets admin page") {
@@ -58,7 +58,7 @@ definition {
 
 			DataSetAdmin.createDataSetEntryViaAPI(
 				dataSetName = "Data Set Test",
-				restApplication = "/c/fdsentries");
+				restApplication = "/data-set-manager/entries");
 		}
 
 		task ("And a data set view created via api") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetView.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetView.testcase
@@ -18,7 +18,7 @@ definition {
 
 			DataSetAdmin.createDataSetEntryViaAPI(
 				dataSetName = "Data Set Test",
-				restApplication = "/c/fdsentries");
+				restApplication = "/data-set-manager/entries");
 
 			Refresh();
 		}
@@ -565,7 +565,7 @@ definition {
 		}
 
 		task ("Then confirm the name, REST application, REST Schema and REST Endpoint of the created Dataset entry are displayed.") {
-			for (var key_text : list "Data Set Test,/c/fdsentries,FDSEntry,/") {
+			for (var key_text : list "Data Set Test,/data-set-manager/entries,FDSEntry,/") {
 				AssertElementPresent(locator1 = "CP2Utils#ANY_TEXT");
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetView.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetView.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewBug.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewBug.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewDateFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewDateFilters.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-188645=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-188645=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -18,7 +18,7 @@ definition {
 
 			DataSetAdmin.createDataSetEntryViaAPI(
 				dataSetName = "Data Set Fields Test",
-				restApplication = "/c/fdsfields",
+				restApplication = "/data-set-manager/fields",
 				restEndpoint = "/",
 				restSchema = "FDSField");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -18,7 +18,7 @@ definition {
 
 			JSONDataSet._createDataSetEntry(
 				dataSetName = "Data Set Test",
-				restApplication = "/c/fdsdatefilters",
+				restApplication = "/data-set-manager/date-filters",
 				restEndpoint = "/",
 				restSchema = "FDSDateFilter");
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-188645=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-188645=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewPagination.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewPagination.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewPagination.testcase
@@ -20,7 +20,7 @@ definition {
 		task ("The user goes to add a new data set") {
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdsentries");
+				key_type = "/data-set-manager/entries");
 		}
 
 		task ("Add a new view") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewSorting.testcase
@@ -18,7 +18,7 @@ definition {
 
 			DataSetAdmin.createDataSet(
 				key_name = "Test Data Set",
-				key_type = "/c/fdssorts");
+				key_type = "/data-set-manager/sorts");
 
 			Refresh();
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewSorting.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewSorting.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-188645=true";
+	property custom.properties = "feature.flag.LPS-164563=true${line.separator}feature.flag.LPS-188645=true${line.separator}feature.flag.LPS-167253=true";
 	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";


### PR DESCRIPTION
Rebased followup of https://github.com/liferay-frontend/liferay-portal/pull/3508

In this PR we are changing the way we create the object definitions supporting dataset manager persistence model. We are using System object definitions now.

This has implications in:
* The API we use to create the definitions
* The naming of the headless endpoints (context path)
* The naming of the object definitions themselves, which affects how we calculate the class name in various places

Other notes:
* There is no upgrade process as application is under FF
* We are not renaming the object definitions to the UI/user friendly abstractions and therefore the endpoint names don't change (just the context path does)
