### PR TITLE
LPS-187257 add doAsGroupId to session_click request

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
@@ -19,6 +19,8 @@ const TOKEN_SERIALIZE = 'serialize://';
 function getSessionClickFormData(cmd) {
 	const doAsUserIdEncoded = Liferay.ThemeDisplay.getDoAsUserIdEncoded();
 
+	const doAsGroupId = Liferay.ThemeDisplay.getScopeGroupId();
+
 	const formData = new FormData();
 
 	formData.append('cmd', cmd);
@@ -26,6 +28,10 @@ function getSessionClickFormData(cmd) {
 
 	if (doAsUserIdEncoded) {
 		formData.append('doAsUserId', doAsUserIdEncoded);
+	}
+
+	if (doAsGroupId) {
+		formData.append('doAsGroupId', doAsGroupId);
 	}
 
 	return formData;


### PR DESCRIPTION
Hey guys,

This is a new pull request related to [this one](https://github.com/liferay-frontend/liferay-portal/pull/3515), which was eventually rejected by Brian, as you can see [here](https://github.com/brianchandotcom/liferay-portal/pull/137473#issuecomment-1624196490), so instead of setting the param in the URL, we are adding it to the form data we sent in POST request.

Thanks.