### PR TITLE
LPS-196695 Scroll not possible in modal windows in iOS devices

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -169,10 +169,6 @@ AUI.add(
 							}
 
 							iframeNode.focus();
-
-							if (UA.ios) {
-								iframeNode.attr('scrolling', 'no');
-							}
 						}
 					})
 				);


### PR DESCRIPTION
Hey guys,

This piece of code is blocking scroll functionality in modal windows for iOS devices. It was added as part of [LPSA-35005](https://liferay.atlassian.net/browse/LPSA-35005), however it is not needed anymore since that original issue is now fixed through CSS, so we can get rid of this condition.

Thanks.

Regards.