### PR TITLE
LPS-197848 Use the permissionKey as value in the form

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ItemActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ItemActionForm.tsx
@@ -449,6 +449,7 @@ const ItemActionForm = ({
 									placeholder={Liferay.Language.get(
 										'add-a-value-here'
 									)}
+									value={actionData.permissionKey}
 								/>
 							</ClayForm.Group>
 


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPS-197848

In this PR we're giving the right value to the "Headless Action Key" field for the action being edited, which we missed in the original PR