### PR TITLE
LPS-188958 add aria-labelledby attribute to checkbox in taglib search iterator

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/search/ImageConfigurationEntriesChecker.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/search/ImageConfigurationEntriesChecker.java
@@ -40,7 +40,7 @@ public class ImageConfigurationEntriesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		String name = AMImageConfigurationEntry.class.getSimpleName();
 
@@ -50,7 +50,7 @@ public class ImageConfigurationEntriesChecker extends EmptyOnClickRowChecker {
 			httpServletRequest, checked, disabled,
 			_liferayPortletResponse.getNamespace() + RowChecker.ROW_IDS + name,
 			primaryKey, checkBoxRowIds, "'#" + getAllRowIds() + "'",
-			StringPool.BLANK);
+			StringPool.BLANK, rowElementId);
 	}
 
 	private String _getEntryRowIds() {

--- a/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/search/GroupChecker.java
+++ b/modules/apps/analytics/analytics-settings-web/src/main/java/com/liferay/analytics/settings/web/internal/search/GroupChecker.java
@@ -43,7 +43,8 @@ public class GroupChecker extends EmptyOnClickRowChecker {
 	protected String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
 		boolean disabled, String name, String value, String checkBoxRowIds,
-		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+		String checkBoxAllRowIds, String checkBoxPostOnClick,
+		String rowElementId) {
 
 		if (!checked && _ids.contains(value)) {
 			disabled = true;
@@ -51,7 +52,7 @@ public class GroupChecker extends EmptyOnClickRowChecker {
 
 		return super.getRowCheckBox(
 			httpServletRequest, checked, disabled, name, value, checkBoxRowIds,
-			checkBoxAllRowIds, checkBoxPostOnClick);
+			checkBoxAllRowIds, checkBoxPostOnClick, rowElementId);
 	}
 
 	private final String _channelId;

--- a/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/search/AnnouncementsEntryChecker.java
+++ b/modules/apps/announcements/announcements-web/src/main/java/com/liferay/announcements/web/internal/search/AnnouncementsEntryChecker.java
@@ -58,7 +58,7 @@ public class AnnouncementsEntryChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		long entryId = GetterUtil.getLong(primaryKey);
 
@@ -113,7 +113,8 @@ public class AnnouncementsEntryChecker extends EmptyOnClickRowChecker {
 			StringBundler.concat(
 				_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
 				AnnouncementsEntry.class.getSimpleName()),
-			primaryKey, checkBoxRowIds, checkBoxAllRowIds, StringPool.BLANK);
+			primaryKey, checkBoxRowIds, checkBoxAllRowIds, StringPool.BLANK,
+			rowElementId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/search/EntriesChecker.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/search/EntriesChecker.java
@@ -58,7 +58,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		long entryId = GetterUtil.getLong(primaryKey);
 
@@ -87,7 +87,8 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 		return getRowCheckBox(
 			httpServletRequest, checked, disabled,
 			_liferayPortletResponse.getNamespace() + RowChecker.ROW_IDS + name,
-			primaryKey, checkBoxRowIds, checkBoxAllRowIds, StringPool.BLANK);
+			primaryKey, checkBoxRowIds, checkBoxAllRowIds, StringPool.BLANK,
+			rowElementId);
 	}
 
 	private String _getEntryRowIds() {

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/search/EntriesChecker.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/search/EntriesChecker.java
@@ -67,7 +67,7 @@ public class EntriesChecker extends RowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		Object result = _getModel(primaryKey);
 
@@ -82,7 +82,7 @@ public class EntriesChecker extends RowChecker {
 			_liferayPortletResponse.getNamespace() + RowChecker.ROW_IDS + name,
 			primaryKey, _getEntryRowIds(), "'#" + getAllRowIds() + "'",
 			_liferayPortletResponse.getNamespace() + "toggleActionsButton();",
-			getData(result));
+			getData(result), rowElementId);
 	}
 
 	@Override
@@ -91,9 +91,17 @@ public class EntriesChecker extends RowChecker {
 
 		Object result = resultRow.getObject();
 
+		Map<String, Object> data = resultRow.getData();
+
+		String rowElementId = null;
+
+		if (data != null) {
+			rowElementId = GetterUtil.getString(data.get("rowElementId"));
+		}
+
 		return getRowCheckBox(
 			httpServletRequest, isChecked(result), isDisabled(result),
-			resultRow.getPrimaryKey());
+			resultRow.getPrimaryKey(), rowElementId);
 	}
 
 	@Override
