### PR TITLE
LPS-188817 Fix clay modal height

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -217,6 +217,7 @@ const Modal = ({
 					id={id}
 					observer={observer}
 					role={role}
+					scrollable
 					size={url && !size ? 'full-screen' : size}
 					status={status}
 					zIndex={zIndex}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.scss
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.scss
@@ -37,13 +37,11 @@
 			}
 		}
 
-		.modal-content {
-			--modal-bottom-spacing: 120px;
-
-			.modal-body {
-				max-height: calc(100vh - var(--modal-bottom-spacing));
-				overflow-y: auto;
-			}
+		&.modal-dialog-scrollable
+			.modal-content
+			> :not(.modal-header, .modal-body, .modal-footer) {
+			display: flex;
+			flex-direction: column;
 		}
 
 		.modal-body .loading-animation {


### PR DESCRIPTION
This PR changes the height of the Clay modal window to fill the available space in the viewport and making the title (modal-header) and buttons (modal-footer) always visible.

<img width="1440" alt="image" src="https://github.com/liferay-frontend/liferay-portal/assets/46778114/de21adce-e47f-468c-96c4-e69bb27d9ce2">

Before forward it, this PR requires:
- https://github.com/liferay/clay/issues/5639 => Fix merged in Clay
- https://github.com/liferay/clay/issues/5643

Other PRs that depend on this:
- https://github.com/liferay-commerce/liferay-portal/pull/3738 => We need to verify if https://liferay.atlassian.net/browse/COMMERCE-8983 is still working after this fix.

Previous PR:
- https://github.com/liferay-frontend/liferay-portal/pull/3534 => This PR set the modal to the standard Clay behavior.

POC:
- https://github.com/liferay-frontend/liferay-portal/pull/3537 => This PR is an example of how it will be once the fixes in Clay are available in DXP.