### PR TITLE
LPS-189296 Data Set Manager shows selection bar when opening the actions menu of a view

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -86,9 +86,11 @@ const ListItem = ({item, schema}) => {
 			})}
 			flex
 			onClick={() => {
-				selectItems(item[selectedItemsKey]);
+				if (selectable) {
+					selectItems(item[selectedItemsKey]);
 
-				onSelect?.({selectedItems: [item]});
+					onSelect?.({selectedItems: [item]});
+				}
 			}}
 		>
 			{selectable && (


### PR DESCRIPTION
### References

- [LPS-189296 Data Set Manager shows selection bar when opening the actions menu of a view](https://issues.liferay.com/browse/LPS-189296)

### What is the goal of this PR?

A simple bugfix, of a very noticeable bug.

### What does it look like?

See movie in JIRA.

### Steps to reproduce

See movie in JIRA.