### PR TITLE
LPS-192619 - Allow users to translate field labels (column names)

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -20,6 +20,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -244,16 +245,22 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
 						_language.get(locale, "sortable"), "sortable", false)));
 
-		fdsFieldObjectDefinition.setEnableLocalization(true);
+		if (FeatureFlagManagerUtil.isEnabled("LPS-172017")) {
+			fdsFieldObjectDefinition.setEnableLocalization(true);
 
-		_objectDefinitionLocalService.updateObjectDefinition(fdsFieldObjectDefinition);
+			fdsFieldObjectDefinition =
+				_objectDefinitionLocalService.updateObjectDefinition(
+					fdsFieldObjectDefinition);
+		}
 
 		ObjectField fieldLabelObjectField = ObjectFieldUtil.createObjectField(
 			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 			_language.get(locale, "column-label"), "label", false);
 
-		fieldLabelObjectField.setLocalized(true);
+		if (FeatureFlagManagerUtil.isEnabled("LPS-172017")) {
+			fieldLabelObjectField.setLocalized(true);
+		}
 
 		_objectFieldLocalService.addCustomObjectField(
 			fieldLabelObjectField.getExternalReferenceCode(), userId,
@@ -269,8 +276,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 			fieldLabelObjectField.getName(),
 			fieldLabelObjectField.getReadOnly(),
 			fieldLabelObjectField.getReadOnlyConditionExpression(),
-			fieldLabelObjectField.isRequired(),
-			fieldLabelObjectField.isState(),
+			fieldLabelObjectField.isRequired(), fieldLabelObjectField.isState(),
 			fieldLabelObjectField.getObjectFieldSettings());
 
 		_objectDefinitionLocalService.publishSystemObjectDefinition(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -225,10 +225,6 @@ public class FDSViewsPortlet extends MVCPortlet {
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "column-label"), "label", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(locale, "name"), "name", true),
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -247,6 +243,35 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
 						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
 						_language.get(locale, "sortable"), "sortable", false)));
