### PR TITLE
LPS-191694 Migrate printPage function to frontend-js-web

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/printPageButtonPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/printPageButtonPropsTransformer.js
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {printPage} from 'frontend-js-web';
+
+export default function ({additionalProps, ...otherProps}) {
+	return {
+		...otherProps,
+		onClick: () => {
+			printPage(additionalProps.printPageURL);
+		},
+	};
+}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entries_abstract.jsp
@@ -266,45 +266,40 @@ for (AssetEntry assetEntry : assetEntryResult.getAssetEntries()) {
 						>
 
 							<%
-							String id = assetEntry.getEntryId() + StringUtil.randomId();
 							String label = LanguageUtil.format(request, "print-x", HtmlUtil.escape(title));
+
+							String printPageURL = PortletURLBuilder.createRenderURL(
+								renderResponse
+							).setMVCPath(
+								"/view_content.jsp"
+							).setParameter(
+								"assetEntryId", assetEntry.getEntryId()
+							).setParameter(
+								"languageId", LanguageUtil.getLanguageId(request)
+							).setParameter(
+								"type", assetRendererFactory.getType()
+							).setParameter(
+								"viewMode", Constants.PRINT
+							).setWindowState(
+								LiferayWindowState.POP_UP
+							).buildString();
 							%>
 
 							<clay:button
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"printPageURL", printPageURL
+									).build()
+								%>'
 								aria-label="<%= label %>"
 								borderless="<%= true %>"
 								displayType="secondary"
 								icon="print"
-								onClick='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage_" + id + "();" %>'
+								propsTransformer="js/printPageButtonPropsTransformer"
 								small="<%= true %>"
 								title="<%= label %>"
 								type="button"
 							/>
-
-							<aui:script>
-								function <portlet:namespace />printPage_<%= id %>() {
-									window.open(
-										'<%=
-										PortletURLBuilder.createRenderURL(
-											renderResponse
-										).setMVCPath(
-											"/view_content.jsp"
-										).setParameter(
-											"assetEntryId", assetEntry.getEntryId()
-										).setParameter(
-											"languageId", LanguageUtil.getLanguageId(request)
-										).setParameter(
-											"type", assetRendererFactory.getType()
-										).setParameter(
-											"viewMode", Constants.PRINT
-										).setWindowState(
-											LiferayWindowState.POP_UP
-										).buildPortletURL() %>',
-										'',
-										'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-									);
-								}
-							</aui:script>
 						</clay:content-col>
 					</c:if>
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -338,44 +338,37 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 						<c:otherwise>
 
 							<%
-							String id = assetEntry.getEntryId() + StringUtil.randomId();
+							String printPageURL = PortletURLBuilder.createRenderURL(
+								renderResponse
+							).setMVCPath(
+								"/view_content.jsp"
+							).setParameter(
+								"assetEntryId", assetEntry.getEntryId()
+							).setParameter(
+								"languageId", LanguageUtil.getLanguageId(request)
+							).setParameter(
+								"type", assetRendererFactory.getType()
+							).setParameter(
+								"viewMode", Constants.PRINT
+							).setWindowState(
+								LiferayWindowState.POP_UP
+							).buildString();
 							%>
 
 							<clay:button
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"printPageURL", printPageURL
+									).build()
+								%>'
 								aria-label="<%= label %>"
 								borderless="<%= true %>"
 								displayType="secondary"
 								icon="print"
-								onClick='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage_" + id + "();" %>'
+								propsTransformer="js/printPageButtonPropsTransformer"
 								small="<%= true %>"
 								type="button"
 							/>