@@ -164,11 +172,17 @@ public class EntriesChecker extends RowChecker {
 		HttpServletRequest httpServletRequest, boolean checked,
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick,
-		Map<String, Object> data) {
+		Map<String, Object> data, String rowElementId) {
 
-		StringBundler sb = new StringBundler(16);
+		StringBundler sb = new StringBundler(19);
 
 		sb.append("<input ");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/search/CustomFieldChecker.java
+++ b/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/search/CustomFieldChecker.java
@@ -41,7 +41,7 @@ public class CustomFieldChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		ExpandoColumn expandoColumn =
 			ExpandoColumnLocalServiceUtil.getDefaultTableColumn(
@@ -49,7 +49,7 @@ public class CustomFieldChecker extends EmptyOnClickRowChecker {
 
 		return super.getRowCheckBox(
 			httpServletRequest, checked, disabled,
-			String.valueOf(expandoColumn.getColumnId()));
+			String.valueOf(expandoColumn.getColumnId()), rowElementId);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/dao/search/JournalRowChecker.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/dao/search/JournalRowChecker.java
@@ -46,7 +46,7 @@ public class JournalRowChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
@@ -68,7 +68,7 @@ public class JournalRowChecker extends EmptyOnClickRowChecker {
 			StringBundler.concat(
 				_portletResponse.getNamespace(), RowChecker.ROW_IDS,
 				JournalArticle.class.getSimpleName(), "']"),
-			"'#" + getAllRowIds() + "'", StringPool.BLANK);
+			"'#" + getAllRowIds() + "'", StringPool.BLANK, rowElementId);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/search/EntriesChecker.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/search/EntriesChecker.java
@@ -60,7 +60,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
@@ -135,7 +135,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 				_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
 				name, StringPool.BLANK),
 			primaryKey, checkBoxRowIds, "'#" + getAllRowIds() + "'",
