### PR TITLE
LPS-197681 - Prevent users to save fields multiple times

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -162,6 +162,7 @@ const SaveFDSFieldsModalContent = ({
 
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
+		
 		const creationData: Array<{name: string; type: string}> = [];
 		const deletionIds: Array<number> = [];
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -139,6 +139,9 @@ const SaveFDSFieldsModalContent = ({
 }: ISaveFDSFieldsModalContentProps) => {
 	const [fields, setFields] = useState<Array<IField> | null>(null);
 	const [query, setQuery] = useState('');
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState<boolean>(
+		false
+	);
 
 	const onSearch = (query: string) => {
 		setQuery(query);
@@ -158,6 +161,7 @@ const SaveFDSFieldsModalContent = ({
 	};
 
 	const saveFDSFields = async () => {
+		setSaveButtonDisabled(true);
 		const creationData: Array<{name: string; type: string}> = [];
 		const deletionIds: Array<number> = [];
 
@@ -191,6 +195,8 @@ const SaveFDSFieldsModalContent = ({
 
 		if (!response.ok) {
 			openDefaultFailureToast();
+
+			setSaveButtonDisabled(false);
 
 			return;
 		}
@@ -358,7 +364,10 @@ const SaveFDSFieldsModalContent = ({
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton onClick={() => saveFDSFields()}>
+						<ClayButton
+							disabled={saveButtonDisabled}
+							onClick={() => saveFDSFields()}
+						>
 							{Liferay.Language.get('save')}
 						</ClayButton>
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -162,7 +162,7 @@ const SaveFDSFieldsModalContent = ({
 
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
-		
+
 		const creationData: Array<{name: string; type: string}> = [];
 		const deletionIds: Array<number> = [];
 


### PR DESCRIPTION
Related bug https://liferay.atlassian.net/browse/LPS-197681

## Problem
It is possible to add fields more than once in a Dataset View

## Proposed solution
Disabled **Save** button while making the request

### Before 

[Screencast from 2023-09-29 09-14-03.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/ae037f47-b513-4dc7-bc34-4d75435ff15e)

### After

[Screencast from 2023-09-29 10-03-53.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/97b1a4b4-6aa9-43b6-ab24-9262fa3ea629)

