### PR TITLE
LPS-195447 Remove image added by ckeditor

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,6 +25,10 @@
 			max-width: 100%;
 		}
 
+		img[data-cke-saved-src]:not([data-fileentryid]) {
+			visibility: hidden;
+		}
+
 		.cover-image-container {
 			background-position: center;
 			background-repeat: no-repeat;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -417,6 +417,14 @@
 								uploadImageReturnType: '',
 							});
 
+							const ckeditorImage = document.querySelector(
+								'[data-cke-saved-src]'
+							);
+
+							if (ckeditorImage) {
+								ckeditorImage.remove();
+							}
+
 							const fragment = CKEDITOR.htmlParser.fragment.fromHtml(
 								editor.getData()
 							);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195447

When pasting Ctrl - V in blogs, the image is added twice. 
This is due to CKEditor adding the second image and so I removed the second image as it is not needed.

Please let me know if there are any questions or comments about this.
Thank you.