### PR TITLE
LPS-186552 - Manage localized object fields in Dataset manager

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -78,7 +78,7 @@ export async function getFields(fdsView: FDSViewType) {
 
 		const localizablePropertySuffix = '_i18n';
 
-		if (propertyValue.includes(localizablePropertySuffix)) {
+		if (propertyKey.includes(localizablePropertySuffix)) {
 			return;
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -72,9 +72,23 @@ export async function getFields(fdsView: FDSViewType) {
 			return;
 		}
 
+		// Filter <field_name>_i18n properties from the UI
+		// We only need the <field_name> property for the field selection
+		// and hide the _i18n that shows the internals
+
+		const localizablePropertySuffix = '_i18n';
+
+		if (propertyValue.includes(localizablePropertySuffix)) {
+			return;
+		}
+
+		if (propertyValue.additionalProperties) {
+			return;
+		}
+
 		const type = propertyValue.type;
 
-		if (type === 'object' || type === 'array') {
+		if (type === 'array') {
 			return;
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -19,6 +19,7 @@ import {fetch, openToast} from 'frontend-js-web';
 import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';
 
+const LOCALIZABLE_PROPERTY_SUFFIX = '_i18n';
 interface IField {
 	format: string;
 	label: string;
@@ -61,8 +62,6 @@ export async function getFields(fdsView: FDSViewType) {
 	const isObjectSchema =
 		responseJSON.components.schemas[restSchema].xml.name === 'ObjectEntry';
 
-	const localizablePropertySuffix = '_i18n';
-
 	Object.keys(properties).map((propertyKey) => {
 		const propertyValue = properties[propertyKey];
 
@@ -74,17 +73,18 @@ export async function getFields(fdsView: FDSViewType) {
 			return;
 		}
 
-		if (propertyKey.includes(localizablePropertySuffix)) {
-			return;
-		}
-
-		if (propertyValue.additionalProperties) {
+		if (propertyKey.includes(LOCALIZABLE_PROPERTY_SUFFIX)) {
 			return;
 		}
 
 		const type = propertyValue.type;
 
-		if (type === 'array') {
+		const isAFieldProperty =
+			isObjectSchema &&
+			propertyValue.extensions['x-parent-map'] &&
+			propertyValue.extensions['x-parent-map'] === 'properties';
+
+		if (type === 'array' || (type === 'object' && !isAFieldProperty)) {
 			return;
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -61,6 +61,8 @@ export async function getFields(fdsView: FDSViewType) {
 	const isObjectSchema =
 		responseJSON.components.schemas[restSchema].xml.name === 'ObjectEntry';
 
+	const localizablePropertySuffix = '_i18n';
+
 	Object.keys(properties).map((propertyKey) => {
 		const propertyValue = properties[propertyKey];
 
@@ -71,12 +73,6 @@ export async function getFields(fdsView: FDSViewType) {
 		if (propertyKey === 'x-class-name') {
 			return;
 		}
-
-		// Filter <field_name>_i18n properties from the UI
-		// We only need the <field_name> property for the field selection
-		// and hide the _i18n that shows the internals
-
-		const localizablePropertySuffix = '_i18n';
 
 		if (propertyKey.includes(localizablePropertySuffix)) {
 			return;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -20,11 +20,56 @@ import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';
 
 const LOCALIZABLE_PROPERTY_SUFFIX = '_i18n';
+
+const NOT_ALLOWED_KEYS_AS_FIELD_NAME = ['x-class-name', 'x-schema-name'];
+
 interface IField {
 	format: string;
 	label: string;
 	name: string;
 	type: string;
+}
+
+function getValidFields(
+	properties: any,
+	isObjectSchema: boolean
+): Array<IField> {
+	const fields: Array<IField> = [];
+
+	Object.keys(properties).map((propertyKey) => {
+		const propertyValue = properties[propertyKey];
+
+		if (isObjectSchema && !propertyValue.extensions) {
+			return;
+		}
+
+		if (NOT_ALLOWED_KEYS_AS_FIELD_NAME.includes(propertyKey)) {
+			return;
+		}
+
+		if (propertyKey.includes(LOCALIZABLE_PROPERTY_SUFFIX)) {
+			return;
+		}
+
+		const type = propertyValue.type;
+
+		if (type === 'array') {
+			return;
+		}
+
+		if (propertyValue.$ref) {
+			return;
+		}
+
+		fields.push({
+			format: properties[propertyKey].format || type,
+			label: propertyKey,
+			name: propertyKey,
+			type,
+		});
+	});
+
+	return fields;
 }
 
 export async function getFields(fdsView: FDSViewType) {
@@ -57,48 +102,13 @@ export async function getFields(fdsView: FDSViewType) {
 		return [];
 	}
 
-	const fieldsArray: Array<IField> = [];
-
 	const isObjectSchema =
 		responseJSON.components.schemas[restSchema].xml.name === 'ObjectEntry';
 
-	Object.keys(properties).map((propertyKey) => {
-		const propertyValue = properties[propertyKey];
-
-		if (isObjectSchema && !propertyValue.extensions) {
-			return;
-		}
-
-		if (propertyKey === 'x-class-name') {
-			return;
-		}
-
-		if (propertyKey.includes(LOCALIZABLE_PROPERTY_SUFFIX)) {
-			return;
-		}
-
-		const type = propertyValue.type;
-
-		const isAFieldProperty =
-			isObjectSchema &&
-			propertyValue.extensions['x-parent-map'] &&
-			propertyValue.extensions['x-parent-map'] === 'properties';
-
-		if (type === 'array' || (type === 'object' && !isAFieldProperty)) {
-			return;
-		}
-
-		if (propertyValue.$ref) {
-			return;
-		}
-
-		fieldsArray.push({
-			format: properties[propertyKey].format || type,
-			label: propertyKey,
-			name: propertyKey,
-			type,
-		});
-	});
+	const fieldsArray: Array<IField> = getValidFields(
+		properties,
+		isObjectSchema
+	);
 
 	return fieldsArray;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -21,7 +21,12 @@ import {FDSViewType} from './FDSViews';
 
 const LOCALIZABLE_PROPERTY_SUFFIX = '_i18n';
 
-const NOT_ALLOWED_KEYS_AS_FIELD_NAME = ['x-class-name', 'x-schema-name'];
+const NOT_ALLOWED_KEYS_AS_FIELD_NAME = [
+	'actions',
+	'scopeKey',
+	'x-class-name',
+	'x-schema-name',
+];
 
 interface IField {
 	format: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -35,18 +35,11 @@ interface IField {
 	type: string;
 }
 
-function getValidFields(
-	properties: any,
-	isObjectSchema: boolean
-): Array<IField> {
+function getValidFields(properties: any): Array<IField> {
 	const fields: Array<IField> = [];
 
 	Object.keys(properties).map((propertyKey) => {
 		const propertyValue = properties[propertyKey];
-
-		if (isObjectSchema && !propertyValue.extensions) {
-			return;
-		}
 
 		if (NOT_ALLOWED_KEYS_AS_FIELD_NAME.includes(propertyKey)) {
 			return;
@@ -107,13 +100,7 @@ export async function getFields(fdsView: FDSViewType) {
 		return [];
 	}
 
-	const isObjectSchema =
-		responseJSON.components.schemas[restSchema].xml.name === 'ObjectEntry';
-
-	const fieldsArray: Array<IField> = getValidFields(
-		properties,
-		isObjectSchema
-	);
+	const fieldsArray: Array<IField> = getValidFields(properties);
 
 	return fieldsArray;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -92,42 +92,23 @@ export function getValueFromItem(item, fieldName) {
 	return item[fieldName];
 }
 
-export function getCurrentLanguageId() {
-	return (
-		Liferay.ThemeDisplay.getLanguageId() ??
-		Liferay.ThemeDisplay.getBCP47LanguageId() ??
-		Liferay.ThemeDisplay.getDefaultLanguageId()
-	);
-}
-
 export function getValueDetailsFromItem(item, fieldName) {
 	if (!fieldName) {
 		return null;
 	}
 
-	const i18nFieldName = `${fieldName}_i18n`;
+	const i18nRawTextFieldName = `${fieldName}RawText`;
 
 	let rootPropertyName = fieldName;
 	const valuePath = [];
 	let navigatedValue = item;
 
 	if (
-		Object.hasOwn(item, i18nFieldName) &&
-		Object.values(i18nFieldName).length
+		Object.hasOwn(item, i18nRawTextFieldName) &&
+		Object.values(i18nRawTextFieldName).length
 	) {
 		valuePath.push(fieldName);
-
-		// select value from current language key
-		// label_i18n: {'en_US': 'the label', 'fr_FR': 'the fr label'}
-
-		const selectedValue = item[i18nFieldName][getCurrentLanguageId()];
-
-		// get translated text or the first one available
-		// this could happen if the user choose a language but there is no available translation
-
-		navigatedValue = selectedValue
-			? selectedValue
-			: item[i18nFieldName][Object.keys(item[i18nFieldName])[0]];
+		navigatedValue = navigatedValue[i18nRawTextFieldName];
 	}
 	else if (Array.isArray(fieldName)) {
 		rootPropertyName = fieldName[0];

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -92,16 +92,44 @@ export function getValueFromItem(item, fieldName) {
 	return item[fieldName];
 }
 
+export function getCurrentLanguageId() {
+	return (
+		Liferay.ThemeDisplay.getLanguageId() ??
+		Liferay.ThemeDisplay.getBCP47LanguageId() ??
+		Liferay.ThemeDisplay.getDefaultLanguageId()
+	);
+}
+
 export function getValueDetailsFromItem(item, fieldName) {
 	if (!fieldName) {
 		return null;
 	}
 
+	const i18nFieldName = `${fieldName}_i18n`;
+
 	let rootPropertyName = fieldName;
 	const valuePath = [];
 	let navigatedValue = item;
 
-	if (Array.isArray(fieldName)) {
+	if (
+		Object.hasOwn(item, i18nFieldName) &&
+		Object.values(i18nFieldName).length
+	) {
+		valuePath.push(fieldName);
+
+		// select value from current language key
+		// label_i18n: {'en_US': 'the label', 'fr_FR': 'the fr label'}
+
+		const selectedValue = item[i18nFieldName][getCurrentLanguageId()];
+
+		// get translated text or the first one available
+		// this could happen if the user choose a language but there is no available translation
+
+		navigatedValue = selectedValue
+			? selectedValue
+			: item[i18nFieldName][Object.keys(item[i18nFieldName])[0]];
+	}
+	else if (Array.isArray(fieldName)) {
 		rootPropertyName = fieldName[0];
 
 		fieldName.forEach((property) => {


### PR DESCRIPTION
### Goal
Allow users to select any field that available in the API from the Dataset manager **Fields** tab so it can be displayed in the Dataset fragment, with their translations.

### Solution
After enabling the needed feature flags, the solution works fine out of the box, displaying the translated contents when they are available.

Minor changes were needed to:
- avoid filtering `longText` and `richText` fields,
- allow hidding internal fields (`_i18n`)
- check that if a `richText` content is present there is a special `<fieldName>RawText` property that does not store markup.

### Test notes
Having more than one tab open to change the user language and check that changes are applied not always work.

**Note**
Needs the `feature.flag.LPS-146755=true` & `feature.flag.LPS-172017=true` to enable adding translations to object entries.

[Screencast from 2023-07-25 15-46-10.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/7e9f0076-0843-4238-8cb8-815fa8a333be)
