### PR TITLE
LPS-195636 Apply filters defined as client extensions in the fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/npmscripts.config.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/npmscripts.config.js
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+module.exports = {
+	build: {
+		main: 'src/main/resources/META-INF/resources/js/index.ts',
+	},
+};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -212,7 +212,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		sb.append("\" >");
 
 		ComponentDescriptor componentDescriptor = new ComponentDescriptor(
-			"{FrontendDataSet} from frontend-data-set-web",
+			"{FDSViewFragment} from frontend-data-set-views-web",
 			fragmentRendererContext.getFragmentElementId(), null, true);
 
 		Writer writer = new CharArrayWriter();
@@ -520,7 +520,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					return JSONUtil.put(
 						"entityFieldType", FDSEntityFieldTypes.STRING
 					).put(
-						"esmURL", fdsFilterCET.getURL()
+						"cxFilterImplURL", fdsFilterCET.getURL()
 					).put(
 						"id", properties.get("fieldName")
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -500,11 +500,11 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					return JSONUtil.put(
 						"entityFieldType", FDSEntityFieldTypes.STRING
 					).put(
+						"esmURL", fdsFilterCET.getURL()
+					).put(
 						"id", properties.get("fieldName")
 					).put(
 						"label", properties.get("name")
-					).put(
-						"moduleURL", fdsFilterCET.getURL()
 					).put(
 						"type", "clientExtension"
 					);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -6,6 +6,7 @@
 package com.liferay.frontend.data.set.views.web.internal.fragment.renderer;
 
 import com.liferay.client.extension.type.FDSCellRendererCET;
+import com.liferay.client.extension.type.FDSFilterCET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRenderer;
@@ -481,6 +482,31 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						)
 					).put(
 						"type", "selection"
+					);
+				}
+
+				String clientExtensionERC = MapUtil.getString(
+					properties, "clientExtensionERC");
+
+				if (Validator.isNotNull(clientExtensionERC)) {
+					ThemeDisplay themeDisplay =
+						(ThemeDisplay)httpServletRequest.getAttribute(
+							WebKeys.THEME_DISPLAY);
+
+					FDSFilterCET fdsFilterCET =
+						(FDSFilterCET)_cetManager.getCET(
+							themeDisplay.getCompanyId(), clientExtensionERC);
+
+					return JSONUtil.put(
+						"entityFieldType", FDSEntityFieldTypes.STRING
+					).put(
+						"id", properties.get("fieldName")
+					).put(
+						"label", properties.get("name")
+					).put(
+						"moduleURL", fdsFilterCET.getURL()
+					).put(
+						"type", "clientExtension"
 					);
 				}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -405,6 +405,26 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 				fdsViewObjectDefinition, fdsViewObjectEntry,
 				"fdsViewFDSDynamicFilterRelationship"));
 
