### PR TITLE
LPS-198051 Moving styles to BaseEditor so they apply to every editor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BalloonEditor.js
@@ -6,10 +6,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import DEFAULT_BALLOON_EDITOR_CONFIG from './config/DefaultBalloonEditorConfiguration';
-
-import '../css/main.scss';
 import BaseEditor from './BaseEditor';
+import DEFAULT_BALLOON_EDITOR_CONFIG from './config/DefaultBalloonEditorConfiguration';
 
 const EMPTY_OBJECT = {};
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -7,6 +7,8 @@ import CKEditor from 'ckeditor4-react';
 import PropTypes from 'prop-types';
 import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
 
+import '../css/main.scss';
+
 const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
 const CONTEXT_URL = Liferay.ThemeDisplay.getPathContext();
 const CURRENT_PATH = CONTEXT_URL ? CONTEXT_URL + BASEPATH : BASEPATH;


### PR DESCRIPTION
Hey guys,

These kind of styles used to apply to every editor, not only to BalloonEditor, although we messed it up when taking them away from Styled Theme. As an example you can see [LPS-139143](https://liferay.atlassian.net/browse/LPS-139143).

In case you want to know more, you can see [LPS-198051](https://liferay.atlassian.net/browse/LPS-198051) and [this Slack thread](https://liferay.slack.com/archives/C3JBR21HA/p1696343137651109).

Thanks.

Regards.