### PR TITLE
LPS-197363 Console errors after leaving empty mandatory fields in the Extension client 

### DIFF
--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.ts
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.ts
@@ -117,6 +117,24 @@ class CollapseProvider {
 			trigger = this._getTrigger(panel);
 		}
 
+		// If the initial trigger isn't found, assume it could be a clay:panel
+		// taglib and attempt to expand it.
+
+		if (!trigger) {
+			const clayPanelTrigger = panel
+				.closest('.panel')
+				?.getElementsByClassName('panel-header')?.[0];
+
+			if (
+				clayPanelTrigger &&
+				clayPanelTrigger.classList.contains('collapsed')
+			) {
+				clayPanelTrigger.click();
+			}
+
+			return;
+		}
+
 		if (!panel) {
 			panel = this._getPanel(trigger);
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197363

Since this CollapseProvider would still need to work for the deprecated liferay-ui:panel taglibs, this seemed like the least intrusive addition. I used `.click()` since the clay panel would need to be managed by the react component instead manually manipulating the DOM like the rest of the `show` method was doing.

## Demo with fix

https://github.com/liferay-frontend/liferay-portal/assets/4496722/7853cfc7-c43d-4fe9-a5a7-c5fa283dcb12

