### PR TITLE
[Spike] LPS-192287 Research how to redirect the users back to the page where the action was triggered

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -106,7 +106,9 @@ export function formatActionURL(url, item) {
 		return '';
 	}
 
-	const replacedURL = url.replace(new RegExp('{(.*?)}', 'mg'), (matched) =>
+	let replacedURL = url.replace("{currentURL}", Liferay.currentURL);
+
+	replacedURL = replacedURL.replace(new RegExp('{(.*?)}', 'mg'), (matched) =>
 		getValueFromItem(
 			item,
 			matched.substring(1, matched.length - 1).split('.')


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-192287

This simply replaces `{currentURL}` in the action item URL to allow defining a redirect to the current page. I left additional notes in the ticket: https://liferay.atlassian.net/browse/LPS-192287?focusedCommentId=2469347 

**Unrelated bug to note:**
- There is a strange issue with the data set fragment where links don't navigate properly (and actually causes all links on the page to break). Clicking on a link will stay on the same page but the styling looks slightly off. The URL is correct, but I had to manually reload the page to navigate to the new page.

## Demo

https://github.com/liferay-frontend/liferay-portal/assets/4496722/95bc9847-4e0c-4a2f-8816-bfc60b9798a9

