### PR TITLE
LPS-195332 Use dynamic filters defined in fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
+	compileOnly project(":apps:list-type:list-type-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:object:object-rest-api")
 	compileOnly project(":apps:portal-template:portal-template-react-renderer-api")

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly project(":apps:client-extension:client-extension-api")
 	compileOnly project(":apps:client-extension:client-extension-type-api")
 	compileOnly project(":apps:fragment:fragment-api")
+	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:info:info-api")
 	compileOnly project(":apps:item-selector:item-selector-api")

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -185,6 +185,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					fragmentRendererContext, httpServletRequest));
 		}
 		catch (Exception exception) {
+			_log.error("Unable to render frontend data set view", exception);
+
 			throw new IOException(exception);
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -11,6 +11,10 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.list.type.model.ListTypeDefinition;
+import com.liferay.list.type.model.ListTypeEntry;
+import com.liferay.list.type.service.ListTypeDefinitionLocalService;
+import com.liferay.list.type.service.ListTypeEntryLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
@@ -22,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -235,7 +240,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			).put(
 				"filters",
 				_getFiltersJSONArray(
-					fdsViewObjectDefinition, fdsViewObjectEntry)
+					fdsViewObjectDefinition, fdsViewObjectEntry,
+					httpServletRequest)
 			).put(
 				"id", "FDS_" + fragmentRendererContext.getFragmentElementId()
 			).put(
@@ -364,7 +370,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 	private JSONArray _getFiltersJSONArray(
 			ObjectDefinition fdsViewObjectDefinition,
-			ObjectEntry fdsViewObjectEntry)
+			ObjectEntry fdsViewObjectEntry,
+			HttpServletRequest httpServletRequest)
 		throws Exception {
 
 		Set<ObjectEntry> fdsFilterObjectEntries = new TreeSet<>(
@@ -392,26 +399,93 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 				Map<String, Object> properties =
 					fdsFilterObjectEntry.getProperties();
 
-				if (!Objects.equals(
-						MapUtil.getString(properties, "type"), "date")) {
+				String type = MapUtil.getString(properties, "type");
 
-					return null;
+				if (Objects.equals(type, "date")) {
+					return JSONUtil.put(
+						"entityFieldType", type
+					).put(
+						"id", properties.get("fieldName")
+					).put(
+						"label", properties.get("name")
+					).put(
+						"max", _getDateJSONObject(properties.get("to"))
+					).put(
+						"min", _getDateJSONObject(properties.get("from"))
+					).put(
+						"type", "dateRange"
+					);
 				}
 
-				return JSONUtil.put(
-					"entityFieldType", properties.get("type")
-				).put(
-					"id", properties.get("fieldName")
-				).put(
-					"label", properties.get("name")
-				).put(
-					"max", _getDateJSONObject(properties.get("to"))
-				).put(
-					"min", _getDateJSONObject(properties.get("from"))
-				).put(
-					"type", "dateRange"
-				);
+				String listTypeDefinitionId = MapUtil.getString(
+					properties, "listTypeDefinitionId");
+
+				if (Validator.isNotNull(listTypeDefinitionId)) {
+					ThemeDisplay themeDisplay =
+						(ThemeDisplay)httpServletRequest.getAttribute(
+							WebKeys.THEME_DISPLAY);
+
+					ListTypeDefinition listTypeDefinition =
+						_listTypeDefinitionLocalService.
+							getListTypeDefinitionByExternalReferenceCode(
+								listTypeDefinitionId,
+								themeDisplay.getCompanyId());
+
+					List<ListTypeEntry> listTypeEntries =
+						_listTypeEntryLocalService.getListTypeEntries(
+							listTypeDefinition.getListTypeDefinitionId());
+
+					Locale locale = themeDisplay.getLocale();
+
+					return JSONUtil.put(
+						"autocompleteEnabled", true
+					).put(
+						"entityFieldType", type
+					).put(
+						"id", properties.get("fieldName")
+					).put(
+						"items",
+						_getListTypeEntriesJSONArray(listTypeEntries, locale)
+					).put(
+						"label", _language.get(locale, "search")
+					).put(
+						"label", properties.get("name")
+					).put(
+						"multiple", properties.get("multiple")
+					).put(
+						"selectedData",
+						_getSelectedDataJSONObject(
+							listTypeEntries, locale,
+							MapUtil.getString(properties, "preselectedValues"))
+					).put(
+						"type", "selection"
+					);
+				}
+
+				return null;
 			});
+	}
+
+	private JSONArray _getListTypeEntriesJSONArray(
+		List<ListTypeEntry> listTypeEntries, Locale locale) {
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		for (ListTypeEntry listTypeEntry : listTypeEntries) {
+			JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+			jsonObject.put(
+				"key", listTypeEntry.getKey()
+			).put(
+				"label", listTypeEntry.getName(locale)
+			).put(
+				"value", listTypeEntry.getKey()
+			);
+
+			jsonArray.put(jsonObject);
+		}
+
+		return jsonArray;
 	}
 
 	private ObjectEntry _getObjectEntry(
@@ -477,6 +551,47 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		return relatedObjectEntriesPage.getItems();
 	}
 
