### PR TITLE
LPS-190100 - Add the `disableIncompatibleActions` API to the clay:management-toolbar

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -239,6 +239,7 @@ public class DLAdminManagementToolbarDisplayContext
 				dropdownItem.setIcon("password-policies");
 				dropdownItem.setLabel(
 					LanguageUtil.get(_httpServletRequest, "permissions"));
+				dropdownItem.setMultipleTypesBulkActionDisabled(true);
 				dropdownItem.setQuickAction(false);
 			}
 		).build();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/DropdownItem.java
@@ -22,6 +22,12 @@ public class DropdownItem extends NavigationItem {
 		put("key", key);
 	}
 
+	public void setMultipleTypesBulkActionDisabled(
+		Boolean multipleTypesBulkActionDisabled) {
+
+		put("multipleTypesBulkActionDisabled", multipleTypesBulkActionDisabled);
+	}
+
 	public void setQuickAction(boolean quickAction) {
 		put("quickAction", quickAction);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1514,6 +1514,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description></description>
+			<name>disableIncompatibleActions</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>managementToolbarDisplayContext</code>]]>.</description>
 			<name>displayContext</name>
 			<required>false</required>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/liferay-clay.tld
@@ -1514,12 +1514,6 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description></description>
-			<name>disableIncompatibleActions</name>
-			<required>false</required>
-			<rtexprvalue>true</rtexprvalue>
-		</attribute>
-		<attribute>
 			<description>Deprecated as of 7.4.0, replaced by the attribute <![CDATA[<code>managementToolbarDisplayContext</code>]]>.</description>
 			<name>displayContext</name>
 			<required>false</required>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -29,14 +29,7 @@ function disableActionIfNeeded(item, event, bulkSelection) {
 		return {
 			...item,
 			items: item.items?.map((child) =>
-				disableActionIfNeeded(
-					child,
-					event,
-					bulkSelection
-
-					// incompatibleSelection
-
-				)
+				disableActionIfNeeded(child, event, bulkSelection)
 			),
 		};
 	}


### PR DESCRIPTION
Refactor of https://github.com/liferay-frontend/liferay-portal/pull/3533

The previous PR implemented a specific solution for Document & Media, but we wanted an API that would allow developers to disable incompatible actions from the Management Toolbar dropdown.