### PR TITLE
LPS-188354 Modify VerticalNav.js to receive and render icons for the items of the vertical list by using setData function from NavigationItem.java

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 13.9.2
+Bundle-Version: 13.10.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.base,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -79,5 +79,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "13.9.2"
+	"version": "13.10.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/IconItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/IconItem.java
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.taglib.clay.servlet.taglib.util;
+
+import java.util.HashMap;
+
+/**
+ * @author Stefan Tanasie
+ */
+public class IconItem extends HashMap<String, Object> {
+
+	public void setSymbol(String symbol) {
+		put("symbol", symbol);
+	}
+
+	public void setTitle(String title) {
+		put("title", title);
+	}
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/VerticalNavItem.java
@@ -16,6 +16,10 @@ public class VerticalNavItem extends NavigationItem {
 		put("expanded", expanded);
 	}
 
+	public void setIcons(List<IconItem> icons) {
+		put("icons", icons);
+	}
+
 	public void setId(String id) {
 		put("id", id);
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -4,6 +4,7 @@
  */
 
 import {VerticalNav as ClayVerticalNav} from '@clayui/core';
+import ClayIcon from '@clayui/icon';
 import React from 'react';
 
 export default function VerticalNav({
@@ -42,6 +43,17 @@ export default function VerticalNav({
 					key={item.id}
 				>
 					{item.label}
+
+					{item.icons?.map((icon) => {
+						return (
+							<ClayIcon
+								className="c-ml-1 text-muted"
+								key={icon.symbol}
+								symbol={icon.symbol}
+								title={icon.title}
+							/>
+						);
+					})}
 				</ClayVerticalNav.Item>
 			)}
 		</ClayVerticalNav>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/util/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.4.0
+version 4.5.0


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to allow vertical nav items to render icons besides the label. 
https://liferay.atlassian.net/browse/LPS-191478
This icons are needed for fragments-web and asset-categories-admin-web modules for https://liferay.atlassian.net/browse/LPS-188310

Proposed Solution
========
What we did to solve this problem is to use the data parameter contained in the tag (which is set with setData method from NavigationItem.java) to pass the necessary data to the frontend component so it is able to include the icons needed.
