### PR TITLE
LPS-195615 - Allow admins translate filter names

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -457,7 +457,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						"label",
 						() -> {
 							String label = String.valueOf(
-								properties.get("name"));
+								properties.get("label"));
 
 							if (Validator.isNotNull(label)) {
 								return label;
@@ -514,7 +514,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						"label",
 						() -> {
 							String label = String.valueOf(
-								properties.get("name"));
+								properties.get("label"));
 
 							if (Validator.isNotNull(label)) {
 								return label;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -454,7 +454,17 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"id", properties.get("fieldName")
 					).put(
-						"label", properties.get("name")
+						"label",
+						() -> {
+							String label = String.valueOf(
+								properties.get("name"));
+
+							if (Validator.isNotNull(label)) {
+								return label;
+							}
+
+							return String.valueOf(properties.get("fieldName"));
+						}
 					).put(
 						"max", _getDateJSONObject(properties.get("to"))
 					).put(
@@ -501,7 +511,17 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 								"value", listTypeEntry.getKey()
 							))
 					).put(
-						"label", properties.get("name")
+						"label",
+						() -> {
+							String label = String.valueOf(
+								properties.get("name"));
+
+							if (Validator.isNotNull(label)) {
+								return label;
+							}
+
+							return String.valueOf(properties.get("fieldName"));
+						}
 					).put(
 						"multiple", properties.get("multiple")
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -376,16 +376,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					"fieldName", String.valueOf(fdsFieldProperties.get("name"))
 				).put(
 					"label",
-					() -> {
-						String label = String.valueOf(
-							fdsFieldProperties.get("label"));
-
-						if (Validator.isNotNull(label)) {
-							return label;
-						}
-
-						return String.valueOf(fdsFieldProperties.get("name"));
-					}
+					_getLabelFromProperties(fdsFieldProperties, "label", "name")
 				).put(
 					"sortable", (boolean)fdsFieldProperties.get("sortable")
 				);
@@ -455,16 +446,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						"id", properties.get("fieldName")
 					).put(
 						"label",
-						() -> {
-							String label = String.valueOf(
-								properties.get("label"));
-
-							if (Validator.isNotNull(label)) {
-								return label;
-							}
-
-							return String.valueOf(properties.get("fieldName"));
-						}
+						_getLabelFromProperties(
+							properties, "label", "fieldName")
 					).put(
 						"max", _getDateJSONObject(properties.get("to"))
 					).put(
@@ -512,16 +495,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 							))
 					).put(
 						"label",
-						() -> {
-							String label = String.valueOf(
-								properties.get("label"));
-
-							if (Validator.isNotNull(label)) {
-								return label;
-							}
-
-							return String.valueOf(properties.get("fieldName"));
-						}
+						_getLabelFromProperties(
+							properties, "label", "fieldName")
 					).put(
 						"multiple", properties.get("multiple")
 					).put(
@@ -592,6 +567,19 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					"target", properties.get("type")
 				);
 			});
+	}
+
+	private String _getLabelFromProperties(
+		Map<String, Object> fdsFieldProperties, String defaultLabel,
+		String fallbackLabel) {
+
+		String label = String.valueOf(fdsFieldProperties.get(defaultLabel));
+
+		if (Validator.isNotNull(label)) {
+			return label;
+		}
+
+		return String.valueOf(fdsFieldProperties.get(fallbackLabel));
 	}
 
 	private ObjectEntry _getObjectEntry(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -376,7 +376,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					"fieldName", String.valueOf(fdsFieldProperties.get("name"))
 				).put(
 					"label",
-					_getLabelFromProperties(fdsFieldProperties, "label", "name")
+					_getLabelFromProperties("label", "name", fdsFieldProperties)
 				).put(
 					"sortable", (boolean)fdsFieldProperties.get("sortable")
 				);
@@ -447,7 +447,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"label",
 						_getLabelFromProperties(
-							properties, "label", "fieldName")
+							"label", "fieldName", properties)
 					).put(
 						"max", _getDateJSONObject(properties.get("to"))
 					).put(
@@ -496,7 +496,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"label",
 						_getLabelFromProperties(
-							properties, "label", "fieldName")
+							"label", "fieldName", properties)
 					).put(
 						"multiple", properties.get("multiple")
 					).put(
@@ -570,16 +570,16 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 	}
 
 	private String _getLabelFromProperties(
-		Map<String, Object> fdsFieldProperties, String defaultLabel,
-		String fallbackLabel) {
+		String defaultProperty, String fallbackProperty,
+		Map<String, Object> fdsFieldProperties) {
 
-		String label = String.valueOf(fdsFieldProperties.get(defaultLabel));
+		String label = String.valueOf(fdsFieldProperties.get(defaultProperty));
 
 		if (Validator.isNotNull(label)) {
 			return label;
 		}
 
-		return String.valueOf(fdsFieldProperties.get(fallbackLabel));
+		return String.valueOf(fdsFieldProperties.get(fallbackProperty));
 	}
 
 	private ObjectEntry _getObjectEntry(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -589,28 +589,190 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				companyId, "FDSEntry");
 
