### PR TITLE
LPS-189174 Walkthroughs PoC

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/Constants.tsx
@@ -42,10 +42,46 @@ const FDS_DEFAULT_PROPS = {
 
 const ALLOWED_ENDPOINTS_PARAMETERS = ['scopeKey', 'siteId', 'userId'];
 
+const WALKTHROUGH_CONFIGURATION = {
+	id: 'dataSetEditDescriptionV1',
+	steps: [
+		{
+			content: 'Click here to go to the view page.',
+			id: 'step1ViewPage',
+			nodeToHighlight:
+				'#portlet_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet > div > div > div > div > div > div.container-fluid.container-xl.mt-3 > div.data-set-content-wrapper > ul > li > div.justify-content-center.autofit-col.autofit-col-expand > div > a',
+			onNext(element: HTMLElement) {
+				element.click();
+			},
+			title: 'Visit The View Page',
+		},
+		{
+			content:
+				'Enter any description and click outside of the input to continue.',
+			id: 'step2Description',
+			nodeToHighlight:
+				'#portlet_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet > div > div > div > div:nth-child(2) > div:nth-child(2)',
+			pause: true,
+			title: 'Fill Out A Description',
+		},
+		{
+			content: 'Click here to save your changes.',
+			id: 'step3Save',
+			nodeToHighlight:
+				'#portlet_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet > div > div > div > div.sheet-footer > div > div:nth-child(1) > button',
+			onNext(element: HTMLElement) {
+				element.click();
+			},
+			title: 'Save The View',
+		},
+	],
+};
+
 export {
 	API_URL,
 	FDS_DEFAULT_PROPS,
 	FUZZY_OPTIONS,
 	OBJECT_RELATIONSHIP,
 	ALLOWED_ENDPOINTS_PARAMETERS,
+	WALKTHROUGH_CONFIGURATION,
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -13,9 +13,14 @@ import {
 } from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
 import {fetch, navigate, openModal, openToast} from 'frontend-js-web';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
-import {API_URL, FDS_DEFAULT_PROPS, OBJECT_RELATIONSHIP} from './Constants';
+import {
+	API_URL,
+	FDS_DEFAULT_PROPS,
+	OBJECT_RELATIONSHIP,
+	WALKTHROUGH_CONFIGURATION,
+} from './Constants';
 import {FDSEntryType} from './FDSEntries';
 import RequiredMark from './components/RequiredMark';
 
@@ -204,6 +209,13 @@ const FDSViews = ({
 	fdsViewURL,
 	namespace,
 }: IFDSViewsInterface) => {
+	useEffect(() => {
+
+		// @ts-ignore
+
+		Liferay.Walkthrough.initialize(WALKTHROUGH_CONFIGURATION);
+	}, []);
+
 	const getViewURL = (itemData: FDSViewType) => {
 		const url = new URL(fdsViewURL);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -10,9 +10,9 @@ import ClayLayout from '@clayui/layout';
 import ClayList from '@clayui/list';
 import classNames from 'classnames';
 import {fetch, navigate, openToast} from 'frontend-js-web';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
-import {API_URL} from '../Constants';
+import {API_URL, WALKTHROUGH_CONFIGURATION} from '../Constants';
 import {IFDSViewSectionInterface} from '../FDSView';
 import RequiredMark from '../components/RequiredMark';
 
@@ -26,6 +26,28 @@ const Details = ({
 
 	const fdsViewDescriptionRef = useRef<HTMLInputElement>(null);
 	const fdsViewLabelRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+
+		// @ts-ignore
+
+		Liferay.Walkthrough.initialize(WALKTHROUGH_CONFIGURATION);
+	}, []);
+
+	const handleDescriptionBlur = () => {
+
+		// When input has a value and blurred, show the next step.
+
+		if (fdsViewDescriptionRef.current?.value) {
+
+			// @ts-ignore
+
+			Liferay.Walkthrough.setStep(
+				'dataSetEditDescriptionV1',
+				'step3Save'
+			);
+		}
+	};
 
 	const updateFDSView = async () => {
 		const body = {
@@ -127,6 +149,7 @@ const Details = ({
 					<ClayInput
 						defaultValue={fdsView.description}
 						id={`${namespace}fdsViewDesctiptionInput`}
+						onBlur={handleDescriptionBlur}
 						ref={fdsViewDescriptionRef}
 						type="text"
 					/>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/Constants.d.ts
@@ -37,10 +37,31 @@ declare const FDS_DEFAULT_PROPS: {
 	style: 'fluid';
 };
 declare const ALLOWED_ENDPOINTS_PARAMETERS: string[];
+declare const WALKTHROUGH_CONFIGURATION: {
+	id: string;
+	steps: (
+		| {
+				content: string;
+				id: string;
+				nodeToHighlight: string;
+				onNext(element: HTMLElement): void;
+				title: string;
+				pause?: undefined;
+		  }
+		| {
+				content: string;
+				id: string;
+				nodeToHighlight: string;
+				pause: boolean;
+				title: string;
+		  }
+	)[];
+};
 export {
 	API_URL,
 	FDS_DEFAULT_PROPS,
 	FUZZY_OPTIONS,
 	OBJECT_RELATIONSHIP,
 	ALLOWED_ENDPOINTS_PARAMETERS,
+	WALKTHROUGH_CONFIGURATION,
 };

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java
@@ -55,15 +55,7 @@ public class WalkthroughBottomJSPDynamicInclude implements DynamicInclude {
 				_configurationProvider.getGroupConfiguration(
 					WalkthroughConfiguration.class, group.getGroupId());
 
-			if (!walkthroughConfiguration.enabled()) {
-				return;
-			}
-
 			steps = walkthroughConfiguration.steps();
-
-			if (Validator.isNull(steps)) {
-				return;
-			}
 		}
 		catch (Exception exception) {
 			_log.error(exception);

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/Hotspot.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/Hotspot.js
@@ -3,33 +3,47 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import React, {forwardRef, useCallback, useEffect} from 'react';
+import getCN from 'classnames';
+import React, {forwardRef, useCallback, useEffect, useState} from 'react';
 
 import {useObserveRect} from '../hooks/useObserveRect';
 import {doAlign} from '../utils';
 
-export const Hotspot = forwardRef(({onHotspotClick, trigger}, ref) => {
+export const Hotspot = forwardRef(({nodeToHighlight, onClick}, ref) => {
+
+	/**
+	 * Checks if the hotspot has been aligned. Used to hide the hotspot until
+	 * it is aligned so there isn't a flash of a mispositioned hotspot.
+	 *
+	 * The CSS style `visibility: hidden` is being used to hide the hotspot
+	 * since `doAlign` needs the element to be part of the document otherwise
+	 * it won't properly align.
+	 */
+	const [aligned, setAligned] = useState(false);
+
 	const align = useCallback(() => {
-		if (trigger && ref?.current) {
+		if (nodeToHighlight && ref?.current) {
 			doAlign({
 				points: ['cc', 'tl'],
 				sourceElement: ref.current,
-				targetElement: trigger,
+				targetElement: nodeToHighlight,
 			});
+
+			setAligned(true);
 		}
-	}, [ref, trigger]);
+	}, [ref, nodeToHighlight, setAligned]);
 
 	useEffect(() => {
 		align();
 	}, [align]);
 
-	useObserveRect(align, trigger);
+	useObserveRect(align, nodeToHighlight);
 
 	return (
 		<div
 			aria-label={Liferay.Language.get('start-the-walkthrough')}
-			className="lfr-walkthrough-hotspot"
-			onClick={onHotspotClick}
+			className={getCN('lfr-walkthrough-hotspot', {invisible: !aligned})}
+			onClick={onClick}
 			ref={ref}
 		>
 			<div className="lfr-walkthrough-hotspot-inner" />

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/Step.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/Step.js
@@ -1,0 +1,414 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import {ClayCheckbox} from '@clayui/form';
+import ClayLayout from '@clayui/layout';
+import ClayPopover from '@clayui/popover';
+import {ReactPortal, usePrevious} from '@liferay/frontend-js-react-web';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
+
+import {Hotspot} from '../components/Hotspot';
+import {Overlay} from '../components/Overlay';
+import {useClickOutside} from '../hooks/useClickOutside';
+import {useObserveRect} from '../hooks/useObserveRect';
+import {doAlign} from '../utils';
+
+const OVERLAY_OFFSET_X = 15;
+const OVERLAY_OFFSET_Y = -10;
+
+/**
+ * This map humanize tuples received from dom-align
+ * library to be passed in a format that ClayPopover allows
+ */
+const ALIGNMENTS_MAP = {
+	'bottom': ['tc', 'bc'],
+	'bottom-left': ['tl', 'bl'],
+	'bottom-right': ['tr', 'br'],
+	'left': ['cr', 'cl'],
+	'left-bottom': ['br', 'bl'],
+	'left-top': ['tr', 'tl'],
+	'right': ['cl', 'cr'],
+	'right-bottom': ['bl', 'br'],
+	'right-top': ['tl', 'tr'],
+	'top': ['bc', 'tc'],
+	'top-left': ['bl', 'tl'],
+	'top-right': ['br', 'tr'],
+};
+
+/**
+ * Since we can't set tuples as keys for literal dictionaries
+ * and maps where are some errors with references like a.get(['bc','tc']) => undefined.
+ * We are joining tuples to string to map there and use to lookup in some usages.
+ */
+const ALIGNMENTS_INVERSE_MAP = {
+	bctc: 'top',
+	blbr: 'right-bottom',
+	bltl: 'top-left',
+	brbl: 'left-bottom',
+	brtr: 'top-right',
+	clcr: 'right',
+	crcl: 'left',
+	tcbc: 'bottom',
+	tlbl: 'bottom-left',
+	tltr: 'right-top',
+	trbr: 'bottom-right',
+	trtl: 'left-top',
+};
+
+/**
+ * This map matches with new positions when the positioning has been given by the user or the default positioning fails.
+ *
+ * For example, if we receive on ALIGNMENTS_INVERSE_MAP, a lookup for brtr,
+ * it points to 'top-right'. Here, at the ALIGNMENTS_GUESS_MAP,
+ * we should make corrections if the positioning cannot be achieved in this case, for brtr.
+ *
+ * A general rule was applied:
+ * If the received INVERSE value is top or top something, we should place it to bottom, and vice-versa for bottom and bottom something.
+ * If the received INVERSE value is right, it should place to left, and vice-versa.
+ * We should remove guesses from the top since people will not place things on top that will collide at the beginning of the viewport.
+ */
+const ALIGNMENTS_GUESS_MAP = {
+	...ALIGNMENTS_INVERSE_MAP,
+	blbr: 'top',
+	brbl: 'top',
+	clcr: 'left',
+	crcl: 'right',
+	tcbc: 'top',
+	tlbl: 'top',
+	tltr: 'top',
+	trbr: 'top',
+};
+
+let walkthroughExceptionShown = false;
+
+/**
+ * Gets the node to highlight element and prints a warning in the console if
+ * one isn't found.
+ * @param {string} nodeToHighlightSelector A query selector.
+ * @returns {Element|null}
+ */
+const getNodeToHighlight = (nodeToHighlightSelector) => {
+	const selectedElement = document.querySelector(nodeToHighlightSelector);
+
+	if (selectedElement) {
+		return selectedElement;
+	}
+
+	// Only show the warning once.
+
+	if (!walkthroughExceptionShown) {
+		console.warn(
+			`Walkthrough Exception: ${nodeToHighlightSelector} element for highlight does not exist in DOM`
+		);
+
+		walkthroughExceptionShown = true;
+	}
+
+	return null;
+};
+
+/**
+ * Checks if a determining element is inside the viewport
+ * @param {Node} element Element to be checked
+ * @param {ClientRect} maybeRect boundingClientRect
+ * of the element for avoiding calling getBoundingClientRect again.
+ * This operation is very costly for browsers.
+ * @returns {boolean}
+ */
+function isVisibleInViewport(element, maybeRect) {
+	let boundingRect = maybeRect;
+
+	if (!boundingRect) {
+		boundingRect = element.getBoundingClientRect();
+	}
+
+	return (
+		boundingRect.top >= 0 &&
+		boundingRect.left >= 0 &&
+		boundingRect.bottom <=
+			(window.innerHeight || document.documentElement.clientHeight) &&
+		boundingRect.right <=
+			(window.innerWidth || document.documentElement.clientWidth)
+	);
+}
+
+/**
+ * Displays a hotspot and popover aligned to the `nodeToHighlightSelector`.
+ *
+ * This component should focus on the display and the functionality of aligning
+ * the hotspot and popover.
+ */
+function Step({
+	closeOnClickOutside = false,
+	closeable = true,
+	content,
+	currentStepIndex,
+	darkbg = true,
+	nodeToHighlightSelector,
+	onNextClick = () => {},
+	onPopoverVisibleChange = () => {},
+	onPreviousClick = () => {},
+	popoverVisible = false,
+	initialPopoverAlignPosition = 'right-top',
+	skippable = true,
+	title,
+	totalStepCount,
+}) {
+	const [popoverAlignPosition, setPopoverAlignPosition] = useState(
+		initialPopoverAlignPosition
+	);
+	const [doNotShowMeThisAgainValue, setDoNotShowMeThisAgainValue] = useState(
+		false
+	);
+	const [nodeToHighlight, setNodeToHighlight] = useState(() =>
+		getNodeToHighlight(nodeToHighlightSelector)
+	);
+
+	const hotspotRef = useRef(null);
+	const popoverRef = useRef(null);
+
+	const previousNodeToHighlight = usePrevious(nodeToHighlight);
+
+	/**
+	 * Find and keep `nodeToHighlight` up-to-date.
+	 *
+	 * Creates a Mutation Observer to continually check if element exists. This
+	 * will keep `nodeToHighlight` accurate if the element is ever added or
+	 * removed from the page.
+	 */
+	useEffect(() => {
+		if (nodeToHighlightSelector) {
+
+			// Reset popoverAlignPosition, otherwise the value from a previous
+			// or next step could be carried over.
+
+			setPopoverAlignPosition(initialPopoverAlignPosition);
+
+			// Update nodeToHighlight if an element is found.
+
+			setNodeToHighlight(getNodeToHighlight(nodeToHighlightSelector));
+
+			// Initialize MutationObserver for continual changes in the DOM.
+
+			const observer = new MutationObserver(() => {
+				const selectedElement = document.querySelector(
+					nodeToHighlightSelector
+				);
+
+				if (selectedElement) {
+					setNodeToHighlight(selectedElement);
+				}
+				else {
+					setNodeToHighlight(null);
+				}
+			});
+
+			observer.observe(document.body, {
+				attributes: true,
+				childList: true,
+				subtree: true,
+			});
+
+			return () => {
+				observer.disconnect();
+			};
+		}
+	}, [initialPopoverAlignPosition, nodeToHighlightSelector]);
+
+	/**
+	 * Performs the following:
+	 * - Aligns the positioning of the hotspot and popover. Finds the
+	 * appropriate side to display the popover where space allows.
+	 * - If darkbg = false, a shadow around the nodeToHighlight is added and the
+	 * shadow from the previous nodeToHighlight is removed.
+	 * - Scrolls to the popover if the popover isn't visible in the viewport.
+	 */
+	const align = useCallback(
+		(boundingRect) => {
+			if (popoverVisible && popoverRef.current && nodeToHighlight) {
+				const points = ALIGNMENTS_MAP[popoverAlignPosition];
+
+				const alignment = doAlign({
+					offset: [OVERLAY_OFFSET_X, OVERLAY_OFFSET_Y],
+					overflow: {
+						adjustX: true,
+						adjustY: true,
+					},
+					points,
+					sourceElement: popoverRef.current,
+					targetElement: nodeToHighlight,
+				});
+
+				const alignmentString = alignment.points.join('');
+
+				const pointsString = points.join('');
+
+				if (alignment.overflow.adjustX) {
+					setPopoverAlignPosition(
+						ALIGNMENTS_GUESS_MAP[alignmentString]
+					);
+				}
+				else if (pointsString !== alignmentString) {
+					setPopoverAlignPosition(
+						ALIGNMENTS_INVERSE_MAP[alignmentString]
+					);
+				}
+
+				if (!darkbg) {
+					nodeToHighlight?.classList.add(
+						'lfr-walkthrough-element-shadow'
+					);
+
+					if (
+						previousNodeToHighlight &&
+						nodeToHighlight !== previousNodeToHighlight
+					) {
+						previousNodeToHighlight?.classList.remove(
+							'lfr-walkthrough-element-shadow'
+						);
+					}
+				}
+
+				if (!isVisibleInViewport(popoverRef.current, boundingRect)) {
+					popoverRef.current.scrollIntoView();
+				}
+			}
+		},
+		[
+			darkbg,
+			nodeToHighlight,
+			popoverAlignPosition,
+			previousNodeToHighlight,
+			popoverVisible,
+		]
+	);
+
+	useEffect(() => {
+		align();
+	}, [align]);
+
+	useObserveRect(align, popoverRef?.current);
+
+	useClickOutside(
+		['.lfr-walkthrough-popover', '.lfr-walkthrough-hotspot'],
+		() => {
+			if (closeOnClickOutside) {
+				onPopoverVisibleChange(false);
+			}
+		}
+	);
+
+	if (!nodeToHighlight) {
+		return null;
+	}
+
+	if (!popoverVisible) {
+		return (
+			<Hotspot
+				nodeToHighlight={nodeToHighlight}
+				onClick={() => onPopoverVisibleChange(true)}
+				ref={hotspotRef}
+			/>
+		);
+	}
+
+	return (
+		<>
+			{darkbg && (
+				<Overlay
+					popoverVisible={popoverVisible}
+					trigger={nodeToHighlight}
+				/>
+			)}
+
+			<ReactPortal>
+				<ClayPopover
+					alignPosition={popoverAlignPosition}
+					className="lfr-walkthrough-popover"
+					displayType="secondary"
+					header={
+						<ClayLayout.ContentRow noGutters verticalAlign="center">
+							<ClayLayout.ContentCol expand>
+								{/* @TODO: Use language key */}
+
+								<span>{`Step ${
+									currentStepIndex + 1
+								} of ${totalStepCount}: ${title}`}</span>
+							</ClayLayout.ContentCol>
+
+							{closeable && (
+								<ClayLayout.ContentCol>
+									<ClayButtonWithIcon
+										aria-label={Liferay.Language.get(
+											'close'
+										)}
+										className="close"
+										displayType="unstyled"
+										onClick={() =>
+											onPopoverVisibleChange(false)
+										}
+										small
+										symbol="times"
+									/>
+								</ClayLayout.ContentCol>
+							)}
+						</ClayLayout.ContentRow>
+					}
+					onShowChange={onPopoverVisibleChange}
+					ref={popoverRef}
+					show={popoverVisible}
+					size="lg"
+				>
+					<div
+						dangerouslySetInnerHTML={{
+							__html: content,
+						}}
+					/>
+
+					<ClayLayout.ContentRow noGutters verticalAlign="center">
+						{skippable && (
+							<ClayLayout.ContentCol expand>
+								<ClayCheckbox
+									checked={doNotShowMeThisAgainValue}
+									label={Liferay.Language.get(
+										'do-not-show-me-this-again'
+									)}
+									onChange={() => {
+										setDoNotShowMeThisAgainValue(
+											!doNotShowMeThisAgainValue
+										);
+									}}
+								/>
+							</ClayLayout.ContentCol>
+						)}
+
+						<ClayLayout.ContentCol>
+							<ClayButton.Group spaced>
+								{currentStepIndex > 0 && (
+									<ClayButton
+										displayType="secondary"
+										onClick={onPreviousClick}
+										small
+									>
+										{Liferay.Language.get('previous')}
+									</ClayButton>
+								)}
+
+								<ClayButton onClick={onNextClick} small>
+									{currentStepIndex + 1 !== totalStepCount
+										? Liferay.Language.get('ok')
+										: Liferay.Language.get('close')}
+								</ClayButton>
+							</ClayButton.Group>
+						</ClayLayout.ContentCol>
+					</ClayLayout.ContentRow>
+				</ClayPopover>
+			</ReactPortal>
+		</>
+	);
+}
+
+export default Step;

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/WalkthroughPOC.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/components/WalkthroughPOC.js
@@ -1,0 +1,261 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import './Walkthrough.scss';
+
+import React, {useEffect, useState} from 'react';
+
+import {useLocalStorage} from '../hooks/useLocalStorage';
+import Step from './Step';
+
+/**
+ * Gets the step configuration and index for the matching step id.
+ * Index is used to show the step count in the title (i.e. "Step 1 of 2") and
+ * to easily get the next or previous step like `stepIndex + 1`.
+ * @param {object} walkthroughConfiguration
+ * @param {number} stepId
+ * @returns {Array} [stepConfiguration, stepIndex]
+ */
+function getStepConfiguration(walkthroughConfiguration, stepId) {
+	if (!walkthroughConfiguration) {
+		return [null, 0];
+	}
+
+	const stepIndex = walkthroughConfiguration?.steps?.findIndex(
+		(stepConfiguration) => stepConfiguration.id === stepId
+	);
+
+	const stepConfiguration = walkthroughConfiguration?.steps?.[stepIndex];
+
+	if (stepConfiguration) {
+		return [stepConfiguration, stepIndex];
+	}
+
+	// If no matching step ID is found, return the first step.
+
+	return [walkthroughConfiguration?.steps?.[0], 0];
+}
+
+/**
+ * Gets the walkthrough state with the matching ID.
+ * @param {object} walkthroughStates Local storage walkthrough states.
+ * @param {string} walkthroughId ID defined in the walkthrough configuration.
+ * @return {object} A walkthrough state object.
+ */
+function getWalkthroughState(walkthroughStates, walkthroughId) {
+	return walkthroughStates.find(
+		(walkthroughState) => walkthroughState.id === walkthroughId
+	);
+}
+
+/**
+ * Displays the walkthrough defined by the `walkthroughConfiguration` state.
+ *
+ * This component focuses on managing the walkthrough state and using the
+ * correct walkthrough configuration when there are multiple walkthroughs.
+ */
+function Walkthrough({configuration}) {
+	const [walkthroughStates, setWalkthroughStates] = useLocalStorage(
+		`${themeDisplay.getUserId()}-walkthroughStates`,
+		[]
+	);
+
+	const [walkthroughConfiguration, setWalkthroughConfiguration] = useState(
+		configuration
+	);
+
+	const currentWalkthroughState = getWalkthroughState(
+		walkthroughStates,
+		walkthroughConfiguration?.id
+	);
+
+	const [currentStepConfiguration, currentStepIndex] = getStepConfiguration(
+		walkthroughConfiguration,
+		currentWalkthroughState?.currentStep
+	);
+
+	/**
+	 * A helper function to update the walkthrough state for the current
+	 * walkthrough by finding the matching ID and merging with the passed-in
+	 * `newConfiguration` object.
+	 * @param {object} newConfiguration
+	 */
+	const updateWalkthroughStates = (newConfiguration) => {
+		setWalkthroughStates(
+			walkthroughStates.map((walkthrough) => {
+				if (walkthrough.id === currentWalkthroughState?.id) {
+					return {
+						...walkthrough,
+						...newConfiguration,
+					};
+				}
+				else {
+					return walkthrough;
+				}
+			})
+		);
+	};
+
+	/**
+	 * When the "next" button is clicked in the Step popover.
+	 */
+	const handleNextClick = () => {
+		if (isLastStep()) {
+			updateWalkthroughStates({dismissed: true, popoverVisible: false});
+		}
+		else {
+			const nextIndex = currentStepIndex + 1;
+
+			const nextStepConfiguration =
+				walkthroughConfiguration?.steps?.[nextIndex];
+
+			if (nextStepConfiguration) {
+				if (currentStepConfiguration.pause) {
+					updateWalkthroughStates({
+						paused: true,
+					});
+				}
+				else {
+					updateWalkthroughStates({
+						currentStep: nextStepConfiguration.id,
+					});
+				}
+			}
+		}
+
+		// Perform `onNext` function if defined.
+
+		if (typeof currentStepConfiguration.onNext === 'function') {
+			currentStepConfiguration.onNext(
+				document.querySelector(currentStepConfiguration.nodeToHighlight)
+			);
+		}
+	};
+
+	/**
+	 * Update the walkthrough state when popover is opened or closed.
+	 */
+	const handlePopoverVisibleChange = (value) => {
+		updateWalkthroughStates({
+			popoverVisible: value,
+		});
+	};
+
+	/**
+	 * When the "previous" button is clicked in the Step popover.
+	 */
+	const handlePreviousClick = () => {
+		const previousIndex = currentStepIndex - 1;
+
+		const previousStepConfiguration =
+			walkthroughConfiguration?.steps?.[previousIndex];
+
+		if (previousStepConfiguration) {
+			updateWalkthroughStates({
+				currentStep: previousStepConfiguration.id,
+			});
+		}
+	};
+
+	/**
+	 * If the current step is the last step.
+	 * @returns {boolean}
+	 */
+	const isLastStep = () => {
+		return currentStepIndex + 1 >= walkthroughConfiguration?.steps?.length;
+	};
+
+	/**
+	 * Setup event handlers for Liferay.Walkthrough functions.
+	 */
+	useEffect(() => {
+
+		/**
+		 * Adds a new walkthrough state object if one doesn't exist yet.
+		 */
+		function handleInitialize({configuration}) {
+			const walkthroughIdExists = walkthroughStates.some(
+				(walkthroughState) => walkthroughState.id === configuration.id
+			);
+
+			if (!walkthroughIdExists) {
+				setWalkthroughStates([
+					...walkthroughStates,
+					{
+						dismissed: false,
+						id: configuration.id,
+						paused: false,
+						popoverVisible: false,
+					},
+				]);
+			}
+
+			// Set configuration if it isn't dismissed.
+
+			const walkthroughState = getWalkthroughState(
+				walkthroughStates,
+				configuration.id
+			);
+
+			if (!walkthroughState?.dismissed || !walkthroughState) {
+				setWalkthroughConfiguration(configuration);
+			}
+		}
+
+		/**
+		 * Finds the matching walkthrough ID and replaces the current step ID.
+		 */
+		function handleSetStep({stepId, walkthroughId}) {
+			setWalkthroughStates(
+				walkthroughStates.map((walkthrough) => {
+					if (walkthrough.id === walkthroughId) {
+						return {
+							...walkthrough,
+							currentStep: stepId,
+							paused: false,
+							popoverVisible: true,
+						};
+					}
+					else {
+						return walkthrough;
+					}
+				})
+			);
+		}
+
+		Liferay.on('walkthroughInitialize', handleInitialize);
+		Liferay.on('walkthroughSetStep', handleSetStep);
+
+		return () => {
+			Liferay.detach('walkthroughInitialize', handleInitialize);
+			Liferay.detach('walkthroughSetStep', handleSetStep);
+		};
+	}, [walkthroughStates, setWalkthroughStates]);
+
+	if (currentWalkthroughState?.dismissed || currentWalkthroughState?.paused) {
+		return null;
+	}
+
+	return (
+		<Step
+			closeOnClickOutside={walkthroughConfiguration?.closeOnClickOutside}
+			closeable={walkthroughConfiguration?.closeable}
+			content={currentStepConfiguration?.content}
+			currentStepIndex={currentStepIndex}
+			darkbg={walkthroughConfiguration?.darkbg}
+			initialPopoverAlignPosition={currentStepConfiguration?.positioning}
+			nodeToHighlightSelector={currentStepConfiguration?.nodeToHighlight}
+			onNextClick={handleNextClick}
+			onPopoverVisibleChange={handlePopoverVisibleChange}
+			onPreviousClick={handlePreviousClick}
+			popoverVisible={currentWalkthroughState?.popoverVisible}
+			skippable={walkthroughConfiguration?.skippable}
+			title={currentStepConfiguration?.title}
+			totalStepCount={walkthroughConfiguration?.steps?.length}
+		/>
+	);
+}
+
+export default Walkthrough;

--- a/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
+++ b/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/resources/META-INF/resources/index.js
@@ -4,11 +4,9 @@
  */
 
 import {render} from '@liferay/frontend-js-react-web';
-import {localStorage} from 'frontend-js-web';
 import React from 'react';
 
-import Walkthrough from './components/Walkthrough';
-import {LOCAL_STORAGE_KEYS} from './utils';
+import Walkthrough from './components/WalkthroughPOC';
 
 const DEFAULT_CONTAINER_ID = 'walkthroughContainer';
 
@@ -25,16 +23,7 @@ const getDefaultContainer = () => {
 };
 
 function Root(props) {
-	if (
-		!localStorage.getItem(
-			LOCAL_STORAGE_KEYS.SKIPPABLE,
-			localStorage.TYPES.NECESSARY
-		)
-	) {
-		return <Walkthrough {...props} />;
-	}
-
-	return null;
+	return <Walkthrough {...props} />;
 }
 
 export default function main(props = {}) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -93,6 +93,7 @@ import toggleControls from './util/toggle_controls';
 import toggleDisabled from './util/toggle_disabled';
 import toggleRadio from './util/toggle_radio';
 import toggleSelectBox from './util/toggle_select_box';
+import Walkthrough from './util/walkthrough/walkthrough';
 import zIndex from './zIndex';
 
 Liferay = window.Liferay || {};
@@ -360,5 +361,7 @@ Liferay.Util.Cookie = Cookie;
 
 Liferay.Util.LocalStorage = localStorage;
 Liferay.Util.SessionStorage = sessionStorage;
+
+Liferay.Walkthrough = Walkthrough;
 
 export {portlet};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/walkthrough/walkthrough.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/walkthrough/walkthrough.js
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+function initialize(configuration) {
+	Liferay.fire('walkthroughInitialize', {configuration});
+}
+
+function setStep(walkthroughId, stepId) {
+	Liferay.fire('walkthroughSetStep', {stepId, walkthroughId});
+}
+
+export default {initialize, setStep};


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-186948

## Demo: Multi-page walkthrough with pause in a react app
Here's a demo of a walkthrough being used in the Data Set react app. It's able to show the popover in a react app, navigate between pages, and wait for a description to be added before resuming.

https://github.com/liferay-frontend/liferay-portal/assets/4496722/b4785221-3dbe-43a1-98f8-cc2e6d07b0ab

**See the demo code:** https://github.com/liferay-frontend/liferay-portal/pull/3545/commits/ab24e6d92fe3e997357889c9eb9f7b50a1b2849f

- `Liferay.Walkthrough.initialize` is used to start the walkthrough and define the steps.
  - To handle multiple pages, `Liferay.Walkthrough.initialize` must be called on each page with the same configuration.
- `onNext` is used to interact with elements on the page. `element` is the `nodeToHighlight` element selected.
- `pause: true` is used to stop the walkthrough. 
- To resume, `Liferay.Walkthrough.setStep('dataSetEditDescriptionV1','step3Save');` is called

## Brief rundown on the current walkthough structure

- This walkthrough component is added to every page through [WalkthroughBottomJSPDynamicInclude.java](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-walkthrough-web/src/main/java/com/liferay/frontend/js/walkthrough/web/internal/servlet/taglib/WalkthroughBottomJSPDynamicInclude.java)
- In the UI, a site-level walkthrough configuration is set in Product Menu > Configuration > Site Settings > Walkthrough
![Screenshot 2023-07-21 at 8 48 09 PM](https://github.com/liferay-frontend/liferay-portal/assets/4496722/8ffca228-cd7a-4dfb-8ddf-c1bf13a3a5ba)
- Local storage used to keep track of the current step and if the walkthrough was completed
  - `${themeDisplay.getUserId()}-walkthrough-current-step`
  - `${themeDisplay.getUserId()}-walkthrough-popover-visible`
  - `${themeDisplay.getUserId()}-${themeDisplay.getSiteGroupId()}-walkthrough-dismissed`

## Dev details for your thoughts

- Local storage is used to keep track of current walkthrough states (if there are multiple walkthroughs in progress) 
![Screenshot 2023-08-03 at 7 12 05 PM](https://github.com/liferay-frontend/liferay-portal/assets/4496722/eb3b8c6d-d35e-4297-ae71-dd346c528f06)
- Events are used to update the local storage [(See listeners in the walkthrough component)](https://github.com/liferay-frontend/liferay-portal/pull/3545/commits/5b26fb77871e27b5250876f8d6375905ada82a8c#diff-a83ae377658f3b63f51444643dba45863f8b3cdacd3fab23d0d00ee7a5030689R170-R235)
- To handle elements that are added/removed from the page, a Mutation Observer is used. I'll have to look into making it more performant, but right now it's constantly doing a `querySelector` to know if a hotspot can be added or removed. [(See code)](https://github.com/liferay-frontend/liferay-portal/pull/3545/commits/5b26fb77871e27b5250876f8d6375905ada82a8c#diff-101789a8a3f16d01ddccb287511649a249f280ed87d8c4476260760a1e71afdbR175-R219)
- Instead of using `pages` `next` `previous` to handle navigation, I was thinking using `onPrevious` and `onNext` could satisfy the same requirements while making the order of the steps more clear and flexible to do more functionality like clicking on buttons on the page. (See the confluence doc below for a comparison)

[Link to confluence doc with more details about the comparison between the current and proposed API](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/2428108823/LPS-186948+-+Research+ways+to+enable+breakpoints+for+walkthroughs#API)