### PR TITLE
LPS-197722 Do not apply the dynamic selection filter when no prepopulated values have been selected

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -501,9 +501,6 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 							listTypeEntries, themeDisplay.getLocale(),
 							MapUtil.getString(properties, "preselectedValues"));
 
-					boolean hasPreloadedData =
-						selectedItemsJSONArray.length() > 0;
-
 					return JSONUtil.put(
 						"autocompleteEnabled", true
 					).put(
@@ -529,22 +526,14 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"preloadedData",
 						() -> {
-							if (!hasPreloadedData) {
+							if (JSONUtil.isEmpty(selectedItemsJSONArray)) {
 								return null;
 							}
 
 							return JSONUtil.put(
 								"exclude",
-								() -> {
-									Boolean include = (Boolean)properties.get(
-										"include");
-
-									if ((include != null) && !include) {
-										return true;
-									}
-
-									return false;
-								}
+								() -> Boolean.FALSE.equals(
+									(Boolean)properties.get("include"))
 							).put(
 								"selectedItems", selectedItemsJSONArray
 							);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -496,6 +496,14 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						_listTypeEntryLocalService.getListTypeEntries(
 							listTypeDefinition.getListTypeDefinitionId());
 
+					JSONArray selectedItemsJSONArray =
+						_getSelectedItemsJSONArray(
+							listTypeEntries, themeDisplay.getLocale(),
+							MapUtil.getString(properties, "preselectedValues"));
+
+					boolean hasPreloadedData =
+						selectedItemsJSONArray.length() > 0;
+
 					return JSONUtil.put(
 						"autocompleteEnabled", true
 					).put(
@@ -520,15 +528,27 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						"multiple", properties.get("multiple")
 					).put(
 						"preloadedData",
-						JSONUtil.put(
-							"exclude", false
-						).put(
-							"selectedItems",
-							_getSelectedItemsJSONArray(
-								listTypeEntries, themeDisplay.getLocale(),
-								MapUtil.getString(
-									properties, "preselectedValues"))
-						)
+						() -> {
+							if (!hasPreloadedData) {
+								return null;
+							}
+
+							return JSONUtil.put(
+								"exclude",
+								() -> {
+									Boolean include = (Boolean)properties.get(
+										"include");
+
+									if ((include != null) && !include) {
+										return true;
+									}
+
+									return false;
+								}
+							).put(
+								"selectedItems", selectedItemsJSONArray
+							);
+						}
 					).put(
 						"type", "selection"
 					);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.tsx
@@ -217,36 +217,41 @@ function Body({
 							</ClayForm.FeedbackGroup>
 						)}
 					</ClayForm.Group>
-					<ClayForm.Group>
-						<label htmlFor={includeModeFormElementId}>
-							{Liferay.Language.get('filter-mode')}
 
-							<span
-								className="label-icon lfr-portal-tooltip ml-2"
-								title={Liferay.Language.get(
-									'include-returns-only-the-selected-values.-exclude-returns-all-except-the-selected-ones'
-								)}
+					{preselectedValues?.length > 0 && (
+						<ClayForm.Group>
+							<label htmlFor={includeModeFormElementId}>
+								{Liferay.Language.get('filter-mode')}
+
+								<span
+									className="label-icon lfr-portal-tooltip ml-2"
+									title={Liferay.Language.get(
+										'include-returns-only-the-selected-values.-exclude-returns-all-except-the-selected-ones'
+									)}
+								>
+									<ClayIcon symbol="question-circle-full" />
+								</span>
+							</label>
+
+							<ClayRadioGroup
+								name={includeModeFormElementId}
+								onChange={(val: any) =>
+									onIncludeModeChange(val)
+								}
+								value={includeMode}
 							>
-								<ClayIcon symbol="question-circle-full" />
-							</span>
-						</label>
+								<ClayRadio
+									label={Liferay.Language.get('include')}
+									value="include"
+								/>
 
-						<ClayRadioGroup
-							name={includeModeFormElementId}
-							onChange={(val: any) => onIncludeModeChange(val)}
-							value={includeMode}
-						>
-							<ClayRadio
-								label={Liferay.Language.get('include')}
-								value="include"
-							/>
-
-							<ClayRadio
-								label={Liferay.Language.get('exclude')}
-								value="exclude"
-							/>
-						</ClayRadioGroup>
-					</ClayForm.Group>
+								<ClayRadio
+									label={Liferay.Language.get('exclude')}
+									value="exclude"
+								/>
+							</ClayRadioGroup>
+						</ClayForm.Group>
+					)}
 				</>
 			)}
 		</>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.tsx
@@ -109,7 +109,6 @@ function Body({
 						{
 							disabled: true,
 							label: Liferay.Language.get('select'),
-							selected: true,
 							value: '',
 						},
 						...picklists.map((item) => ({
@@ -118,7 +117,7 @@ function Body({
 						})),
 					]}
 					title={Liferay.Language.get('source-options')}
-					value={selectedPicklist?.externalReferenceCode}
+					value={selectedPicklist?.externalReferenceCode || ''}
 				/>
 			</ClayForm.Group>
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -12,7 +12,7 @@ import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
 import {InputLocalized} from 'frontend-js-components-web';
 import {IClientExtensionRenderer, fetch, openModal, sub} from 'frontend-js-web';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {API_URL, OBJECT_RELATIONSHIP} from '../Constants';
 import {FDSViewType} from '../FDSViews';
@@ -83,8 +83,18 @@ function AddFDSFilterModalContent({
 	const [from, setFrom] = useState<string>(
 		(filter as IDateFilter)?.from ?? ''
 	);
+	const getFilterIncludeMode = useCallback(() => {
+		return filter
+			? (filter as ISelectionFilter)?.include
+				? 'include'
+				: 'exclude'
+			: 'include';
+	}, [filter]);
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
 		fdsFilterLabelTranslations
+	);
+	const [includeMode, setIncludeMode] = useState<string>(() =>
+		getFilterIncludeMode()
 	);
 	const [isValidDateRange, setIsValidDateRange] = useState<boolean>(true);
 	const [multiple, setMultiple] = useState<boolean>(
@@ -123,18 +133,6 @@ function AddFDSFilterModalContent({
 			}
 		});
 	}, [filter]);
-
-	const [includeMode, setIncludeMode] = useState<string>(() => {
-		if (preselectedValues?.length === 0) {
-			return 'include';
-		}
-
-		return filter
-			? (filter as ISelectionFilter)?.include
-				? 'include'
-				: 'exclude'
-			: 'include';
-	});
 
 	const handleFilterSave = async () => {
 		setSaveButtonDisabled(true);
@@ -301,7 +299,10 @@ function AddFDSFilterModalContent({
 		if (preselectedValues?.length === 0) {
 			setIncludeMode('include');
 		}
-	}, [preselectedValues]);
+		else {
+			setIncludeMode(getFilterIncludeMode());
+		}
+	}, [preselectedValues, getFilterIncludeMode]);
 
 	return (
 		<>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -86,13 +86,6 @@ function AddFDSFilterModalContent({
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
 		fdsFilterLabelTranslations
 	);
-	const [includeMode, setIncludeMode] = useState<string>(
-		filter
-			? (filter as ISelectionFilter)?.include
-				? 'include'
-				: 'exclude'
-			: 'include'
-	);
 	const [isValidDateRange, setIsValidDateRange] = useState<boolean>(true);
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as ISelectionFilter)?.multiple ?? true
@@ -130,6 +123,18 @@ function AddFDSFilterModalContent({
 			}
 		});
 	}, [filter]);
