### PR TITLE
[TS] LPS-191923 zh_HK has invalid characters when used as a date mask

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_date/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_date/page.jsp
@@ -72,6 +72,11 @@ if (!BrowserSnifferUtil.isMobile(request)) {
 
 	mask = simpleDateFormatPattern;
 
+	// Replace single quotes to prevent the string from breaking when passing
+	// into the A.DatePicker mask. This is used for the zh_HK locale which
+	// returns the format yyyy'年'MM'月'dd'日'.
+
+	mask = mask.replaceAll("'", "");
 	mask = mask.replaceAll("yyyy", "%Y");
 	mask = mask.replaceAll("MM", "%m");
 	mask = mask.replaceAll("dd", "%d");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191923

Follow-up from: https://github.com/liferay-frontend/liferay-portal/pull/3560

From my investigation, the format being returned was `yyyy'年'MM'月'dd'日'` where the single quotes were causing an issue when adding it into the javascript (see screenshot).

<img width="311" alt="Screenshot 2023-08-15 at 3 51 49 PM" src="https://github.com/liferay-frontend/liferay-portal/assets/4496722/433403df-5199-4ef4-8db8-2ed0db5d27c7">

My fix is to remove all single quotes that could cause the javascript strings to break.

I was looking up the [Hong Kong date format](https://worldpopulationreview.com/country-rankings/date-format-by-country) and they do use (yy)yy年(m)m月(d)d日 so it does seem like those characters should be part of the mask.

## Demo

https://github.com/liferay-frontend/liferay-portal/assets/4496722/3d235508-54a7-475c-aad7-310c6031501a


cc @wanderlast 