### PR TITLE
LPS-194840 Check editor has resizer for firefox

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/videoembed/plugin.js
@@ -362,8 +362,10 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 
 		afterInit(editor) {
 			editor.on('resize', () => {
-				editor.resizer.hide();
-				selectWidget(editor);
+				if (editor.resizer) {
+					editor.resizer.hide();
+					selectWidget(editor);
+				}
 			});
 
 			ALIGN_VALUES.forEach((alignValue) => {
@@ -638,7 +640,9 @@ if (!CKEDITOR.plugins.get('videoembed')) {
 						}
 					}
 					else {
-						editor.resizer.hide();
+						if (editor.resizer) {
+							editor.resizer.hide();
+						}
 					}
 				}
 			});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194840

Firefox calls 'selectionChange' when previewing content in Documents and Media which results in errors since there is no editor.resizer.
I added checks for editor.resizer for this specific firfox issue.

Let me know if there are any questions or comments about this.
Thank you!