+
+		fdsFieldObjectDefinition.setEnableLocalization(true);
+
+		_objectDefinitionLocalService.updateObjectDefinition(fdsFieldObjectDefinition);
+
+		ObjectField fieldLabelObjectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+			ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+			_language.get(locale, "column-label"), "label", false);
+
+		fieldLabelObjectField.setLocalized(true);
+
+		_objectFieldLocalService.addCustomObjectField(
+			fieldLabelObjectField.getExternalReferenceCode(), userId,
+			fieldLabelObjectField.getListTypeDefinitionId(),
+			fdsFieldObjectDefinition.getObjectDefinitionId(),
+			fieldLabelObjectField.getBusinessType(),
+			fieldLabelObjectField.getDBType(),
+			fieldLabelObjectField.isIndexed(),
+			fieldLabelObjectField.isIndexedAsKeyword(),
+			fieldLabelObjectField.getIndexedLanguageId(),
+			fieldLabelObjectField.getLabelMap(),
+			fieldLabelObjectField.isLocalized(),
+			fieldLabelObjectField.getName(),
+			fieldLabelObjectField.getReadOnly(),
+			fieldLabelObjectField.getReadOnlyConditionExpression(),
+			fieldLabelObjectField.isRequired(),
+			fieldLabelObjectField.isState(),
+			fieldLabelObjectField.getObjectFieldSettings());
 
 		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsFieldObjectDefinition.getObjectDefinitionId());

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -72,7 +72,9 @@ public class SaveFDSFieldsMVCResourceCommand
 			ObjectEntry objectEntry = _objectEntryService.addObjectEntry(
 				0, objectDefinition.getObjectDefinitionId(),
 				HashMapBuilder.<String, Serializable>put(
-					"label", String.valueOf(creationDataJSONObject.get("name"))
+					"label_i18n", HashMapBuilder.put(
+						themeDisplay.getLanguageId(), String.valueOf(creationDataJSONObject.get("name"))
+					).build()
 				).put(
 					"name", String.valueOf(creationDataJSONObject.get("name"))
 				).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -13,7 +13,6 @@ import ClayModal from '@clayui/modal';
 import {FDS_INTERNAL_CELL_RENDERERS} from '@liferay/frontend-data-set-web';
 import {
 	InputLocalized,
-	LocalizedValue,
 	ManagementToolbar,
 } from 'frontend-js-components-web';
 import {
@@ -36,6 +35,7 @@ import OrderableTable from '../components/OrderableTable';
 import '../../css/FDSEntries.scss';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
+type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 
 interface IFDSField {
 	externalReferenceCode: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -417,11 +417,19 @@ const EditFDSFieldModalContent = ({
 	);
 
 	const fdsFieldTranslations = fdsField.label_i18n;
-	const fieldLabel = Liferay.FeatureFlags['LPS-172017']
-		? fdsField.label_i18n[defaultLanguageId] || ''
-		: fdsField.label;
 
-	const [i18nFieldLabels, setI18nFieldLabels] = useState(fdsFieldTranslations);
+	let fieldLabel: string;
+
+	if (Liferay.FeatureFlags['LPS-172017']) {
+		fieldLabel = fdsField.label_i18n[defaultLanguageId] ?? fdsField.name;
+	}
+	else {
+		fieldLabel = fdsField.label;
+	}
+
+	const [i18nFieldLabels, setI18nFieldLabels] = useState(
+		fdsFieldTranslations
+	);
 
 	const editFDSField = async () => {
 		let body;
@@ -680,7 +688,13 @@ const Fields = ({
 
 		const responseJSON = await response.json();
 
-		const storedFDSFields = responseJSON?.items;
+		const storedFDSFields = responseJSON?.items.map((field: any) => {
+			if (!field.label) {
+				field.label = field.name;
+			}
+
+			return field;
+		});
 
 		if (!storedFDSFields) {
 			openToast({
@@ -884,10 +898,22 @@ const Fields = ({
 		});
 
 	const onEditFDSField = ({editedFDSField}: {editedFDSField: IFDSField}) => {
+		let updatedFDSField: IFDSField;
+
+		if (!editedFDSField.label) {
+			updatedFDSField = {
+				...editedFDSField,
+				label: editedFDSField.name,
+			};
+		}
+		else {
+			updatedFDSField = {...editedFDSField};
+		}
+
 		setFDSFields(
 			fdsFields?.map((fdsField) => {
-				if (fdsField.id === editedFDSField.id) {
-					return editedFDSField;
+				if (fdsField.id === updatedFDSField.id) {
+					return updatedFDSField;
 				}
 
 				return fdsField;


### PR DESCRIPTION
Related story/task: [LPS-176516](https://liferay.atlassian.net/browse/LPS-176516) / [LPS-192619](https://liferay.atlassian.net/browse/LPS-192619)

### Problem
Field names of a data set created by users cannot be translated, so once they set a string, it will be displayed for all languages. We need to add translation support for those fields.

Data sets use System Objects. Currently, the translation support for Objects in under a feature flag (LPS-172017) and the creation of localized System Objects is not fully supported.

### Solution
Using the specified feature flag (LPS-172017) and @dsanz workaround for adding localization support for System Objects the Data Set manager allow users create translatable fields. If the feature flag is not enabled, the application will work saving just one string for all languages.

#### Feature flag disabled
##### Object creation (no translation available)
![Screenshot from 2023-08-31 13-12-01](https://github.com/liferay-frontend/liferay-portal/assets/132653342/028fb060-910b-486c-9d99-0a928b4e4de4)

##### Edit an object field (no translation available)
![Screenshot from 2023-08-31 13-13-14](https://github.com/liferay-frontend/liferay-portal/assets/132653342/fcec58d2-d4aa-41d2-a728-4371045a7080)

##### Object field payload (single string -> `label`)
![Screenshot from 2023-08-31 13-13-49](https://github.com/liferay-frontend/liferay-portal/assets/132653342/78c80f13-5037-410e-807a-d4a9acfc2bd9)

##### Translation stored in the default FDSField db table
![Screenshot from 2023-08-31 13-28-53](https://github.com/liferay-frontend/liferay-portal/assets/132653342/91f3016e-db56-4977-b066-c957b466d357)

#### Feature flag enabled
##### Object creation allows translations
![Screenshot from 2023-08-31 14-28-57](https://github.com/liferay-frontend/liferay-portal/assets/132653342/1ad84eb6-bc42-43a4-8db1-2b6c624bfb42)

##### Data set field edition shows the InputLocalized component
![Screenshot from 2023-08-31 14-30-45](https://github.com/liferay-frontend/liferay-portal/assets/132653342/de477c35-3080-4cf2-bd28-d2f5e29d1ae5)

##### Object field payload (object with translations -> `label_i18n:{en_US: '...'}`
![Screenshot from 2023-08-31 14-31-27](https://github.com/liferay-frontend/liferay-portal/assets/132653342/54a6ba97-5a95-494e-816d-ca3e439e8d03)

##### Translations stored in a new FDSField_l db table
![Screenshot from 2023-08-31 14-32-08](https://github.com/liferay-frontend/liferay-portal/assets/132653342/a3d0a392-5b79-4512-8717-77be02d9ad52)


