### PR TITLE
[TS] LPS-194413 Updating spring-boot to 2.7.11

### DIFF
--- a/modules/util/client-extension-util-spring-boot/build.gradle
+++ b/modules/util/client-extension-util-spring-boot/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
-	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
-	api group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
+	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
+	api group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
+	api group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.11"
 }

--- a/workspaces/liferay-delectablebonsai-workspace/client-extensions/liferay-delectablebonsai-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-delectablebonsai-workspace/client-extensions/liferay-delectablebonsai-etc-spring-boot/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -31,9 +31,9 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
 	implementation group: "org.json", name: "json", version: "20230227"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.11"
 }
 
 repositories {

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -30,10 +30,10 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot", version: "latest.release"
 	implementation group: "org.apache.commons", name: "commons-lang3", version: "3.12.0"
 	implementation group: "org.json", name: "json", version: "20230227"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-activemq", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-activemq", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.11"
 }
 
 repositories {

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/build.gradle
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -31,9 +31,9 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "org.json", name: "json", version: "20220320"
-	implementation group: "org.springframework.boot", name: "spring-boot", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
 }
 
 repositories {

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -31,9 +31,9 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.delivery.client", version: "latest.release"
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
-	implementation group: "org.springframework.boot", name: "spring-boot", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
 }
 
 repositories {

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -31,9 +31,9 @@ dependencies {
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
 	implementation group: "net.datafaker", name: "datafaker", version: "1.9.0"
 	implementation group: "org.json", name: "json", version: "20230227"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.11"
 }
 
 repositories {

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-cron/build.gradle
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-cron/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -32,9 +32,9 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.headless.delivery.client", version: "latest.release"
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
 	implementation group: "org.json", name: "json", version: "20220320"
-	implementation group: "org.springframework.boot", name: "spring-boot", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
 }
 
 repositories {

--- a/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-ticket-workspace/client-extensions/liferay-ticket-etc-spring-boot/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	dependencies {
 		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
-		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.9"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.11"
 	}
 
 	repositories {
@@ -31,9 +31,9 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.portal.search.rest.client", version: "latest.release"
 	implementation group: "commons-logging", name: "commons-logging", version: "1.2"
 	implementation group: "org.json", name: "json", version: "20220320"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
-	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.11"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.11"
 }
 
 repositories {


### PR DESCRIPTION
Hello,

Updating **spring-boot** and its related libraries from **2.7.9** to **2.7.11** in order to fix vulnerability CVE-2023-20862.

Thank you and best regards,
István