### PR TITLE
LPS-170286 | Refactor method to get fragment resource title properly

### DIFF
--- a/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
+++ b/modules/apps/document-library/document-library-taglib/src/main/resources/META-INF/resources/repository_browser/page.jsp
@@ -93,6 +93,7 @@ RepositoryBrowserTagDisplayContext repositoryBrowserTagDisplayContext = (Reposit
 							<c:otherwise>
 								<clay:horizontal-card
 									horizontalCard="<%= repositoryBrowserTagDisplayContext.getHorizontalCard(repositoryEntry) %>"
+									translated="<%= false %>"
 								/>
 							</c:otherwise>
 						</c:choose>


### PR DESCRIPTION
**Descripción**: Modify method `getTitle()` from `HorizontalCardTag.java` to make same as the one in `VerticalCardTag.java` and avoid escaping lowercase **a** to **%A**
![image](https://github.com/liferay/liferay-portal/assets/40394495/d6a1ac16-06fe-4999-b67e-a329f9f2b57b)

Lima Review: https://github.com/liferay-lima/liferay-portal/pull/4573
**Jira Ticket**: https://liferay.atlassian.net/browse/LPS-170286