### PR TITLE
LPS-198378 Add className prop to BetaButton component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/beta_indicator/BetaButton.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/beta_indicator/BetaButton.tsx
@@ -7,6 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayPopover, {ALIGN_POSITIONS} from '@clayui/popover';
 import {ClayTooltipProvider} from '@clayui/tooltip';
+import classNames from 'classnames';
 import React, {useState} from 'react';
 
 import useId from '../hooks/useId';
@@ -16,9 +17,11 @@ import LearnMessage, {
 import BetaBadge, {betaClassNames} from './BetaBadge';
 
 export default function BetaButton({
+	containerClassName,
 	learnResourceContext,
 	tooltipAlign = 'top',
 }: {
+	containerClassName?: string;
 	learnResourceContext: object;
 	tooltipAlign: typeof ALIGN_POSITIONS[number];
 }) {
@@ -30,7 +33,10 @@ export default function BetaButton({
 		<LearnResourcesContext.Provider value={learnResourceContext}>
 			<ClayTooltipProvider>
 				<div
-					className="tooltip-container"
+					className={classNames(
+						'tooltip-container',
+						containerClassName
+					)}
 					data-tooltip-align={tooltipAlign}
 					title={Liferay.Language.get('open-beta-definition')}
 				>

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/beta_indicator/BetaButton.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/beta_indicator/BetaButton.d.ts
@@ -7,9 +7,11 @@
 
 import {ALIGN_POSITIONS} from '@clayui/popover';
 export default function BetaButton({
+	containerClassName,
 	learnResourceContext,
 	tooltipAlign,
 }: {
+	containerClassName?: string;
 	learnResourceContext: object;
 	tooltipAlign: typeof ALIGN_POSITIONS[number];
 }): JSX.Element;

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/experience_selector/ExperienceSelector.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/experience_selector/ExperienceSelector.tsx
@@ -22,6 +22,7 @@ interface BaseProps {
 }
 
 interface ExperienceSelectorProps extends BaseProps {
+	className?: string;
 	disabled?: boolean;
 	label?: string;
 	onChangeExperience?: (key: React.Key) => void;

--- a/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/experience_selector/ExperienceSelector.d.ts
+++ b/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/experience_selector/ExperienceSelector.d.ts
@@ -11,6 +11,7 @@ interface BaseProps {
 	selectedItem?: SegmentExperience;
 }
 interface ExperienceSelectorProps extends BaseProps {
+	className?: string;
 	disabled?: boolean;
 	label?: string;
 	onChangeExperience?: (key: React.Key) => void;

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/Tabs.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/Tabs.js
@@ -4,7 +4,6 @@
  */
 
 import ClayTabs from '@clayui/tabs';
-import {ExperienceSelector} from '@liferay/layout-js-components-web';
 import React, {useState} from 'react';
 
 import LayoutReports from './layout_reports/LayoutReports';
@@ -17,19 +16,10 @@ const TAB_COMPONENTS = {
 
 export default function Tabs({segments, tabs}) {
 	const [activeTab, setActiveTab] = useState(0);
+	const {segmentsExperiences, selectedSegmentsExperience} = segments;
 
 	return (
 		<>
-			{segments.segmentsExperiences.length > 1 ? (
-				<ExperienceSelector
-					className="c-px-3 c-py-1 page-audit__experience-selector"
-					segmentsExperiences={segments.segmentsExperiences}
-					selectedSegmentsExperience={
-						segments.selectedSegmentsExperience
-					}
-				/>
-			) : null}
-
 			<ClayTabs
 				active={activeTab}
 				className="px-2"
@@ -51,6 +41,13 @@ export default function Tabs({segments, tabs}) {
 			<ClayTabs.Content activeIndex={activeTab} fade>
 				{tabs.map((tab, index) => {
 					const Component = TAB_COMPONENTS[tab.id];
+					const props = {
+						url: tab.url,
+						...(tab.id === 'performance' && {
+							segmentsExperiences,
+							selectedSegmentsExperience,
+						}),
+					};
 
 					return (
 						<ClayTabs.TabPane
@@ -59,7 +56,7 @@ export default function Tabs({segments, tabs}) {
 							id={`tabpanel-${index}`}
 							key={tab.id}
 						>
-							<Component url={tab.url} />
+							<Component {...props} />
 						</ClayTabs.TabPane>
 					);
 				})}

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/render_times/Filter.tsx
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/render_times/Filter.tsx
@@ -58,7 +58,7 @@ export default function Filter({
 	}));
 
 	return (
-		<div className="d-flex pt-3">
+		<div className="d-flex">
 			<SearchForm
 				className="flex-grow-1"
 				label={Liferay.Language.get('search-fragments')}

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/render_times/RenderTimes.tsx
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/render_times/RenderTimes.tsx
@@ -67,6 +67,7 @@ export default function RenderTimes({
 	return (
 		<>
 			<BetaButton
+				containerClassName="c-mb-3"
 				learnResourceContext={learnResources}
 				tooltipAlign="top-left"
 			/>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/render_times/RenderTimes.tsx
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/render_times/RenderTimes.tsx
@@ -5,7 +5,11 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayEmptyState from '@clayui/empty-state';
-import {SearchResultsMessage} from '@liferay/layout-js-components-web';
+import {
+	ExperienceSelector,
+	SearchResultsMessage,
+	SegmentExperience,
+} from '@liferay/layout-js-components-web';
 import {BetaButton} from 'frontend-js-components-web';
 import {fetch} from 'frontend-js-web';
 import React, {useContext, useEffect, useMemo, useState} from 'react';
@@ -17,7 +21,15 @@ import FragmentList from './FragmentList';
 import ResultsBar from './ResultsBar';
 import getFragmentsByFilterValue from './getFragmentsByFilterValue';
 
-export default function RenderTimes({url}: {url: string}) {
+export default function RenderTimes({
+	segmentsExperiences,
+	selectedSegmentsExperience,
+	url,
+}: {
+	segmentsExperiences: SegmentExperience[];
+	selectedSegmentsExperience: SegmentExperience;
+	url: string;
+}) {
 	const [ascending, setAscending] = useState(false);
 	const [filters, setFilters] = useState<FragmentFilter>({
 		origin: null,
@@ -58,6 +70,15 @@ export default function RenderTimes({url}: {url: string}) {
 				learnResourceContext={learnResources}
 				tooltipAlign="top-left"
 			/>
+
+			{segmentsExperiences.length > 1 ? (
+				<ExperienceSelector
+					className="page-audit__experience-selector"
+					segmentsExperiences={segmentsExperiences}
+					selectedSegmentsExperience={selectedSegmentsExperience}
+				/>
+			) : null}
+
 			<Filter
 				filters={filters}
 				isAscendingSort={ascending}

--- a/modules/apps/layout/layout-reports-web/test/js/components/Tabs.test.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/Tabs.test.js
@@ -20,29 +20,6 @@ jest.mock(
 	() => jest.fn(() => <div />)
 );
 
-const mockSegments = {
-	segmentsExperiences: [
-		{
-			active: true,
-			segmentsEntryId: '0',
-			segmentsEntryName: 'Anyone',
-			segmentsExperienceId: '33590',
-			segmentsExperienceName: 'Experience Default',
-			statusLabel: 'Active',
-			url: 'url',
-		},
-	],
-	selectedSegmentsExperience: {
-		active: true,
-		segmentsEntryId: '0',
-		segmentsEntryName: 'Anyone',
-		segmentsExperienceId: '33590',
-		segmentsExperienceName: 'Experience Default',
-		statusLabel: 'Active',
-		url: 'url',
-	},
-};
-
 const mockTabs = [
 	{
 		id: 'page-speed-insights',
@@ -56,42 +33,9 @@ const mockTabs = [
 	},
 ];
 
-const renderTabs = ({segments = mockSegments} = {}) =>
-	render(<Tabs segments={segments} tabs={mockTabs} />);
-
 describe('Tabs', () => {
-	it('does not render the experience selector when there is only the default experience', () => {
-		renderTabs();
-
-		expect(
-			screen.queryByText('Experience Default')
-		).not.toBeInTheDocument();
-	});
-
-	it('renders experience selector if there is more than one experience', () => {
-		const newSegments = {
-			...mockSegments,
-			segmentsExperiences: [
-				...mockSegments.segmentsExperiences,
-				{
-					active: true,
-					segmentsEntryId: '0',
-					segmentsEntryName: 'Anyone',
-					segmentsExperienceId: '33591',
-					segmentsExperienceName: 'Experience1',
-					statusLabel: 'Inactive',
-					url: 'url',
-				},
-			],
-		};
-
-		renderTabs({segments: newSegments});
-
-		expect(screen.getByText('Experience Default')).toBeInTheDocument();
-	});
-
 	it('renders tabs', async () => {
-		renderTabs();
+		render(<Tabs segments={{}} tabs={mockTabs} />);
 
 		expect(screen.getByText('Performance')).toBeInTheDocument();
 		expect(screen.getByText('Page Speed')).toBeInTheDocument();

--- a/modules/apps/layout/layout-reports-web/test/js/components/render_times/RenderTimes.test.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/render_times/RenderTimes.test.js
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {act, render, screen} from '@testing-library/react';
+import React from 'react';
+
+import RenderTimes from '../../../../src/main/resources/META-INF/resources/js/components/render_times/RenderTimes';
+
+import '@testing-library/jest-dom/extend-expect';
+
+jest.mock('frontend-js-web', () => ({
+	...jest.requireActual('frontend-js-web'),
+	fetch: () => Promise.resolve({json: () => ({})}),
+}));
+
+const mockSegmentsExperiences = [
+	{
+		active: true,
+		segmentsEntryId: '0',
+		segmentsEntryName: 'Anyone',
+		segmentsExperienceId: '33590',
+		segmentsExperienceName: 'Experience Default',
+		statusLabel: 'Active',
+		url: 'url',
+	},
+];
+
+const mockSelectedSegmentsExperience = {
+	active: true,
+	segmentsEntryId: '0',
+	segmentsEntryName: 'Anyone',
+	segmentsExperienceId: '33590',
+	segmentsExperienceName: 'Experience Default',
+	statusLabel: 'Active',
+	url: 'url',
+};
+
+const renderRenderTimes = ({segments = mockSegmentsExperiences} = {}) =>
+	render(
+		<RenderTimes
+			segmentsExperiences={segments}
+			selectedSegmentsExperience={mockSelectedSegmentsExperience}
+			url="url"
+		/>
+	);
+
+describe('RenderTimes', () => {
+	it('does not render the experience selector when there is only the default experience', async () => {
+		await act(async () => renderRenderTimes());
+
+		expect(
+			screen.queryByText('Experience Default')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders experience selector if there is more than one experience', async () => {
+		const newSegments = [
+			...mockSegmentsExperiences,
+			{
+				active: true,
+				segmentsEntryId: '0',
+				segmentsEntryName: 'Anyone',
+				segmentsExperienceId: '33591',
+				segmentsExperienceName: 'Experience1',
+				statusLabel: 'Inactive',
+				url: 'url',
+			},
+		];
+
+		await act(async () => renderRenderTimes({segments: newSegments}));
+
+		expect(screen.getByText('Experience Default')).toBeInTheDocument();
+	});
+});

--- a/modules/apps/layout/layout-reports-web/types/src/main/resources/META-INF/resources/js/components/render_times/RenderTimes.d.ts
+++ b/modules/apps/layout/layout-reports-web/types/src/main/resources/META-INF/resources/js/components/render_times/RenderTimes.d.ts
@@ -5,4 +5,13 @@
 
 /// <reference types="react" />
 
-export default function RenderTimes({url}: {url: string}): JSX.Element;
+import {SegmentExperience} from '@liferay/layout-js-components-web';
+export default function RenderTimes({
+	segmentsExperiences,
+	selectedSegmentsExperience,
+	url,
+}: {
+	segmentsExperiences: SegmentExperience[];
+	selectedSegmentsExperience: SegmentExperience;
+	url: string;
+}): JSX.Element;


### PR DESCRIPTION
Hi guys!

From the Echo team we are using your `BetaButton` component in the Page Audit panel. And because of this story https://liferay.atlassian.net/browse/LPS-198257 we need to add a style to this component, so we've added a new prop, `className` to pass any additional styles to the `BetaButton` component. You just have to check this commit https://github.com/liferay-frontend/liferay-portal/pull/3743/commits/c4cf02d822cd1d3ff1a0d2ba55d8913115936267. What do you think?

Thanks in advance! 😄 