### PR TITLE
LPS-197444 Make the wrapped request behave as a real one

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/RequestDispatcherUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/RequestDispatcherUtil.java
@@ -35,6 +35,12 @@ public class RequestDispatcherUtil {
 			new HttpServletRequestWrapper(httpServletRequest) {
 
 				@Override
+				public String getContextPath() {
+					return (String)getAttribute(
+						RequestDispatcher.INCLUDE_CONTEXT_PATH);
+				}
+
+				@Override
 				public long getDateHeader(String name) {
 					if (name.equals(HttpHeaders.IF_MODIFIED_SINCE)) {
 						return -1;
@@ -76,6 +82,24 @@ public class RequestDispatcherUtil {
 				public String getPathInfo() {
 					return (String)getAttribute(
 						RequestDispatcher.INCLUDE_PATH_INFO);
+				}
+
+				@Override
+				public String getQueryString() {
+					return (String)getAttribute(
+						RequestDispatcher.INCLUDE_QUERY_STRING);
+				}
+
+				@Override
+				public String getRequestURI() {
+					return (String)getAttribute(
+						RequestDispatcher.INCLUDE_REQUEST_URI);
+				}
+
+				@Override
+				public String getServletPath() {
+					return (String)getAttribute(
+						RequestDispatcher.INCLUDE_SERVLET_PATH);
 				}
 
 			},


### PR DESCRIPTION
Since we are delegating in the usual portal request dispatching from ComboServlet, we need to make the rest of the portal think that the requests from ComboServlet are real.

Because we are using RequestDispatcher.include, the request that the portal sees (unless we do something to remediate it) is for /combo, not for the subresources the combo is trying to gather together.

In this commit we override some of the wrapped request methods to make portal think the request is a normal one.