### PR TITLE
LPS-196289 - Send prepopulated filters

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -562,7 +562,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"id", properties.get("fieldName")
 					).put(
-						"label", properties.get("name")
+						"label", properties.get("label")
 					).put(
 						"moduleURL", fdsFilterCET.getURL()
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -440,16 +440,55 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 				String type = MapUtil.getString(properties, "type");
 
 				if (Objects.equals(type, "date")) {
+					boolean hasPreloadedData;
+
+					String from = MapUtil.getString(properties, "from");
+					String to = MapUtil.getString(properties, "to");
+
+					if (Validator.isNotNull(to) || Validator.isNotNull(from)) {
+						hasPreloadedData = true;
+					}
+					else {
+						hasPreloadedData = false;
+					}
+
 					return JSONUtil.put(
+						"active", hasPreloadedData
+					).put(
 						"entityFieldType", FDSEntityFieldTypes.DATE
 					).put(
 						"id", properties.get("fieldName")
 					).put(
 						"label", _getValue("label", "fieldName", properties)
 					).put(
-						"max", _getDateJSONObject(properties.get("to"))
-					).put(
-						"min", _getDateJSONObject(properties.get("from"))
+						"preloadedData",
+						() -> {
+							if (!hasPreloadedData) {
+								return null;
+							}
+
+							return JSONUtil.put(
+								"from",
+								() -> {
+									if (Validator.isNull(from)) {
+										return null;
+									}
+
+									return _getDateJSONObject(
+										properties.get("from"));
+								}
+							).put(
+								"to",
+								() -> {
+									if (Validator.isNull(to)) {
+										return null;
+									}
+
+									return _getDateJSONObject(
+										properties.get("to"));
+								}
+							);
+						}
 					).put(
 						"type", "dateRange"
 					);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -444,11 +444,13 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 				String type = MapUtil.getString(properties, "type");
 
 				if (Objects.equals(type, "date")) {
-					String from = _getDateJSONObject(properties.get("from"));
-					String to = _getDateJSONObject(properties.get("to"));
+					JSONObject fromJSONObject = _getDateJSONObject(
+						properties.get("from"));
+					JSONObject toJSONObject = _getDateJSONObject(
+						properties.get("to"));
 
 					boolean hasPreloadedData =
-						Validator.isNotNull(to) || Validator.isNotNull(from);
+						!!fromJSONObject || !!toJSONObject;
 
 					return JSONUtil.put(
 						"active", hasPreloadedData
@@ -466,9 +468,9 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 							}
 
 							return JSONUtil.put(
-								"from", from
+								"from", fromJSONObject
 							).put(
-								"to", to
+								"to", toJSONObject
 							);
 						}
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -562,7 +562,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"id", properties.get("fieldName")
 					).put(
-						"label", properties.get("label")
+						"label", _getValue("label", "fieldName", properties)
 					).put(
 						"moduleURL", fdsFilterCET.getURL()
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -328,6 +328,10 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 	}
 
 	private JSONObject _getDateJSONObject(Object object) {
+		if (object == null) {
+			return null;
+		}
+
 		Calendar calendar = Calendar.getInstance();
 
 		Timestamp timestamp = (Timestamp)object;
@@ -440,17 +444,11 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 				String type = MapUtil.getString(properties, "type");
 
 				if (Objects.equals(type, "date")) {
-					boolean hasPreloadedData;
+					String from = _getDateJSONObject(properties.get("from"));
+					String to = _getDateJSONObject(properties.get("to"));
 
-					String from = MapUtil.getString(properties, "from");
-					String to = MapUtil.getString(properties, "to");
-
-					if (Validator.isNotNull(to) || Validator.isNotNull(from)) {
-						hasPreloadedData = true;
-					}
-					else {
-						hasPreloadedData = false;
-					}
+					boolean hasPreloadedData =
+						Validator.isNotNull(to) || Validator.isNotNull(from);
 
 					return JSONUtil.put(
 						"active", hasPreloadedData
@@ -468,25 +466,9 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 							}
 
 							return JSONUtil.put(
-								"from",
-								() -> {
-									if (Validator.isNull(from)) {
-										return null;
-									}
-
-									return _getDateJSONObject(
-										properties.get("from"));
-								}
+								"from", from
 							).put(
-								"to",
-								() -> {
-									if (Validator.isNull(to)) {
-										return null;
-									}
-
-									return _getDateJSONObject(
-										properties.get("to"));
-								}
+								"to", to
 							);
 						}
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -450,7 +450,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						properties.get("to"));
 
 					boolean hasPreloadedData =
-						!!fromJSONObject || !!toJSONObject;
+						(fromJSONObject != null) || (toJSONObject != null);
 
 					return JSONUtil.put(
 						"active", hasPreloadedData

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -519,7 +519,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"multiple", properties.get("multiple")
 					).put(
-						"selectedData",
+						"preloadedData",
 						JSONUtil.put(
 							"exclude", false
 						).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -240,11 +240,13 @@ public class FDSViewsPortlet extends MVCPortlet {
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(
 							locale, "fds-filter-client-extension-erc"),
-						"fdsFilterClientExtensionERC", true),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "name"), "name", true)));
+						"fdsFilterClientExtensionERC", true)));
+
+		_enableLocalization(fdsClientExtensionFilterObjectDefinition);
+
+		_addLocalizedCustomObjectField(
+			_language.get(locale, "label"), "label",
+			fdsClientExtensionFilterObjectDefinition, userId);
 
 		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Filters.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Filters.scss
