### PR TITLE
LPS-198123 Return detailed message for exception.

### DIFF
--- a/modules/apps/client-extension/client-extension-api/build.gradle
+++ b/modules/apps/client-extension/client-extension-api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/exception/ClientExtensionEntryTypeSettingsException.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/exception/ClientExtensionEntryTypeSettingsException.java
@@ -6,6 +6,8 @@
 package com.liferay.client.extension.exception;
 
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 
 /**
  * @author Brian Wing Shun Chan
@@ -14,6 +16,10 @@ public class ClientExtensionEntryTypeSettingsException extends PortalException {
 
 	public ClientExtensionEntryTypeSettingsException(
 		String messageKey, Object... messageArguments) {
+
+		super(
+			LanguageUtil.format(
+				LocaleUtil.getDefault(), messageKey, messageArguments));
 
 		_messageKey = messageKey;
 		_messageArguments = messageArguments;


### PR DESCRIPTION
Hi Frontend Infra Team,
I am working on this solution for https://liferay.atlassian.net/browse/LPS-198123 and received a request to make some changes in a previous PR: https://github.com/liferay-peds/liferay-portal/pull/320#issuecomment-1757268247.

I wanted to request some assistance with this and confirm that this is a possible/necessary change before I go through and add it. It looks like the way `getLocalizedMessage` is used, I would need to modify or move the existing calls/thrown exceptions in all the files that use ClientExtensionEntryTypeSettingsException. Please let me know if this is the correct way to go about this, or if something else is more preferable. 

Thank you!