### PR TITLE
LPS-191694 Migrate printpage function to frontend-js-web

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -275,8 +275,23 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 						>
 
 							<%
-							String id = assetEntry.getEntryId() + StringUtil.randomId();
 							String label = LanguageUtil.format(request, "print-x", HtmlUtil.escape(title));
+
+							String printPageURL = PortletURLBuilder.createRenderURL(
+								renderResponse
+							).setMVCPath(
+								"/view_content.jsp"
+							).setParameter(
+								"assetEntryId", assetEntry.getEntryId()
+							).setParameter(
+								"languageId", LanguageUtil.getLanguageId(request)
+							).setParameter(
+								"type", assetRendererFactory.getType()
+							).setParameter(
+								"viewMode", Constants.PRINT
+							).setWindowState(
+								LiferayWindowState.POP_UP
+							).buildString();
 							%>
 
 							<clay:button
@@ -284,36 +299,11 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 								borderless="<%= true %>"
 								displayType="secondary"
 								icon="print"
-								onClick='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage_" + id + "();" %>'
+								onClick='<%= "Liferay.Util.printPage('" + printPageURL + "')" %>'
 								small="<%= true %>"
 								title="<%= label %>"
 								type="button"
 							/>
-
-							<aui:script>
-								function <portlet:namespace />printPage_<%= id %>() {
-									window.open(
-										'<%=
-										PortletURLBuilder.createRenderURL(
-											renderResponse
-										).setMVCPath(
-											"/view_content.jsp"
-										).setParameter(
-											"assetEntryId", assetEntry.getEntryId()
-										).setParameter(
-											"languageId", LanguageUtil.getLanguageId(request)
-										).setParameter(
-											"type", assetRendererFactory.getType()
-										).setParameter(
-											"viewMode", Constants.PRINT
-										).setWindowState(
-											LiferayWindowState.POP_UP
-										).buildPortletURL() %>',
-										'',
-										'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-									);
-								}
-							</aui:script>
 						</clay:content-col>
 					</c:if>
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -90,6 +90,7 @@ import createActionURL from './util/portlet_url/create_action_url.es';
 import createPortletURL from './util/portlet_url/create_portlet_url.es';
 import createRenderURL from './util/portlet_url/create_render_url.es';
 import createResourceURL from './util/portlet_url/create_resource_url.es';
+import printPage from './util/print_page';
 import removeEntitySelection from './util/remove_entity_selection';
 import selectFolder from './util/select_folder';
 import {getSessionValue, setSessionValue} from './util/session.es';
@@ -369,5 +370,7 @@ Liferay.Util.Cookie = Cookie;
 
 Liferay.Util.LocalStorage = localStorage;
 Liferay.Util.SessionStorage = sessionStorage;
+
+Liferay.Util.printPage = printPage;
 
 export {portlet};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/print_page.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/print_page.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const DEFAULT_OPTIONS = {
+	directories: 0,
+	height: 480,
+	left: 80,
+	location: 1,
+	menubar: 1,
+	resizable: 1,
+	scrollbars: 'yes',
+	status: 0,
+	toolbar: 0,
+	top: 180,
+	width: 640,
+};
+
+export default function printPage(url, options = DEFAULT_OPTIONS) {
+	const nextOptions = {
+		...DEFAULT_OPTIONS,
+		...options,
+	};
+
+	let stringOptions = '';
+
+	Object.keys(nextOptions).map((key) => {
+		stringOptions += key + '=' + nextOptions[key] + ',';
+	});
+
+	window.open(url, '', stringOptions);
+}

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/print.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/print.jsp
@@ -49,21 +49,11 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 				borderless="<%= true %>"
 				displayType="secondary"
 				icon="print"
-				onClick='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
+				onClick='<%= "Liferay.Util.printPage('" + printPageURL + "')" %>'
 				small="<%= true %>"
 				title="<%= title %>"
 				type="button"
 			/>
 		</clay:content-col>
-
-		<aui:script>
-			function <portlet:namespace />printPage() {
-				window.open(
-					'<%= printPageURL %>',
-					'',
-					'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-				);
-			}
-		</aui:script>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -202,17 +202,6 @@ if (portletTitleBasedNavigation) {
 								print();
 							</aui:script>
 						</c:when>
-						<c:otherwise>
-							<aui:script>
-								function <portlet:namespace />printPage() {
-									window.open(
-										'<%= printPageURL %>',
-										'',
-										'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-									);
-								}
-							</aui:script>
-						</c:otherwise>
 					</c:choose>
 
 					<liferay-util:include page="/wiki/top_links.jsp" servletContext="<%= application %>" />
@@ -319,7 +308,7 @@ if (portletTitleBasedNavigation) {
 								label="<%= true %>"
 								markupView="lexicon"
 								message="print"
-								url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
+								url='<%= "javascript:Liferay.Util.printPage('" + printPageURL + "')" %>'
 							/>
 						</div>
 					</c:if>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-191386)

Motivation
======
We have noticed that the function printPage it's been used in several components, so we think that it would be more effective to move this function to a place where it can be reused by other components so we can avoid duplicating code.

## Proposed solution
I have created the file print_page.js and moved the code there. Firstly, I have created a DEFAULT_OPTIONS object to store the options of the window.open() function. Then, I have added the nextOptions object in case we want to pass non default values in the future, because all the use cases in the portal use the same configuration, I have created the nextOptions object just in case we want to change it in the future. Then I have converted the nextOptions object to a String, because the window.open() function only accepts strings as the options parameter.

### Steps to verify functionality 
**- Asset Publisher**
    1. Go to Site Builder > Pages > create a Content Page 
    2. Add an Asset Publisher to the web 
    3. Click on the Asset Publisher and go to it’s Configuration 
    4. In Setup > Asset Selection > Manual 
    5. In Asset Entries > Basic Document > select a document
    6. In Display Settings > Display Template > Abstracts > Publish page
    7. Go to the page view > below the picture, click on the print icon

**- For the other one case, follow the steps until 5**
    1. In Display Settings > Display Template > Full content > Publish page
    2. Go to the page view > below the picture, click on the print icon
![asset_publisher_web](https://github.com/liferay-frontend/liferay-portal/assets/91208451/17edb91b-2aae-4eda-8fa0-a031442b0ae8)

**- Journal Content** 
    1. Go to Content & Data > Web Content
    2. Create a Web Content and add a description > Publish
    4. Go to Site Builder > Pages > create a Content Page
    5. Add a Web Content Display widget to the page 
    6. Go to the widget configuration > Select the Web Content created > Publish page
    7. Go to the page view > below the Web Content, click on the print icon
![journal_content_web](https://github.com/liferay-frontend/liferay-portal/assets/91208451/edc2c23a-508b-43b5-8711-065bd7a0d3cc)

**- Wiki**
    1. Go to Site Builder > Pages > create a Content Page 
    2. Add a Wiki widget to the page > Publish 
    3. Go to the page view > Click on the print icon of the wiki widget
![wiki_web](https://github.com/liferay-frontend/liferay-portal/assets/91208451/12bfdd00-2d8d-4379-9a63-53f82c6aa61b)

