### PR TITLE
LPS-167073 HR_15 When user activates "Page Audit" button and Side panel pop-up, Focus is not moving to Side panel window

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -352,7 +352,10 @@ SideNavigation.prototype = {
 	_focusTrigger() {
 		const toggler = this.toggler;
 
-		if (!toggler) {
+		if (
+			!toggler ||
+			!document.activeElement.classList.contains('sidenav-close')
+		) {
 			return;
 		}
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -1277,17 +1277,6 @@ SideNavigation.prototype = {
 				instance
 			);
 
-			instance._subscribeSidenavTransitionEnd(content, () => {
-				removeClass(container, 'sidenav-transition');
-				removeClass(toggler, 'sidenav-transition');
-
-				instance._emit('open.lexicon.sidenav');
-
-				dispatchCustomEvent(document, 'open.lexicon.sidenav', instance);
-
-				this._focusNavigation();
-			});
-
 			const isReducedMotion = instance.isReducedMotion();
 
 			setClasses(content, {
@@ -1304,6 +1293,19 @@ SideNavigation.prototype = {
 				'active': true,
 				[openClass]: true,
 				'sidenav-transition': !isReducedMotion,
+			});
+
+			instance._subscribeSidenavTransitionEnd(content, () => {
+				if (!isReducedMotion) {
+					removeClass(container, 'sidenav-transition');
+					removeClass(toggler, 'sidenav-transition');
+				}
+
+				instance._emit('open.lexicon.sidenav');
+
+				dispatchCustomEvent(document, 'open.lexicon.sidenav', instance);
+
+				this._focusNavigation();
 			});
 		}
 	},

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
@@ -288,7 +288,8 @@ public class LayoutReportsProductNavigationControlMenuEntry
 					ProductNavigationControlMenuEntryConstants.
 						SESSION_CLICKS_KEY)) {
 
-				sb.append("lfr-has-layout-reports-panel open-admin-panel ");
+				sb.append(
+					"lfr-has-layout-reports-panel open-admin-panel open ");
 			}
 
 			sb.append("cadmin d-print-none lfr-admin-panel ");

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/css/main.scss
@@ -3,11 +3,6 @@
 html#{$cadmin-selector} {
 	.cadmin {
 		&.lfr-layout-reports-panel {
-			&.open-admin-panel.sidenav-menu-slider {
-				visibility: visible;
-				width: 320px;
-			}
-
 			.failing-element {
 				&:not(:first-child) {
 					margin-top: 8px;

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/App.js
@@ -44,7 +44,6 @@ export default function App(props) {
 				'open'
 			);
 
-			layoutReportsPanelId.focus();
 			setPanelIsOpen(true);
 		});
 
@@ -54,7 +53,6 @@ export default function App(props) {
 				'closed'
 			);
 
-			layoutReportsPanelToggle.focus();
 			setPanelIsOpen(false);
 		});
 

