### PR TITLE
LPS-189317 Only prevent drop event for images (files), not for portlets.

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -183,7 +183,9 @@ name = HtmlUtil.escapeJS(name);
 		var validDropTarget =
 			element.isContentEditable || !!element.getAttribute('droppable');
 
-		if (!validDropTarget) {
+		var droppedFiles = event._event.dataTransfer.files || [];
+
+		if (!validDropTarget && droppedFiles.length > 0) {
 			event.preventDefault();
 			event.stopImmediatePropagation();
 		}


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPS-189317

When the Page Comments portlet is in a widget page, the rest of the porlets does not work via drag&drop. This is because when there is an editor, we are preventing the drag&drop events. The origin of this is https://issues-archive.liferay.com/browse/LPS-87348 

My proposal is to prevent this drop event inly when you are dropping images (more generic, files), so it does not affect to portlets. 

Let me know your thoughts on this. Thanks! 