### PR TITLE
LPS-194257 - Fix etag caching mechanism

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/etag/ETagUtil.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/etag/ETagUtil.java
@@ -29,14 +29,18 @@ public class ETagUtil {
 			return false;
 		}
 
-		int hashCode = _hashCode(
-			byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
+		String eTag = httpServletResponse.getHeader(HttpHeaders.ETAG);
 
-		String eTag = StringBundler.concat(
-			StringPool.QUOTE, StringUtil.toHexString(hashCode),
-			StringPool.QUOTE);
+		if (eTag == null) {
+			int hashCode = _hashCode(
+				byteBuffer.array(), byteBuffer.position(), byteBuffer.limit());
 
-		httpServletResponse.setHeader(HttpHeaders.ETAG, eTag);
+			eTag = StringBundler.concat(
+				StringPool.QUOTE, StringUtil.toHexString(hashCode),
+				StringPool.QUOTE);
+
+			httpServletResponse.setHeader(HttpHeaders.ETAG, eTag);
+		}
 
 		String ifNoneMatch = httpServletRequest.getHeader(
 			HttpHeaders.IF_NONE_MATCH);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java
@@ -66,22 +66,26 @@ public class HeaderFilter extends BasePortalFilter {
 			}
 		}
 
-		long lastModified = getLastModified(httpServletRequest);
+		String ifNoneMatch = httpServletRequest.getHeader(HttpHeaders.IF_NONE_MATCH);
 
