### PR TITLE
LPS-130738 Language selector dropdown menu is empty after cloning

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -150,7 +150,7 @@ AUI.add(
 
 					let clonedRow;
 
-					if (inputsLocalized && !paletteIsCloned) {
+					if (inputsLocalized._nodes.length > 0 && !paletteIsCloned) {
 						const palette = document.querySelector(
 							"[id$='PaletteBoundingBox']"
 						);
@@ -163,7 +163,7 @@ AUI.add(
 
 						trigger.placeAfter(list);
 
-						list.append(palette);
+						list.append(palette.cloneNode(true));
 					}
 
 					if (instance.url) {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -361,6 +361,8 @@ AUI.add(
 					const inputLocalizedNamespaceId = `${inputLocalizedNamespace}${inputLocalizedId}`;
 
 					Liferay.InputLocalized.register(inputLocalizedNamespaceId, {
+						adminMode: inputLocalized.get('adminMode'),
+						availableLocales: inputLocalized.get('availableLocales'),
 						boundingBox: `#${inputLocalizedNamespaceId}PaletteBoundingBox`,
 						columns: inputLocalized.get('columns'),
 						contentBox: `#${inputLocalizedNamespaceId}PaletteContentBox`,
@@ -386,11 +388,15 @@ AUI.add(
 						inputPlaceholder: '#' + inputLocalizedNamespaceId,
 						items: inputLocalized.get('items'),
 						itemsError: inputLocalized.get('itemsError'),
+						languagesDropdownDirection: inputLocalized.get('languagesDropdownDirection'),
+						languagesTranslationsAriaLabels: inputLocalized.get('languagesTranslationsAriaLabels'),
+						lazy: inputLocalized.get('lazy'),
 						name: inputLocalizedId,
 						namespace: inputLocalized.get('namespace'),
 						selected: inputLocalized
 							.get('items')
 							.indexOf(inputLocalized.getSelectedLanguageId()),
+						selectedLanguageId: inputLocalized.get('selectedLanguageId'),
 						toggleSelection: inputLocalized.get('toggleSelection'),
 						translatedLanguages: inputLocalized.get(
 							'translatedLanguages'

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -150,7 +150,7 @@ AUI.add(
 
 					let clonedRow;
 
-					if (inputsLocalized._nodes.length > 0 && !paletteIsCloned) {
+					if (!!inputsLocalized._nodes.length && !paletteIsCloned) {
 						const palette = document.querySelector(
 							"[id$='PaletteBoundingBox']"
 						);
@@ -362,7 +362,9 @@ AUI.add(
 
 					Liferay.InputLocalized.register(inputLocalizedNamespaceId, {
 						adminMode: inputLocalized.get('adminMode'),
-						availableLocales: inputLocalized.get('availableLocales'),
+						availableLocales: inputLocalized.get(
+							'availableLocales'
+						),
 						boundingBox: `#${inputLocalizedNamespaceId}PaletteBoundingBox`,
 						columns: inputLocalized.get('columns'),
 						contentBox: `#${inputLocalizedNamespaceId}PaletteContentBox`,
@@ -388,15 +390,21 @@ AUI.add(
 						inputPlaceholder: '#' + inputLocalizedNamespaceId,
 						items: inputLocalized.get('items'),
 						itemsError: inputLocalized.get('itemsError'),
-						languagesDropdownDirection: inputLocalized.get('languagesDropdownDirection'),
-						languagesTranslationsAriaLabels: inputLocalized.get('languagesTranslationsAriaLabels'),
+						languagesDropdownDirection: inputLocalized.get(
+							'languagesDropdownDirection'
+						),
+						languagesTranslationsAriaLabels: inputLocalized.get(
+							'languagesTranslationsAriaLabels'
+						),
 						lazy: inputLocalized.get('lazy'),
 						name: inputLocalizedId,
 						namespace: inputLocalized.get('namespace'),
 						selected: inputLocalized
 							.get('items')
 							.indexOf(inputLocalized.getSelectedLanguageId()),
-						selectedLanguageId: inputLocalized.get('selectedLanguageId'),
+						selectedLanguageId: inputLocalized.get(
+							'selectedLanguageId'
+						),
 						toggleSelection: inputLocalized.get('toggleSelection'),
 						translatedLanguages: inputLocalized.get(
 							'translatedLanguages'

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -250,7 +250,7 @@ AUI.add(
 					Liferay.once('beforeScreenFlip', () => {
 						overlay.destroy();
 
-						instance._overlay = null;
+						instance._overlayMap.clear();
 					});
 
 					instance._overlayMap.set(trigger.generateID(), overlay);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -602,6 +602,8 @@ AUI.add(
 
 					Liferay.once('beforeScreenFlip', () => {
 						menuInstance._focusManager = null;
+
+						menuInstance._trigger = null;
 					});
 				}
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -114,13 +114,13 @@ AUI.add(
 
 					handles.length = 0;
 
-					const overlay = instance._overlay;
+					const trigger = instance._activeTrigger;
+
+					const overlay = instance._overlayMap.get(trigger.generateID());
 
 					if (overlay) {
 						overlay.hide();
 					}
-
-					const trigger = instance._activeTrigger;
 
 					instance._activeMenu = null;
 					instance._activeTrigger = null;
@@ -204,7 +204,15 @@ AUI.add(
 			_getMenu(trigger) {
 				const instance = this;
 
-				let overlay = instance._overlay;
+				if (!instance._overlayMap) {
+					instance._overlayMap = new Map();
+				}
+
+				if (!instance._trigger) {
+					instance._trigger = trigger;
+				}
+
+				let overlay = instance._overlayMap.get(trigger.generateID());
 
 				if (!overlay) {
 					const MenuOverlay = A.Component.create({
@@ -243,7 +251,7 @@ AUI.add(
 						instance._overlay = null;
 					});
 
-					instance._overlay = overlay;
+					instance._overlayMap.set(trigger.generateID(), overlay);
 				}
 				else {
 					overlay.set('align.node', trigger);
@@ -384,7 +392,7 @@ AUI.add(
 				if (menu) {
 					const cssClass = trigger.attr(ATTR_CLASS_NAME);
 
-					const overlay = instance._overlay;
+					const overlay = instance._overlayMap.get(trigger.generateID());
 
 					const align = overlay.get('align');
 
@@ -524,8 +532,10 @@ AUI.add(
 
 				let focusManager = menuInstance._focusManager;
 
+				const trigger = menuInstance._trigger;
+
 				if (!focusManager) {
-					const bodyNode = menuInstance._overlay.bodyNode;
+					const bodyNode = menuInstance._overlayMap.get(trigger.generateID()).bodyNode;
 
 					bodyNode.plug(A.Plugin.NodeFocusManager, {
 						circular: true,

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -116,7 +116,9 @@ AUI.add(
 
 					const trigger = instance._activeTrigger;
 
-					const overlay = instance._overlayMap.get(trigger.generateID());
+					const overlay = instance._overlayMap.get(
+						trigger.generateID()
+					);
 
 					if (overlay) {
 						overlay.hide();
@@ -392,7 +394,9 @@ AUI.add(
 				if (menu) {
 					const cssClass = trigger.attr(ATTR_CLASS_NAME);
 
-					const overlay = instance._overlayMap.get(trigger.generateID());
+					const overlay = instance._overlayMap.get(
+						trigger.generateID()
+					);
 
 					const align = overlay.get('align');
 
@@ -535,7 +539,9 @@ AUI.add(
 				const trigger = menuInstance._trigger;
 
 				if (!focusManager) {
-					const bodyNode = menuInstance._overlayMap.get(trigger.generateID()).bodyNode;
+					const bodyNode = menuInstance._overlayMap.get(
+						trigger.generateID()
+					).bodyNode;
 
 					bodyNode.plug(A.Plugin.NodeFocusManager, {
 						circular: true,


### PR DESCRIPTION
Hey guys,

When we use localized inputs with Auto Fields we are not correctly managing the menu because we tried to keep only one menu for all the triggers, what ended up in mixing references and showing empty dropdown menus.

My solution is adding a map of `menu` <-> `trigger` so this references does not get mixed up.

Thanks.