@@ -1,6 +1,4 @@
-html:not(#__):not(#___)
-	.cadmin
-	.dropdown-menu.fds-field-name-dropdown-menu {
+html:not(#__):not(#___) .cadmin .dropdown-menu.fds-field-name-dropdown-menu {
 	max-height: 500px;
 	max-width: 550px;
 	width: 100%;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Filters.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/Filters.scss
@@ -1,6 +1,6 @@
 html:not(#__):not(#___)
 	.cadmin
-	.dropdown-menu.fds-cell-renderers-dropdown-menu {
+	.dropdown-menu.fds-field-name-dropdown-menu {
 	max-height: 500px;
 	max-width: 550px;
 	width: 100%;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/DateRangeFilter.tsx
@@ -93,7 +93,7 @@ function Body({
 					inputName={toFormElementId}
 					onChange={onToChange}
 					placeholder="YYYY-MM-DD"
-					value={to ? format(new Date(to), 'yyyy-MM-dd'): ''}
+					value={to ? format(new Date(to), 'yyyy-MM-dd') : ''}
 					years={{
 						end: getYear(new Date()) + 25,
 						start: getYear(new Date()) - 50,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/DateRangeFilter.tsx
@@ -64,10 +64,7 @@ function Body({
 					inputName={fromFormElementId}
 					onChange={onFromChange}
 					placeholder="YYYY-MM-DD"
-					value={format(
-						from ? new Date(from) : new Date(),
-						'yyyy-MM-dd'
-					)}
+					value={from ? format(new Date(from), 'yyyy-MM-dd') : ''}
 					years={{
 						end: getYear(new Date()) + 25,
 						start: getYear(new Date()) - 50,
@@ -96,7 +93,7 @@ function Body({
 					inputName={toFormElementId}
 					onChange={onToChange}
 					placeholder="YYYY-MM-DD"
-					value={format(to ? new Date(to) : new Date(), 'yyyy-MM-dd')}
+					value={to ? format(new Date(to), 'yyyy-MM-dd'): ''}
 					years={{
 						end: getYear(new Date()) + 25,
 						start: getYear(new Date()) - 50,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -11,7 +11,6 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
-import {format} from 'date-fns';
 import {InputLocalized} from 'frontend-js-components-web';
 import {IClientExtensionRenderer, fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
@@ -329,7 +328,7 @@ function AddFDSFilterModalContent({
 					<ClayForm.Group>
 						<InputLocalized
 							id={nameFormElementId}
-							label={Liferay.Language.get('label')}
+							label={Liferay.Language.get('name')}
 							name="label"
 							onChange={setI18nFilterLabels}
 							translations={i18nFilterLabels}
@@ -338,7 +337,7 @@ function AddFDSFilterModalContent({
 				) : (
 					<ClayForm.Group>
 						<label htmlFor={nameFormElementId}>
-							{Liferay.Language.get('label')}
+							{Liferay.Language.get('name')}
 
 							<span
 								className="label-icon lfr-portal-tooltip ml-2"
@@ -351,12 +350,12 @@ function AddFDSFilterModalContent({
 						</label>
 
 						<ClayInput
-							aria-label={Liferay.Language.get('label')}
+							aria-label={Liferay.Language.get('name')}
 							name={nameFormElementId}
 							onChange={(event) => setLabel(event.target.value)}
 							placeholder={
 								selectedField?.label ||
-								Liferay.Language.get('label')
+								Liferay.Language.get('name')
 							}
 							value={label}
 						/>
@@ -778,7 +777,7 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				]}
 				fields={[
 					{
-						label: Liferay.Language.get('label'),
+						label: Liferay.Language.get('name'),
 						name: 'label',
 					},
 					{

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -96,13 +96,14 @@ function AddFDSFilterModalContent({
 			: 'include'
 	);
 	const [isValidDateRange, setIsValidDateRange] = useState<boolean>(true);
-	const [saveButtonDisabled, setSaveButtonDisabled] = useState<boolean>();
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as ISelectionFilter)?.multiple ?? true
 	);
 	const [label, setLabel] = useState(filter?.label || '');
 	const [picklists, setPicklists] = useState<IPickList[]>([]);
 	const [preselectedValues, setPreselectedValues] = useState<any[]>([]);
+	const [preselectedValueInput, setPreselectedValueInput] = useState('');
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState<boolean>();
 	const [selectedField, setSelectedField] = useState<IField | null>(
 		fields.find((item) => item.name === filter?.fieldName) || null
 	);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -245,13 +245,13 @@ function AddFDSFilterModalContent({
 		fieldNames?.includes(item.name) ? item.name : undefined
 	);
 
-	const CellRendererDropdown = ({
-		cellRenderers,
+	const FieldNameDropdown = ({
+		fields,
 		inUseFields,
 		namespace,
 		onItemClick,
 	}: {
-		cellRenderers: IField[];
+		fields: IField[];
 		inUseFields: (string | undefined)[];
 		namespace: string;
 		onItemClick: Function;
@@ -260,13 +260,14 @@ function AddFDSFilterModalContent({
 			<ClayDropDown
 				closeOnClick
 				menuElementAttrs={{
-					className: 'fds-cell-renderers-dropdown-menu',
+					className: 'fds-field-name-dropdown-menu',
 				}}
 				trigger={
 					<ClayButton
-						aria-labelledby={`${namespace}cellRenderersLabel`}
+						aria-labelledby={`${namespace}fieldsLabel`}
 						className="form-control form-control-select form-control-select-secondary"
 						displayType="secondary"
+						id={selectedFieldFormElementId}
 					>
 						{selectedField
 							? selectedField.label
@@ -274,8 +275,8 @@ function AddFDSFilterModalContent({
 					</ClayButton>
 				}
 			>
-				<ClayDropDown.ItemList items={cellRenderers} role="listbox">
-					{cellRenderers.map((cellRenderer) => (
+				<ClayDropDown.ItemList items={fields} role="listbox">
+					{fields.map((field) => (
 						<ClayDropDown.Item
 							className="align-items-center d-flex justify-content-between"
 							disabled={
@@ -283,13 +284,13 @@ function AddFDSFilterModalContent({
 								(filterType === EFilterType.SELECTION &&
 									!picklists.length)
 							}
-							key={cellRenderer.name}
-							onClick={() => onItemClick(cellRenderer)}
+							key={field.name}
+							onClick={() => onItemClick(field)}
 							roleItem="option"
 						>
-							{cellRenderer.label}
+							{field.label}
 
-							{inUseFields.includes(cellRenderer.name) && (
+							{inUseFields.includes(field.name) && (
 								<ClayLabel displayType="info">
 									{Liferay.Language.get('in-use')}
 								</ClayLabel>
@@ -372,8 +373,8 @@ function AddFDSFilterModalContent({
 						{Liferay.Language.get('filter-by')}
 					</label>
 
-					<CellRendererDropdown
-						cellRenderers={fields}
+					<FieldNameDropdown
+						fields={fields}
 						inUseFields={inUseFields}
 						namespace={namespace}
 						onItemClick={(item: IField) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -616,8 +616,7 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				(filterType === EFilterType.SELECTION &&
 					item.format === EFieldFormat.STRING) ||
 				(filterType === EFilterType.DATE_RANGE &&
-					(item.format === EFieldFormat.DATE_TIME ||
-						item.format === EFieldFormat.DATE))
+					item.format === EFieldFormat.DATE)
 		);
 
 		if (!availableFields.length) {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -229,9 +229,25 @@ function AddFDSFilterModalContent({
 
 		const responseJSON = await response.json();
 
+		let updatedFilter: any = {};
+
+		if (filterType === EFilterType.DATE_RANGE) {
+			if (!responseJSON.from) {
+				updatedFilter.from = '';
+			}
+			if (!responseJSON.to) {
+				updatedFilter.to = '';
+			}
+
+			updatedFilter = {...responseJSON, ...updatedFilter};
+		}
+		else {
+			updatedFilter = {...responseJSON};
+		}
+
 		openDefaultSuccessToast();
 
-		onSave({...responseJSON, displayType, filterType});
+		onSave({...updatedFilter, displayType, filterType});
 
 		closeModal();
 	};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -102,7 +102,6 @@ function AddFDSFilterModalContent({
 	const [label, setLabel] = useState(filter?.label || '');
 	const [picklists, setPicklists] = useState<IPickList[]>([]);
 	const [preselectedValues, setPreselectedValues] = useState<any[]>([]);
-	const [preselectedValueInput, setPreselectedValueInput] = useState('');
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState<boolean>();
 	const [selectedField, setSelectedField] = useState<IField | null>(
 		fields.find((item) => item.name === filter?.fieldName) || null

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -83,7 +83,7 @@ function AddFDSFilterModalContent({
 	>();
 	const fdsFilterLabelTranslations = filter?.label_i18n ?? {};
 	const [from, setFrom] = useState<string>(
-		(filter as IDateFilter)?.from ?? format(new Date(), 'yyyy-MM-dd')
+		(filter as IDateFilter)?.from ?? ''
 	);
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
 		fdsFilterLabelTranslations
@@ -107,9 +107,7 @@ function AddFDSFilterModalContent({
 		fields.find((item) => item.name === filter?.fieldName) || null
 	);
 	const [selectedPicklist, setSelectedPicklist] = useState<IPickList>();
-	const [to, setTo] = useState<string>(
-		(filter as IDateFilter)?.to ?? format(new Date(), 'yyyy-MM-dd')
-	);
+	const [to, setTo] = useState<string>((filter as IDateFilter)?.to ?? '');
 
 	useEffect(() => {
 		getAllPicklists().then((items) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -229,25 +229,9 @@ function AddFDSFilterModalContent({
 
 		const responseJSON = await response.json();
 
-		let updatedFilter: any = {};
-
-		if (filterType === EFilterType.DATE_RANGE) {
-			if (!responseJSON.from) {
-				updatedFilter.from = '';
-			}
-			if (!responseJSON.to) {
-				updatedFilter.to = '';
-			}
-
-			updatedFilter = {...responseJSON, ...updatedFilter};
-		}
-		else {
-			updatedFilter = {...responseJSON};
-		}
-
 		openDefaultSuccessToast();
 
-		onSave({...updatedFilter, displayType, filterType});
+		onSave({...responseJSON, displayType, filterType});
 
 		closeModal();
 	};
@@ -697,6 +681,15 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 					onSave={(newfilter) => {
 						const newFilters = filters.map((item) => {
 							if (item.id === newfilter.id) {
+								if (
+									item.filterType === EFilterType.DATE_RANGE
+								) {
+									(newfilter as IDateFilter).from =
+										(newfilter as IDateFilter).from || '';
+									(newfilter as IDateFilter).to =
+										(newfilter as IDateFilter).to || '';
+								}
+
 								return {...item, ...newfilter};
 							}
 


### PR DESCRIPTION
Story https://liferay.atlassian.net/browse/LPS-185991
Task https://liferay.atlassian.net/browse/LPS-196289

## Problem
After defining a date filter in the Dataset manager it does not show it in the fragment. It also happens with selection filter.

## Solution
We need to define a filter and cover some use cases:
- if the user does not select any date, the fragment does not show any filter applied
- if the user selects at least one date, the fragment will display the filter applied
- if the user defines a selection filter that uses preselected values, the filter with the preselected values appears in the fragment

## Other changes
- fix url for `date` filter so the user can delete them
- refactor/rename `fieldName` dropdown component (soon replaced by Clay Picker)
- update persistance layer: `name` by `label`
