### PR TITLE
LPS-189883 Prevent multiple click events on save button

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -312,7 +312,7 @@ const AddFDSEntryModalContent = ({
 	restApplications,
 }: IAddFDSEntryModalContentInterface) => {
 	const [fdsEntryLabel, setFDSEntryLabel] = useState('');
-	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [labelValidationError, setLabelValidationError] = useState(false);
 	const [
 		requiredRESTApplicationValidationError,
@@ -380,7 +380,7 @@ const AddFDSEntryModalContent = ({
 			loadData();
 		}
 		else {
-			setIsSubmitting(false);
+			setSaveButtonDisabled(false);
 			openToast({
 				message: Liferay.Language.get(
 					'your-request-failed-to-complete'
@@ -719,9 +719,9 @@ const AddFDSEntryModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={isSubmitting}
+							disabled={saveButtonDisabled}
 							onClick={() => {
-								setIsSubmitting(true);
+								setSaveButtonDisabled(true);
 
 								const success = validate();
 
@@ -729,7 +729,7 @@ const AddFDSEntryModalContent = ({
 									addFDSEntry();
 								}
 								else {
-									setIsSubmitting(false);
+									setSaveButtonDisabled(false);
 								}
 							}}
 						>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -312,6 +312,7 @@ const AddFDSEntryModalContent = ({
 	restApplications,
 }: IAddFDSEntryModalContentInterface) => {
 	const [fdsEntryLabel, setFDSEntryLabel] = useState('');
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [labelValidationError, setLabelValidationError] = useState(false);
 	const [
 		requiredRESTApplicationValidationError,
@@ -379,6 +380,7 @@ const AddFDSEntryModalContent = ({
 			loadData();
 		}
 		else {
+			setIsSubmitting(false);
 			openToast({
 				message: Liferay.Language.get(
 					'your-request-failed-to-complete'
@@ -717,11 +719,17 @@ const AddFDSEntryModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
+							disabled={isSubmitting}
 							onClick={() => {
+								setIsSubmitting(true);
+
 								const success = validate();
 
 								if (success) {
 									addFDSEntry();
+								}
+								else {
+									setIsSubmitting(false);
 								}
 							}}
 						>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -56,7 +56,7 @@ const AddFDSViewModalContent = ({
 	loadData,
 	namespace,
 }: IAddFDSViewModalContentInterface) => {
-	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
 	const fdsViewDescriptionRef = useRef<HTMLInputElement>(null);
@@ -96,7 +96,7 @@ const AddFDSViewModalContent = ({
 			loadData();
 		}
 		else {
-			setIsSubmitting(false);
+			setSaveButtonDisabled(false);
 			openToast({
 				message: Liferay.Language.get(
 					'your-request-failed-to-complete'
@@ -173,9 +173,9 @@ const AddFDSViewModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={isSubmitting}
+							disabled={saveButtonDisabled}
 							onClick={() => {
-								setIsSubmitting(true);
+								setSaveButtonDisabled(true);
 
 								const success = validate();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -56,6 +56,7 @@ const AddFDSViewModalContent = ({
 	loadData,
 	namespace,
 }: IAddFDSViewModalContentInterface) => {
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [labelValidationError, setLabelValidationError] = useState(false);
 
 	const fdsViewDescriptionRef = useRef<HTMLInputElement>(null);
@@ -95,6 +96,7 @@ const AddFDSViewModalContent = ({
 			loadData();
 		}
 		else {
+			setIsSubmitting(false);
 			openToast({
 				message: Liferay.Language.get(
 					'your-request-failed-to-complete'
@@ -171,7 +173,10 @@ const AddFDSViewModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
+							disabled={isSubmitting}
 							onClick={() => {
+								setIsSubmitting(true);
+
 								const success = validate();
 
 								if (success) {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -159,9 +159,8 @@ function AddFDSFilterModalContent({
 		setIsValidDateRange(isValid);
 	}, [from, to]);
 
-	const handleFilterSave = async (event: any) => {
+	const handleFilterSave = async () => {
 		setIsSubmitting(true);
-		event.preventDefault();
 
 		if (!selectedField) {
 			alertFailed();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -106,6 +106,7 @@ function AddFDSFilterModalContent({
 			: 'include'
 	);
 	const [isValidDateRange, setIsValidDateRange] = useState(true);
+	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as IDynamicFilter)?.multiple ?? true
 	);
@@ -158,7 +159,10 @@ function AddFDSFilterModalContent({
 		setIsValidDateRange(isValid);
 	}, [from, to]);
 
-	const handleFilterSave = async () => {
+	const handleFilterSave = async (event: any) => {
+		setIsSubmitting(true);
+		event.preventDefault();
+
 		if (!selectedField) {
 			alertFailed();
 
@@ -219,6 +223,7 @@ function AddFDSFilterModalContent({
 		});
 
 		if (!response.ok) {
+			setIsSubmitting(false);
 			alertFailed();
 
 			return null;
@@ -590,7 +595,8 @@ function AddFDSFilterModalContent({
 							disabled={
 								!selectedField ||
 								(!multiple && preselectedValues.length > 1) ||
-								!isValidDateRange
+								!isValidDateRange ||
+								isSubmitting
 							}
 							onClick={handleFilterSave}
 							type="submit"

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -106,7 +106,7 @@ function AddFDSFilterModalContent({
 			: 'include'
 	);
 	const [isValidDateRange, setIsValidDateRange] = useState(true);
-	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as IDynamicFilter)?.multiple ?? true
 	);
@@ -160,7 +160,7 @@ function AddFDSFilterModalContent({
 	}, [from, to]);
 
 	const handleFilterSave = async () => {
-		setIsSubmitting(true);
+		setSaveButtonDisabled(true);
 
 		if (!selectedField) {
 			alertFailed();
@@ -222,7 +222,7 @@ function AddFDSFilterModalContent({
 		});
 
 		if (!response.ok) {
-			setIsSubmitting(false);
+			setSaveButtonDisabled(false);
 			alertFailed();
 
 			return null;
@@ -595,7 +595,7 @@ function AddFDSFilterModalContent({
 								!selectedField ||
 								(!multiple && preselectedValues.length > 1) ||
 								!isValidDateRange ||
-								isSubmitting
+								saveButtonDisabled
 							}
 							onClick={handleFilterSave}
 							type="submit"

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -778,7 +778,7 @@ function Filters({fdsView, fdsViewsURL, namespace}: IProps) {
 					type: 'cancel',
 				},
 				{
-					displayType: 'warning',
+					displayType: 'danger',
 					label: Liferay.Language.get('delete'),
 					onClick: ({processClose}: {processClose: Function}) => {
 						processClose();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -228,17 +228,17 @@ const AddFDSSortModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={isSubmitting || !selectedField}
-							onClick={handleSave}
-						>
-							{Liferay.Language.get('save')}
-						</ClayButton>
-
-						<ClayButton
 							displayType="secondary"
 							onClick={() => closeModal()}
 						>
 							{Liferay.Language.get('cancel')}
+						</ClayButton>
+
+						<ClayButton
+							disabled={isSubmitting || !selectedField}
+							onClick={handleSave}
+						>
+							{Liferay.Language.get('save')}
 						</ClayButton>
 					</ClayButton.Group>
 				}
@@ -353,17 +353,17 @@ const EditFDSSortModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={isSubmitting}
-							onClick={handleSave}
-						>
-							{Liferay.Language.get('save')}
-						</ClayButton>
-
-						<ClayButton
 							displayType="secondary"
 							onClick={() => closeModal()}
 						>
 							{Liferay.Language.get('cancel')}
+						</ClayButton>
+
+						<ClayButton
+							disabled={isSubmitting}
+							onClick={handleSave}
+						>
+							{Liferay.Language.get('save')}
 						</ClayButton>
 					</ClayButton.Group>
 				}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -457,7 +457,7 @@ const Sorting = ({
 					type: 'cancel',
 				},
 				{
-					displayType: 'warning',
+					displayType: 'danger',
 					label: Liferay.Language.get('delete'),
 					onClick: async ({
 						processClose,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -120,14 +120,14 @@ const AddFDSSortModalContent = ({
 	fields,
 	onSave,
 }: IAddFDSSortModalContentInterface) => {
-	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [selectedField, setSelectedField] = useState<string>();
 	const [selectedSortingDirection, setSelectedSortingDirection] = useState<
 		string
 	>(SORTING_DIRECTION.ASCENDING.value);
 
 	const handleSave = async () => {
-		setIsSubmitting(true);
+		setSaveButtonDisabled(true);
 
 		const field = fields.find(
 			(item: IField) => item.name === selectedField
@@ -153,7 +153,7 @@ const AddFDSSortModalContent = ({
 		});
 
 		if (!response.ok) {
-			setIsSubmitting(false);
+			setSaveButtonDisabled(false);
 
 			alertFailed();
 
@@ -228,7 +228,7 @@ const AddFDSSortModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={isSubmitting || !selectedField}
+							disabled={saveButtonDisabled || !selectedField}
 							onClick={handleSave}
 						>
 							{Liferay.Language.get('save')}
@@ -261,13 +261,13 @@ const EditFDSSortModalContent = ({
 	namespace,
 	onSave,
 }: IEditFDSSortModalContentProps) => {
-	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [selectedSortingDirection, setSelectedSortingDirection] = useState(
 		fdsSort.sortingDirection
 	);
 
 	const handleSave = async () => {
-		setIsSubmitting(true);
+		setSaveButtonDisabled(true);
 
 		const response = await fetch(
 			`${API_URL.FDS_SORTS}/by-external-reference-code/${fdsSort.externalReferenceCode}`,
@@ -284,7 +284,7 @@ const EditFDSSortModalContent = ({
 		);
 
 		if (!response.ok) {
-			setIsSubmitting(false);
+			setSaveButtonDisabled(false);
 
 			alertFailed();
 
@@ -353,7 +353,7 @@ const EditFDSSortModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={isSubmitting}
+							disabled={saveButtonDisabled}
 							onClick={handleSave}
 						>
 							{Liferay.Language.get('save')}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -228,17 +228,17 @@ const AddFDSSortModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							displayType="secondary"
-							onClick={() => closeModal()}
-						>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
-
-						<ClayButton
 							disabled={isSubmitting || !selectedField}
 							onClick={handleSave}
 						>
 							{Liferay.Language.get('save')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => closeModal()}
+						>
+							{Liferay.Language.get('cancel')}
 						</ClayButton>
 					</ClayButton.Group>
 				}
@@ -353,17 +353,17 @@ const EditFDSSortModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							displayType="secondary"
-							onClick={() => closeModal()}
-						>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
-
-						<ClayButton
 							disabled={isSubmitting}
 							onClick={handleSave}
 						>
 							{Liferay.Language.get('save')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => closeModal()}
+						>
+							{Liferay.Language.get('cancel')}
 						</ClayButton>
 					</ClayButton.Group>
 				}


### PR DESCRIPTION
### Problem
QA found that it is possible to create multiple Dataset entries when the user double click the Save button.
The problem occurs when:
- creating a new Data set entry,
- creating a new Data set view,
- creating a filter for a Data set view

It seems that the problem previously occurred when creating a new Sorting, but was fixed.

https://github.com/liferay-frontend/liferay-portal/assets/132653342/816ea17e-7a20-4db6-a539-4eaa9dd4b867

### Possible solution
As the issue was solved in the Sorting tab, using a state variable and disabling the Save button, we try to use the same approach.

The solution needed to be adapted a bit for each page/view due to minor differences with the behavior.

Changes in the Sorting tab are related to the order of the buttons, to have the same order across the different pages/views. 

Applying changes in the type of delete modals to have the same type in all the pages/views
