### PR TITLE
LRQA-82935 java.lang.Exception in FrontendDataSetClientExtension#CanAssertClientExtensionInDropdown

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -97,8 +97,9 @@ definition {
 	@description = "LPS-185873 Confirm that the Client Extension label is displayed on the drop-down item"
 	@priority = 5
 	test CanAssertClientExtensionInDropdown {
-		property osgi.modules.includes = "frontend-data-set-sample-web";
+		property osgi.modules.includes = "liferay-sample-fds-cell-renderer";
 		property test.liferay.virtual.instance = "false";
+		property test.name.skip.portal.instance = "FrontendDataSetClientExtension#CanChangeFilterWithClientExtension";
 		property test.run.type = "single";
 
 		task ("Given a client extension zip file deployed") {


### PR DESCRIPTION
**Description:**
Element is not present in console "STARTED liferaysamplefdscellrenderer_7.4.13"

JIRA Ticket:
[LRQA-82935](https://liferay.atlassian.net/browse/LRQA-82935)