### PR TITLE
LPS-193195 Save order of DSM entities on drop

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -45,14 +45,11 @@ interface IFDSAction {
 	url: string;
 }
 
-const noop = () => {};
-
 const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionInterface) => {
 	const [activeSection, setActiveSection] = useState(SECTIONS.ACTIONS);
 	const [activeTab, setActiveTab] = useState(0);
 	const [fdsActions, setFDSActions] = useState<Array<IFDSAction>>([]);
 	const [loading, setLoading] = useState(true);
-	const [newActionsOrder, setNewActionsOrder] = useState<string>('');
 	const [initialActionFormValues, setInitialActionFormValues] = useState<
 		IFDSAction
 	>();
@@ -175,12 +172,16 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionInterface) => {
 		setActiveSection(SECTIONS.EDIT_ITEM_ACTION);
 	};
 
-	const updateFDSActionsOrder = async () => {
+	const updateFDSActionsOrder = async ({
+		fdsActionsOrder,
+	}: {
+		fdsActionsOrder: string;
+	}) => {
 		const response = await fetch(
 			`${API_URL.FDS_VIEWS}/by-external-reference-code/${fdsView.externalReferenceCode}`,
 			{
 				body: JSON.stringify({
-					fdsActionsOrder: newActionsOrder,
+					fdsActionsOrder,
 				}),
 				headers: {
 					'Accept': 'application/json',
@@ -198,12 +199,13 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionInterface) => {
 
 		const responseJSON = await response.json();
 
-		const fdsFiltersOrder = responseJSON?.fdsActionsOrder;
+		const storedFDSActionsOrder = responseJSON?.fdsActionsOrder;
 
-		if (fdsFiltersOrder && fdsFiltersOrder === newActionsOrder) {
+		if (
+			storedFDSActionsOrder &&
+			storedFDSActionsOrder === fdsActionsOrder
+		) {
 			openDefaultSuccessToast();
-
-			setNewActionsOrder('');
 		}
 		else {
 			openDefaultFailureToast();
@@ -303,19 +305,15 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionInterface) => {
 									noItemsTitle={Liferay.Language.get(
 										'no-actions-were-created'
 									)}
-									onCancelButtonClick={noop}
 									onOrderChange={({
-										orderedItems,
+										order,
 									}: {
-										orderedItems: IFDSAction[];
+										order: string;
 									}) => {
-										setNewActionsOrder(
-											orderedItems
-												.map((filter) => filter.id)
-												.join(',')
-										);
+										updateFDSActionsOrder({
+											fdsActionsOrder: order,
+										});
 									}}
-									onSaveButtonClick={updateFDSActionsOrder}
 								/>
 							</ClayTabs.TabPane>
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -9,7 +9,7 @@ import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
-import {fetch, navigate, openModal} from 'frontend-js-web';
+import {fetch, openModal} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
@@ -351,15 +351,10 @@ const EditFDSSortModalContent = ({
 	);
 };
 
-const Sorting = ({
-	fdsView,
-	fdsViewsURL,
-	namespace,
-}: IFDSViewSectionInterface) => {
+const Sorting = ({fdsView, namespace}: IFDSViewSectionInterface) => {
 	const [fields, setFields] = React.useState<IField[]>([]);
 	const [fdsSorts, setFDSSorts] = useState<Array<IFDSSort>>([]);
 	const [loading, setLoading] = useState(true);
-	const [newFDSSortsOrder, setNewFDSSortsOrder] = React.useState<string>('');
 
 	useEffect(() => {
 		const getFDSSort = async () => {
@@ -491,12 +486,16 @@ const Sorting = ({
 		});
 	};
 
-	const handleSave = async () => {
+	const updateFDSSortsOrder = async ({
+		fdsSortsOrder,
+	}: {
+		fdsSortsOrder: string;
+	}) => {
 		const response = await fetch(
 			`${API_URL.FDS_VIEWS}/by-external-reference-code/${fdsView.externalReferenceCode}`,
 			{
 				body: JSON.stringify({
-					fdsSortsOrder: newFDSSortsOrder,
+					fdsSortsOrder,
 				}),
 				headers: {
 					'Accept': 'application/json',
@@ -514,12 +513,10 @@ const Sorting = ({
 
 		const responseJSON = await response.json();
 
-		const fdsSortsOrder = responseJSON?.fdsSortsOrder;
+		const storedFDSSortsOrder = responseJSON?.fdsSortsOrder;
 
-		if (fdsSortsOrder && fdsSortsOrder === newFDSSortsOrder) {
+		if (storedFDSSortsOrder && storedFDSSortsOrder === fdsSortsOrder) {
 			openDefaultSuccessToast();
-
-			setNewFDSSortsOrder('');
 		}
 		else {
 			openDefaultFailureToast();
@@ -557,7 +554,6 @@ const Sorting = ({
 								onClick: handleCreation,
 							},
 						]}
-						disableSave={!newFDSSortsOrder.length}
 						fields={[
 							{
 								headingTitle: true,
@@ -583,19 +579,9 @@ const Sorting = ({
 						noItemsTitle={Liferay.Language.get(
 							'no-default-sort-created-yet'
 						)}
-						onCancelButtonClick={() => navigate(fdsViewsURL)}
-						onOrderChange={({
-							orderedItems,
-						}: {
-							orderedItems: IFDSSort[];
-						}) => {
-							setNewFDSSortsOrder(
-								orderedItems
-									.map((fdsSort) => fdsSort.id)
-									.join(',')
-							);
+						onOrderChange={({order}: {order: string}) => {
+							updateFDSSortsOrder({fdsSortsOrder: order});
 						}}
-						onSaveButtonClick={handleSave}
 						title={Liferay.Language.get('sorting')}
 					/>
 				</>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/OrderableTable.d.ts
@@ -32,15 +32,12 @@ interface IOrderableTableProps {
 		typeof ClayDropDownWithItems
 	>['items'];
 	creationMenuLabel?: string;
-	disableSave?: boolean;
 	fields: Array<IField>;
 	items: Array<any>;
 	noItemsButtonLabel: string;
 	noItemsDescription: string;
 	noItemsTitle: string;
-	onCancelButtonClick: Function;
-	onOrderChange: (args: {orderedItems: any[]}) => void;
-	onSaveButtonClick: Function;
+	onOrderChange: (args: {order: string}) => void;
 	title?: string;
 }
 declare const OrderableTable: ({
@@ -48,15 +45,12 @@ declare const OrderableTable: ({
 	className,
 	creationMenuItems,
 	creationMenuLabel,
-	disableSave,
 	fields,
 	items: initialItems,
 	noItemsButtonLabel,
 	noItemsDescription,
 	noItemsTitle,
-	onCancelButtonClick,
 	onOrderChange,
-	onSaveButtonClick,
 	title,
 }: IOrderableTableProps) => JSX.Element;
 export default OrderableTable;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Fields.d.ts
@@ -10,7 +10,6 @@ import '../../css/Fields.scss';
 declare const Fields: ({
 	fdsClientExtensionCellRenderers,
 	fdsView,
-	fdsViewsURL,
 	namespace,
 	saveFDSFieldsURL,
 }: IFDSViewSectionInterface) => JSX.Element;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Filters.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Filters.d.ts
@@ -5,16 +5,10 @@
 
 /// <reference types="react" />
 
-import {FDSViewType} from '../FDSViews';
+import {IFDSViewSectionInterface} from '../FDSView';
 import '../../css/Filters.scss';
-interface IProps {
-	fdsView: FDSViewType;
-	fdsViewsURL: string;
-	namespace: string;
-}
 declare function Filters({
 	fdsView,
-	fdsViewsURL,
 	namespace,
-}: IProps): JSX.Element;
+}: IFDSViewSectionInterface): JSX.Element;
 export default Filters;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Sorting.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Sorting.d.ts
@@ -8,7 +8,6 @@
 import {IFDSViewSectionInterface} from '../FDSView';
 declare const Sorting: ({
 	fdsView,
-	fdsViewsURL,
 	namespace,
 }: IFDSViewSectionInterface) => JSX.Element;
 export default Sorting;

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
@@ -118,8 +118,6 @@ definition {
 			DataSetAdmin.goToTab(tabName = "Fields");
 
 			DataSetAdmin.addFields(key_fieldList = ${key_fieldList});
-
-			Button.clickSave();
 		}
 
 		if (isSet(key_ListItemsPerPage)) {


### PR DESCRIPTION
### References

- [LPS-188333 Auto-save order of fields/sorts/filters so that "Save" and "Cancel" buttons are not needed](https://issues.liferay.com/browse/LPS-188333)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/3641

### What is the goal of this PR?

Instead of an explicit save button, we are saving order on drop event. In addition:
- we are removing the `Cancel` button
- we are fixing a bug where drag and drop broke after first use 

See technical notes in comments.

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/5435511/b78dee41-789a-44e1-943d-7c9f8c2cbdf2

