### PR TITLE
LPS-194344 Scrape the spritemap and add RequiredMark for required inputs

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/fds_view.jsp
@@ -29,6 +29,8 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsViewLabel"));
 			"namespace", liferayPortletResponse.getNamespace()
 		).put(
 			"saveFDSFieldsURL", fdsViewsDisplayContext.getSaveFDSFieldsURL()
+		).put(
+			"spritemap", themeDisplay.getPathThemeSpritemap()
 		).build()
 	%>'
 />

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -68,6 +68,7 @@ interface IFDSViewSectionInterface {
 	namespace: string;
 	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
+	spritemap: string;
 }
 
 interface IFDSViewInterface {
@@ -76,6 +77,7 @@ interface IFDSViewInterface {
 	fdsViewsURL: string;
 	namespace: string;
 	saveFDSFieldsURL: string;
+	spritemap: string;
 }
 
 const FDSView = ({
@@ -84,6 +86,7 @@ const FDSView = ({
 	fdsViewsURL,
 	namespace,
 	saveFDSFieldsURL,
+	spritemap,
 }: IFDSViewInterface) => {
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
@@ -154,6 +157,7 @@ const FDSView = ({
 							setFDSView({...fdsView, ...updatedFdsViewData});
 						}}
 						saveFDSFieldsURL={saveFDSFieldsURL}
+						spritemap={spritemap}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -90,21 +90,21 @@ const Actions = ({spritemap}: {spritemap: string}) => {
 			const responseText = await response.text();
 
 			if (responseText.length) {
-				const XMLString = await new window.DOMParser().parseFromString(
+				const spritemapDocument = new DOMParser().parseFromString(
 					responseText,
 					'text/xml'
 				);
 
-				const availableIconSymbolElements = XMLString.querySelectorAll(
+				const symbolElements = spritemapDocument.querySelectorAll(
 					'symbol'
 				);
 
-				const iconSymbols = Array.from(
-					availableIconSymbolElements!
-				).map((element) => ({
-					label: element.id,
-					value: element.id,
-				}));
+				const iconSymbols = Array.from(symbolElements!).map(
+					(element) => ({
+						label: element.id,
+						value: element.id,
+					})
+				);
 
 				setAvailableIconSymbols(iconSymbols);
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -11,9 +11,11 @@ import ClayLayout from '@clayui/layout';
 import ClayPanel from '@clayui/panel';
 import ClayTabs from '@clayui/tabs';
 import {InputLocalized} from 'frontend-js-components-web';
-import React, {useState} from 'react';
+import {fetch} from 'frontend-js-web';
+import React, {useEffect, useState} from 'react';
 
 import OrderableTable from '../components/OrderableTable';
+import RequiredMark from '../components/RequiredMark';
 
 const MESSAGE_TYPES = [
 	{
@@ -68,9 +70,12 @@ const TYPES = [
 
 const noop = () => {};
 
-const Actions = () => {
+const Actions = ({spritemap}: {spritemap: string}) => {
 	const [activeSection, setActiveSection] = useState(SECTIONS.ACTIONS);
 	const [activeTab, setActiveTab] = useState(0);
+	const [availableIconSymbols, setAvailableIconSymbols] = useState<
+		Array<{label: string; value: string}>
+	>([]);
 	const [
 		confirmationMessageTranslations,
 		setConfirmationMessageTranslations,
@@ -78,9 +83,40 @@ const Actions = () => {
 	const [iconSymbol, setIconSymbol] = useState('bolt');
 	const [labelTranslations, setLabelTranslations] = useState({});
 
+	useEffect(() => {
+		const getIcons = async () => {
+			const response = await fetch(spritemap);
+
+			const responseText = await response.text();
+
+			if (responseText.length) {
+				const XMLString = await new window.DOMParser().parseFromString(
+					responseText,
+					'text/xml'
+				);
+
+				const availableIconSymbolElements = XMLString.querySelectorAll(
+					'symbol'
+				);
+
+				const iconSymbols = Array.from(
+					availableIconSymbolElements!
+				).map((element) => ({
+					label: element.id,
+					value: element.id,
+				}));
+
+				setAvailableIconSymbols(iconSymbols);
+			}
+		};
+
+		getIcons();
+	}, [spritemap]);
+
 	return (
 		<ClayLayout.ContainerFluid>
 			<ClayBreadcrumb
+				className="my-2"
 				items={[
 					{
 						active: activeSection === SECTIONS.ACTIONS,
@@ -203,37 +239,34 @@ const Actions = () => {
 											placeholder={Liferay.Language.get(
 												'action-name'
 											)}
+											required
 											translations={labelTranslations}
 										/>
 									</ClayLayout.Col>
 
 									<ClayLayout.Col
 										className="align-items-center d-flex justify-content-center"
-										size={1}
+										size={4}
 									>
 										<ClayIcon
-											className="w-50"
+											className="mr-4"
 											symbol={iconSymbol}
 										/>
-									</ClayLayout.Col>
 
-									<ClayLayout.Col size={3}>
 										<ClayForm.Group>
 											<label htmlFor="iconInput">
 												{Liferay.Language.get('icon')}
 											</label>
 
-											<ClayInput
+											<ClaySelectWithOption
+												defaultValue="bolt"
 												id="iconInput"
 												onChange={(event) =>
 													setIconSymbol(
-														event?.target.value
+														event.target.value
 													)
 												}
-												placeholder={Liferay.Language.get(
-													'please-select-an-option'
-												)}
-												value={iconSymbol}
+												options={availableIconSymbols}
 											/>
 										</ClayForm.Group>
 									</ClayLayout.Col>
@@ -254,6 +287,8 @@ const Actions = () => {
 										<ClayForm.Group>
 											<label htmlFor="actionTypeSelect">
 												{Liferay.Language.get('type')}
+
+												<RequiredMark />
 											</label>
 
 											<ClaySelectWithOption
@@ -261,7 +296,7 @@ const Actions = () => {
 												id="actionTypeSelect"
 												options={TYPES}
 												placeholder={Liferay.Language.get(
-													'select-an-option'
+													'please-select-an-option'
 												)}
 											/>
 										</ClayForm.Group>
@@ -273,6 +308,8 @@ const Actions = () => {
 										<ClayForm.Group>
 											<label htmlFor="urlInput">
 												{Liferay.Language.get('url')}
+
+												<RequiredMark />
 											</label>
 
 											<ClayInput

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -14,6 +14,7 @@ interface IFDSViewSectionInterface {
 	namespace: string;
 	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
+	spritemap: string;
 }
 interface IFDSViewInterface {
 	fdsClientExtensionCellRenderers: IClientExtensionRenderer[];
@@ -21,6 +22,7 @@ interface IFDSViewInterface {
 	fdsViewsURL: string;
 	namespace: string;
 	saveFDSFieldsURL: string;
+	spritemap: string;
 }
 declare const FDSView: ({
 	fdsClientExtensionCellRenderers,
@@ -28,6 +30,7 @@ declare const FDSView: ({
 	fdsViewsURL,
 	namespace,
 	saveFDSFieldsURL,
+	spritemap,
 }: IFDSViewInterface) => JSX.Element;
 export {IFDSViewSectionInterface};
 export default FDSView;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
@@ -5,5 +5,5 @@
 
 /// <reference types="react" />
 
-declare const Actions: () => JSX.Element;
+declare const Actions: ({spritemap}: {spritemap: string}) => JSX.Element;
 export default Actions;


### PR DESCRIPTION
Continuation of https://github.com/brianchandotcom/liferay-portal/pull/139849
A proper variant of https://github.com/liferay-frontend/liferay-portal/pull/3622

Reason for a new PR is that a lot of changes happened in the meanwhile (mostly by @thektan), and conflict resolution.

In this PR I am doing the following:
- passing `spritemap` from the backend to our `Actions` component
- consuming the `spritemap` in a `ClaySelect` that offers the scraped icons
- adjusting the icon preview that updates as the user is changing the icon in the `ClaySelect`
- importing and using the `RequiredMark` component to mark inputs as required
