### PR TITLE
LPS-191427 Drag and Drop not working correctly for image in CKEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js
@@ -61,18 +61,23 @@ const ClassicEditor = forwardRef(
 						const data = event.data.dataTransfer.getData(
 							'text/html'
 						);
-						const editor = event.editor;
 
-						if (data) {
-							const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
-								data
-							);
+						if (!data) {
+							return;
+						}
 
-							const name = fragment.children[0].name;
+						const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
+							data
+						);
 
-							if (name) {
-								return editor.pasteFilter.check(name);
-							}
+						let element = fragment.children[0];
+
+						if (element.hasClass('cke_widget_image')) {
+							element = element.children[0];
+						}
+
+						if (event.editor.pasteFilter && element.name) {
+							return event.editor.pasteFilter.check(element.name);
 						}
 					}}
 					onInstanceReady={({editor}) => {


### PR DESCRIPTION
### References

- [LPS-191427 Drag and Drop not working correctly for image in CKEditor](https://issues.liferay.com/browse/LPS-191427)
- Related to [LPS-117317 Unable to drag and drop an image when using IE11](https://issues.liferay.com/browse/LPS-117317)
- Related PR: https://github.com/liferay-frontend/liferay-portal/pull/403

### What is the goal of this PR?

This was fixed in legacy CKEditor in LPS-117317. See discussion and concerns with solution in https://github.com/liferay-frontend/liferay-portal/pull/403#issuecomment-700645982. As time has proven, there was no need to dive into a cleaner solution, that would require a larger refactor of base CKEditor.

It is notable that, back then, we [intentionally did not port the issue to the React version](https://github.com/liferay-frontend/liferay-portal/pull/403#issuecomment-700645982). My reasoning was:
> I intentionally did not port the change in this PR to [ClassicEditor mirror of drop code](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/ClassicEditor.js#L121-L137). This is because drag handler does not ever show in ClassicEditor. I actually think this behavior is better, drag handler is quite awkward to use. If out goal is to eventually replace editors with ClassicEditor, then it makes sense to me not to worry too much about current ckeditor handler inconsistencies and push this quick fix.

At some point we equalized the handler behavior, so the bug became active in the React version. In this PR, we are porting the same fix.

### What does it look like?

After fix:

https://github.com/liferay-frontend/liferay-portal/assets/5435511/855fd45a-ef98-4c51-858d-6ae87427b64e

### Steps to reproduce

See steps in JIRA.