### PR TITLE
LPS-198083 Upgrade `webpack` inside `frontend-js-svg4everybody-web`

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -41,6 +41,7 @@ config = {
 				'fs',
 				'path',
 				'process',
+				'webpack',
 				'~',
 			],
 		],

--- a/modules/apps/frontend-js/frontend-js-svg4everybody-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-svg4everybody-web/package.json
@@ -1,7 +1,4 @@
 {
-	"dependencies": {
-		"webpack": "5.70.0"
-	},
 	"main": "index.js",
 	"name": "frontend-js-svg4everybody-web",
 	"private": true,


### PR DESCRIPTION
[Jira ticket](https://liferay.atlassian.net/browse/LPS-196980)

`yarn why webpack` inside `frontend-js-svg4everybody-web` returns `webpack@5.70.0` which is wrong. This is due to the `modules/package.json`'s resolution field specifying `webpack@5.70.0`.

So I added an extra commit that handles the `resolutions` change. I'm not 100% sure that's the right call, but I think it is.
