### PR TITLE
LPS-187257 Passing doAsUserLanguageId in session_click to avoid unwanted language changes

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
@@ -10,6 +10,8 @@ const TOKEN_SERIALIZE = 'serialize://';
 function getSessionClickFormData(cmd) {
 	const doAsUserIdEncoded = Liferay.ThemeDisplay.getDoAsUserIdEncoded();
 
+	const doAsUserLanguageId = Liferay.ThemeDisplay.getDoAsUserLanguageId();
+
 	const formData = new FormData();
 
 	formData.append('cmd', cmd);
@@ -17,6 +19,10 @@ function getSessionClickFormData(cmd) {
 
 	if (doAsUserIdEncoded) {
 		formData.append('doAsUserId', doAsUserIdEncoded);
+	}
+
+	if (doAsUserLanguageId) {
+		formData.append('doAsUserLanguageId', doAsUserLanguageId);
 	}
 
 	return formData;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
@@ -10,7 +10,7 @@ const TOKEN_SERIALIZE = 'serialize://';
 function getSessionClickFormData(cmd) {
 	const doAsUserIdEncoded = Liferay.ThemeDisplay.getDoAsUserIdEncoded();
 
-	const doAsUserLanguageId = Liferay.ThemeDisplay.getDoAsUserLanguageId();
+	const doAsUserLanguageId = document.documentElement.lang;
 
 	const formData = new FormData();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3631,6 +3631,14 @@ public class PortalImpl implements Portal {
 			}
 		}
 
+		if (Validator.isNotNull(doAsUserLanguageId) && initialize) {
+			Locale userLocale = LocaleUtil.fromLanguageId(doAsUserLanguageId);
+
+			setLocale(httpServletRequest, httpServletResponse, userLocale);
+
+			return userLocale;
+		}
+
 		if ((user != null) && !user.isGuestUser()) {
 			Locale userLocale = getAvailableLocale(groupId, user.getLocale());
 

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -239,6 +239,9 @@
 			getDoAsUserIdEncoded: function() {
 				return '<%= UnicodeFormatter.toString(themeDisplay.getDoAsUserId()) %>';
 			},
+			getDoAsUserLanguageId: function() {
+				return '<%= UnicodeFormatter.toString(themeDisplay.getDoAsUserLanguageId()) %>';
+			},
 			getLanguageId: function() {
 				return '<%= LanguageUtil.getLanguageId(request) %>';
 			},

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -239,9 +239,6 @@
 			getDoAsUserIdEncoded: function() {
 				return '<%= UnicodeFormatter.toString(themeDisplay.getDoAsUserId()) %>';
 			},
-			getDoAsUserLanguageId: function() {
-				return '<%= UnicodeFormatter.toString(themeDisplay.getDoAsUserLanguageId()) %>';
-			},
 			getLanguageId: function() {
 				return '<%= LanguageUtil.getLanguageId(request) %>';
 			},


### PR DESCRIPTION
Hey guys,

This is a new pull request for this case. I'm changing a little bit the approach this time. 

Basically, during session_click we initialize Theme Display, and during Theme Display initialization we store user language in HTTP Session, which is later retrieved when opening Control Panel.

So far, we are deciding which is the user language based on the default language for a layout following the criteria:

1. Getting a visible Layout (for the user) belonging to the Layoutset for default’s VirtualHost.
2. If there’s no Layout found, then it looks for the User’s personal site.
3. If there’s no Layout found, then it searchs for the default Layout for other’s sites the user belongs to.

That leads into situations where the user sees how the language is unexpectedly changed when navigating from public pages to control panel.

This pull request is sending doAsUserLanguageId parameter with the value of the actual language the user is seeing the public page before navigating to Control Panel, so that's the one stored in HTTP session and later recovered, so we can keep the same language through navigation.

Thanks.

Regards.