### PR TITLE
LPS-193195 Add auto-save to FDS view

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -225,10 +225,10 @@ interface IOrderableTableProps {
 	noItemsButtonLabel: string;
 	noItemsDescription: string;
 	noItemsTitle: string;
-	onCancelButtonClick: Function;
+	onCancelButtonClick?: Function;
 	onCreationButtonClick: Function;
 	onOrderChange: (args: {orderedItems: any[]}) => void;
-	onSaveButtonClick: Function;
+	onSaveButtonClick?: Function;
 	title: string;
 }
 
@@ -376,22 +376,26 @@ const OrderableTable = ({
 				)}
 			</ClayLayout.SheetSection>
 
-			{!!items.length && (
+			{!!items.length && (onSaveButtonClick || onCancelButtonClick) && (
 				<ClayLayout.SheetFooter>
 					<ClayButton.Group spaced>
-						<ClayButton
-							disabled={disableSave}
-							onClick={() => onSaveButtonClick()}
-						>
-							{Liferay.Language.get('save')}
-						</ClayButton>
+						{onSaveButtonClick && (
+							<ClayButton
+								disabled={disableSave}
+								onClick={() => onSaveButtonClick()}
+							>
+								{Liferay.Language.get('save')}
+							</ClayButton>
+						)}
 
-						<ClayButton
-							displayType="secondary"
-							onClick={() => onCancelButtonClick()}
-						>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
+						{onCancelButtonClick && (
+							<ClayButton
+								displayType="secondary"
+								onClick={() => onCancelButtonClick()}
+							>
+								{Liferay.Language.get('cancel')}
+							</ClayButton>
+						)}
 					</ClayButton.Group>
 				</ClayLayout.SheetFooter>
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -943,7 +943,6 @@ const Fields = ({
 						'add-fields-to-show-in-your-view'
 					)}
 					noItemsTitle={Liferay.Language.get('no-fields-added-yet')}
-					onCancelButtonClick={() => navigate(fdsViewsURL)}
 					onCreationButtonClick={onCreationButtonClick}
 					onOrderChange={({
 						orderedItems,
@@ -956,7 +955,6 @@ const Fields = ({
 
 						updateFDSFieldsOrder();
 					}}
-					onSaveButtonClick={() => updateFDSFieldsOrder()}
 					title={Liferay.Language.get('fields')}
 				/>
 			) : (

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -749,6 +749,8 @@ const Fields = ({
 								(fdsField: IFDSField) => fdsField.id !== item.id
 							) || []
 						);
+
+						updateFDSFieldsOrder();
 					},
 				},
 			],
@@ -842,6 +844,8 @@ const Fields = ({
 						});
 
 						setFDSFields(newFDSFields);
+
+						updateFDSFieldsOrder();
 					}}
 					saveFDSFieldsURL={saveFDSFieldsURL}
 				/>
@@ -949,6 +953,8 @@ const Fields = ({
 						fdsFieldsOrderRef.current = orderedItems
 							.map((item) => item.id)
 							.join(',');
+
+						updateFDSFieldsOrder();
 					}}
 					onSaveButtonClick={() => updateFDSFieldsOrder()}
 					title={Liferay.Language.get('fields')}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -841,14 +841,12 @@ function Filters({fdsView, fdsViewsURL, namespace}: IProps) {
 				noItemsTitle={Liferay.Language.get(
 					'no-default-filters-were-created'
 				)}
-				onCancelButtonClick={() => navigate(fdsViewsURL)}
 				onCreationButtonClick={onCreationButtonClick}
 				onOrderChange={({orderedItems}: {orderedItems: IFilter[]}) => {
 					setNewFiltersOrder(
 						orderedItems.map((filter) => filter.id).join(',')
 					);
 				}}
-				onSaveButtonClick={updateFDSFiltersOrder}
 				title={Liferay.Language.get('filters')}
 			/>
 		</ClayLayout.ContainerFluid>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -679,6 +679,12 @@ function Filters({fdsView, fdsViewsURL, namespace}: IProps) {
 		getFilters();
 	}, [fdsView]);
 
+	useEffect(() => {
+		if (newFiltersOrder.length) {
+			updateFDSFiltersOrder();
+		}
+	}, [newFiltersOrder]);
+
 	const updateFDSFiltersOrder = async () => {
 		const response = await fetch(
 			`${API_URL.FDS_VIEWS}/by-external-reference-code/${fdsView.externalReferenceCode}`,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -423,6 +423,12 @@ const Sorting = ({
 		});
 	}, [fdsView]);
 
+	useEffect(() => {
+		if (newFDSSortsOrder.length) {
+			handleSave();
+		}
+	}, [newFDSSortsOrder]);
+
 	const handleCreation = () =>
 		openModal({
 			contentComponent: ({closeModal}: {closeModal: Function}) => (

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -604,7 +604,6 @@ const Sorting = ({
 						noItemsTitle={Liferay.Language.get(
 							'no-default-sort-created-yet'
 						)}
-						onCancelButtonClick={() => navigate(fdsViewsURL)}
 						onCreationButtonClick={handleCreation}
 						onOrderChange={({
 							orderedItems,
@@ -617,7 +616,6 @@ const Sorting = ({
 									.join(',')
 							);
 						}}
-						onSaveButtonClick={handleSave}
 						title={Liferay.Language.get('sorting')}
 					/>
 				</>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -32,10 +32,10 @@ interface IOrderableTableProps {
 	noItemsButtonLabel: string;
 	noItemsDescription: string;
 	noItemsTitle: string;
-	onCancelButtonClick: Function;
+	onCancelButtonClick?: Function;
 	onCreationButtonClick: Function;
 	onOrderChange: (args: {orderedItems: any[]}) => void;
-	onSaveButtonClick: Function;
+	onSaveButtonClick?: Function;
 	title: string;
 }
 declare const OrderableTable: ({


### PR DESCRIPTION
This PR enable autosave for `fields`, `filters` and `sorting` tabs of the FDS Views and remove the save and cancel buttons