### PR TITLE
LPS-191845 Console error message after adding the Data Set Fragment to page

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/side_panel/SidePanel.js
@@ -329,11 +329,12 @@ export default class SidePanel extends React.Component {
 	}
 
 	render() {
-		const visibility = this.state.visible ? 'is-visible' : 'is-hidden';
 		const loading =
 			this.state.loading || (this.state.moving && this.state.visible)
 				? 'is-loading'
 				: '';
+		const moving = this.state.moving ? 'is-moving' : '';
+		const visibility = this.state.visible ? 'is-visible' : 'is-hidden';
 
 		const content = (
 			<>
@@ -366,6 +367,7 @@ export default class SidePanel extends React.Component {
 					className={classNames(
 						'fds-side-panel',
 						`fds-side-panel-${this.state.size}`,
+						moving,
 						visibility,
 						loading
 					)}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_side_panel.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_side_panel.scss
@@ -28,6 +28,10 @@
 		z-index: 10;
 	}
 
+	&.is-hidden:not(.is-moving) {
+		visibility: hidden;
+	}
+
 	&:not(.is-loading) .loader {
 		opacity: 0;
 		pointer-events: none;
@@ -41,6 +45,7 @@
 	&.is-visible {
 		box-shadow: -10px 20px 30px rgba(39, 40, 51, 0.15);
 		transform: translateX(0);
+		visibility: visible;
 	}
 
 	&.fds-side-panel-xs {

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
@@ -71,9 +71,11 @@ const ReactPortal = React.forwardRef<HTMLElement, IProps>(
 		 * This ensures the portal children are unmounted first.
 		 */
 		Liferay.on('beforeNavigate', () => {
-			ReactDOM.unmountComponentAtNode(
-				content as Element | DocumentFragment
-			);
+			if (content) {
+				ReactDOM.unmountComponentAtNode(
+					content as Element | DocumentFragment
+				);
+			}
 		});
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-create-portal

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
@@ -5,7 +5,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import ReactDOM, {createPortal} from 'react-dom';
+import {createPortal} from 'react-dom';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
@@ -60,23 +60,6 @@ const ReactPortal = React.forwardRef<HTMLElement, IProps>(
 				{className: classNames(cssClass, children.props.className), id}
 			);
 		}
-
-		/**
-		 * When navigating to another page, this error is sometimes thrown:
-		 *
-		 * "Uncaught DOMException: Failed to execute 'removeChild' on 'Node':
-		 * The node to be removed is not a child of this node."
-		 *
-		 * This is caused when the container is unmounted before the children.
-		 * This ensures the portal children are unmounted first.
-		 */
-		Liferay.on('beforeNavigate', () => {
-			if (content) {
-				ReactDOM.unmountComponentAtNode(
-					content as Element | DocumentFragment
-				);
-			}
-		});
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-create-portal
 		return createPortal(content, container || document.body);

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/ReactPortal.tsx
@@ -5,7 +5,7 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import {createPortal} from 'react-dom';
+import ReactDOM, {createPortal} from 'react-dom';
 
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 
@@ -42,7 +42,7 @@ const ReactPortal = React.forwardRef<HTMLElement, IProps>(
 	) => {
 		const cssClass = classNames('lfr-tooltip-scope', className);
 
-		let content;
+		let content: React.ReactNode;
 
 		if (Wrapper) {
 			content = (
@@ -60,6 +60,21 @@ const ReactPortal = React.forwardRef<HTMLElement, IProps>(
 				{className: classNames(cssClass, children.props.className), id}
 			);
 		}
+
+		/**
+		 * When navigating to another page, this error is sometimes thrown:
+		 *
+		 * "Uncaught DOMException: Failed to execute 'removeChild' on 'Node':
+		 * The node to be removed is not a child of this node."
+		 *
+		 * This is caused when the container is unmounted before the children.
+		 * This ensures the portal children are unmounted first.
+		 */
+		Liferay.on('beforeNavigate', () => {
+			ReactDOM.unmountComponentAtNode(
+				content as Element | DocumentFragment
+			);
+		});
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-create-portal
 		return createPortal(content, container || document.body);

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -70,7 +70,31 @@ export default function render(
 				destroy: () => {
 					container.classList.remove('lfr-tooltip-scope');
 
-					ReactDOM.unmountComponentAtNode(container);
+					/**
+					 * When navigating to another page, this error can be thrown
+					 * when a component uses a React portal:
+					 *
+					 * "Uncaught DOMException: Failed to execute 'removeChild'
+					 * on 'Node': The node to be removed is not a child of this
+					 * node."
+					 *
+					 * This is because the contents of the React portal can be
+					 * placed in an additional senna surface <div> so when
+					 * `container.removeChild(child)` is called, this error is
+					 * thrown. (`container` being document.body and `child`
+					 * being the portal contents)
+					 *
+					 * This temporarily catches this error until a better fix
+					 * can be found.
+					 */
+					try {
+						ReactDOM.unmountComponentAtNode(container);
+					}
+					catch (error) {
+						if (process.env.NODE_ENV === 'development') {
+							console.error(error);
+						}
+					}
 				},
 			},
 			{


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191845

**Fixes 2 issues:**
1. If the data set fragment is on the page, when navigating away, the page breaks due to the contents of ReactPortal unable to unmount. This seems to be because the container (document body) is unmounted before the children. Looks to be related to this react issue which manually removing the children seemed to be the only working solution I could come up with. https://github.com/facebook/react/issues/14811 

2. The side panel would flash open on initial load (for some reason only on certain pages like the data set fragment and I found one of the object edit pages this happened on as well). I added CSS to visibly hide the side panel when it wasn't visible or moving.

**Recording of side panel flashing open**

https://github.com/liferay-frontend/liferay-portal/assets/4496722/a9b997c5-1b88-4b82-86d4-1852fe491ec1

## Demo with fixes

https://github.com/liferay-frontend/liferay-portal/assets/4496722/4af63700-739f-49c4-a4bd-3991974a12f9

