### PR TITLE
LPS-192593 LPS-192917 Add permissions action and permissions to data set entry actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -9,9 +9,7 @@ import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
 import com.liferay.object.model.ObjectDefinition;
-import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -39,11 +37,12 @@ import javax.portlet.ResourceURL;
 public class FDSViewsDisplayContext {
 
 	public FDSViewsDisplayContext(
-		CETManager cetManager, RenderRequest renderRequest,
-		RenderResponse renderResponse,
+		CETManager cetManager, ObjectDefinition fdsEntryObjectDefinition,
+		RenderRequest renderRequest, RenderResponse renderResponse,
 		ServiceTrackerList<String> serviceTrackerList) {
 
 		_cetManager = cetManager;
+		_fdsEntryObjectDefinition = fdsEntryObjectDefinition;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 		_serviceTrackerList = serviceTrackerList;
@@ -113,10 +112,6 @@ public class FDSViewsDisplayContext {
 	}
 
 	public String getPermissionsURL() {
-		ObjectDefinition fdsEntryObjectDefinition =
-			ObjectDefinitionLocalServiceUtil.fetchObjectDefinition(
-				_themeDisplay.getCompanyId(), "FDSEntry");
-
 		return PortletURLBuilder.create(
 			PortalUtil.getControlPanelPortletURL(
 				_renderRequest,
@@ -128,10 +123,10 @@ public class FDSViewsDisplayContext {
 		).setRedirect(
 			PortletURLUtil.getCurrent(_renderRequest, _renderResponse)
 		).setParameter(
-			"modelResource", fdsEntryObjectDefinition.getClassName()
+			"modelResource", _fdsEntryObjectDefinition.getClassName()
 		).setParameter(
 			"modelResourceDescription",
-			fdsEntryObjectDefinition.getLabel(_themeDisplay.getLocale())
+			_fdsEntryObjectDefinition.getLabel(_themeDisplay.getLocale())
 		).setParameter(
 			"resourcePrimKey", "{id}"
 		).setWindowState(
@@ -166,6 +161,7 @@ public class FDSViewsDisplayContext {
 	}
 
 	private final CETManager _cetManager;
+	private final ObjectDefinition _fdsEntryObjectDefinition;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private final ServiceTrackerList<String> _serviceTrackerList;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -37,18 +38,22 @@ import javax.portlet.ResourceURL;
 public class FDSViewsDisplayContext {
 
 	public FDSViewsDisplayContext(
-		CETManager cetManager, ObjectDefinition fdsEntryObjectDefinition,
+		CETManager cetManager,
+		ObjectDefinitionLocalService objectDefinitionLocalService,
 		RenderRequest renderRequest, RenderResponse renderResponse,
 		ServiceTrackerList<String> serviceTrackerList) {
 
 		_cetManager = cetManager;
-		_fdsEntryObjectDefinition = fdsEntryObjectDefinition;
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 		_serviceTrackerList = serviceTrackerList;
 
 		_themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
+
+		_fdsEntryObjectDefinition =
+			objectDefinitionLocalService.fetchObjectDefinition(
+				_themeDisplay.getCompanyId(), "FDSEntry");
 	}
 
 	public JSONArray getFDSCellRendererCETsJSONArray() throws Exception {
@@ -74,6 +79,29 @@ public class FDSViewsDisplayContext {
 				RenderRequest.RENDER_PHASE)
 		).setMVCPath(
 			"/fds_entries.jsp"
+		).buildString();
+	}
+
+	public String getFDSEntryPermissionsURL() {
+		return PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(
+				_renderRequest,
+				"com_liferay_portlet_configuration_web_portlet_" +
+					"PortletConfigurationPortlet",
+				ActionRequest.RENDER_PHASE)
+		).setMVCPath(
+			"/edit_permissions.jsp"
+		).setRedirect(
+			PortletURLUtil.getCurrent(_renderRequest, _renderResponse)
+		).setParameter(
+			"modelResource", _fdsEntryObjectDefinition.getClassName()
+		).setParameter(
+			"modelResourceDescription",
+			_fdsEntryObjectDefinition.getLabel(_themeDisplay.getLocale())
+		).setParameter(
+			"resourcePrimKey", "{id}"
+		).setWindowState(
+			LiferayWindowState.POP_UP
 		).buildString();
 	}
 
@@ -108,29 +136,6 @@ public class FDSViewsDisplayContext {
 				RenderRequest.RENDER_PHASE)
 		).setMVCPath(
 			"/fds_view.jsp"
-		).buildString();
-	}
-
-	public String getPermissionsURL() {
-		return PortletURLBuilder.create(
-			PortalUtil.getControlPanelPortletURL(
-				_renderRequest,
-				"com_liferay_portlet_configuration_web_portlet_" +
-					"PortletConfigurationPortlet",
-				ActionRequest.RENDER_PHASE)
-		).setMVCPath(
-			"/edit_permissions.jsp"
-		).setRedirect(
-			PortletURLUtil.getCurrent(_renderRequest, _renderResponse)
-		).setParameter(
-			"modelResource", _fdsEntryObjectDefinition.getClassName()
-		).setParameter(
-			"modelResourceDescription",
-			_fdsEntryObjectDefinition.getLabel(_themeDisplay.getLocale())
-		).setParameter(
-			"resourcePrimKey", "{id}"
-		).setWindowState(
-			LiferayWindowState.POP_UP
 		).buildString();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -86,24 +86,24 @@ public class FDSViewsPortlet extends MVCPortlet {
 			WebKeys.THEME_DISPLAY);
 
 		try {
-			ObjectDefinition fdsEntryObjectDefinition = _generate(
+			_generate(
 				themeDisplay.getCompanyId(), themeDisplay.getLocale(),
 				themeDisplay.getUserId());
-
-			renderRequest.setAttribute(
-				FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
-				new FDSViewsDisplayContext(
-					_cetManager, fdsEntryObjectDefinition, renderRequest,
-					renderResponse, _serviceTrackerList));
 		}
 		catch (Exception exception) {
 			_log.error(exception);
 		}
 
+		renderRequest.setAttribute(
+			FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
+			new FDSViewsDisplayContext(
+				_cetManager, _objectDefinitionLocalService, renderRequest,
+				renderResponse, _serviceTrackerList));
+
 		super.doDispatch(renderRequest, renderResponse);
 	}
 
-	private synchronized ObjectDefinition _generate(
+	private synchronized void _generate(
 			long companyId, Locale locale, long userId)
 		throws Exception {
 
@@ -112,7 +112,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 				companyId, "FDSEntry");
 
 		if (fdsEntryObjectDefinition != null) {
-			return fdsEntryObjectDefinition;
+			return;
 		}
 
 		fdsEntryObjectDefinition =
@@ -379,8 +379,6 @@ public class FDSViewsPortlet extends MVCPortlet {
 			LocalizedMapUtil.getLocalizedMap("FDSView FDSSort Relationship"),
 			"fdsViewFDSSortRelationship",
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		return fdsEntryObjectDefinition;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -97,7 +97,8 @@ public class FDSViewsPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
 			new FDSViewsDisplayContext(
-				_cetManager, renderRequest, _serviceTrackerList));
+				_cetManager, renderRequest, renderResponse,
+				_serviceTrackerList));
 
 		super.doDispatch(renderRequest, renderResponse);
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -85,33 +85,37 @@ public class FDSViewsPortlet extends MVCPortlet {
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		ObjectDefinition fdsEntryObjectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				themeDisplay.getCompanyId(), "FDSEntry");
+		try {
+			ObjectDefinition fdsEntryObjectDefinition = _generate(
+				themeDisplay.getCompanyId(), themeDisplay.getLocale(),
+				themeDisplay.getUserId());
 
-		if (fdsEntryObjectDefinition == null) {
-			try {
-				fdsEntryObjectDefinition = _generate(
-					themeDisplay.getLocale(), themeDisplay.getUserId());
-			}
-			catch (Exception exception) {
-				_log.error(exception);
-			}
+			renderRequest.setAttribute(
+				FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
+				new FDSViewsDisplayContext(
+					_cetManager, fdsEntryObjectDefinition, renderRequest,
+					renderResponse, _serviceTrackerList));
 		}
-
-		renderRequest.setAttribute(
-			FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
-			new FDSViewsDisplayContext(
-				_cetManager, fdsEntryObjectDefinition, renderRequest,
-				renderResponse, _serviceTrackerList));
+		catch (Exception exception) {
+			_log.error(exception);
+		}
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
 
-	private synchronized ObjectDefinition _generate(Locale locale, long userId)
+	private synchronized ObjectDefinition _generate(
+			long companyId, Locale locale, long userId)
 		throws Exception {
 
 		ObjectDefinition fdsEntryObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				companyId, "FDSEntry");
+
+		if (fdsEntryObjectDefinition != null) {
+			return fdsEntryObjectDefinition;
+		}
+
+		fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
 				"FDSEntry", userId, 0, "FDSEntry", "FDSEntry", false,
 				LocalizedMapUtil.getLocalizedMap("FDS Entry"), true, "FDSEntry",

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -91,7 +91,8 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		if (fdsEntryObjectDefinition == null) {
 			try {
-				_generate(themeDisplay.getLocale(), themeDisplay.getUserId());
+				fdsEntryObjectDefinition = _generate(
+					themeDisplay.getLocale(), themeDisplay.getUserId());
 			}
 			catch (Exception exception) {
 				_log.error(exception);
@@ -107,7 +108,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 		super.doDispatch(renderRequest, renderResponse);
 	}
 
-	private synchronized void _generate(Locale locale, long userId)
+	private synchronized ObjectDefinition _generate(Locale locale, long userId)
 		throws Exception {
 
 		ObjectDefinition fdsEntryObjectDefinition =
@@ -374,6 +375,8 @@ public class FDSViewsPortlet extends MVCPortlet {
 			LocalizedMapUtil.getLocalizedMap("FDSView FDSSort Relationship"),
 			"fdsViewFDSSortRelationship",
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		return fdsEntryObjectDefinition;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -85,37 +85,32 @@ public class FDSViewsPortlet extends MVCPortlet {
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		try {
-			_generate(
-				themeDisplay.getCompanyId(), themeDisplay.getLocale(),
-				themeDisplay.getUserId());
-		}
-		catch (Exception exception) {
-			_log.error(exception);
+		ObjectDefinition fdsEntryObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				themeDisplay.getCompanyId(), "FDSEntry");
+
+		if (fdsEntryObjectDefinition == null) {
+			try {
+				_generate(themeDisplay.getLocale(), themeDisplay.getUserId());
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
 		}
 
 		renderRequest.setAttribute(
 			FDSViewsWebKeys.FDS_VIEWS_DISPLAY_CONTEXT,
 			new FDSViewsDisplayContext(
-				_cetManager, renderRequest, renderResponse,
-				_serviceTrackerList));
+				_cetManager, fdsEntryObjectDefinition, renderRequest,
+				renderResponse, _serviceTrackerList));
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
 
-	private synchronized void _generate(
-			long companyId, Locale locale, long userId)
+	private synchronized void _generate(Locale locale, long userId)
 		throws Exception {
 
 		ObjectDefinition fdsEntryObjectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				companyId, "FDSEntry");
-
-		if (fdsEntryObjectDefinition != null) {
-			return;
-		}
-
-		fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
 				"FDSEntry", userId, 0, "FDSEntry", "FDSEntry", false,
 				LocalizedMapUtil.getLocalizedMap("FDS Entry"), true, "FDSEntry",

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_entries.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_entries.jsp
@@ -15,6 +15,8 @@
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()
 		).put(
+			"permissionsURL", fdsViewsDisplayContext.getPermissionsURL()
+		).put(
 			"restApplications", fdsViewsDisplayContext.getRESTApplicationsJSONArray()
 		).build()
 	%>'

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_entries.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_entries.jsp
@@ -15,7 +15,7 @@
 		).put(
 			"namespace", liferayPortletResponse.getNamespace()
 		).put(
-			"permissionsURL", fdsViewsDisplayContext.getPermissionsURL()
+			"permissionsURL", fdsViewsDisplayContext.getFDSEntryPermissionsURL()
 		).put(
 			"restApplications", fdsViewsDisplayContext.getRESTApplicationsJSONArray()
 		).build()

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -831,12 +831,14 @@ const RenameFDSEntryModalContent = ({
 interface IFDSEntriesInterface {
 	fdsViewsURL: string;
 	namespace: string;
+	permissionsURL: string;
 	restApplications: Array<string>;
 }
 
 const FDSEntries = ({
 	fdsViewsURL,
 	namespace,
+	permissionsURL,
 	restApplications,
 }: IFDSEntriesInterface) => {
 	const creationMenu = {
@@ -1041,6 +1043,11 @@ const FDSEntries = ({
 						icon: 'trash',
 						label: Liferay.Language.get('delete'),
 						onClick: onDeleteClick,
+					},
+					{
+						href: permissionsURL,
+						label: Liferay.Language.get('permissions'),
+						target: 'modal-permissions',
 					},
 				]}
 				sorting={[{direction: 'desc', key: 'dateCreated'}]}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -1046,11 +1046,13 @@ const FDSEntries = ({
 					{
 						data: {
 							permissionKey: 'permissions',
+							size: 'full-screen',
+							title: Liferay.Language.get('permissions'),
 						},
 						href: permissionsURL,
 						icon: 'password-policies',
 						label: Liferay.Language.get('permissions'),
-						target: 'modal-permissions',
+						target: 'modal',
 					},
 					{
 						separator: true,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -1021,6 +1021,7 @@ const FDSEntries = ({
 					{
 						data: {
 							id: 'view',
+							permissionKey: 'get',
 						},
 						icon: 'pencil',
 						label: Liferay.Language.get('edit'),
@@ -1031,6 +1032,9 @@ const FDSEntries = ({
 						type: 'group',
 					},
 					{
+						data: {
+							permissionKey: 'update',
+						},
 						icon: 'blank',
 						label: Liferay.Language.get('rename'),
 						onClick: onRenameClick,
@@ -1040,14 +1044,25 @@ const FDSEntries = ({
 						type: 'group',
 					},
 					{
+						data: {
+							permissionKey: 'permissions',
+						},
+						href: permissionsURL,
+						icon: 'password-policies',
+						label: Liferay.Language.get('permissions'),
+						target: 'modal-permissions',
+					},
+					{
+						separator: true,
+						type: 'group',
+					},
+					{
+						data: {
+							permissionKey: 'delete',
+						},
 						icon: 'trash',
 						label: Liferay.Language.get('delete'),
 						onClick: onDeleteClick,
-					},
-					{
-						href: permissionsURL,
-						label: Liferay.Language.get('permissions'),
-						target: 'modal-permissions',
 					},
 				]}
 				sorting={[{direction: 'desc', key: 'dateCreated'}]}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -30,11 +30,13 @@ declare type FDSEntryType = {
 interface IFDSEntriesInterface {
 	fdsViewsURL: string;
 	namespace: string;
+	permissionsURL: string;
 	restApplications: Array<string>;
 }
 declare const FDSEntries: ({
 	fdsViewsURL,
 	namespace,
+	permissionsURL,
 	restApplications,
 }: IFDSEntriesInterface) => JSX.Element;
 export {FDSEntryType};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -93,6 +93,7 @@ function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 		const {
 			confirmationMessage,
 			errorMessage,
+			size,
 			status,
 			successMessage,
 			title,
@@ -109,7 +110,7 @@ function Actions({actions, itemData, itemId, menuActive, onMenuActiveChange}) {
 				}
 				else {
 					openModal({
-						size: resolveModalSize(target),
+						size: size || resolveModalSize(target),
 						title,
 						url,
 					});
@@ -220,7 +221,9 @@ const actionType = PropTypes.shape({
 		errorMessage: PropTypes.string,
 		method: PropTypes.oneOf(['delete', 'get', 'patch', 'post']),
 		permissionKey: PropTypes.string,
+		size: PropTypes.oneOf(['sm', 'lg', 'full-screen']),
 		successMessage: PropTypes.string,
+		title: PropTypes.string,
 	}),
 	href: PropTypes.string,
 	icon: PropTypes.string,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
@@ -11,6 +11,7 @@ import React, {useContext} from 'react';
 
 import FrontendDataSetContext from '../FrontendDataSetContext';
 import {formatActionURL} from '../utils/index';
+import {openPermissionsModal} from '../utils/modals/index';
 import DefaultContent from './DefaultRenderer';
 
 function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
@@ -61,6 +62,11 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 					title: currentAction.title,
 					url: formattedHref,
 				});
+			}
+			if (currentAction.target === 'modal-permissions') {
+				event.preventDefault();
+
+				openPermissionsModal(formattedHref);
 			}
 			else if (currentAction.target === 'sidePanel') {
 				event.preventDefault();

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
@@ -170,6 +170,7 @@ ActionLinkRenderer.propTypes = {
 			size: PropTypes.string,
 			target: PropTypes.oneOf([
 				'modal',
+				'modal-permissions',
 				'sidePanel',
 				'link',
 				'async',

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -89,7 +89,14 @@ export interface IItemsActions {
 	label?: string;
 	onClick?: Function;
 	separator?: boolean;
-	target?: 'async' | 'headless' | 'link' | 'modal' | 'sidePanel' | 'event';
+	target?:
+		| 'async'
+		| 'headless'
+		| 'link'
+		| 'modal'
+		| 'modal-permissions'
+		| 'sidePanel'
+		| 'event';
 	type?: string;
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.d.ts
@@ -82,6 +82,8 @@ export interface IItemsActions {
 		id?: string;
 		method?: 'delete' | 'get';
 		permissionKey?: string;
+		size?: 'sm' | 'lg' | 'full-screen';
+		title?: string;
 	};
 	href?: string;
 	icon?: string;


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPS-192593
**Subtask:** https://liferay.atlassian.net/browse/LPS-192917

For data set entries:
- Adds "Permissions" action that allows configuring permissions
- "View", "Rename", "Permissions", "Delete" actions will hide if the user has no permissions for the action

Note: In order for a different role to have access to the "Data Sets" application in the application menu, I had to:
1. Go to a role
2. "Define Permissions" tab
3. "Control Panel > Object > Data Sets"
4. Enable "Access In Control Panel"

The start of the demo video shows that in the beginning.

## Demo

Showing the permissions changed on the "Power User" role. 
Left is the admin, right is the power user.

https://github.com/liferay-frontend/liferay-portal/assets/4496722/b30d13a8-0564-4752-ae7d-39631f740e21

