### PR TITLE
LPS-190851 LPS-193388 OrderableTable Creation Menu 

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -4,7 +4,7 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import ClayDropDown from '@clayui/drop-down';
+import ClayDropDown, {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayEmptyState from '@clayui/empty-state';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
@@ -219,6 +219,10 @@ const OrderableTableRow = ({
 
 interface IOrderableTableProps {
 	actions?: Array<IAction>;
+	creationMenuItems?: React.ComponentProps<
+		typeof ClayDropDownWithItems
+	>['items'];
+	creationMenuLabel?: string;
 	disableSave?: boolean;
 	fields: Array<IField>;
 	items: Array<any>;
@@ -226,7 +230,6 @@ interface IOrderableTableProps {
 	noItemsDescription: string;
 	noItemsTitle: string;
 	onCancelButtonClick: Function;
-	onCreationButtonClick: Function;
 	onOrderChange: (args: {orderedItems: any[]}) => void;
 	onSaveButtonClick: Function;
 	title: string;
@@ -234,6 +237,8 @@ interface IOrderableTableProps {
 
 const OrderableTable = ({
 	actions,
+	creationMenuItems,
+	creationMenuLabel = Liferay.Language.get('add'),
 	disableSave,
 	fields,
 	items: initialItems,
@@ -241,7 +246,6 @@ const OrderableTable = ({
 	noItemsDescription,
 	noItemsTitle,
 	onCancelButtonClick,
-	onCreationButtonClick,
 	onOrderChange,
 	onSaveButtonClick,
 	title,
@@ -306,14 +310,37 @@ const OrderableTable = ({
 							<Search onSearch={onSearch} query={query} />
 						</ManagementToolbar.Item>
 
-						<ManagementToolbar.Item>
-							<ClayButtonWithIcon
-								aria-label={Liferay.Language.get('add')}
-								className="nav-btn nav-btn-monospaced"
-								onClick={() => onCreationButtonClick()}
-								symbol="plus"
-							/>
-						</ManagementToolbar.Item>
+						{creationMenuItems?.length && (
+							<ManagementToolbar.Item>
+								{creationMenuItems.length > 1 ? (
+									<ClayDropDownWithItems
+										items={creationMenuItems}
+										trigger={
+											<ClayButtonWithIcon
+												aria-label={creationMenuLabel}
+												className="nav-btn nav-btn-monospaced"
+												symbol="plus"
+												title={creationMenuLabel}
+											/>
+										}
+									/>
+								) : (
+									<ClayButtonWithIcon
+										aria-label={
+											creationMenuItems[0].label ??
+											creationMenuLabel
+										}
+										className="nav-btn nav-btn-monospaced"
+										onClick={creationMenuItems[0].onClick}
+										symbol="plus"
+										title={
+											creationMenuItems[0].label ??
+											creationMenuLabel
+										}
+									/>
+								)}
+							</ManagementToolbar.Item>
+						)}
 					</ManagementToolbar.ItemList>
 				</ManagementToolbar.Container>
 
@@ -366,12 +393,28 @@ const OrderableTable = ({
 						description={noItemsDescription}
 						title={noItemsTitle}
 					>
-						<ClayButton
-							displayType="secondary"
-							onClick={() => onCreationButtonClick()}
-						>
-							{noItemsButtonLabel}
-						</ClayButton>
+						{creationMenuItems?.length &&
+							(creationMenuItems.length > 1 ? (
+								<ClayDropDownWithItems
+									alignmentPosition={4}
+									items={creationMenuItems}
+									trigger={
+										<ClayButton
+											aria-label={creationMenuLabel}
+											displayType="secondary"
+										>
+											{noItemsButtonLabel}
+										</ClayButton>
+									}
+								/>
+							) : (
+								<ClayButton
+									displayType="secondary"
+									onClick={creationMenuItems[0].onClick}
+								>
+									{noItemsButtonLabel}
+								</ClayButton>
+							))}
 					</ClayEmptyState>
 				)}
 			</ClayLayout.SheetSection>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -895,6 +895,12 @@ const Fields = ({
 							onClick: handleDelete,
 						},
 					]}
+					creationMenuItems={[
+						{
+							label: Liferay.Language.get('add-fields'),
+							onClick: onCreationButtonClick,
+						},
+					]}
 					fields={[
 						{
 							label: Liferay.Language.get('name'),
@@ -940,7 +946,6 @@ const Fields = ({
 					)}
 					noItemsTitle={Liferay.Language.get('no-fields-added-yet')}
 					onCancelButtonClick={() => navigate(fdsViewsURL)}
-					onCreationButtonClick={onCreationButtonClick}
 					onOrderChange={({
 						orderedItems,
 					}: {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -818,6 +818,12 @@ function Filters({fdsView, fdsViewsURL, namespace}: IProps) {
 						onClick: handleDelete,
 					},
 				]}
+				creationMenuItems={[
+					{
+						label: Liferay.Language.get('new-filter'),
+						onClick: onCreationButtonClick,
+					},
+				]}
 				disableSave={!newFiltersOrder.length}
 				fields={[
 					{
@@ -842,7 +848,6 @@ function Filters({fdsView, fdsViewsURL, namespace}: IProps) {
 					'no-default-filters-were-created'
 				)}
 				onCancelButtonClick={() => navigate(fdsViewsURL)}
-				onCreationButtonClick={onCreationButtonClick}
 				onOrderChange={({orderedItems}: {orderedItems: IFilter[]}) => {
 					setNewFiltersOrder(
 						orderedItems.map((filter) => filter.id).join(',')

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -578,6 +578,12 @@ const Sorting = ({
 								onClick: handleDelete,
 							},
 						]}
+						creationMenuItems={[
+							{
+								label: Liferay.Language.get('new-default-sort'),
+								onClick: handleCreation,
+							},
+						]}
 						disableSave={!newFDSSortsOrder.length}
 						fields={[
 							{
@@ -605,7 +611,6 @@ const Sorting = ({
 							'no-default-sort-created-yet'
 						)}
 						onCancelButtonClick={() => navigate(fdsViewsURL)}
-						onCreationButtonClick={handleCreation}
 						onOrderChange={({
 							orderedItems,
 						}: {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {ClayDropDownWithItems} from '@clayui/drop-down';
 import React from 'react';
 import '../../css/OrderableTable.scss';
 interface IAction {
@@ -26,6 +27,9 @@ interface IField {
 }
 interface IOrderableTableProps {
 	actions?: Array<IAction>;
+	creationMenuItems?: React.ComponentProps<
+		typeof ClayDropDownWithItems
+	>['items'];
 	disableSave?: boolean;
 	fields: Array<IField>;
 	items: Array<any>;
@@ -40,6 +44,7 @@ interface IOrderableTableProps {
 }
 declare const OrderableTable: ({
 	actions,
+	creationMenuItems,
 	disableSave,
 	fields,
 	items: initialItems,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -30,6 +30,7 @@ interface IOrderableTableProps {
 	creationMenuItems?: React.ComponentProps<
 		typeof ClayDropDownWithItems
 	>['items'];
+	creationMenuLabel?: string;
 	disableSave?: boolean;
 	fields: Array<IField>;
 	items: Array<any>;
@@ -37,7 +38,6 @@ interface IOrderableTableProps {
 	noItemsDescription: string;
 	noItemsTitle: string;
 	onCancelButtonClick: Function;
-	onCreationButtonClick: Function;
 	onOrderChange: (args: {orderedItems: any[]}) => void;
 	onSaveButtonClick: Function;
 	title: string;
@@ -45,6 +45,7 @@ interface IOrderableTableProps {
 declare const OrderableTable: ({
 	actions,
 	creationMenuItems,
+	creationMenuLabel,
 	disableSave,
 	fields,
 	items: initialItems,
@@ -52,7 +53,6 @@ declare const OrderableTable: ({
 	noItemsDescription,
 	noItemsTitle,
 	onCancelButtonClick,
-	onCreationButtonClick,
 	onOrderChange,
 	onSaveButtonClick,
 	title,


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPS-190851
**Subtask:** https://liferay.atlassian.net/browse/LPS-193388

This adds 2 new props to the `OrderableTable` component:
- `creationMenuItems` (array): This is passed into `<ClayDropdownWithItems items={creationMenuItems} />` so it can accept any dropdown items.
- `creationMenuLabel` (string): The tooltip text that appears when hovering over the button

When there is only 1 item, the `label` and `onClick` will be passed into a `ClayButton` which should appear like how it previously was.

**Example use:**

```javascript
<OrderableTable
	creationMenuItems={[
		{
			label: Liferay.Language.get('client-extension'),
			onClick: handleCreateClientExtension
		},
		{
			label: Liferay.Language.get('date-range'),
			onClick: handleCreateDateRange
		},
		{
			label: Liferay.Language.get('selection'),
			onClick: handleCreateSelection
		}
	]}
	creationMenuLabel={Liferay.Language.get('new-filter')}
/>
```

## Screenshots

<img width="1247" alt="Screenshot 2023-08-24 at 4 38 28 PM" src="https://github.com/liferay-frontend/liferay-portal/assets/4496722/838cb98d-df81-46cb-9da2-16328ee5d3c7">

<img width="1240" alt="Screenshot 2023-08-24 at 4 38 10 PM" src="https://github.com/liferay-frontend/liferay-portal/assets/4496722/4398aac3-279e-4bba-a301-9db9aff01fcc">

cc @chestofwonders 
