### PR TITLE
LPS-194121 Apply new renderer public API on FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
@@ -108,7 +108,7 @@ const Filter = ({moduleURL, type, ...otherProps}) => {
 								...filter,
 							}),
 					}}
-					htmlBuilder={Component}
+					htmlElementBuilder={Component}
 				/>
 			) : (
 				<Component setFilter={setFilter} {...otherProps} />

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FDSCellRendererArgs} from '@liferay/js-api/data-set';
+import {FDSTableCellHTMLElementBuilderArgs} from '@liferay/js-api/data-set';
 import {ClientExtension} from 'frontend-js-components-web';
 import {TRenderer, getRenderer} from 'frontend-js-web';
 import React, {ComponentType, useContext, useEffect, useState} from 'react';
@@ -171,7 +171,7 @@ function TableCell({
 	) {
 		return (
 			<DndTableCell columnName={String(field.fieldName)}>
-				<ClientExtension<FDSCellRendererArgs>
+				<ClientExtension<FDSTableCellHTMLElementBuilderArgs>
 					args={{value}}
 					htmlElementBuilder={cellRenderer.htmlElementBuilder}
 				/>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/TableCell.tsx
@@ -165,12 +165,15 @@ function TableCell({
 		);
 	}
 
-	if (cellRenderer.type === 'clientExtension' && cellRenderer.htmlBuilder) {
+	if (
+		cellRenderer.type === 'clientExtension' &&
+		cellRenderer.htmlElementBuilder
+	) {
 		return (
 			<DndTableCell columnName={String(field.fieldName)}>
 				<ClientExtension<FDSCellRendererArgs>
 					args={{value}}
-					htmlBuilder={cellRenderer.htmlBuilder}
+					htmlElementBuilder={cellRenderer.htmlElementBuilder}
 				/>
 			</DndTableCell>
 		);

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/ClientExtension.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/ClientExtension.tsx
@@ -7,18 +7,18 @@ import React, {useEffect, useRef} from 'react';
 
 interface IClientExtensionProps<T> {
 	args: T;
-	htmlBuilder: (args: T) => HTMLElement;
+	htmlElementBuilder: (args: T) => HTMLElement;
 }
 
 export default function ClientExtension<T>({
 	args,
-	htmlBuilder,
+	htmlElementBuilder,
 }: IClientExtensionProps<T>): React.ReactElement {
 	const containerRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		if (containerRef.current) {
-			containerRef.current.appendChild(htmlBuilder(args));
+			containerRef.current.appendChild(htmlElementBuilder(args));
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/ClientExtension.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/ClientExtension.d.ts
@@ -6,10 +6,10 @@
 import React from 'react';
 interface IClientExtensionProps<T> {
 	args: T;
-	htmlBuilder: (args: T) => HTMLElement;
+	htmlElementBuilder: (args: T) => HTMLElement;
 }
 export default function ClientExtension<T>({
 	args,
-	htmlBuilder,
+	htmlElementBuilder,
 }: IClientExtensionProps<T>): React.ReactElement;
 export {};

--- a/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@liferay/js-api": "0.3.0-pre.0",
+		"@liferay/js-api": "0.4.0-pre.0",
 		"axe-core": "4.2.0",
 		"clipboard": "2.0.4",
 		"cropperjs": "1.5.11",

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/getRenderer.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/getRenderer.ts
@@ -32,7 +32,7 @@ async function getRenderer({
 
 		if (type === 'clientExtension') {
 			renderer = {
-				htmlBuilder: module[symbolName],
+				htmlElementBuilder: module[symbolName],
 				type,
 			};
 		}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/types.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/types.ts
@@ -7,7 +7,7 @@ import {FDSCellRenderer} from '@liferay/js-api/data-set';
 
 export interface IClientExtensionRenderer {
 	erc?: string;
-	htmlBuilder?: FDSCellRenderer;
+	htmlElementBuilder?: FDSCellRenderer;
 	name?: string;
 	type: 'clientExtension';
 	url?: string;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/types.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/types.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FDSTableCellHTMLElementBuilder} from '@liferay/js-api/data-set';
+interface IHTMLElementBuilder {
+	(args: any): HTMLElement;
+}
 
 export interface IClientExtensionRenderer {
 	erc?: string;
-	htmlElementBuilder?: FDSTableCellHTMLElementBuilder;
+	htmlElementBuilder?: IHTMLElementBuilder;
 	name?: string;
 	type: 'clientExtension';
 	url?: string;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/types.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/types.ts
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FDSCellRenderer} from '@liferay/js-api/data-set';
+import {FDSTableCellHTMLElementBuilder} from '@liferay/js-api/data-set';
 
 export interface IClientExtensionRenderer {
 	erc?: string;
-	htmlElementBuilder?: FDSCellRenderer;
+	htmlElementBuilder?: FDSTableCellHTMLElementBuilder;
 	name?: string;
 	type: 'clientExtension';
 	url?: string;

--- a/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/types.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/types.d.ts
@@ -5,10 +5,12 @@
 
 /// <reference types="react" />
 
-import {FDSTableCellHTMLElementBuilder} from '@liferay/js-api/data-set';
+interface IHTMLElementBuilder {
+	(args: any): HTMLElement;
+}
 export interface IClientExtensionRenderer {
 	erc?: string;
-	htmlElementBuilder?: FDSTableCellHTMLElementBuilder;
+	htmlElementBuilder?: IHTMLElementBuilder;
 	name?: string;
 	type: 'clientExtension';
 	url?: string;
@@ -21,3 +23,4 @@ export interface IInternalRenderer {
 	url?: string;
 }
 export declare type TRenderer = IClientExtensionRenderer | IInternalRenderer;
+export {};

--- a/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/types.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/types.d.ts
@@ -8,7 +8,7 @@
 import {FDSCellRenderer} from '@liferay/js-api/data-set';
 export interface IClientExtensionRenderer {
 	erc?: string;
-	htmlBuilder?: FDSCellRenderer;
+	htmlElementBuilder?: FDSCellRenderer;
 	name?: string;
 	type: 'clientExtension';
 	url?: string;

--- a/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/types.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/types.d.ts
@@ -5,10 +5,10 @@
 
 /// <reference types="react" />
 
-import {FDSCellRenderer} from '@liferay/js-api/data-set';
+import {FDSTableCellHTMLElementBuilder} from '@liferay/js-api/data-set';
 export interface IClientExtensionRenderer {
 	erc?: string;
-	htmlElementBuilder?: FDSCellRenderer;
+	htmlElementBuilder?: FDSTableCellHTMLElementBuilder;
 	name?: string;
 	type: 'clientExtension';
 	url?: string;

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@liferay/js-api": "^0.2.0-pre.0",
+		"@liferay/js-api": "^0.4.0-pre.0",
 		"serve": "^14.2.0"
 	},
 	"description": "Liferay Sample Frontend Data Set Cell Renderer",

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@liferay/js-api": "^0.4.0-pre.0",
+		"@liferay/js-api": "0.4.0-pre.0",
 		"serve": "^14.2.0"
 	},
 	"description": "Liferay Sample Frontend Data Set Cell Renderer",

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-cell-renderer/src/index.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import type {FDSCellRenderer} from '@liferay/js-api/data-set';
+import type {FDSTableCellHTMLElementBuilder} from '@liferay/js-api/data-set';
 
-const fdsCellRenderer: FDSCellRenderer = ({value}) => {
+const fdsCellRenderer: FDSTableCellHTMLElementBuilder = ({value}) => {
 	const element = document.createElement('div');
 
 	element.innerHTML = value === 'Green' ? '🍏' : value.toString();

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-filter/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-filter/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@liferay/js-api": "^0.3.0-pre.0",
+		"@liferay/js-api": "0.4.0-pre.0",
 		"serve": "^14.2.0"
 	},
 	"description": "Liferay Sample FDS Filter",

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-filter/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-filter/src/index.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import type {FDSFilter} from '@liferay/js-api/data-set';
+import type {FDSFilterHTMLElementBuilder} from '@liferay/js-api/data-set';
 
-const mySampleFilter: FDSFilter = ({filter, setFilter}) => {
+const mySampleFilter: FDSFilterHTMLElementBuilder = ({filter, setFilter}) => {
 	const div = document.createElement('div');
 	const button = document.createElement('button');
 	const input = document.createElement('input');


### PR DESCRIPTION
### References

- [LPS-189354 Standardize renderer APIs](https://issues.liferay.com/browse/LPS-189354)
- new public API: https://github.com/liferay/liferay-frontend-projects/pull/1157

### What is the goal of this PR?

We are applying new renderers API, along with new naming conventions.

After this PR, we'll be able to safely remove old API from `js-api/data-set/index.ts`

Testing this locally will result in an error, caused by https://github.com/liferay-frontend/liferay-portal/pull/3611 . I did test this with commit from the other PR, and all works fine. 

### What does it look like?

No changes in UI