+
+		// {{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{
+		ObjectEntry objectEntry = new ObjectEntry();
+
+		objectEntry.setId(Long.MAX_VALUE);
+
+		objectEntry.setProperties(
+			HashMapBuilder.<String, Object>put(
+				"clientExtensionERC", "LXC:liferay-sample-fds-filter"
+			).put(
+				"fieldName", "id"
+			).put(
+				"filterName", "id"
+			).put(
+				"name", "id"
+			).build());
+
+		fdsFilterObjectEntries.add(objectEntry);
+		// }}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}
+
 		return JSONUtil.toJSONArray(
 			fdsFilterObjectEntries,
 			(ObjectEntry fdsFilterObjectEntry) -> {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/FDSViewFragment.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/FDSViewFragment.tsx
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrontendDataSet} from '@liferay/frontend-data-set-web';
+
+import PropTypes from "prop-types";
+import React, {useEffect, useState} from "react";
+
+function FDSViewFragment({
+    id,
+    filters,
+    views,
+    ...otherProps
+}: {id: string, filters: any, views: any[]}) {
+    const [resolvedFilters, setResolvedFilters] = useState(null);
+
+    useEffect(() => {
+        const promises = filters.map((filter: any) => {
+            if (!filter.cxFilterImplURL) {
+                return Promise.resolve(filter);
+            }
+
+            // @ts-ignore
+            return import(
+                /* webpackIgnore: true */ filter.cxFilterImplURL
+            ).then(module => ({
+                ...filter,
+                cxFilterImpl: module['default']
+            }));
+        });
+
+        Promise.all(promises).then((resolvedFilters: any) => {
+            setResolvedFilters(resolvedFilters);
+        })
+
+    }, [filters]);
+
+    return (
+        resolvedFilters ?
+            <FrontendDataSet
+                id={id}
+                filters={resolvedFilters}
+                views={views}
+                {...otherProps}
+            /> :
+            <></>
+    );
+}
+
+FDSViewFragment.propTypes = {
+    id: PropTypes.string,
+    filters: PropTypes.array,
+    views: PropTypes.array,
+};
+
+export default FDSViewFragment;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/index.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export {default as FDSViewFragment} from './fds_view/FDSViewFragment';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/FDSViewFragment.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/FDSViewFragment.d.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+import PropTypes from 'prop-types';
+declare function FDSViewFragment({
+	id,
+	filters,
+	views,
+	...otherProps
+}: {
+	id: string;
+	filters: any;
+	views: any[];
+}): JSX.Element;
+declare namespace FDSViewFragment {
+	var propTypes: {
+		id: PropTypes.Requireable<string>;
+		filters: PropTypes.Requireable<any[]>;
+		views: PropTypes.Requireable<any[]>;
+	};
+}
+export default FDSViewFragment;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export {default as FDSViewFragment} from './fds_view/FDSViewFragment';

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -22,10 +22,7 @@ import ClayEmptyState from '@clayui/empty-state';
 import FrontendDataSetContext from './FrontendDataSetContext';
 import ManagementBar from './management_bar/ManagementBar';
 import CreationMenu from './management_bar/components/CreationMenu';
-import {
-	getFilterSelectedItemsLabel,
-	getOdataFilterString,
-} from './management_bar/components/filters/Filter';
+import {FILTER_IMPL_MAP} from './management_bar/components/filters/Filter';
 import Modal from './modal/Modal';
 import SidePanel from './side_panel/SidePanel';
 import EVENTS from './utils/eventsDefinitions';
@@ -148,10 +145,12 @@ const FrontendDataSet = ({
 						filter.active = true;
 						filter.selectedData = preloadedData;
 
-						filter.odataFilterString = getOdataFilterString(filter);
-						filter.selectedItemsLabel = getFilterSelectedItemsLabel(
-							filter
-						);
+						const filterImpl = FILTER_IMPL_MAP[filter.type];
+
+						filter.odataFilterString =
+							filterImpl.getOdataFilterString(filter);
+						filter.selectedItemsLabel =
+							filterImpl.getFilterSelectedItemsLabel(filter);
 					}
 
 					return filter;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/ClientExtensionFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/ClientExtensionFilter.js
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClientExtension} from 'frontend-js-components-web';
+import PropTypes from 'prop-types';
+import React, {useEffect, useState} from "react";
+
+const getSelectedItemsLabel = ({selectedData}) => {
+	return '';
+};
+
+const getOdataString = ({entityFieldType, id, selectedData}) => {
+	return '';
+};
+
+function ClientExtensionFilter({
+	entityFieldType,
+	esmURL,
+	id,
+	selectedData,
+	setFilter,
+}) {
+	const [htmlElementBuilder, setHTMLElementBuilder] = useState(() =>
+		(() => document.createElement("div"))
+	);
+
+	useEffect(() => {
+		const getModule = async () => {
+			const cetModule = await import(
+				/* webpackIgnore: true */ esmURL
+			);
+
+			setHTMLElementBuilder(() => cetModule['default']);
+		};
+
+		getModule();
+	}, [esmURL]);
+
+	return (
+		<ClientExtension
+			args={{
+				filter: {
+					selectedData
+				},
+				setFilter: ({
+					odataFilterString,
+					selectedData,
+					selectedItemsLabel
+				}) =>
+					setFilter({
+						active: true,
+						id: id,
+						... {
+							odataFilterString,
+							selectedData,
+							selectedItemsLabel
+						},
+					}),
+			}}
+			htmlElementBuilder={htmlElementBuilder}
+		/>
+	);
+}
+
+ClientExtensionFilter.propTypes = {
+	entityFieldType: PropTypes.string,
+	esmURL: PropTypes.string,
+	id: PropTypes.string.isRequired,
+	selectedData: PropTypes.shape({
+		exclude: PropTypes.bool,
+		data: PropTypes.object,
+	}),
+	setFilter: PropTypes.func.isRequired,
+};
+
+export {getSelectedItemsLabel, getOdataString};
+export default ClientExtensionFilter;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
@@ -4,12 +4,15 @@
  */
 
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import {ClientExtension} from 'frontend-js-components-web';
 import React, {useContext, useEffect, useState} from 'react';
 
 import {getComponentByModuleURL} from '../../../utils/modules';
 import ViewsContext from '../../../views/ViewsContext';
 import {VIEWS_ACTION_TYPES} from '../../../views/viewsReducer';
+import ClientExtensionFilter, {
+	getOdataString as getClientExtensionFilterOdataString,
+	getSelectedItemsLabel as getClientExtensionFilterSelectedItemsLabel,
+} from './ClientExtensionFilter';
 import DateRangeFilter, {
 	getOdataString as getDateRangeFilterOdataString,
 	getSelectedItemsLabel as getDateRangeFilterSelectedItemsLabel,
@@ -20,12 +23,15 @@ import SelectionFilter, {
 } from './SelectionFilter';
 
 const FILTER_TYPE_COMPONENT = {
+	clientExtension: ClientExtensionFilter,
 	dateRange: DateRangeFilter,
 	selection: SelectionFilter,
 };
 
 const getFilterSelectedItemsLabel = (filter) => {
 	switch (filter.type) {
+		case 'clientExtension':
+			return getClientExtensionFilterSelectedItemsLabel(filter);
 		case 'dateRange':
 			return getDateRangeFilterSelectedItemsLabel(filter);
 		case 'selection':
@@ -37,6 +43,8 @@ const getFilterSelectedItemsLabel = (filter) => {
 
 const getOdataFilterString = (filter) => {
 	switch (filter.type) {
+		case 'clientExtension':
+			return getClientExtensionFilterOdataString(filter);
 		case 'dateRange':
 			return getDateRangeFilterOdataString(filter);
 		case 'selection':
@@ -66,24 +74,11 @@ const Filter = ({moduleURL, type, ...otherProps}) => {
 
 	useEffect(() => {
 		if (moduleURL) {
-			if (type === 'clientExtension') {
-				const getModule = async () => {
-					const cetModule = await import(
-						/* webpackIgnore: true */ moduleURL
-					);
-
-					setComponent(() => cetModule['default']);
-				};
-
-				getModule();
-			}
-			else {
-				getComponentByModuleURL(moduleURL).then((FetchedComponent) =>
-					setComponent(() => FetchedComponent)
-				);
-			}
+			getComponentByModuleURL(moduleURL).then((FetchedComponent) =>
+				setComponent(() => FetchedComponent)
+			);
 		}
-	}, [moduleURL, type]);
+	}, [moduleURL]);
 
 	const setFilter = ({id, ...otherProps}) => {
 		viewsDispatch({
@@ -97,22 +92,7 @@ const Filter = ({moduleURL, type, ...otherProps}) => {
 
 	return Component ? (
 		<div className="data-set-filter">
-			{type === 'clientExtension' ? (
-				<ClientExtension
-					args={{
-						filter: otherProps,
-						setFilter: (filter) =>
-							setFilter({
-								active: true,
-								id: otherProps.id,
-								...filter,
-							}),
-					}}
-					htmlElementBuilder={Component}
-				/>
-			) : (
-				<Component setFilter={setFilter} {...otherProps} />
-			)}
+			<Component setFilter={setFilter} {...otherProps} />
 		</div>
 	) : (
 		<ClayLoadingIndicator size="sm" />

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
@@ -66,7 +66,7 @@ const Filter = ({moduleURL, type, ...otherProps}) => {
 
 	useEffect(() => {
 		if (moduleURL) {
-			if (type === 'client-extension') {
+			if (type === 'clientExtension') {
 				const getModule = async () => {
 					const cetModule = await import(
 						/* webpackIgnore: true */ moduleURL
@@ -97,7 +97,7 @@ const Filter = ({moduleURL, type, ...otherProps}) => {
 
 	return Component ? (
 		<div className="data-set-filter">
-			{type === 'client-extension' ? (
+			{type === 'clientExtension' ? (
 				<ClientExtension
 					args={{
 						filter: otherProps,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/Filter.js
@@ -9,68 +9,28 @@ import React, {useContext, useEffect, useState} from 'react';
 import {getComponentByModuleURL} from '../../../utils/modules';
 import ViewsContext from '../../../views/ViewsContext';
 import {VIEWS_ACTION_TYPES} from '../../../views/viewsReducer';
-import ClientExtensionFilter, {
-	getOdataString as getClientExtensionFilterOdataString,
-	getSelectedItemsLabel as getClientExtensionFilterSelectedItemsLabel,
-} from './ClientExtensionFilter';
-import DateRangeFilter, {
-	getOdataString as getDateRangeFilterOdataString,
-	getSelectedItemsLabel as getDateRangeFilterSelectedItemsLabel,
-} from './DateRangeFilter';
-import SelectionFilter, {
-	getOdataString as getSelectionFilterOdataString,
-	getSelectedItemsLabel as getSelectionFilterSelectedItemsLabel,
-} from './SelectionFilter';
+import clientExtensionFilter from './clientExtensionFilter';
+import dateRangeFilter from './dateRangeFilter';
+import selectionFilter from './selectionFilter';
 
-const FILTER_TYPE_COMPONENT = {
-	clientExtension: ClientExtensionFilter,
-	dateRange: DateRangeFilter,
-	selection: SelectionFilter,
+const FILTER_IMPL_MAP = {
+	clientExtension: clientExtensionFilter,
+	dateRange: dateRangeFilter,
+	selection: selectionFilter,
 };
 
-const getFilterSelectedItemsLabel = (filter) => {
-	switch (filter.type) {
-		case 'clientExtension':
-			return getClientExtensionFilterSelectedItemsLabel(filter);
-		case 'dateRange':
-			return getDateRangeFilterSelectedItemsLabel(filter);
-		case 'selection':
-			return getSelectionFilterSelectedItemsLabel(filter);
-		default:
-			return '';
-	}
-};
-
-const getOdataFilterString = (filter) => {
-	switch (filter.type) {
-		case 'clientExtension':
-			return getClientExtensionFilterOdataString(filter);
-		case 'dateRange':
-			return getDateRangeFilterOdataString(filter);
-		case 'selection':
-			return getSelectionFilterOdataString(filter);
-		default:
-			return '';
-	}
-};
-
-const Filter = ({moduleURL, type, ...otherProps}) => {
+const Filter = ({id, moduleURL, type, ...otherProps}) => {
 	const [{filters}, viewsDispatch] = useContext(ViewsContext);
 
-	const [Component, setComponent] = useState(() => {
-		if (!moduleURL) {
-			const Matched = FILTER_TYPE_COMPONENT[type];
+	const filterImpl = FILTER_IMPL_MAP[type];
 
-			if (!Matched) {
-				throw new Error(`Filter type '${type}' not found.`);
-			}
+	if (!filterImpl) {
+		throw new Error(`Filter type '${type}' not found.`);
+	}
 
-			return Matched;
-		}
-		else {
-			return null;
-		}
-	});
+	const [Component, setComponent] = useState(
+		() => moduleURL ? null : filterImpl.Component
+	);
 
 	useEffect(() => {
 		if (moduleURL) {
@@ -80,24 +40,47 @@ const Filter = ({moduleURL, type, ...otherProps}) => {
 		}
 	}, [moduleURL]);
 
-	const setFilter = ({id, ...otherProps}) => {
+	const filterId = id;
+
+	const setFilter = ({id, selectedData, ...otherProps}) => {
+		if (id !== undefined && id !== filterId) {
+			throw new Error(
+				`Trying to modify filter ${id} from filter ${filterId}`
+			);
+		}
+
+		const newFilter = {
+			...(filters.find(filter => filter.id === filterId)),
+			selectedData,
+			...otherProps,
+		};
+
+		newFilter.odataFilterString = filterImpl.getOdataString(newFilter);
+		newFilter.selectedItemsLabel = filterImpl.getSelectedItemsLabel(
+			newFilter
+		);
+
 		viewsDispatch({
 			type: VIEWS_ACTION_TYPES.UPDATE_FILTERS,
-			value: filters.map((filter) => ({
-				...filter,
-				...(filter.id === id ? {...otherProps} : {}),
-			})),
+			value: filters.map(
+				(filter) => filter.id === filterId ? newFilter : filter
+			),
 		});
 	};
 
 	return Component ? (
 		<div className="data-set-filter">
-			<Component setFilter={setFilter} {...otherProps} />
+			<Component
+				id={id}
+				setFilter={setFilter}
+				type={type}
+				{...otherProps}
+			/>
 		</div>
 	) : (
 		<ClayLoadingIndicator size="sm" />
 	);
 };
 
-export {getFilterSelectedItemsLabel, getOdataFilterString};
+export {FILTER_IMPL_MAP};
 export default Filter;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/clientExtensionFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/clientExtensionFilter.js
@@ -16,9 +16,7 @@ const getOdataString = ({entityFieldType, id, selectedData}) => {
 };
 
 function ClientExtensionFilter({
-	entityFieldType,
 	esmURL,
-	id,
 	selectedData,
 	setFilter,
 }) {
@@ -45,18 +43,11 @@ function ClientExtensionFilter({
 					selectedData
 				},
 				setFilter: ({
-					odataFilterString,
 					selectedData,
-					selectedItemsLabel
 				}) =>
 					setFilter({
 						active: true,
-						id: id,
-						... {
-							odataFilterString,
-							selectedData,
-							selectedItemsLabel
-						},
+						selectedData,
 					}),
 			}}
 			htmlElementBuilder={htmlElementBuilder}
@@ -65,9 +56,7 @@ function ClientExtensionFilter({
 }
 
 ClientExtensionFilter.propTypes = {
-	entityFieldType: PropTypes.string,
 	esmURL: PropTypes.string,
-	id: PropTypes.string.isRequired,
 	selectedData: PropTypes.shape({
 		exclude: PropTypes.bool,
 		data: PropTypes.object,
@@ -75,5 +64,8 @@ ClientExtensionFilter.propTypes = {
 	setFilter: PropTypes.func.isRequired,
 };
 
-export {getSelectedItemsLabel, getOdataString};
-export default ClientExtensionFilter;
+export default {
+	Component: ClientExtensionFilter,
+	getSelectedItemsLabel,
+	getOdataString
+};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/clientExtensionFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/clientExtensionFilter.js
@@ -5,37 +5,19 @@
 
 import {ClientExtension} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from "react";
+import React from "react";
 
-const getSelectedItemsLabel = ({selectedData}) => {
-	return '';
-};
-
-const getOdataString = ({entityFieldType, id, selectedData}) => {
-	return '';
-};
+const getSelectedItemsLabel =
+	(filterProps) =>
+		filterProps.cxFilterImpl.getSelectedItemsLabel(filterProps);
+const getOdataString =
+	(filterProps) => filterProps.cxFilterImpl.getOdataString(filterProps);
 
 function ClientExtensionFilter({
-	esmURL,
+	cxFilterImpl,
 	selectedData,
 	setFilter,
 }) {
-	const [htmlElementBuilder, setHTMLElementBuilder] = useState(() =>
-		(() => document.createElement("div"))
-	);
-
-	useEffect(() => {
-		const getModule = async () => {
-			const cetModule = await import(
-				/* webpackIgnore: true */ esmURL
-			);
-
-			setHTMLElementBuilder(() => cetModule['default']);
-		};
-
-		getModule();
-	}, [esmURL]);
-
 	return (
 		<ClientExtension
 			args={{
@@ -50,13 +32,17 @@ function ClientExtensionFilter({
 						selectedData,
 					}),
 			}}
-			htmlElementBuilder={htmlElementBuilder}
+			htmlElementBuilder={cxFilterImpl.htmlElementBuilder}
 		/>
 	);
 }
 
 ClientExtensionFilter.propTypes = {
-	esmURL: PropTypes.string,
+	cxFilterImpl: PropTypes.shape({
+		getOdataString: PropTypes.func,
+		getSelectedItemsLabel: PropTypes.func,
+		htmlElementBuilder: PropTypes.func,
+	}),
 	selectedData: PropTypes.shape({
 		exclude: PropTypes.bool,
 		data: PropTypes.object,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/dateRangeFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/dateRangeFilter.js
@@ -66,7 +66,6 @@ const getOdataString = ({entityFieldType, id, selectedData}) => {
 };
 
 const DateRangeFilter = ({
-	entityFieldType,
 	id,
 	max,
 	min,
@@ -156,7 +155,7 @@ const DateRangeFilter = ({
 					disabled={submitDisabled}
 					onClick={() => {
 						if (actionType === 'delete') {
-							setFilter({active: false, id});
+							setFilter({active: false});
 						}
 						else {
 							const newSelectedData = {
@@ -170,16 +169,7 @@ const DateRangeFilter = ({
 
 							setFilter({
 								active: true,
-								id,
-								odataFilterString: getOdataString({
-									entityFieldType,
-									id,
-									selectedData: newSelectedData,
-								}),
 								selectedData: newSelectedData,
-								selectedItemsLabel: getSelectedItemsLabel({
-									selectedData: newSelectedData,
-								}),
 							});
 						}
 					}}
@@ -215,5 +205,8 @@ DateRangeFilter.propTypes = {
 	}),
 };
 
-export {getSelectedItemsLabel, getOdataString};
-export default DateRangeFilter;
+export default {
+	Component: DateRangeFilter,
+	getSelectedItemsLabel,
+	getOdataString
+};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/selectionFilter.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/filters/selectionFilter.js
@@ -80,7 +80,6 @@ const getOdataString = ({entityFieldType, id, selectedData}) => {
 function SelectionFilter({
 	apiURL,
 	autocompleteEnabled,
-	entityFieldType,
 	id,
 	inputPlaceholder,
 	itemKey,
@@ -393,7 +392,7 @@ function SelectionFilter({
 					disabled={submitDisabled}
 					onClick={() => {
 						if (actionType === 'delete') {
-							setFilter({active: false, id});
+							setFilter({active: false});
 						}
 						else {
 							const newSelectedData = {
@@ -403,17 +402,7 @@ function SelectionFilter({
 
 							setFilter({
 								active: true,
-								id,
-								odataFilterString: getOdataString({
-									entityFieldType,
-									id,
-									multiple,
-									selectedData: newSelectedData,
-								}),
 								selectedData: newSelectedData,
-								selectedItemsLabel: getSelectedItemsLabel({
-									selectedData: newSelectedData,
-								}),
 							});
 						}
 					}}
@@ -447,7 +436,6 @@ const Item = ({multiple, ...props}) => {
 SelectionFilter.propTypes = {
 	apiURL: PropTypes.string,
 	autocompleteEnabled: PropTypes.bool,
-	entityFieldType: PropTypes.string,
 	id: PropTypes.string.isRequired,
 	inputPlaceholder: PropTypes.string,
 	itemKey: PropTypes.string,
@@ -477,5 +465,8 @@ SelectionFilter.propTypes = {
 	setFilter: PropTypes.func.isRequired,
 };
 
-export {getSelectedItemsLabel, getOdataString};
-export default SelectionFilter;
+export default {
+	Component: SelectionFilter,
+	getSelectedItemsLabel,
+	getOdataString
+};

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/ClientExtension.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/ClientExtension.tsx
@@ -22,7 +22,7 @@ export default function ClientExtension<T>({
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
+	}, [htmlElementBuilder]);
 
 	return <div ref={containerRef}></div>;
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-filter/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-fds-filter/src/index.ts
@@ -5,7 +5,15 @@
 
 import type {FDSFilterHTMLElementBuilder} from '@liferay/js-api/data-set';
 
-const mySampleFilter: FDSFilterHTMLElementBuilder = ({filter, setFilter}) => {
+function getOdataString(filter: any) {
+	return filter.selectedData;
+}
+
+function getSelectedItemsLabel(filter: any) {
+	return filter.selectedData;
+}
+
+const htmlElementBuilder: FDSFilterHTMLElementBuilder = ({filter, setFilter}) => {
 	const div = document.createElement('div');
 	const button = document.createElement('button');
 	const input = document.createElement('input');
@@ -16,9 +24,8 @@ const mySampleFilter: FDSFilterHTMLElementBuilder = ({filter, setFilter}) => {
 	button.innerText = 'Submit';
 	button.onclick = () =>
 		setFilter({
-			odataFilterString: input.value,
 			selectedData: input.value,
-		});
+		} as any);
 
 	if (filter.selectedData) {
 		input.value = filter.selectedData;
@@ -33,4 +40,8 @@ const mySampleFilter: FDSFilterHTMLElementBuilder = ({filter, setFilter}) => {
 	return div;
 };
 
-export default mySampleFilter;
+export {
+	getOdataString, 
+	getSelectedItemsLabel, 
+	htmlElementBuilder 
+};


### PR DESCRIPTION
This PR contains the implementation of "Apply filters defined as client extensions in the fragment".

The second commit is a refactor to make `Filter.js` simpler by encapsulating the specific code of CXs into its own component/module.

Then, there's a third commit to be able to see the PR in action that is assigning the sample CX filter to all possible dataset fragments.

And finally, the last commits are a proposal to change both the internal FDS filter contract and the public external FDS filter CX contract to make things less error prone and more explicit.

Basically the change consists in requiring three different artifacts to render a filter from the FDS framework:

1. A React component (as before)
2. A method that given the filter data returns an odata query
3. A method that given the filter data returns a human friendly string describing the filter configuration

I believe this makes the code better since we are always using the same code to compute the odata and UI strings given a filter data. Before the change these were computed in two different places:

1. On initialization given the preselected data we got from the server (when no component has been created yet)
2. When the filter component kicks in

It was the responsibility of the component to pass the strings in the `setFilter` method which could cause problems like:

1. If the component forgot to pass the strings, the filter would show mismatched data.
2. If the component computed the strings differently from the functions, the filter could behave differently when preinitialized vs when configured by the user.

One final caveat: I've loaded the CX implementations before rendering the whole FDS component to make things easier, as we can rely on synchronous code through all the FDS implementation. However, we could also implement asynchronous code inside the FDS itself to not block the rendering. I'm not sure if it would be worth the complexity, because if a CX is missing it makes sense to fail the whole FDS rendering, I think, since it is a low level thing (the CX) so we don't want to be very lenient, most probably.