### PR TITLE
[TS] LPS-191923 - certain locales have characters in their short date format that are invalid in a date mask

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -72,6 +72,7 @@ if (!BrowserSnifferUtil.isMobile(request)) {
 
 	mask = simpleDateFormatPattern;
 
+	mask = mask.replaceAll("('[^ -~]+')", "");
 	mask = mask.replaceAll("yyyy", "%Y");
 	mask = mask.replaceAll("MM", "%m");
 	mask = mask.replaceAll("dd", "%d");


### PR DESCRIPTION
Hi @liferay-frontend team,

I'm sending this to you since it's part of the old input-date tag, but please let me know if this should be going to someone else. 

Currently, we grab the localized version of the short date format and then use it as our mask for our date selector in A.DatePicker. However, problems can arise for specific locales. While zh_CN and zh_TW both work fine due to having a short date format of YYYY-MM-DD, the zh_HK locale defaults to returning a short date format of YYYY年-MM月-DD日 which contains characters invalid for use in a mask. To fix this, I've added a regex that removes all non-ASCII characters from the mask. I chose this since it seemed the most elegant way to handle it particularly since date formats can also differ when it comes to separators (some locales use periods, some dashes, some slashes). I've tested with other non-Latin alphabet languages (Korean, Japanese, etc) and I have not seen any issues with any of these other locales since they use similar formatting to zh_CN/zh_TW, but please let me know if you feel I should be testing anything else. Thanks!