-
-							<aui:script>
-								function <portlet:namespace />printPage_<%= id %>() {
-									window.open(
-										'<%=
-											PortletURLBuilder.createRenderURL(
-												renderResponse
-											).setMVCPath(
-												"/view_content.jsp"
-											).setParameter(
-												"assetEntryId", assetEntry.getEntryId()
-											).setParameter(
-												"languageId", LanguageUtil.getLanguageId(request)
-											).setParameter(
-												"type", assetRendererFactory.getType()
-											).setParameter(
-												"viewMode", Constants.PRINT
-											).setWindowState(
-												LiferayWindowState.POP_UP
-											).buildPortletURL()
-										%>',
-										'',
-										'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-									);
-								}
-							</aui:script>
 						</c:otherwise>
 					</c:choose>
 				</clay:content-col>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -130,6 +130,7 @@ export {default as memoize} from './liferay/util/memoize';
 export {default as navigate} from './liferay/util/navigate.es';
 export {default as normalizeFriendlyURL} from './liferay/util/normalize_friendly_url';
 export {default as openWindow} from './liferay/util/open_window';
+export {default as printPage} from './liferay/util/print_page';
 export {default as removeEntitySelection} from './liferay/util/remove_entity_selection';
 export {default as showCapsLock} from './liferay/util/show_caps_lock';
 export {default as runScriptsInElement} from './liferay/util/run_scripts_in_element.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/print_page.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/print_page.js
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const DEFAULT_OPTIONS = {
+	directories: 0,
+	height: 480,
+	left: 80,
+	location: 1,
+	menubar: 1,
+	resizable: 1,
+	scrollbars: 'yes',
+	status: 0,
+	toolbar: 0,
+	top: 180,
+	width: 640,
+};
+
+export default function printPage(url, options = DEFAULT_OPTIONS) {
+	const nextOptions = {
+		...DEFAULT_OPTIONS,
+		...options,
+	};
+
+	const arrayOptions = Object.entries(nextOptions).map(
+		(key, value) => `${key}=${value}`
+	);
+
+	const stringOptions = arrayOptions.join(',');
+
+	window.open(url, '', stringOptions);
+}

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/printPageButtonPropsTransformer.js
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/js/printPageButtonPropsTransformer.js
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {printPage} from 'frontend-js-web';
+
+export default function ({additionalProps, ...otherProps}) {
+	return {
+		...otherProps,
+		onClick: () => {
+			printPage(additionalProps.printPageURL);
+		},
+	};
+}

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/print.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/print.jsp
@@ -36,25 +36,20 @@ String viewMode = ParamUtil.getString(request, "viewMode");
 			%>
 
 			<clay:button
+				additionalProps='<%=
+					HashMapBuilder.<String, Object>put(
+						"printPageURL", printPageURL
+					).build()
+				%>'
 				aria-label="<%= title %>"
 				borderless="<%= true %>"
 				displayType="secondary"
 				icon="print"
-				onClick='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
+				propsTransformer="js/printPageButtonPropsTransformer"
 				small="<%= true %>"
 				title="<%= title %>"
 				type="button"
 			/>
 		</clay:content-col>
-
-		<aui:script>
-			function <portlet:namespace />printPage() {
-				window.open(
-					'<%= printPageURL %>',
-					'',
-					'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-				);
-			}
-		</aui:script>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/printPageButtonEventListener.js
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/js/printPageButtonEventListener.js
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {printPage} from 'frontend-js-web';
+
+export default function ({namespace, printPageURL}) {
+	const printPageButton = document.getElementById(
+		`${namespace}printPageButton`
+	);
+
+	if (printPageButton) {
+		printPageButton.addEventListener('click', (event) => {
+			event.preventDefault();
+
+			printPage(printPageURL);
+		});
+	}
+}

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -92,13 +92,13 @@ PortletURL editPageURL = PortletURLBuilder.createRenderURL(
 	"title", title
 ).buildPortletURL();
 
-PortletURL printPageURL = PortletURLBuilder.create(
+String printPageURL = PortletURLBuilder.create(
 	PortletURLUtil.clone(viewPageURL, renderResponse)
 ).setParameter(
 	"viewMode", Constants.PRINT
 ).setWindowState(
 	LiferayWindowState.POP_UP
-).buildPortletURL();
+).buildString();
 
 PortletURL categorizedPagesURL = PortletURLBuilder.createRenderURL(
 	renderResponse
@@ -193,17 +193,6 @@ if (portletTitleBasedNavigation) {
 								print();
 							</aui:script>
 						</c:when>
-						<c:otherwise>
-							<aui:script>
-								function <portlet:namespace />printPage() {
-									window.open(
-										'<%= printPageURL %>',
-										'',
-										'directories=0,height=480,left=80,location=1,menubar=1,resizable=1,scrollbars=yes,status=0,toolbar=0,top=180,width=640'
-									);
-								}
-							</aui:script>
-						</c:otherwise>
 					</c:choose>
 
 					<liferay-util:include page="/wiki/top_links.jsp" servletContext="<%= application %>" />
@@ -307,10 +296,20 @@ if (portletTitleBasedNavigation) {
 
 							<liferay-ui:icon
 								icon="print"
+								id="printPageButton"
 								label="<%= true %>"
 								markupView="lexicon"
 								message="print"
-								url='<%= "javascript:" + liferayPortletResponse.getNamespace() + "printPage();" %>'
+								url="javascript:void(0);"
+							/>
+
+							<liferay-frontend:component
+								context='<%=
+									HashMapBuilder.<String, Object>put(
+										"printPageURL", printPageURL
+									).build()
+								%>'
+								module="wiki/js/printPageButtonEventListener"
 							/>
 						</div>
 					</c:if>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-191386)

Motivation
======
We have noticed that the function printPage it's been used in several components, so we think that it would be more effective to move this function to a place where it can be reused by other components so we can avoid duplicating code.

## Proposed solution
I have created the file print_page.js and moved the code there. Firstly, I have created a DEFAULT_OPTIONS object to store the options of the window.open() function. Then, I have added the nextOptions object in case we want to pass non default values in the future, because all the use cases in the portal use the same configuration, I have created the nextOptions object just in case we want to change it in the future. Then I have converted the nextOptions object to a String, because the window.open() function only accepts strings as the options parameter.

### Steps to verify functionality 
**- Asset Publisher**
    1. Go to Site Builder > Pages > create a Content Page 
    2. Add an Asset Publisher to the web 
    3. Click on the Asset Publisher and go to it’s Configuration 
    4. In Setup > Asset Selection > Manual 
    5. In Asset Entries > Basic Document > select a document
    6. In Display Settings > Display Template > Abstracts > Publish page
    7. Go to the page view > below the picture, click on the print icon

**- For the other one case, follow the steps until 5**
    1. In Display Settings > Display Template > Full content > Publish page
    2. Go to the page view > below the picture, click on the print icon
![asset_publisher_web](https://github.com/liferay-frontend/liferay-portal/assets/91208451/17edb91b-2aae-4eda-8fa0-a031442b0ae8)

**- Journal Content** 
    1. Go to Content & Data > Web Content
    2. Create a Web Content and add a description > Publish
    4. Go to Site Builder > Pages > create a Content Page
    5. Add a Web Content Display widget to the page 
    6. Go to the widget configuration > Select the Web Content created > Publish page
    7. Go to the page view > below the Web Content, click on the print icon
![journal_content_web](https://github.com/liferay-frontend/liferay-portal/assets/91208451/edc2c23a-508b-43b5-8711-065bd7a0d3cc)

**- Wiki**
    1. Go to Site Builder > Pages > create a Content Page 
    2. Add a Wiki widget to the page > Publish 
    3. Go to the page view > Click on the print icon of the wiki widget
![wiki_web](https://github.com/liferay-frontend/liferay-portal/assets/91208451/12bfdd00-2d8d-4379-9a63-53f82c6aa61b)

