### PR TITLE
LPS-193661

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1092,11 +1092,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			jspWriter.write(" /><span class=\"input-group-inset-item");
 			jspWriter.write(" input-group-inset-item-after\"><button class=\"");
 			jspWriter.write(" navbar-breakpoint-d-none btn btn-monospaced");
-			jspWriter.write(" btn-unstyled\"");
-
-			if (disabled) {
-				jspWriter.write(" disabled");
-			}
+			jspWriter.write(" btn-unstyled\" disabled");
 
 			jspWriter.write(" type=\"button\">");
 
@@ -1109,11 +1105,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			jspWriter.write("</button><button aria-label=\"");
 			jspWriter.write(LanguageUtil.get(resourceBundle, "search"));
 			jspWriter.write("\" class=\"btn btn-monospaced");
-			jspWriter.write(" btn-unstyled\"");
-
-			if (disabled) {
-				jspWriter.write(" disabled");
-			}
+			jspWriter.write(" btn-unstyled\" disabled");
 
 			jspWriter.write(" type=\"submit\">");
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1092,7 +1092,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			jspWriter.write(" /><span class=\"input-group-inset-item");
 			jspWriter.write(" input-group-inset-item-after\"><button class=\"");
 			jspWriter.write(" navbar-breakpoint-d-none btn btn-monospaced");
-			jspWriter.write(" btn-unstyled\">");
+			jspWriter.write(" btn-unstyled\"");
 
 			if (disabled) {
 				jspWriter.write(" disabled");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/ManagementToolbarDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/display/context/ManagementToolbarDisplayContext.java
@@ -98,7 +98,7 @@ public interface ManagementToolbarDisplayContext {
 	}
 
 	public default String getSearchFormName() {
-		return null;
+		return "fm";
 	}
 
 	public default String getSearchInputName() {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -7,7 +7,7 @@ import {ClayButtonWithIcon} from '@clayui/button';
 import {FocusTrap} from '@clayui/core';
 import {ClayInput} from '@clayui/form';
 import {ManagementToolbar} from 'frontend-js-components-web';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 const SearchControls = ({
 	disabled,
@@ -22,6 +22,15 @@ const SearchControls = ({
 	searchValue,
 }) => {
 	const searchInputRef = useRef();
+	const [searchDisabled, setSearchDisabled] = useState(true);
+
+	const onClick = () => {
+		setSearchDisabled(true);
+
+		const form = document.getElementById(`${searchFormName}_search`);
+
+		submitForm(form);
+	};
 
 	useEffect(() => {
 		if (searchMobile) {
@@ -29,10 +38,28 @@ const SearchControls = ({
 		}
 	}, [searchMobile]);
 
+	useEffect(() => {
+		const onPageLoad = () => {
+			setSearchDisabled(false);
+		};
+
+		if (!disabled) {
+			if (document.readyState === 'complete') {
+				onPageLoad();
+			}
+			else {
+				window.addEventListener('load', onPageLoad);
+
+				return () => window.removeEventListener('load', onPageLoad);
+			}
+		}
+	}, [disabled]);
+
 	return (
 		<>
 			<ManagementToolbar.Search
 				action={searchActionURL}
+				id={`${searchFormName}_search`}
 				method={searchFormMethod}
 				name={searchFormName}
 				showMobile={searchMobile}
@@ -63,8 +90,9 @@ const SearchControls = ({
 							<ClayInput.GroupInsetItem after tag="span">
 								<ClayButtonWithIcon
 									aria-label={Liferay.Language.get('search')}
-									disabled={disabled}
+									disabled={searchDisabled}
 									displayType="unstyled"
+									onClick={onClick}
 									symbol="search"
 									title={Liferay.Language.get('search-for')}
 									type="submit"


### PR DESCRIPTION
Hi guys,

The issue here is the end user is clicking "Search" button in MGMT Toolbar before the page is fully rendered causing unexpected errors in the page as you can see in [LPS-193661](https://liferay.atlassian.net/browse/LPS-193661).

My proposal is to disable that button during page loading to enable later on.

On the server side render we don't need. to re-enable the button since it is only used for hydration purposes, so not needed once the page is loaded.

Thanks.

Regards.