-		if (fdsEntryObjectDefinition != null) {
-			return;
-		}
+		ObjectDefinition fdsDateFilterObjectDefinition =
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				"FDSDateFilter", userId, 0, "FDSDateFilter", "FDSDateFilter",
+				false, LocalizedMapUtil.getLocalizedMap("FDS Date Filter"),
+				true, "FDSDateFilter", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Date Filters"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
+				Arrays.asList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_DATE,
+						ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
+						_language.get(locale, "to"), "to", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_DATE,
+						ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
+						_language.get(locale, "from"), "from", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "field-name"), "fieldName", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "type"), "type", false)));
 
-		fdsEntryObjectDefinition = _createFDSEntryObjectDefinition(
-			locale, userId);
+		_enableLocalization(fdsDateFilterObjectDefinition);
+
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "name"), "name",
+			fdsDateFilterObjectDefinition, userId);
+
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
+			userId, fdsDateFilterObjectDefinition.getObjectDefinitionId());
 
 		ObjectDefinition fdsViewObjectDefinition =
 			_createFDSViewObjectDefinition(
 				fdsEntryObjectDefinition, locale, userId);
 
-		_createFDSActionObjectDefintion(
-			fdsViewObjectDefinition, locale, userId);
-		_createFDSClientExtensionFilterObjectDefintion(
-			fdsViewObjectDefinition, locale, userId);
-		_createFDSDateFilterObjectDefinition(
-			fdsViewObjectDefinition, locale, userId);
-		_createFDSDynamicFilterObjectDefintion(
-			fdsViewObjectDefinition, locale, userId);
-		_createFDSFieldObjectDefinition(
-			fdsViewObjectDefinition, locale, userId);
-		_createFDSSortObjectDefinition(fdsViewObjectDefinition, locale, userId);
+		ObjectDefinition fdsDynamicFilterObjectDefinition =
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				"FDSDynamicFilter", userId, 0, "FDSDynamicFilter",
+				"FDSDynamicFilter", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filter"), true,
+				"FDSDynamicFilter", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filters"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
+				Arrays.asList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "field-name"), "fieldName", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
+						_language.get(locale, "include"), "include", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "list-type-definition-id"),
+						"listTypeDefinitionId", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
+						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
+						_language.get(locale, "multiple"), "multiple", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_CLOB, true, false, null,
+						_language.get(locale, "preselected-values"),
+						"preselectedValues", false)));
+
+		_enableLocalization(fdsDynamicFilterObjectDefinition);
+
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "name"), "name",
+			fdsDynamicFilterObjectDefinition, userId);
+
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
+			userId, fdsDynamicFilterObjectDefinition.getObjectDefinitionId());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(
+				"FDSView FDSDynamicFilter Relationship"),
+			"fdsViewFDSDynamicFilterRelationship",
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectDefinition fdsSortObjectDefinition =
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				"FDSSort", userId, 0, "FDSSort", "FDSSort", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Sort"), true, "FDSSort",
+				"300", null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Sorts"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
+				Arrays.asList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "field-name"), "fieldName", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "sorting"), "sortingDirection",
+						true)));
+
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
+			userId, fdsSortObjectDefinition.getObjectDefinitionId());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+			fdsSortObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap("FDSView FDSSort Relationship"),
+			"fdsViewFDSSortRelationship",
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		ObjectDefinition fdsActionObjectDefinition =
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				"FDSAction", userId, 0, "FDSAction", "FDSAction", false,
+				LocalizedMapUtil.getLocalizedMap("FDS Action"), true,
+				"FDSAction", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS Actions"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
+				Arrays.asList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "type"), "type", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "icon"), "icon", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "confirmation-message-type"),
+						"confirmationMessageType", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "method"), "method", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "permission-key"),
+						"permissionKey", false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "url"), "url", false)));
+
+		_enableLocalization(fdsActionObjectDefinition);
+
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "confirmation-message"),
+			"confirmationMessage", fdsActionObjectDefinition, userId);
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "error-message"), "errorMessage",
+			fdsActionObjectDefinition, userId);
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "label"), "label", fdsActionObjectDefinition,
+			userId);
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "success-message"), "successMessage",
+			fdsActionObjectDefinition, userId);
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "title"), "title", fdsActionObjectDefinition,
+			userId);
+
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
+			userId, fdsActionObjectDefinition.getObjectDefinitionId());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+			fdsActionObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap("FDSView FDSAction Relationship"),
+			"fdsViewFDSActionRelationship",
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -289,11 +289,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "name"), "name", true),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(locale, "type"), "type", false)));
+
+		_enableLocalization(fdsDateFilterObjectDefinition);
+
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "label"), "label",
+			fdsDateFilterObjectDefinition, userId);
 
 		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsDateFilterObjectDefinition.getObjectDefinitionId());