+
+	const [includeMode, setIncludeMode] = useState<string>(() => {
+		if (preselectedValues?.length === 0) {
+			return 'include';
+		}
+
+		return filter
+			? (filter as ISelectionFilter)?.include
+				? 'include'
+				: 'exclude'
+			: 'include';
+	});
 
 	const handleFilterSave = async () => {
 		setSaveButtonDisabled(true);
@@ -291,6 +296,12 @@ function AddFDSFilterModalContent({
 			</ClayDropDown>
 		);
 	};
+
+	useEffect(() => {
+		if (preselectedValues?.length === 0) {
+			setIncludeMode('include');
+		}
+	}, [preselectedValues]);
 
 	return (
 		<>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -12,7 +12,7 @@ import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
 import {InputLocalized} from 'frontend-js-components-web';
 import {IClientExtensionRenderer, fetch, openModal, sub} from 'frontend-js-web';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import {API_URL, OBJECT_RELATIONSHIP} from '../Constants';
 import {FDSViewType} from '../FDSViews';
@@ -83,19 +83,10 @@ function AddFDSFilterModalContent({
 	const [from, setFrom] = useState<string>(
 		(filter as IDateFilter)?.from ?? ''
 	);
-	const getFilterIncludeMode = useCallback(() => {
-		return filter
-			? (filter as ISelectionFilter)?.include
-				? 'include'
-				: 'exclude'
-			: 'include';
-	}, [filter]);
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
 		fdsFilterLabelTranslations
 	);
-	const [includeMode, setIncludeMode] = useState<string>(() =>
-		getFilterIncludeMode()
-	);
+	const [includeMode, setIncludeMode] = useState<string>('include');
 	const [isValidDateRange, setIsValidDateRange] = useState<boolean>(true);
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as ISelectionFilter)?.multiple ?? true
@@ -113,22 +104,31 @@ function AddFDSFilterModalContent({
 		getAllPicklists().then((items) => {
 			setPicklists(items);
 
-			const newVal = items.find(
+			const picklist = items.find(
 				(item) =>
 					String(item.externalReferenceCode) ===
 					(filter as any)?.listTypeDefinitionERC
 			);
 
-			if (newVal) {
-				setSelectedPicklist(newVal);
+			if (picklist) {
+				setSelectedPicklist(picklist);
 
-				setPreselectedValues(
-					newVal.listTypeEntries.filter((item) =>
+				const validSavedPreselectedValues = picklist.listTypeEntries.filter(
+					(item) =>
 						JSON.parse(
 							(filter as ISelectionFilter).preselectedValues ||
 								'[]'
 						).includes(item.externalReferenceCode)
-					)
+				);
+
+				setPreselectedValues(validSavedPreselectedValues);
+
+				setIncludeMode(
+					validSavedPreselectedValues?.length
+						? filter && (filter as ISelectionFilter).include
+							? 'include'
+							: 'exclude'
+						: 'include'
 				);
 			}
 		});
@@ -295,15 +295,6 @@ function AddFDSFilterModalContent({
 		);
 	};
 
-	useEffect(() => {
-		if (preselectedValues?.length === 0) {
-			setIncludeMode('include');
-		}
-		else {
-			setIncludeMode(getFilterIncludeMode());
-		}
-	}, [preselectedValues, getFilterIncludeMode]);
-
 	return (
 		<>
 			<ClayModal.Header>
@@ -412,7 +403,19 @@ function AddFDSFilterModalContent({
 								namespace={namespace}
 								onIncludeModeChange={setIncludeMode}
 								onMultipleChange={setMultiple}
-								onPreselectedValuesChange={setPreselectedValues}
+								onPreselectedValuesChange={(values) => {
+									setPreselectedValues(values);
+
+									setIncludeMode(
+										values.length
+											? filter &&
+											  (filter as ISelectionFilter)
+													.include
+												? 'include'
+												: 'exclude'
+											: 'include'
+									);
+								}}
 								onSelectedPicklistChange={setSelectedPicklist}
 								picklists={picklists}
 								preselectedValues={preselectedValues}


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPS-197722

In this PR we're fixing the case where we always passed `exclude: false` from the fragment to the FDS component when it comes to configure a selection filter. Now, value stored in the filter object entry for the `include` property is passed instead.

This was the sole original intent, nevertheless, situation is a bit more complex, due to the fact that:

1. Both `selectedItems` and `exclude` props are part of `preloadedData` filter configuration ([here](https://github.com/liferay/liferay-portal/blob/2813b8cf01dc2043bf7af478454d76504350095c/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java#L530-L550))
2. FDS pre-applies any filter with a non empty `preloadedData` prop ([here](https://github.com/liferay/liferay-portal/blob/8fa21eb74c5f08f6bc127bf60d2722bc4c51523f/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js#L147-L148))
3. We don't want to change .2 at this moment

As a result, the mere fact of sending a value for `exclude` prop caused filter to be pre-applied, which is considered wrong as it lead to weird cases like pre-applying a filter with no selected items.

After discussions with @pablo-agulla and @ugeortiz we concluded that **filter would be pre-applied only if there are selectedItems.**

The above implies that it makes no sense to configure "Filter mode" (which can be `include` or `exclude`) if there are no selected items. This way, no pre-selected data will be passed to the FDS unless there are selected items.

Said that, this PR changes the component logic so that:

- "Filter mode" is hidden in the UI when there are no selected items, shown otherwise. This greatly improves UX 
- When creating a new selection filter, and user adds one or more selected items, "Filter mode" will be shown and pre-set to the default value (`include`)
- If user changes "Filter mode" to `exclude` but then unselect all items, then "Filter mode" is hidden and its value is reset back to `include`
- When editing an existing selection filter, which had Filter mode = `exclude`, and user unselects all items, Filter mode control is hidden and set back to `include`. User can then save the filter in a consistent state. However, if user instead adds selected items before saving, Filter mode will take the value coming from the saved filter (`exclude`) because that is the original value

All this behavior can be seen in the following videos.

Creating a new selection filter, save it under different conditions and seeing the result in the fragment:
https://github.com/liferay-frontend/liferay-portal/assets/861014/796e8adb-e5b0-40a4-8363-2ac88c91ac08

Editing an existing filter which was saved in `exclude` mode:
[dynamic_filter_edition.webm](https://github.com/liferay-frontend/liferay-portal/assets/861014/5a398a47-078e-4066-940d-a7f11bde6dd5)


