### PR TITLE
LPS-192160 Element is not present in DataSetViewFields#CanChangeCellRenderer

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -458,7 +458,7 @@ definition {
 
 		task ("And change the Cell Renderer to "Label"") {
 			Click(
-				dropdownLabel = "Cell Renderer",
+				dropdownLabel = "Renderer",
 				locator1 = "ObjectField#ANY_DROPDOWN_LABEL");
 
 			MenuItem.click(menuItem = "Label");
@@ -470,7 +470,7 @@ definition {
 
 		task ("Then assert the "Label" is present from the column Cell Renderer") {
 			AssertElementPresent(
-				key_tableColumn = "Cell Renderer",
+				key_tableColumn = "Renderer",
 				key_tableRow = "Label",
 				locator1 = "DataSet#FIELDS_TABLE_AND_ROW");
 		}


### PR DESCRIPTION
**Description:**
The cause of this failure is that the label name has been changed. So I changed to the new name.

**Jira Ticket:**
https://liferay.atlassian.net/browse/LPS-192160