### PR TITLE
LRQA-82939 Test fix FrontendDataSetClientExtension#CanAssertTheRendererColumn

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetClientExtension.testcase
@@ -172,6 +172,8 @@ definition {
 				restApplication = "/data-set-manager/fields",
 				restEndpoint = "/",
 				restSchema = "FDSField");
+
+			Refresh();
 		}
 
 		task ("And adding a dataset view ") {


### PR DESCRIPTION
**Description:**
When an entry is created in Data Set, the page not reload automatically, so, when the test tries to found the new entry, not found it. So, I put a reload function.

**Jira Ticket:** 
https://liferay.atlassian.net/browse/LRQA-82939