### PR TITLE
LPS-197289 every search-container should have an unique id

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/search/EntriesChecker.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/search/EntriesChecker.java
@@ -166,9 +166,18 @@ public class EntriesChecker extends RowChecker {
 		String checkBoxAllRowIds, String checkBoxPostOnClick,
 		Map<String, Object> data) {
 
-		StringBundler sb = new StringBundler(16);
+		StringBundler sb = new StringBundler(19);
 
 		sb.append("<input ");
+
+		String rowElementId = (String)httpServletRequest.getAttribute(
+			"liferay-ui:search-container-row:rowElementId");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -55,7 +55,8 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 		<div class="layout-revision-container" id="<portlet:namespace />layoutRevisionsContainer">
 
 			<%
-			for (LayoutRevision rootLayoutRevision : rootLayoutRevisions) {
+			for (int i = 0; i < rootLayoutRevisions.size(); i++) {
+				LayoutRevision rootLayoutRevision = rootLayoutRevisions.get(i);
 			%>
 
 				<div class="layout-variation-container <%= (recentLayoutRevision.getLayoutBranchId() == rootLayoutRevision.getLayoutBranchId()) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace /><%= rootLayoutRevision.getLayoutRevisionId() %>">
@@ -69,6 +70,7 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 					</c:if>
 
 					<liferay-ui:search-container
+						id="<%= liferayPortletResponse.getNamespace() %>layoutRevisionsSearchContainer_<%= i %>"
 						total="<%= LayoutRevisionLocalServiceUtil.getLayoutRevisionsCount(rootLayoutRevision.getLayoutSetBranchId(), rootLayoutRevision.getLayoutBranchId(), rootLayoutRevision.getPlid()) %>"
 					>
 						<liferay-ui:search-container-results

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
@@ -38,9 +38,18 @@ public class EmptyOnClickRowChecker extends RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(15);
+		StringBundler sb = new StringBundler(18);
 
 		sb.append("<input ");
+
+		String rowElementId = (String)httpServletRequest.getAttribute(
+			"liferay-ui:search-container-row:rowElementId");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -261,9 +261,18 @@ public class RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(14);
+		StringBundler sb = new StringBundler(17);
 
 		sb.append("<label><input ");
+
+		String rowElementId = (String)httpServletRequest.getAttribute(
+			"liferay-ui:search-container-row:rowElementId");
+
+		if (rowElementId != null) {
+			sb.append("aria-labelledby=\"");
+			sb.append(rowElementId);
+			sb.append("\" ");
+		}
 
 		if (checked) {
 			sb.append("checked ");

--- a/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/deprecated/list.jsp
@@ -224,6 +224,10 @@ if (iteratorURL != null) {
 
 			boolean rowIsChecked = false;
 
+			String rowElementId = namespace + id + "_" + row.getRowId();
+
+			request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
+
 			if (rowChecker != null) {
 				rowIsChecked = rowChecker.isChecked(row.getObject());
 
@@ -247,14 +251,7 @@ if (iteratorURL != null) {
 			Map<String, Object> data = row.getData();
 		%>
 
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
-				</c:when>
-				<c:otherwise>
-					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" <%= AUIUtil.buildData(data) %>>
-				</c:otherwise>
-			</c:choose>
+			<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "info" : StringPool.BLANK %>" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 			<%
 			for (int j = 0; j < entries.size(); j++) {
@@ -313,6 +310,7 @@ if (iteratorURL != null) {
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+			request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 			request.removeAttribute("liferay-ui:search-container-row:rowId");
 		}
 		%>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/descriptive.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/descriptive.jsp
@@ -100,9 +100,13 @@
 				if (data == null) {
 					data = new HashMap<String, Object>();
 				}
+
+				String rowElementId = namespace + id + "_" + row.getRowId();
+
+				request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
 			%>
 
-				<dd class="list-group-item list-group-item-flex <%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= rowIsChecked ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(row.getState()) ? "list-group-item-" + row.getState() : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+				<dd class="list-group-item list-group-item-flex <%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= rowIsChecked ? "active" : StringPool.BLANK %> <%= Validator.isNotNull(row.getState()) ? "list-group-item-" + row.getState() : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 					<c:if test="<%= rowChecker != null %>">
 						<div class="autofit-col">
 							<div class="checkbox">
@@ -140,6 +144,7 @@
 				request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 				request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+				request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 				request.removeAttribute("liferay-ui:search-container-row:rowId");
 			}
 			%>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/icon.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/icon.jsp
@@ -95,9 +95,13 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 			if (Validator.isNull(rowCssClass)) {
 				rowCssClass = "card-page-item card-page-item-asset";
 			}
+
+			String rowElementId = namespace + id + "_" + row.getRowId();
+
+			request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
 		%>
 
-			<dd class="<%= GetterUtil.getString(row.getClassName()) %> <%= rowCssClass %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
+			<dd class="<%= GetterUtil.getString(row.getClassName()) %> <%= rowCssClass %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 				<%
 				for (int k = 0; k < entries.size(); k++) {
@@ -117,6 +121,7 @@ for (int i = 0; i < resultRowSplitterEntries.size(); i++) {
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 			request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+			request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 			request.removeAttribute("liferay-ui:search-container-row:rowId");
 		}
 		%>

--- a/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/init.jsp
@@ -19,7 +19,6 @@ boolean fixedHeader = GetterUtil.getBoolean((String)request.getAttribute("lifera
 String markupView = (String)request.getAttribute("liferay-ui:search-iterator:markupView");
 boolean paginate = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:search-iterator:paginate"));
 ResultRowSplitter resultRowSplitter = (ResultRowSplitter)request.getAttribute("liferay-ui:search-iterator:resultRowSplitter");
-String rowIdProperty = (String)request.getAttribute("liferay-ui:search-container-row:rowIdProperty");
 String searchContainerRowCssClass = GetterUtil.getString((String)request.getAttribute("liferay-ui:search-container-row:cssClass"));
 String searchResultCssClass = (String)request.getAttribute("liferay-ui:search-iterator:searchResultCssClass");
 String type = (String)request.getAttribute("liferay-ui:search:type");

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -230,6 +230,10 @@ if (fixedHeader) {
 					boolean rowIsChecked = false;
 					boolean rowIsDisabled = false;
 
+					String rowElementId = namespace + id + "_" + row.getRowId();
+
+					request.setAttribute("liferay-ui:search-container-row:rowElementId", rowElementId);
+
 					if (rowChecker != null) {
 						rowIsChecked = rowChecker.isChecked(row.getObject());
 						rowIsDisabled = rowChecker.isDisabled(row.getObject());
@@ -272,14 +276,7 @@ if (fixedHeader) {
 					}
 				%>
 
-					<c:choose>
-						<c:when test="<%= Validator.isNotNull(rowIdProperty) %>">
-							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<portlet:namespace /><%= id %>_<%= row.getRowId() %>" <%= AUIUtil.buildData(data) %>>
-						</c:when>
-						<c:otherwise>
-							<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" <%= AUIUtil.buildData(data) %>>
-						</c:otherwise>
-					</c:choose>
+					<tr class="<%= GetterUtil.getString(row.getClassName()) %> <%= row.getCssClass() %> <%= row.getState() %> <%= rowIsChecked ? "active" : StringPool.BLANK %>" data-qa-id="row" id="<%= rowElementId %>" <%= AUIUtil.buildData(data) %>>
 
 						<%
 						for (int j = 0; j < entries.size(); j++) {
@@ -353,6 +350,7 @@ if (fixedHeader) {
 					request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW);
 					request.removeAttribute(WebKeys.SEARCH_CONTAINER_RESULT_ROW_ENTRY);
 
+					request.removeAttribute("liferay-ui:search-container-row:rowElementId");
 					request.removeAttribute("liferay-ui:search-container-row:rowId");
 				}
 			}

--- a/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java
@@ -328,12 +328,6 @@ public class SearchContainerRowTag<R>
 					FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(
 						String.valueOf(rowIdObject));
 			}
-
-			HttpServletRequest httpServletRequest = getRequest();
-
-			httpServletRequest.setAttribute(
-				"liferay-ui:search-container-row:rowIdProperty",
-				_rowIdProperty);
 		}
 
 		_resultRow = new com.liferay.taglib.search.ResultRow(


### PR DESCRIPTION
This is a fix for the release blocker [LPS-197289](https://liferay.atlassian.net/browse/LPS-197289).

### What caused the issue
My fix was assuming we did not have two search_containers with the same id in the same page (if so, that sounds like the content in them are the same, so why does it display two times?).

### The fix
I checked with @markocikos and my assumption was correct. Because of that, I simply added an unique id for each search_container rendered in the broken page. As you can see, an id wasn't being created so the default (SearchContainer) id was given.

### Other notes
I'm keeping the same changes that were reverted by Brian to unblock the release, they are correct. They are assuming an unique search_container is being provided. **In case this is wrong, please let me know, I'll just change the fix to generate a unique id in [SearchContainerRowTag.java](https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java#L314) using `System.currentTimeMillis()` (so every row would have a unique id even if the search-containers have the same id.**