--- a/modules/apps/layout/layout-reports-web/src/main/resources/com/liferay/layout/reports/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/com/liferay/layout/reports/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item layout-reports-icon ${cssClass}">
-	<button aria-label="${title}" aria-pressed="false" class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-layout-reports-panel open-admin-panel" data-target="#layoutReportsPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" id="layoutReportsPanelToggleId">
+	<button aria-label="${title}" aria-pressed="false" class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-layout-reports-panel open-admin-panel open" data-target="#layoutReportsPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" id="layoutReportsPanelToggleId">
 		${iconTag}
 	</button>
 </li>

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_add_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_add_panel.scss
@@ -18,11 +18,6 @@ html#{$cadmin-selector} {
 	}
 
 	.cadmin {
-		&.lfr-add-panel.open-admin-panel.sidenav-menu-slider {
-			visibility: visible;
-			width: $admin-panel-width;
-		}
-
 		&.lfr-admin-panel {
 			&.sidenav-menu-slider {
 				/* stylelint-disable */

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_body.jsp
@@ -15,7 +15,7 @@
 	String portletNamespace = PortalUtil.getPortletNamespace(ProductNavigationControlMenuPortletKeys.PRODUCT_NAVIGATION_CONTROL_MENU);
 	%>
 
-	<div class="cadmin closed d-print-none lfr-add-panel lfr-admin-panel sidenav-fixed sidenav-menu-slider sidenav-right" id="<%= portletNamespace %>addPanelId">
+	<div class="cadmin closed d-print-none lfr-add-panel lfr-admin-panel sidenav-fixed sidenav-menu-slider sidenav-right" id="<%= portletNamespace %>addPanelId" tabindex="-1">
 		<div class="sidebar sidebar-inverse sidebar-light sidenav-menu">
 			<div class="d-flex justify-content-between p-3 sidebar-header">
 				<h1 class="sr-only"><liferay-ui:message key="widget-selection-panel" /></h1>

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
@@ -16,7 +16,7 @@ String portletNamespace = PortalUtil.getPortletNamespace(ProductNavigationContro
 		aria-label='<%= LanguageUtil.get(request, "add") %>'
 		cssClass="lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
-		data-open-class="open-admin-panel"
+		data-open-class="open-admin-panel open"
 		data-qa-id="add"
 		data-target='<%= "#" + portletNamespace + "addPanelId" %>'
 		data-title='<%= LanguageUtil.get(request, "add") %>'

--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -18,7 +18,7 @@ html#{$cadmin-selector} {
 		}
 	}
 
-	body.open {
+	body.product-menu-open {
 		#wrapper,
 		.cadmin.control-menu-container {
 			@include media-breakpoint-up(sm, $cadmin-grid-breakpoints) {

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/css/main.scss
@@ -3,11 +3,6 @@
 html#{$cadmin-selector} {
 	.cadmin {
 		&.simulation-panel {
-			&.open-admin-panel.sidenav-menu-slider {
-				visibility: visible;
-				width: 320px;
-			}
-
 			.sidebar {
 				border-left: 1px solid $cadmin-gray-300;
 			}

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/body_script.tmpl
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/body_script.tmpl
@@ -13,9 +13,6 @@ sidenavInstance.on(
 	'open.lexicon.sidenav',
 	function(event) {
 		Liferay.fire('SimulationMenu:openSimulationPanel');
-
-		const simulationPanel = document.getElementById('${portletNamespace}simulationPanelId');
-		simulationPanel.focus();
 	}
 );
 

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item d-none d-sm-inline-flex simulation-icon">
-	<button aria-label="${title}" class="btn btn-monospaced btn-sm lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel" data-qa-id="simulation"  data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" id="${portletNamespace}simulationToggleId">
+	<button aria-label="${title}" class="btn btn-monospaced btn-sm lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel open" data-qa-id="simulation"  data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" id="${portletNamespace}simulationToggleId">
 		${iconTag}
 	</button>
 </li>

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/AnalyticsReportsProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/AnalyticsReportsProductNavigationControlMenuEntry.java
@@ -322,7 +322,8 @@ public class AnalyticsReportsProductNavigationControlMenuEntry
 					ProductNavigationControlMenuEntryConstants.
 						SESSION_CLICKS_KEY)) {
 
-				sb.append("lfr-has-analytics-reports-panel open-admin-panel ");
+				sb.append(
+					"lfr-has-analytics-reports-panel open-admin-panel open ");
 			}
 
 			sb.append(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/template/AnalyticsReportsTemplateContextContributor.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/template/AnalyticsReportsTemplateContextContributor.java
@@ -58,7 +58,8 @@ public class AnalyticsReportsTemplateContextContributor
 
 			contextObjects.put(
 				"bodyCssClass",
-				cssClass + " lfr-has-analytics-reports-panel open-admin-panel");
+				cssClass +
+					" lfr-has-analytics-reports-panel open-admin-panel open");
 		}
 	}
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/css/main.scss
@@ -3,11 +3,6 @@
 html#{$cadmin-selector} {
 	.cadmin {
 		&.lfr-analytics-reports-panel {
-			&.open-admin-panel.sidenav-menu-slider {
-				visibility: visible;
-				width: 320px;
-			}
-
 			.sidebar {
 				border-left: 1px solid $cadmin-gray-300;
 				box-shadow: none;

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/META-INF/resources/js/AnalyticsReportsApp.js
@@ -34,12 +34,6 @@ export default function AnalyticsReportsApp({context, portletNamespace}) {
 					'com.liferay.analytics.reports.web_panelState',
 					'open'
 				);
-
-				const analyticsReportsPanel = document.getElementById(
-					`${portletNamespace}analyticsReportsPanelId`
-				);
-
-				analyticsReportsPanel.focus();
 			});
 
 			sidenavInstance.on('closed.lexicon.sidenav', () => {

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/icon.tmpl
@@ -3,7 +3,7 @@
 		aria-label="${title}"
 		class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
-		data-open-class="lfr-has-analytics-reports-panel open-admin-panel"
+		data-open-class="lfr-has-analytics-reports-panel open-admin-panel open"
 		data-target="#${portletNamespace}analyticsReportsPanelId"
 		data-title="${title}"
 		data-toggle="liferay-sidenav"

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/SegmentsExperimentProductNavigationControlMenuEntry.java
@@ -405,7 +405,7 @@ public class SegmentsExperimentProductNavigationControlMenuEntry
 
 			if (panelStateOpen) {
 				sb.append(
-					"lfr-has-segments-experiment-panel open-admin-panel ");
+					"lfr-has-segments-experiment-panel open-admin-panel open ");
 			}
 
 			sb.append("cadmin d-print-none lfr-admin-panel ");

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/template/SegmentsExperimentTemplateContextContributor.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/template/SegmentsExperimentTemplateContextContributor.java
@@ -60,7 +60,7 @@ public class SegmentsExperimentTemplateContextContributor
 			contextObjects.put(
 				"bodyCssClass",
 				cssClass +
-					" lfr-has-segments-experiment-panel open-admin-panel");
+					" lfr-has-segments-experiment-panel open-admin-panel open");
 		}
 	}
 

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/css/main.scss
@@ -4,11 +4,6 @@
 
 html#{$cadmin-selector} .cadmin {
 	&.lfr-segments-experiment-panel {
-		&.open-admin-panel.sidenav-menu-slider {
-			visibility: visible;
-			width: 320px;
-		}
-
 		.btn-secondary {
 			svg.lexicon-icon-ellipsis-v {
 				fill: $gray-600;

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/SegmentsExperimentApp.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/SegmentsExperimentApp.es.js
@@ -43,12 +43,6 @@ export default function SegmentsExperimentApp({context}) {
 					SEGMENTS_EXPERIMENT_PANEL_ID,
 					SEGMENTS_EXPERIMENT_OPEN_PANEL_VALUE
 				);
-
-				const segmentsExperimentPanel = document.getElementById(
-					`${namespace}segmentsExperimentPanelId`
-				);
-
-				segmentsExperimentPanel.focus();
 			});
 
 			Liferay.once('screenLoad', () => {

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
@@ -3,7 +3,7 @@
 		aria-label="${title}"
 		class="btn btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
-		data-open-class="open-admin-panel"
+		data-open-class="open-admin-panel open"
 		data-qa-id="segmentsExperimentPanel"
 		data-target="#${portletNamespace}segmentsExperimentPanelId"
 		data-title="${title}"


### PR DESCRIPTION
Hi guys! I send you the fix for: https://liferay.atlassian.net/browse/LPS-167073

The problem is mainly that, when the operating system's reduce motion is activated, the focus was trying to redirect to the panel when the panel still had a `visibility: hidden` style. 

**What has been fixed?**
- First, the classes necessary to open the panel are set and then the focus is redirected
- Focus is only redirected to the trigger if the active element is a close button.

**What needs to be reviewed?**
- The following commits: 236ac6dce2dc9cbd09ea2a6834da4514d1036f4c and 8c19999e989d9dca5e878b5ccf85afb69cd5599e