@@ -328,10 +330,6 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(locale, "field-name"), "fieldName", true),
 					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "name"), "name", true),
-					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
 						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
 						_language.get(locale, "include"), "include", false),
@@ -349,6 +347,12 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_CLOB, true, false, null,
 						_language.get(locale, "preselected-values"),
 						"preselectedValues", false)));
+
+		_enableLocalization(fdsDynamicFilterObjectDefinition);
+
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "label"), "label",
+			fdsDynamicFilterObjectDefinition, userId);
 
 		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsDynamicFilterObjectDefinition.getObjectDefinitionId());
@@ -589,190 +593,28 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_objectDefinitionLocalService.fetchObjectDefinition(
 				companyId, "FDSEntry");
 
-		ObjectDefinition fdsDateFilterObjectDefinition =
-			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSDateFilter", userId, 0, "FDSDateFilter", "FDSDateFilter",
-				false, LocalizedMapUtil.getLocalizedMap("FDS Date Filter"),
-				true, "FDSDateFilter", null, null, null, null,
-				LocalizedMapUtil.getLocalizedMap("FDS Date Filters"),
-				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
-				WorkflowConstants.STATUS_DRAFT,
-				Arrays.asList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_DATE,
-						ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
-						_language.get(locale, "to"), "to", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_DATE,
-						ObjectFieldConstants.DB_TYPE_DATE, true, false, null,
-						_language.get(locale, "from"), "from", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "field-name"), "fieldName", true),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "type"), "type", false)));
+		if (fdsEntryObjectDefinition != null) {
+			return;
+		}
 
-		_enableLocalization(fdsDateFilterObjectDefinition);
-
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "name"), "name",
-			fdsDateFilterObjectDefinition, userId);
-
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsDateFilterObjectDefinition.getObjectDefinitionId());
+		fdsEntryObjectDefinition = _createFDSEntryObjectDefinition(
+			locale, userId);
 
 		ObjectDefinition fdsViewObjectDefinition =
 			_createFDSViewObjectDefinition(
 				fdsEntryObjectDefinition, locale, userId);
 
-		ObjectDefinition fdsDynamicFilterObjectDefinition =
-			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSDynamicFilter", userId, 0, "FDSDynamicFilter",
-				"FDSDynamicFilter", false,
-				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filter"), true,
-				"FDSDynamicFilter", null, null, null, null,
-				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filters"),
-				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
-				WorkflowConstants.STATUS_DRAFT,
-				Arrays.asList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "field-name"), "fieldName", true),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
-						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
-						_language.get(locale, "include"), "include", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "list-type-definition-id"),
-						"listTypeDefinitionId", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_BOOLEAN,
-						ObjectFieldConstants.DB_TYPE_BOOLEAN, true, false, null,
-						_language.get(locale, "multiple"), "multiple", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_CLOB, true, false, null,
-						_language.get(locale, "preselected-values"),
-						"preselectedValues", false)));
-
-		_enableLocalization(fdsDynamicFilterObjectDefinition);
-
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "name"), "name",
-			fdsDynamicFilterObjectDefinition, userId);
-
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsDynamicFilterObjectDefinition.getObjectDefinitionId());
-
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(
-				"FDSView FDSDynamicFilter Relationship"),
-			"fdsViewFDSDynamicFilterRelationship",
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		ObjectDefinition fdsSortObjectDefinition =
-			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSSort", userId, 0, "FDSSort", "FDSSort", false,
-				LocalizedMapUtil.getLocalizedMap("FDS Sort"), true, "FDSSort",
-				"300", null, null, null,
-				LocalizedMapUtil.getLocalizedMap("FDS Sorts"),
-				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
-				WorkflowConstants.STATUS_DRAFT,
-				Arrays.asList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "field-name"), "fieldName", true),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "sorting"), "sortingDirection",
-						true)));
-
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsSortObjectDefinition.getObjectDefinitionId());
-
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsSortObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap("FDSView FDSSort Relationship"),
-			"fdsViewFDSSortRelationship",
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-
-		ObjectDefinition fdsActionObjectDefinition =
-			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSAction", userId, 0, "FDSAction", "FDSAction", false,
-				LocalizedMapUtil.getLocalizedMap("FDS Action"), true,
-				"FDSAction", null, null, null, null,
-				LocalizedMapUtil.getLocalizedMap("FDS Actions"),
-				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
-				WorkflowConstants.STATUS_DRAFT,
-				Arrays.asList(
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "type"), "type", true),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "icon"), "icon", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "confirmation-message-type"),
-						"confirmationMessageType", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "method"), "method", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "permission-key"),
-						"permissionKey", false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_LONG_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "url"), "url", false)));
-
-		_enableLocalization(fdsActionObjectDefinition);
-
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "confirmation-message"),
-			"confirmationMessage", fdsActionObjectDefinition, userId);
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "error-message"), "errorMessage",
-			fdsActionObjectDefinition, userId);
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "label"), "label", fdsActionObjectDefinition,
-			userId);
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "success-message"), "successMessage",
-			fdsActionObjectDefinition, userId);
-		_addLocalizedCustomObjectField(
-			_language.get(locale, "title"), "title", fdsActionObjectDefinition,
-			userId);
-
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsActionObjectDefinition.getObjectDefinitionId());
-
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsActionObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap("FDSView FDSAction Relationship"),
-			"fdsViewFDSActionRelationship",
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		_createFDSActionObjectDefintion(
+			fdsViewObjectDefinition, locale, userId);
+		_createFDSClientExtensionFilterObjectDefintion(
+			fdsViewObjectDefinition, locale, userId);
+		_createFDSDateFilterObjectDefinition(
+			fdsViewObjectDefinition, locale, userId);
+		_createFDSDynamicFilterObjectDefintion(
+			fdsViewObjectDefinition, locale, userId);
+		_createFDSFieldObjectDefinition(
+			fdsViewObjectDefinition, locale, userId);
+		_createFDSSortObjectDefinition(fdsViewObjectDefinition, locale, userId);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Fields.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Fields.scss
@@ -5,3 +5,7 @@ html:not(#__):not(#___)
 	max-width: 550px;
 	width: 100%;
 }
