### PR TITLE
[TS] LPS-191497 Updating spring-boot-starter-oauth2-resource-server to 2.7.11

### DIFF
--- a/modules/util/client-extension-util-spring-boot/build.gradle
+++ b/modules/util/client-extension-util-spring-boot/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
-	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	api group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation group: "org.apache.commons", name: "commons-lang3", version: "3.12.0"
 	implementation group: "org.json", name: "json", version: "20230227"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-activemq", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
 	implementation group: "net.datafaker", name: "datafaker", version: "1.9.0"
 	implementation group: "org.json", name: "json", version: "20230227"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-spring-boot/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.portal.search.rest.client", version: "latest.release"
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
 	implementation group: "org.json", name: "json", version: "20220320"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }


### PR DESCRIPTION
Updating **spring-boot-starter-oauth2-resource-server** from **2.7.9** to **2.7.11** in order to fix vulnerability CVE-2023-20862.

Please let me know if the Frontend Infrastructure Team is not the correct team to send pull requests concerning Client Extension.

Thank you and best regards,
István