### PR TITLE
LPS-188817 Fix clay modal height

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/FDSView.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/FDSView.scss
@@ -1,5 +1,10 @@
 @import 'atlas-variables';
 
-html:not(#__):not(#___) .cadmin .fds-view-fields-modal .fields {
-	background-color: $gray-200;
+html:not(#__):not(#___) .cadmin .fds-view-fields-modal {
+	display: flex;
+	flex-direction: column;
+
+	.fields {
+		background-color: $gray-200;
+	}
 }


### PR DESCRIPTION
This PR fixes a specific case for the FDS Modal architecture, it adds a CSS for the middle container with the class `.fds-view-fields-modal`.

If other similar cases with middle containers appeared, we could think of a general fix in the DXP or Clay side.

<img width="1440" alt="image" src="https://github.com/liferay-frontend/liferay-portal/assets/46778114/d44bd2cb-de76-45c5-a413-12eb523caae9">