+
+html:not(#__):not(#___) .cadmin .input-localized .form-group {
+	margin-bottom: 0;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Filters.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Filters.scss
@@ -5,3 +5,7 @@ html:not(#__):not(#___)
 	max-width: 550px;
 	width: 100%;
 }
+
+html:not(#__):not(#___) .cadmin .input-localized .form-group {
+	margin-bottom: 0;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -418,8 +418,6 @@ const EditFDSFieldModalContent = ({
 		fdsFieldTranslations
 	);
 
-	const [errorMessage, setErrorMessage] = useState('');
-
 	const editFDSField = async () => {
 		let body;
 		const bodyTmp = {
@@ -464,22 +462,6 @@ const EditFDSFieldModalContent = ({
 		openDefaultSuccessToast();
 
 		onSave({editedFDSField});
-	};
-
-	const validateFDSField = function () {
-		if (Liferay.FeatureFlags['LPS-172017']) {
-			const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
-
-			if (!i18nFieldLabels[defaultLanguageId]) {
-				setErrorMessage(Liferay.Language.get('required'));
-
-				return;
-			}
-
-			setErrorMessage('');
-		}
-
-		editFDSField();
 	};
 
 	const fdsFieldNameInputId = `${namespace}fdsFieldNameInput`;
@@ -584,17 +566,10 @@ const EditFDSFieldModalContent = ({
 				{Liferay.FeatureFlags['LPS-172017'] ? (
 					<ClayForm.Group>
 						<InputLocalized
-							error={errorMessage}
 							id={fdsFieldLabelInputId}
 							label={Liferay.Language.get('label')}
 							name="label"
-							onChange={(newFieldLabel) => {
-								setI18nFieldLabels({
-									...i18nFieldLabels,
-									...newFieldLabel,
-								});
-							}}
-							required
+							onChange={setI18nFieldLabels}
 							translations={i18nFieldLabels}
 						/>
 					</ClayForm.Group>
@@ -641,7 +616,7 @@ const EditFDSFieldModalContent = ({
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton onClick={() => validateFDSField()}>
+						<ClayButton onClick={() => editFDSField()}>
 							{Liferay.Language.get('save')}
 						</ClayButton>
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -467,15 +467,17 @@ const EditFDSFieldModalContent = ({
 	};
 
 	const validateFDSField = function () {
-		const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
+		if (Liferay.FeatureFlags['LPS-172017']) {
+			const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
-		if (!i18nFieldLabels[defaultLanguageId]) {
-			setErrorMessage(Liferay.Language.get('required'));
+			if (!i18nFieldLabels[defaultLanguageId]) {
+				setErrorMessage(Liferay.Language.get('required'));
 
-			return;
+				return;
+			}
+
+			setErrorMessage('');
 		}
-
-		setErrorMessage('');
 
 		editFDSField();
 	};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -520,8 +520,6 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				OBJECT_RELATIONSHIP.FDS_VIEW_FDS_DYNAMIC_FILTER
 			] as ISelectionFilter[];
 
-			// TODO: set a default filter name
-
 			let filtersOrdered: FilterCollection = [
 				...clientExtensionFiltersOrderer.map((item) => ({
 					...item,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -788,8 +788,8 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				]}
 				fields={[
 					{
-						label: Liferay.Language.get('name'),
-						name: 'name',
+						label: Liferay.Language.get('label'),
+						name: 'label',
 					},
 					{
 						label: Liferay.Language.get('Field Name'),

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -105,7 +105,6 @@ function AddFDSFilterModalContent({
 		(filter as ISelectionFilter)?.multiple ?? true
 	);
 	const [label, setLabel] = useState(filter?.label || '');
-	const [labelValidationError, setLabelValidationError] = useState(false);
 	const [picklists, setPicklists] = useState<IPickList[]>([]);
 	const [preselectedValues, setPreselectedValues] = useState<any[]>([]);
 	const [selectedField, setSelectedField] = useState<IField | null>(
@@ -154,7 +153,16 @@ function AddFDSFilterModalContent({
 		};
 
 		if (Liferay.FeatureFlags['LPS-172017']) {
-			body = {...body, label_i18n: i18nFilterLabels};
+			let labels;
+			if (!translationExists({translations: i18nFilterLabels})) {
+				const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
+				labels = {[defaultLanguageId]: selectedField.label};
+			}
+			else {
+				labels = i18nFilterLabels;
+			}
+
+			body = {...body, label_i18n: labels};
 		}
 		else {
 			body = {...body, label: label || selectedField.label};
@@ -239,19 +247,6 @@ function AddFDSFilterModalContent({
 		onSave({...responseJSON, displayType, filterType});
 
 		closeModal();
-	};
-
-	const validateForm = () => {
-		let valid = true;
-
-		if (
-			Liferay.FeatureFlags['LPS-172017'] &&
-			!translationExists({translations: i18nFilterLabels})
-		) {
-			valid = false;
-		}
-
-		setSaveButtonDisabled(!valid);
 	};
 
 	const nameFormElementId = `${namespace}Name`;
@@ -344,27 +339,10 @@ function AddFDSFilterModalContent({
 				{Liferay.FeatureFlags['LPS-172017'] ? (
 					<ClayForm.Group>
 						<InputLocalized
-							error={
-								labelValidationError
-									? Liferay.Language.get(
-											'this-field-is-required'
-									  )
-									: undefined
-							}
 							id={nameFormElementId}
 							label={Liferay.Language.get('label')}
 							name="label"
-							onBlur={() => {
-								setLabelValidationError(
-									!translationExists({
-										translations: i18nFilterLabels,
-									})
-								);
-
-								validateForm();
-							}}
 							onChange={setI18nFilterLabels}
-							required
 							translations={i18nFilterLabels}
 						/>
 					</ClayForm.Group>
@@ -541,6 +519,8 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 			const dynamicFiltersOrderer = responseJSON[
 				OBJECT_RELATIONSHIP.FDS_VIEW_FDS_DYNAMIC_FILTER
 			] as ISelectionFilter[];
+
+			// TODO: set a default filter name
 
 			let filtersOrdered: FilterCollection = [
 				...clientExtensionFiltersOrderer.map((item) => ({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -333,8 +333,8 @@ function AddFDSFilterModalContent({
 							<DateRangeFilterModalContent.Header />
 						)}
 
-						{filterType !== EFilterType.SELECTION && (
-							<DateRangeFilterModalContent.Header />
+						{filterType === EFilterType.SELECTION && (
+							<SelectionFilterModalContent.Header />
 						)}
 					</>
 				)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -11,7 +11,6 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
-
 import {format} from 'date-fns';
 import {InputLocalized} from 'frontend-js-components-web';
 import {IClientExtensionRenderer, fetch, openModal, sub} from 'frontend-js-web';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -11,7 +11,9 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
+
 import {format} from 'date-fns';
+import {InputLocalized} from 'frontend-js-components-web';
 import {IClientExtensionRenderer, fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
@@ -80,8 +82,15 @@ function AddFDSFilterModalContent({
 	const [fieldInUseValidationError, setFieldInUseValidationError] = useState<
 		boolean
 	>();
+	const [errorMessage, setErrorMessage] = useState('');
+	const fdsFilterNameTranslations = filter?.name_i18n || {
+		[defaultLanguageId]: filter?.name || '',
+	};
 	const [from, setFrom] = useState<string>(
 		(filter as IDateFilter)?.from ?? format(new Date(), 'yyyy-MM-dd')
+	);
+	const [i18nFilterNames, setI18nFilterNames] = useState(
+		fdsFilterNameTranslations
 	);
 	const [includeMode, setIncludeMode] = useState<string>(
 		filter
@@ -133,6 +142,18 @@ function AddFDSFilterModalContent({
 	const handleFilterSave = async () => {
 		setSaveButtonDisabled(true);
 
+		if (Liferay.FeatureFlags['LPS-172017']) {
+			if (!i18nFilterNames[defaultLanguageId]) {
+				setErrorMessage(Liferay.Language.get('required'));
+
+				setSaveButtonDisabled(false);
+
+				return;
+			}
+
+			setErrorMessage('');
+		}
+
 		if (!selectedField) {
 			openDefaultFailureToast();
 
@@ -141,8 +162,14 @@ function AddFDSFilterModalContent({
 
 		let body: any = {
 			fieldName: selectedField.name,
-			name: name || selectedField.label,
 		};
+
+		if (Liferay.FeatureFlags['LPS-172017']) {
+			body = {...body, name_i18n: i18nFilterNames};
+		}
+		else {
+			body = {...body, name: name || selectedField.label};
+		}
 
 		let displayType: string = '';
 		let url: string = '';
@@ -312,30 +339,50 @@ function AddFDSFilterModalContent({
 			</ClayModal.Header>
 
 			<ClayModal.Body>
-				<ClayForm.Group>
-					<label htmlFor={nameFormElementId}>
-						{Liferay.Language.get('name')}
+				{Liferay.FeatureFlags['LPS-172017'] ? (
+					<ClayForm.Group>
+						<InputLocalized
+							error={errorMessage}
+							id={nameFormElementId}
+							label={Liferay.Language.get('name')}
+							name="name"
+							onChange={(newFieldLabel) => {
+								setI18nFilterNames({
+									...i18nFilterNames,
+									...newFieldLabel,
+								});
+							}}
+							required
+							translations={i18nFilterNames}
+						/>
+					</ClayForm.Group>
+				) : (
+					<ClayForm.Group>
+						<label htmlFor={nameFormElementId}>
+							{Liferay.Language.get('name')}
 
-						<span
-							className="label-icon lfr-portal-tooltip ml-2"
-							title={Liferay.Language.get(
-								'if-this-value-is-not-provided,-the-name-will-default-to-the-field-name'
-							)}
-						>
-							<ClayIcon symbol="question-circle-full" />
-						</span>
-					</label>
+							<span
+								className="label-icon lfr-portal-tooltip ml-2"
+								title={Liferay.Language.get(
+									'if-this-value-is-not-provided,-the-name-will-default-to-the-field-name'
+								)}
+							>
+								<ClayIcon symbol="question-circle-full" />
+							</span>
+						</label>
 
-					<ClayInput
-						aria-label={Liferay.Language.get('name')}
-						name={nameFormElementId}
-						onChange={(event) => setName(event.target.value)}
-						placeholder={
-							selectedField?.label || Liferay.Language.get('name')
-						}
-						value={name}
-					/>
-				</ClayForm.Group>
+						<ClayInput
+							aria-label={Liferay.Language.get('name')}
+							name={nameFormElementId}
+							onChange={(event) => setName(event.target.value)}
+							placeholder={
+								selectedField?.label ||
+								Liferay.Language.get('name')
+							}
+							value={name}
+						/>
+					</ClayForm.Group>
+				)}
 
 				<ClayForm.Group
 					className={classNames({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -39,10 +39,6 @@ import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 
 import '../../css/Filters.scss';
 
-const translationExists = ({translations}: {translations: any}) => {
-	return Boolean(Object.keys(translations).find((key) => translations[key]));
-};
-
 type FilterCollection = Array<
 	IClientExtensionFilter | IDateFilter | ISelectionFilter
 >;
@@ -153,19 +149,10 @@ function AddFDSFilterModalContent({
 		};
 
 		if (Liferay.FeatureFlags['LPS-172017']) {
-			let labels;
-			if (!translationExists({translations: i18nFilterLabels})) {
-				const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
-				labels = {[defaultLanguageId]: selectedField.label};
-			}
-			else {
-				labels = i18nFilterLabels;
-			}
-
-			body = {...body, label_i18n: labels};
+			body = {...body, label_i18n: i18nFilterLabels};
 		}
 		else {
-			body = {...body, label: label || selectedField.label};
+			body = {...body, label};
 		}
 
 		let displayType: string = '';
@@ -561,7 +548,14 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				filtersOrdered = [...notOrdered, ...filtersOrdered];
 			}
 
-			setFilters(filtersOrdered);
+			setFilters(
+				filtersOrdered.map((filter) => {
+					return {
+						...filter,
+						label: filter.label || '',
+					};
+				})
+			);
 		};
 
 		getFields(fdsView).then((newFields) => {
@@ -654,9 +648,12 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 						fields={availableFields}
 						filterType={filterType}
 						namespace={namespace}
-						onSave={(newfilter) =>
-							setFilters([...filters, newfilter])
-						}
+						onSave={(newfilter) => {
+							if (newfilter.label === undefined) {
+								newfilter.label = '';
+							}
+							setFilters([...filters, newfilter]);
+						}}
 					/>
 				),
 				disableAutoClose: true,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -40,6 +40,10 @@ import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 
 import '../../css/Filters.scss';
 
+const translationExists = ({translations}: {translations: any}) => {
+	return Boolean(Object.keys(translations).find((key) => translations[key]));
+};
+
 type FilterCollection = Array<
 	IClientExtensionFilter | IDateFilter | ISelectionFilter
 >;
@@ -82,7 +86,6 @@ function AddFDSFilterModalContent({
 	const [fieldInUseValidationError, setFieldInUseValidationError] = useState<
 		boolean
 	>();
-	const [errorMessage, setErrorMessage] = useState('');
 	const fdsFilterLabelTranslations = filter?.label_i18n ?? {};
 	const [from, setFrom] = useState<string>(
 		(filter as IDateFilter)?.from ?? format(new Date(), 'yyyy-MM-dd')
@@ -103,6 +106,7 @@ function AddFDSFilterModalContent({
 		(filter as ISelectionFilter)?.multiple ?? true
 	);
 	const [label, setLabel] = useState(filter?.label || '');
+	const [labelValidationError, setLabelValidationError] = useState(false);
 	const [picklists, setPicklists] = useState<IPickList[]>([]);
 	const [preselectedValues, setPreselectedValues] = useState<any[]>([]);
 	const [selectedField, setSelectedField] = useState<IField | null>(
@@ -139,18 +143,6 @@ function AddFDSFilterModalContent({
 
 	const handleFilterSave = async () => {
 		setSaveButtonDisabled(true);
-
-		if (Liferay.FeatureFlags['LPS-172017']) {
-			if (!i18nFilterLabels[defaultLanguageId]) {
-				setErrorMessage(Liferay.Language.get('required'));
-
-				setSaveButtonDisabled(false);
-
-				return;
-			}
-
-			setErrorMessage('');
-		}
 
 		if (!selectedField) {
 			openDefaultFailureToast();
@@ -250,6 +242,19 @@ function AddFDSFilterModalContent({
 		closeModal();
 	};
 
+	const validateForm = () => {
+		let valid = true;
+
+		if (
+			Liferay.FeatureFlags['LPS-172017'] &&
+			!translationExists({translations: i18nFilterLabels})
+		) {
+			valid = false;
+		}
+
+		setSaveButtonDisabled(!valid);
+	};
+
 	const nameFormElementId = `${namespace}Name`;
 	const selectedFieldFormElementId = `${namespace}SelectedField`;
 
@@ -340,16 +345,26 @@ function AddFDSFilterModalContent({
 				{Liferay.FeatureFlags['LPS-172017'] ? (
 					<ClayForm.Group>
 						<InputLocalized
-							error={errorMessage}
+							error={
+								labelValidationError
+									? Liferay.Language.get(
+											'this-field-is-required'
+									  )
+									: undefined
+							}
 							id={nameFormElementId}
 							label={Liferay.Language.get('label')}
 							name="label"
-							onChange={(newFieldLabel) => {
-								setI18nFilterLabels({
-									...i18nFilterLabels,
-									...newFieldLabel,
-								});
+							onBlur={() => {
+								setLabelValidationError(
+									!translationExists({
+										translations: i18nFilterLabels,
+									})
+								);
+
+								validateForm();
 							}}
+							onChange={setI18nFilterLabels}
 							required
 							translations={i18nFilterLabels}
 						/>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -83,14 +83,12 @@ function AddFDSFilterModalContent({
 		boolean
 	>();
 	const [errorMessage, setErrorMessage] = useState('');
-	const fdsFilterNameTranslations = filter?.name_i18n || {
-		[defaultLanguageId]: filter?.name || '',
-	};
+	const fdsFilterLabelTranslations = filter?.label_i18n ?? {};
 	const [from, setFrom] = useState<string>(
 		(filter as IDateFilter)?.from ?? format(new Date(), 'yyyy-MM-dd')
 	);
-	const [i18nFilterNames, setI18nFilterNames] = useState(
-		fdsFilterNameTranslations
+	const [i18nFilterLabels, setI18nFilterLabels] = useState(
+		fdsFilterLabelTranslations
 	);
 	const [includeMode, setIncludeMode] = useState<string>(
 		filter
@@ -104,7 +102,7 @@ function AddFDSFilterModalContent({
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as ISelectionFilter)?.multiple ?? true
 	);
-	const [name, setName] = useState(filter?.name || '');
+	const [label, setLabel] = useState(filter?.label || '');
 	const [picklists, setPicklists] = useState<IPickList[]>([]);
 	const [preselectedValues, setPreselectedValues] = useState<any[]>([]);
 	const [selectedField, setSelectedField] = useState<IField | null>(
@@ -143,7 +141,7 @@ function AddFDSFilterModalContent({
 		setSaveButtonDisabled(true);
 
 		if (Liferay.FeatureFlags['LPS-172017']) {
-			if (!i18nFilterNames[defaultLanguageId]) {
+			if (!i18nFilterLabels[defaultLanguageId]) {
 				setErrorMessage(Liferay.Language.get('required'));
 
 				setSaveButtonDisabled(false);
@@ -165,10 +163,10 @@ function AddFDSFilterModalContent({
 		};
 
 		if (Liferay.FeatureFlags['LPS-172017']) {
-			body = {...body, name_i18n: i18nFilterNames};
+			body = {...body, label_i18n: i18nFilterLabels};
 		}
 		else {
-			body = {...body, name: name || selectedField.label};
+			body = {...body, label: label || selectedField.label};
 		}
 
 		let displayType: string = '';
@@ -319,7 +317,7 @@ function AddFDSFilterModalContent({
 		<>
 			<ClayModal.Header>
 				{filter &&
-					sub(Liferay.Language.get('edit-x-filter'), [filter.name])}
+					sub(Liferay.Language.get('edit-x-filter'), [filter.label])}
 
 				{!filter && (
 					<>
@@ -344,22 +342,22 @@ function AddFDSFilterModalContent({
 						<InputLocalized
 							error={errorMessage}
 							id={nameFormElementId}
-							label={Liferay.Language.get('name')}
-							name="name"
+							label={Liferay.Language.get('label')}
+							name="label"
 							onChange={(newFieldLabel) => {
-								setI18nFilterNames({
-									...i18nFilterNames,
+								setI18nFilterLabels({
+									...i18nFilterLabels,
 									...newFieldLabel,
 								});
 							}}
 							required
-							translations={i18nFilterNames}
+							translations={i18nFilterLabels}
 						/>
 					</ClayForm.Group>
 				) : (
 					<ClayForm.Group>
 						<label htmlFor={nameFormElementId}>
-							{Liferay.Language.get('name')}
+							{Liferay.Language.get('label')}
 
 							<span
 								className="label-icon lfr-portal-tooltip ml-2"
@@ -372,14 +370,14 @@ function AddFDSFilterModalContent({
 						</label>
 
 						<ClayInput
-							aria-label={Liferay.Language.get('name')}
+							aria-label={Liferay.Language.get('label')}
 							name={nameFormElementId}
-							onChange={(event) => setName(event.target.value)}
+							onChange={(event) => setLabel(event.target.value)}
 							placeholder={
 								selectedField?.label ||
-								Liferay.Language.get('name')
+								Liferay.Language.get('label')
 							}
-							value={name}
+							value={label}
 						/>
 					</ClayForm.Group>
 				)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/types.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
+
 export enum EFilterType {
 	CLIENT_EXTENSION = 'CLIENT_EXTENSION',
 	DATE_RANGE = 'DATE_RANGE',
@@ -27,7 +29,7 @@ export interface IFilter {
 	filterType?: EFilterType;
 	id: number;
 	label: string;
-	name: string;
+	label_i18n: LocalizedValue<string>; 
 	type: string;
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/types.ts
@@ -29,7 +29,7 @@ export interface IFilter {
 	filterType?: EFilterType;
 	id: number;
 	label: string;
-	label_i18n: LocalizedValue<string>; 
+	label_i18n: LocalizedValue<string>;
 	type: string;
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/types.d.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+declare type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 export declare enum EFilterType {
 	CLIENT_EXTENSION = 'CLIENT_EXTENSION',
 	DATE_RANGE = 'DATE_RANGE',
@@ -24,7 +25,7 @@ export interface IFilter {
 	filterType?: EFilterType;
 	id: number;
 	label: string;
-	name: string;
+	label_i18n: LocalizedValue<string>;
 	type: string;
 }
 export interface IClientExtensionFilter extends IFilter {
@@ -58,3 +59,4 @@ export interface IListTypeEntry {
 		[key: string]: string;
 	};
 }
+export {};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/getLocalizedValue.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/getLocalizedValue.ts
@@ -40,6 +40,7 @@ export function getLocalizedValue(
 		return null;
 	}
 
+	const i18nFieldName = `${fieldName}_i18n`;
 	const rootPropertyName =
 		typeof fieldName === 'string' ? fieldName : fieldName[0];
 	let navigatedValue = item;
@@ -67,6 +68,17 @@ export function getLocalizedValue(
 				navigatedValue = navigatedValue[formattedProperty];
 			}
 		});
+	}
+	else if (
+		typeof fieldName === 'string' &&
+		item[i18nFieldName] &&
+		Object.keys(Liferay.Language.available).includes(
+			Object.keys(item[i18nFieldName])[0]
+		)
+	) {
+		valuePath.push(fieldName);
+		navigatedValue =
+			navigatedValue[i18nFieldName][getLanguageKey(item[i18nFieldName])];
 	}
 	else if (
 		typeof fieldName === 'string' &&

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -11253,6 +11253,7 @@ new-category=New Category
 new-child-site=New Child Site
 new-class=New Class
 new-classification-rule-for-x=New Classification Rule for {0}
+new-client-extension-filter=New Client Extension Filter
 new-collection-page-item=New Collection Page Item
 new-content=New Content
 new-custom-element=New Custom Element


### PR DESCRIPTION
Story https://liferay.atlassian.net/browse/LPS-186878
Task https://liferay.atlassian.net/browse/LPS-195615

## Problem
Filter name can be edited but it does not allow translations. 

## Solution
Needs a fresh DB
Under FF `LPS-172017` we create System objects that allow translations and use the `InputLocalized` component to deal with them. 
As a fallback, in case there is no match for the selected language, the fragment will return the field name used for the filter

### With FF enabled

[filter-label-w-ff-enabled2.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/954cdef5-e3d3-4cd7-8aa6-8275b4b3a236)

### Without FF enabled

[filter-name-no-ff.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/5157450d-62c4-4322-8166-86ca7dc04016)

### Dataset using fallback

[filter-name-w-wo-translation.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/ba1704b2-fa63-4558-8ccc-aec26a753a3d)

Fix issue with the Fields tab when ff `LPS-172017` is not enabled