### PR TITLE
LPS-185312 Use escape in aui option, also make sure that LPS-190672, LPS-192582 and LPS-192371 won't happen

### DIFF
--- a/portal-web/docroot/html/taglib/aui/option/start.jsp
+++ b/portal-web/docroot/html/taglib/aui/option/start.jsp
@@ -10,5 +10,5 @@
 <option class="<%= cssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> <%= selected ? "selected" : StringPool.BLANK %> <%= Validator.isNotNull(style) ? "style=\"" + style + "\"" : StringPool.BLANK %> value="<%= (value != null) ? HtmlUtil.escapeAttribute(String.valueOf(value)) : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
 
 <c:if test="<%= Validator.isNotNull(label) %>">
-	<liferay-ui:message key="<%= HtmlUtil.escape(String.valueOf(label)) %>" localizeKey="<%= localizeLabel %>" />
+	<liferay-ui:message escape="<%= true %>" key="<%= String.valueOf(label) %>" localizeKey="<%= localizeLabel %>" />
 </c:if>


### PR DESCRIPTION
Hi Team,

https://liferay.atlassian.net/browse/LPS-185312

The previous PR of this ticket caused regression: https://github.com/liferay-frontend/liferay-portal/pull/3365
It caused regression in:
https://liferay.atlassian.net/browse/LPS-190672
https://liferay.atlassian.net/browse/LPS-192582

I reverted it in this PR: https://github.com/liferay-frontend/liferay-portal/pull/3571 so this current PR doesn't show the reverted commits, since it's not merged yet.

Previous PR fixed an XSS issue with the input-move-boxes tag in the liferay-ui taglib.
I modified that PR so that [LPS-190672](https://liferay.atlassian.net/browse/LPS-190672), [LPS-192582](https://liferay.atlassian.net/browse/LPS-192582) and [LPS-192371](https://liferay.atlassian.net/browse/LPS-192371) won't happen. (The last LPS only caused regression on 7.3.x due to backporting)


![password_recovery_works_master](https://github.com/liferay-frontend/liferay-portal/assets/97447507/2a8ef0d7-7a57-4244-9146-ebe92f8acbd1)

Please review my PR!

Thank you and best regards,
Évi