-			StringPool.BLANK);
+			StringPool.BLANK, rowElementId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(EntriesChecker.class);

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/search/EntriesChecker.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/search/EntriesChecker.java
@@ -62,7 +62,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		try {
 			KBArticle kbArticle = null;
@@ -114,7 +114,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 				_liferayPortletResponse.getNamespace() + RowChecker.ROW_IDS +
 					name,
 				primaryKey, checkBoxRowIds, checkBoxAllRowIds,
-				checkBoxPostOnClick);
+				checkBoxPostOnClick, rowElementId);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/search/KBCommentsChecker.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/search/KBCommentsChecker.java
@@ -59,7 +59,7 @@ public class KBCommentsChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		try {
 			long kbCommentId = GetterUtil.getLong(primaryKey);
@@ -77,7 +77,8 @@ public class KBCommentsChecker extends EmptyOnClickRowChecker {
 				httpServletRequest, checked, disabled,
 				_liferayPortletResponse.getNamespace() + RowChecker.ROW_IDS +
 					KBComment.class.getSimpleName(),
-				primaryKey, checkBoxRowIds, getAllRowIds(), StringPool.BLANK);
+				primaryKey, checkBoxRowIds, getAllRowIds(), StringPool.BLANK,
+				rowElementId);
 		}
 		catch (PortalException portalException) {
 

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/search/EntriesChecker.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/search/EntriesChecker.java
@@ -60,7 +60,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		MBThread thread = null;
 
@@ -128,7 +128,7 @@ public class EntriesChecker extends EmptyOnClickRowChecker {
 			httpServletRequest, checked, disabled,
 			_liferayPortletResponse.getNamespace() + RowChecker.ROW_IDS + name,
 			primaryKey, checkBoxRowIds, "'#" + getAllRowIds() + "'",
-			StringPool.BLANK);
+			StringPool.BLANK, rowElementId);
 	}
 
 	private String _getEntryRowIds() {

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/search/UADHierarchyChecker.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/search/UADHierarchyChecker.java
@@ -34,7 +34,8 @@ public class UADHierarchyChecker extends EmptyOnClickRowChecker {
 	protected String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
 		boolean disabled, String name, String value, String checkBoxRowIds,
-		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+		String checkBoxAllRowIds, String checkBoxPostOnClick,
+		String rowElementId) {
 
 		for (UADDisplay<?> uadDisplay : _uadDisplays) {
 			try {
@@ -46,7 +47,8 @@ public class UADHierarchyChecker extends EmptyOnClickRowChecker {
 
 				return super.getRowCheckBox(
 					httpServletRequest, checked, disabled, name, value,
-					checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick);
+					checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick,
+					rowElementId);
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/search/OrganizationUserChecker.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/search/OrganizationUserChecker.java
@@ -77,7 +77,8 @@ public class OrganizationUserChecker extends EmptyOnClickRowChecker {
 	protected String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
 		boolean disabled, String name, String value, String checkBoxRowIds,
-		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+		String checkBoxAllRowIds, String checkBoxPostOnClick,
+		String rowElementId) {
 
 		try {
 			long organizationId = GetterUtil.getLong(value);
@@ -107,7 +108,7 @@ public class OrganizationUserChecker extends EmptyOnClickRowChecker {
 
 		return super.getRowCheckBox(
 			httpServletRequest, checked, disabled, name, value, checkBoxRowIds,
-			checkBoxAllRowIds, checkBoxPostOnClick);
+			checkBoxAllRowIds, checkBoxPostOnClick, rowElementId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/search/NodesChecker.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/search/NodesChecker.java
@@ -58,7 +58,7 @@ public class NodesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		long nodeId = GetterUtil.getLong(primaryKey);
 
@@ -117,7 +117,7 @@ public class NodesChecker extends EmptyOnClickRowChecker {
 				_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
 				name, ""),
 			primaryKey, checkBoxRowIds, "'#" + getAllRowIds() + "'",
-			StringPool.BLANK);
+			StringPool.BLANK, rowElementId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(NodesChecker.class);

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/search/PagesChecker.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/search/PagesChecker.java
@@ -58,7 +58,7 @@ public class PagesChecker extends EmptyOnClickRowChecker {
 	@Override
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		long pageId = GetterUtil.getLong(primaryKey);
 
@@ -117,7 +117,7 @@ public class PagesChecker extends EmptyOnClickRowChecker {
 				_liferayPortletResponse.getNamespace(), RowChecker.ROW_IDS,
 				name, ""),
 			page.getTitle(), checkBoxRowIds, "'#" + getAllRowIds() + "'",
-			StringPool.BLANK);
+			StringPool.BLANK, rowElementId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(PagesChecker.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
@@ -36,11 +36,18 @@ public class EmptyOnClickRowChecker extends RowChecker {
 	protected String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
 		boolean disabled, String name, String value, String checkBoxRowIds,
-		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+		String checkBoxAllRowIds, String checkBoxPostOnClick,
+		String rowElementId) {
 
-		StringBundler sb = new StringBundler(15);
+		StringBundler sb = new StringBundler(18);
 
 		sb.append("<input ");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -93,20 +94,29 @@ public class RowChecker {
 
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
-		boolean disabled, String primaryKey) {
+		boolean disabled, String primaryKey, String rowElementId) {
 
 		return getRowCheckBox(
 			httpServletRequest, checked, disabled, _rowIds, primaryKey,
 			StringUtil.quote(_rowIds), StringUtil.quote(_allRowIds),
-			StringPool.BLANK);
+			StringPool.BLANK, rowElementId);
 	}
 
 	public String getRowCheckBox(
 		HttpServletRequest httpServletRequest, ResultRow resultRow) {
 
+		Map<String, Object> data = resultRow.getData();
+
+		String rowElementId = null;
+
+		if (data != null) {
+			rowElementId = GetterUtil.getString(data.get("rowElementId"));
+		}
+
 		return getRowCheckBox(
 			httpServletRequest, isChecked(resultRow.getObject()),
-			isDisabled(resultRow.getObject()), resultRow.getPrimaryKey());
+			isDisabled(resultRow.getObject()), resultRow.getPrimaryKey(),
+			rowElementId);
 	}
 
 	public String getRowId() {
@@ -259,22 +269,31 @@ public class RowChecker {
 	protected String getRowCheckBox(
 		HttpServletRequest httpServletRequest, boolean checked,
 		boolean disabled, String name, String value, String checkBoxRowIds,
-		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+		String checkBoxAllRowIds, String checkBoxPostOnClick,
+		String rowElementId) {
 
-		StringBundler sb = new StringBundler(14);
+		StringBundler sb = new StringBundler(18);
 
 		sb.append("<label><input ");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");
 		}
 
+		sb.append("class=\"");
+		sb.append(_cssClass);
+		sb.append("\" ");
+
 		if (disabled) {
 			sb.append("disabled ");
 		}
 
-		sb.append("class=\"");
-		sb.append(_cssClass);
 		sb.append("\" name=\"");
 		sb.append(name);
 		sb.append("\" title=\"");

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp
@@ -216,6 +216,8 @@ if (iteratorURL != null) {
 		for (int i = 0; i < resultRows.size(); i++) {
 			com.liferay.portal.kernel.dao.search.ResultRow row = (com.liferay.portal.kernel.dao.search.ResultRow)resultRows.get(i);
 
+			String rowElementId = _getRowElementId(liferayPortletResponse.getNamespace(), id, portletRequest, portletResponse, row);
+
 			primaryKeysJSONArray.put(row.getPrimaryKey());
 
 			request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
@@ -247,14 +249,7 @@ if (iteratorURL != null) {
 			Map<String, Object> data = row.getData();
 		%>
 
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
-				</c:when>
-				<c:otherwise>
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
-				</c:otherwise>
-			</c:choose>
+			<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 			<%
 			for (int j = 0; j < entries.size(); j++) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/descriptive.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/descriptive.jsp
@@ -61,6 +61,8 @@
 			for (int i = 0; i < curResultRows.size(); i++) {
 				com.liferay.portal.kernel.dao.search.ResultRow row = curResultRows.get(i);
 
+				String rowElementId = _getRowElementId(liferayPortletResponse.getNamespace(), id, portletRequest, portletResponse, row);
+
 				primaryKeysJSONArray.put(row.getPrimaryKey());
 
 				request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
@@ -69,6 +71,8 @@
 
 				boolean rowIsChecked = false;
 				boolean rowIsDisabled = false;
+
+				Map<String, Object> data = row.getData();
 
 				if (rowChecker != null) {
 					rowIsChecked = rowChecker.isChecked(row.getObject());
@@ -81,28 +85,14 @@
 					String rowSelector = rowChecker.getRowSelector();
 
 					if (Validator.isNull(rowSelector)) {
-						Map<String, Object> rowData = row.getData();
-
-						if (rowData == null) {
-							rowData = new HashMap<String, Object>();
-						}
-
-						rowData.put("selectable", !rowIsDisabled);
-
-						row.setData(rowData);
+						data.put("selectable", !rowIsDisabled);
 					}
 				}
 
 				request.setAttribute("liferay-ui:search-container-row:rowId", id.concat(StringPool.UNDERLINE.concat(row.getRowId())));
-
-				Map<String, Object> data = row.getData();
-
-				if (data == null) {
-					data = new HashMap<String, Object>();
-				}
 			%>
 
-				<dd class="list-group-item list-group-item-flex <%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= rowIsChecked ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(row.getState()) ? "list-group-item-" + row.getState() : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+				<dd class="list-group-item list-group-item-flex <%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= rowIsChecked ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(row.getState()) ? "list-group-item-" + row.getState() : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 					<c:if test="<%= rowChecker != null %>">
 						<div class="autofit-col">
 							<div class="checkbox">

--- a/portal-web/docroot/html/taglib/ui/search_iterator/icon.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/icon.jsp
@@ -51,6 +51,8 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 		for (int j = 0; j < curResultRows.size(); j++) {
 			com.liferay.portal.kernel.dao.search.ResultRow row = curResultRows.get(j);
 
+			String rowElementId = _getRowElementId(liferayPortletResponse.getNamespace(), id, portletRequest, portletResponse, row);
+
 			primaryKeysJSONArray.put(row.getPrimaryKey());
 
 			request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
@@ -59,6 +61,8 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 
 			boolean rowIsChecked = false;
 			boolean rowIsDisabled = false;
+
+			Map<String, Object> data = row.getData();
 
 			if (rowChecker != null) {
 				rowIsChecked = rowChecker.isChecked(row.getObject());
@@ -71,33 +75,20 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 				String rowSelector = rowChecker.getRowSelector();
 
 				if (Validator.isNull(rowSelector)) {
-					Map<String, Object> rowData = row.getData();
-
-					if (rowData == null) {
-						rowData = new HashMap<String, Object>();
-					}
-
-					rowData.put("selectable", !rowIsDisabled);
-
-					row.setData(rowData);
+					data.put("selectable", !rowIsDisabled);
 				}
 			}
 
 			request.setAttribute("liferay-ui:search-container-row:rowId", id.concat(StringPool.UNDERLINE.concat(row.getRowId())));
 
-			Map<String, Object> data = row.getData();
 			String rowCssClass = row.getCssClass();
-
-			if (data == null) {
-				data = new HashMap<String, Object>();
-			}
 
 			if (Validator.isNull(rowCssClass)) {
 				rowCssClass = "card-page-item card-page-item-asset";
 			}
 		%>
 
-			<dd class="<%= GetterUtil.getString(row.getClassName()) %> <%= rowCssClass %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+			<dd class="<%= GetterUtil.getString(row.getClassName()) %> <%= rowCssClass %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 				<%
 				for (int k = 0; k < entries.size(); k++) {

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -10,6 +10,8 @@
 <%@ page import="com.liferay.portal.kernel.dao.search.ResultRowSplitterEntry" %><%@
 page import="com.liferay.taglib.ui.SearchIteratorTag" %>
 
+<%@ page import="java.util.AbstractMap" %>
+
 <%
 SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("liferay-ui:search:searchContainer");
 
@@ -19,7 +21,6 @@ boolean fixedHeader = GetterUtil.getBoolean((String)request.getAttribute("lifera
 String markupView = (String)request.getAttribute("liferay-ui:search-iterator:markupView");
 boolean paginate = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search-iterator:paginate"));
 ResultRowSplitter resultRowSplitter = (ResultRowSplitter)request.getAttribute("liferay-ui:search-iterator:resultRowSplitter");
-String rowIdProperty = (String)request.getAttribute("liferay-ui:search-container-row:rowIdProperty");
 String searchContainerRowCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:search-container-row:cssClass"));
 String searchResultCssClass = (String)request.getAttribute("liferay-ui:search-iterator:searchResultCssClass");
 String type = (String)request.getAttribute("liferay-ui:search:type");
@@ -38,4 +39,38 @@ List resultRows = searchContainer.getResultRows();
 String summary = searchContainer.getSummary();
 
 JSONArray primaryKeysJSONArray = JSONFactoryUtil.createJSONArray();
+%>
+
+<%!
+private String _getRowElementId(String namespace, String partialId, PortletRequest portletRequest, PortletResponse portletResponse, com.liferay.portal.kernel.dao.search.ResultRow row) {
+	StringBundler sb = new StringBundler(row.getPrimaryKey() == null ? 4 : 6);
+
+	sb.append(namespace);
+	sb.append(partialId);
+	sb.append(StringPool.UNDERLINE);
+	sb.append(row.getRowId());
+
+	if (row.getPrimaryKey() != null) {
+		sb.append(StringPool.UNDERLINE);
+		sb.append(row.getPrimaryKey());
+	}
+
+	String rowElementId = HtmlUtil.escapeAttribute(sb.toString());
+
+	Map<String, Object> data = row.getData();
+
+	if ((data == null) || (data instanceof AbstractMap)) {
+		data = new HashMap<String, Object>();
+
+		if (row.getData() instanceof AbstractMap) {
+			data.putAll(row.getData());
+		}
+	}
+
+	data.put("rowElementId", rowElementId);
+
+	row.setData(data);
+
+	return rowElementId;
+}
 %>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -221,6 +221,8 @@ if (fixedHeader) {
 				for (int i = 0; i < curResultRows.size(); i++) {
 					com.liferay.portal.kernel.dao.search.ResultRow row = curResultRows.get(i);
 
+					String rowElementId = _getRowElementId(liferayPortletResponse.getNamespace(), id, portletRequest, portletResponse, row);
+
 					primaryKeysJSONArray.put(row.getPrimaryKey());
 
 					request.setAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW, row);
@@ -229,6 +231,8 @@ if (fixedHeader) {
 
 					boolean rowIsChecked = false;
 					boolean rowIsDisabled = false;
+
+					Map<String, Object> data = row.getData();
 
 					if (rowChecker != null) {
 						rowIsChecked = rowChecker.isChecked(row.getObject());
@@ -251,35 +255,14 @@ if (fixedHeader) {
 						String rowSelector = rowChecker.getRowSelector();
 
 						if (Validator.isNull(rowSelector)) {
-							Map<String, Object> rowData = row.getData();
-
-							if (rowData == null) {
-								rowData = new HashMap<String, Object>();
-							}
-
-							rowData.put("selectable", !rowIsDisabled);
-
-							row.setData(rowData);
+							data.put("selectable", !rowIsDisabled);
 						}
 					}
 
 					request.setAttribute("liferay-ui:search-container-row:rowId", id.concat(StringPool.UNDERLINE.concat(row.getRowId())));
-
-					Map<String, Object> data = row.getData();
-
-					if (data == null) {
-						data = new HashMap<String, Object>();
-					}
 				%>
 
-					<c:choose>
-						<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
-							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
-						</c:when>
-						<c:otherwise>
-							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
-						</c:otherwise>
-					</c:choose>
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 						<%
 						for (int j = 0; j < entries.size(); j++) {


### PR DESCRIPTION
Related to [LPS-188958](https://liferay.atlassian.net/browse/LPS-188958).

**Issue:** from the accessibility perspective there were no useful information for the user to decide whether select a row or not. 

**Fix:** the discussion taken [here](https://liferay.slack.com/archives/C04A7NLM7L1/p1691584013482139?thread_ts=1690227135.868729&cid=C04A7NLM7L1) decided to refer to the row as a whole adding `aria-labelledby="rowId"` to the checkbox.