+	private JSONObject _getSelectedDataJSONObject(
+			List<ListTypeEntry> listTypeEntries, Locale locale,
+			String preselectedValues)
+		throws JSONException {
+
+		JSONArray jsonArray = _jsonFactory.createJSONArray();
+
+		JSONArray preselectedValuesJSONArray = _jsonFactory.createJSONArray(
+			preselectedValues);
+
+		for (int i = 0; i < preselectedValuesJSONArray.length(); i++) {
+			String key = preselectedValuesJSONArray.getString(i);
+
+			for (ListTypeEntry listTypeEntry : listTypeEntries) {
+				if (Objects.equals(listTypeEntry.getKey(), key)) {
+					JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+					jsonObject.put(
+						"label", listTypeEntry.getName(locale)
+					).put(
+						"value", listTypeEntry.getKey()
+					);
+
+					jsonArray.put(jsonObject);
+
+					break;
+				}
+			}
+		}
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+		jsonObject.put(
+			"exclude", false
+		).put(
+			"selectedItems", jsonArray
+		);
+
+		return jsonObject;
+	}
+
 	private String _interpolateURL(
 		String apiUrl, HttpServletRequest httpServletRequest) {
 
@@ -513,6 +628,12 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private ListTypeDefinitionLocalService _listTypeDefinitionLocalService;
+
+	@Reference
+	private ListTypeEntryLocalService _listTypeEntryLocalService;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -307,16 +307,15 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		List<Long> ids = ListUtil.toList(
-			ListUtil.fromString(
-				MapUtil.getString(
-					fdsViewObjectEntry.getProperties(), "fdsFieldsOrder"),
-				StringPool.COMMA),
-			Long::parseLong);
-
 		Set<ObjectEntry> fdsFieldObjectEntries = new TreeSet<>(
-			Comparator.comparing(
-				ObjectEntry::getId, Comparator.comparingInt(ids::indexOf)));
+			new ObjectEntryComparator(
+				ListUtil.toList(
+					ListUtil.fromString(
+						MapUtil.getString(
+							fdsViewObjectEntry.getProperties(),
+							"fdsFieldsOrder"),
+						StringPool.COMMA),
+					Long::parseLong)));
 
 		fdsFieldObjectEntries.addAll(
 			_getRelatedObjectEntries(
@@ -366,16 +365,15 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		List<Long> ids = ListUtil.toList(
-			ListUtil.fromString(
-				MapUtil.getString(
-					fdsViewObjectEntry.getProperties(), "fdsFiltersOrder"),
-				StringPool.COMMA),
-			Long::parseLong);
-
 		Set<ObjectEntry> fdsFilterObjectEntries = new TreeSet<>(
-			Comparator.comparing(
-				ObjectEntry::getId, Comparator.comparingInt(ids::indexOf)));
+			new ObjectEntryComparator(
+				ListUtil.toList(
+					ListUtil.fromString(
+						MapUtil.getString(
+							fdsViewObjectEntry.getProperties(),
+							"fdsFiltersOrder"),
+						StringPool.COMMA),
+					Long::parseLong)));
 
 		fdsFilterObjectEntries.addAll(
 			_getRelatedObjectEntries(
@@ -522,5 +520,39 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private ReactRenderer _reactRenderer;
+
+	private static class ObjectEntryComparator
+		implements Comparator<ObjectEntry> {
+
+		public ObjectEntryComparator(List<Long> ids) {
+			_ids = ids;
+		}
+
+		@Override
+		public int compare(ObjectEntry objectEntry1, ObjectEntry objectEntry2) {
+			long id1 = objectEntry1.getId();
+			long id2 = objectEntry2.getId();
+
+			int index1 = _ids.indexOf(id1);
+			int index2 = _ids.indexOf(id2);
+
+			if ((index1 == -1) && (index2 == -1)) {
+				return Long.compare(id1, id2);
+			}
+
+			if (index1 == -1) {
+				return 1;
+			}
+
+			if (index2 == -1) {
+				return -1;
+			}
+
+			return Long.compare(index1, index2);
+		}
+
+		private final List<Long> _ids;
+
+	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -11,6 +11,7 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
@@ -403,7 +404,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 
 				if (Objects.equals(type, "date")) {
 					return JSONUtil.put(
-						"entityFieldType", type
+						"entityFieldType", FDSEntityFieldTypes.DATE
 					).put(
 						"id", properties.get("fieldName")
 					).put(
@@ -440,7 +441,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					return JSONUtil.put(
 						"autocompleteEnabled", true
 					).put(
-						"entityFieldType", type
+						"entityFieldType", FDSEntityFieldTypes.STRING
 					).put(
 						"id", properties.get("fieldName")
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -447,8 +447,6 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						"items",
 						_getListTypeEntriesJSONArray(listTypeEntries, locale)
 					).put(
-						"label", _language.get(locale, "search")
-					).put(
 						"label", properties.get("name")
 					).put(
 						"multiple", properties.get("multiple")


### PR DESCRIPTION
# How to test this

1. Create a picklist:

![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/f4e7bb40-b95c-42b6-b5a7-50db1dd309a5)

2. Create an entity in Objects using that picklist in a field (see the `Aperitivo` field at the end:

![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/fcc2cf52-dffa-4791-9575-3bc567853f6b)

3. Create one or more instances of the new entity:

![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/3756394b-41e5-4e40-b9ab-4e46baf8b67d)

4. Create a data set view and define one dynamic filter:

![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/2458d2fb-3d5c-427e-b45e-18a0c8acfc8a)

5. Since there's currently a bug, you will need to tweak the filter to make it work. To do that:
     1. Map the `FDS Dynamic Filters` entity in Objects to the Objects category so that it can be edited from the app menu
     2. Copy the ERC of the picklist and use it to fill in the `list-type-definition-id` of the defined dynamic filter:
     
![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/15435d67-7002-49b0-a1ad-87b8a0acc248)

6. Add a data set fragment to a page and configure it with the data set view. See the filter appear:

![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/e158c1cc-897f-4059-b4ab-6e322e9ce25e)