### PR TITLE
LPS-195696 We need to manage focusManager similarly to overlay when working with several menus on a page

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -608,7 +608,7 @@ AUI.add(
 					);
 
 					Liferay.once('beforeScreenFlip', () => {
-						menuInstance._focusManager = null;
+						menuInstance._focusManagerMap = null;
 
 						menuInstance._trigger = null;
 					});

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -210,9 +210,7 @@ AUI.add(
 					instance._overlayMap = new Map();
 				}
 
-				if (!instance._trigger) {
-					instance._trigger = trigger;
-				}
+				instance._trigger = trigger;
 
 				let overlay = instance._overlayMap.get(trigger.generateID());
 
@@ -534,9 +532,15 @@ AUI.add(
 			() => {
 				const menuInstance = Menu._INSTANCE;
 
-				let focusManager = menuInstance._focusManager;
-
 				const trigger = menuInstance._trigger;
+
+				if (!menuInstance._focusManagerMap) {
+					menuInstance._focusManagerMap = new Map();
+				}
+
+				let focusManager = menuInstance._focusManagerMap.get(
+					trigger.generateID()
+				);
 
 				if (!focusManager) {
 					const bodyNode = menuInstance._overlayMap.get(
@@ -598,7 +602,10 @@ AUI.add(
 						}
 					});
 
-					menuInstance._focusManager = focusManager;
+					menuInstance._focusManagerMap.set(
+						trigger.generateID(),
+						focusManager
+					);
 
 					Liferay.once('beforeScreenFlip', () => {
 						menuInstance._focusManager = null;


### PR DESCRIPTION
Hi guys,

This [LPS-195696](https://liferay.atlassian.net/browse/LPS-195696) was caused by [LPS-130738](https://liferay.atlassian.net/browse/LPS-130738), because in that one we started managing one overlay for every menu in the page (we had to do it that way to properly deal with auto fields). 

But after that, focusManager stopped working because it was always related to the first menu in the page, so I'm following the same approach, having one focusManager for each menu trigger.

Thanks.

Regards.