-		if (lastModified > 0) {
-			long ifModifiedSince = httpServletRequest.getDateHeader(
-				HttpHeaders.IF_MODIFIED_SINCE);
+		if (ifNoneMatch == null) {
+			long lastModified = getLastModified(httpServletRequest);
 
-			httpServletResponse.setDateHeader(
-				HttpHeaders.LAST_MODIFIED, lastModified);
+			if (lastModified > 0) {
+				long ifModifiedSince = httpServletRequest.getDateHeader(
+					HttpHeaders.IF_MODIFIED_SINCE);
 
-			if (lastModified <= ifModifiedSince) {
 				httpServletResponse.setDateHeader(
-					HttpHeaders.LAST_MODIFIED, ifModifiedSince);
-				httpServletResponse.setStatus(
-					HttpServletResponse.SC_NOT_MODIFIED);
+					HttpHeaders.LAST_MODIFIED, lastModified);
 
-				return;
+				if (lastModified <= ifModifiedSince) {
+					httpServletResponse.setDateHeader(
+						HttpHeaders.LAST_MODIFIED, ifModifiedSince);
+					httpServletResponse.setStatus(
+						HttpServletResponse.SC_NOT_MODIFIED);
+
+					return;
+				}
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/header/HeaderFilter.java
@@ -66,7 +66,8 @@ public class HeaderFilter extends BasePortalFilter {
 			}
 		}
 
-		String ifNoneMatch = httpServletRequest.getHeader(HttpHeaders.IF_NONE_MATCH);
+		String ifNoneMatch = httpServletRequest.getHeader(
+			HttpHeaders.IF_NONE_MATCH);
 
 		if (ifNoneMatch == null) {
 			long lastModified = getLastModified(httpServletRequest);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
@@ -84,6 +84,9 @@ public class LanguageFilter extends BasePortalFilter {
 
 		String eTagKey = _getETagKey(httpServletRequest);
 
+		httpServletResponse.setHeader(
+			HttpHeaders.CACHE_CONTROL, "private, no-cache");
+
 		if ((ifNoneMatch != null) &&
 			ifNoneMatch.equals(_eTagValues.get(eTagKey))) {
 
@@ -106,9 +109,6 @@ public class LanguageFilter extends BasePortalFilter {
 
 			_log.debug("Translating response " + completeURL);
 		}
-
-		httpServletResponse.setHeader(
-			HttpHeaders.CACHE_CONTROL, "private, no-cache");
 
 		String content = bufferCacheServletResponse.getString();
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
@@ -87,8 +87,12 @@ public class LanguageFilter extends BasePortalFilter {
 		httpServletResponse.setHeader(
 			HttpHeaders.CACHE_CONTROL, "private, no-cache");
 
+		String eTagValue = _eTagValues.get(eTagKey);
+
 		if ((ifNoneMatch != null) &&
 			ifNoneMatch.equals(_eTagValues.get(eTagKey))) {
+
+			httpServletResponse.setHeader(HttpHeaders.ETAG, eTagValue);
 
 			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 
@@ -114,7 +118,7 @@ public class LanguageFilter extends BasePortalFilter {
 
 		content = translateResponse(httpServletRequest, content);
 
-		String eTagValue =
+		eTagValue =
 			StringPool.QUOTE + DigesterUtil.digest("SHA-1", content) +
 				StringPool.QUOTE;
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
@@ -28,10 +28,8 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.ResourceBundle;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.portlet.PortletConfig;
 
@@ -67,8 +65,6 @@ public class LanguageFilter extends BasePortalFilter {
 			return;
 		}
 
-		_eTagValues.clear();
-
 		_portletConfig = PortletConfigFactoryUtil.create(
 			portlets.get(0), filterConfig.getServletContext());
 	}
@@ -79,25 +75,8 @@ public class LanguageFilter extends BasePortalFilter {
 			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
 
-		String ifNoneMatch = httpServletRequest.getHeader(
-			HttpHeaders.IF_NONE_MATCH);
-
-		String eTagKey = _getETagKey(httpServletRequest);
-
 		httpServletResponse.setHeader(
 			HttpHeaders.CACHE_CONTROL, "private, no-cache");
-
-		String eTagValue = _eTagValues.get(eTagKey);
-
-		if ((ifNoneMatch != null) &&
-			ifNoneMatch.equals(_eTagValues.get(eTagKey))) {
-
-			httpServletResponse.setHeader(HttpHeaders.ETAG, eTagValue);
-
-			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
-
-			return;
-		}
 
 		BufferCacheServletResponse bufferCacheServletResponse =
 			new BufferCacheServletResponse(httpServletResponse);
@@ -118,13 +97,20 @@ public class LanguageFilter extends BasePortalFilter {
 
 		content = translateResponse(httpServletRequest, content);
 
-		eTagValue =
+		String eTag =
 			StringPool.QUOTE + DigesterUtil.digest("SHA-1", content) +
 				StringPool.QUOTE;
 
-		_eTagValues.put(eTagKey, eTagValue);
+		httpServletResponse.setHeader(HttpHeaders.ETAG, eTag);
 
-		httpServletResponse.setHeader(HttpHeaders.ETAG, eTagValue);
+		String ifNoneMatch = httpServletRequest.getHeader(
+			HttpHeaders.IF_NONE_MATCH);
+
+		if ((ifNoneMatch != null) && ifNoneMatch.equals(eTag)) {
+			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+
+			return;
+		}
 
 		ServletResponseUtil.write(httpServletResponse, content);
 	}
@@ -151,14 +137,8 @@ public class LanguageFilter extends BasePortalFilter {
 			locale, content);
 	}
 
-	private String _getETagKey(HttpServletRequest httpServletRequest) {
-		return LanguageUtil.getLanguageId(httpServletRequest) +
-			StringPool.POUND + httpServletRequest.getRequestURI();
-	}
-
 	private static final Log _log = LogFactoryUtil.getLog(LanguageFilter.class);
 
-	private final Map<String, String> _eTagValues = new ConcurrentHashMap<>();
 	private PortletConfig _portletConfig;
 
 	private static class NoCacheHttpServletRequestWrapper

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -332,9 +332,10 @@ public class WebServerServlet extends HttpServlet {
 
 			_checkResourcePermission(httpServletRequest, httpServletResponse);
 
-			String ifNoneMatch = httpServletRequest.getHeader(HttpHeaders.IF_NONE_MATCH);
+			String ifNoneMatch = httpServletRequest.getHeader(
+				HttpHeaders.IF_NONE_MATCH);
 
-			if (ifNoneMatch == null && _lastModified) {
+			if ((ifNoneMatch == null) && _lastModified) {
 				long lastModified = getLastModified(httpServletRequest);
 
 				if (lastModified > 0) {

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -332,7 +332,9 @@ public class WebServerServlet extends HttpServlet {
 
 			_checkResourcePermission(httpServletRequest, httpServletResponse);
 
-			if (_lastModified) {
+			String ifNoneMatch = httpServletRequest.getHeader(HttpHeaders.IF_NONE_MATCH);
+
+			if (ifNoneMatch == null && _lastModified) {
 				long lastModified = getLastModified(httpServletRequest);
 
 				if (lastModified > 0) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-194257

I am slightly nervous for this change, as I don't know the ramifications throughout the rest of portal and the upgrade process. Theoretically I believe these are the right changes according to the http spec, but I am slightly nervous that we aren't following that spec well in DXP and thus could have regressions. From my tests though, this seems most in line with http's expectations for caching.


## Cause of failure:
The root cause of failure is from the change to etag caching introduced in [7.4.3.84-ga84](https://github.com/liferay/liferay-portal/releases/tag/7.4.3.84-ga84)

Before our change, we were depending on a [Cache-Control header](https://github.com/liferay/liferay-portal/blob/5de5d4cd38c63a2ed1f3915ba71c57a3e4fcef86/portal-web/docroot/WEB-INF/liferay-web.xml#L144-L159) of `max-age=315360000`. We also sent an Etag, but in order for the client to store the ETag and for subsequent requests to use `If-None-Match`, the `Cache-Control` *[must](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)* be set to `no-cache` so that the client would re-validate the cache using `If-None-Match`. Note: pre-u84, we have other caching issues with Languages and so the ETag solution was to provide a more robust mechanism.

The mistake we made was not realizing that HeaderFilter was setting a [Cache-Control](https://github.com/liferay/liferay-portal/blob/5de5d4cd38c63a2ed1f3915ba71c57a3e4fcef86/portal-web/docroot/WEB-INF/liferay-web.xml#L144-L159) header that was causing the browser to essentially cache a resource forever and not validate the resources ETag. When we changed our resource requests from having unique query params such as `?t=12345` to using ESM, we were relying on a Cache-Control of `no-cache` plus an `ETag` header for every request.

Because of this failure, we have issues when upgrading from anything before u84 to anything at u84 or after.

## How we plan to fix in DXP (this PR):
- Use the `no-cache` header to ensure revalidation
- Use the right etag and avoid overwriting it in the EtagFilter
- Always return Etag in the response headers, even in the case where it matches the If-None-Match
- Prioritize If-None-Match over If-Modified-Since because that is the spec
- Recompute the etag on each request so that we can properly invalidate if the same client makes multiple requests and content changes between the two.

These changes will fix future issues. However, even with these changes, it may require users to clear their client cache. To fix the browser cache, you can send the `no-cache` header from your CDN to ensure that clients are properly updated.

## How to fix when upgrading to u84+
You will need to purge the cache of your CDN or also by sending a `no-cache` response to the client.

## Note on CDNs:
These fixes should help address consistency in DXP for caching resources. However, this doesn't necessarily mean a CDN will work properly out of the box. It is up to the administrator to configure the CDN to work with DXP. The headers required to work with DXP are `ETag` in response and also `If-None-Match` in the request. For example, in nginx, when using `proxy_pass` and `proxy_cache_revalidate`, you must pass the headers through from the client to the origin server. For example:
```  
proxy_set_header If-None-Match $http_if_none_match;
proxy_set_header Cache-Control $http_cache_control;
```
