### PR TITLE
LPS-199992 Every page with a Clay tag throws the `hasBodyContent` warning

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -95,9 +95,9 @@ export default function render(
 			if (children.length) {
 				renderData.children = children;
 			}
-
-			delete renderData.hasBodyContent;
 		}
+
+		delete renderData.hasBodyContent;
 
 		// eslint-disable-next-line @liferay/portal/no-react-dom-render
 		ReactDOM.render(


### PR DESCRIPTION
### References

- [LPS-199992 Every page with a Clay tag throws the `hasBodyContent` warning](https://issues.liferay.com/browse/LPS-199992)
- Regression bug from [LPS-173758 Provide a clay taglib for Tabs component](https://liferay.atlassian.net/browse/LPS-173758)

### What is the goal of this PR?

A small bugfix. I grew tired of looking at this warning on every page :sweat_smile:  

`hasBodyContent` prop is a part of an internal mechanism that allows Clay tags to be nested within other Clay tags. It is meant to be removed, after modifying render behavior. We do this correctly, when it is set to `true`. But, when it is set to `false`, we do nothing and it ends up in regular component props. In this PR, we are fixing cleanup, always deleting the prop.

### What does it look like?

#### Before PR
![screen](https://github.com/liferay-frontend/liferay-portal/assets/5435511/569ebaf2-5c60-40e9-8919-fe3e5f864bdf)
#### After PR

Error is not in logs.

### Steps to reproduce

Open any page in DXP.