### PR TITLE
LPS-194004 Add Accessibility Menu to Personal Menu

### DIFF
--- a/modules/apps/accessibility/accessibility-menu-web/build.gradle
+++ b/modules/apps/accessibility/accessibility-menu-web/build.gradle
@@ -7,8 +7,10 @@ dependencies {
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:product-navigation:product-navigation-personal-menu-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/accessibility/accessibility-menu-web/src/main/java/com/liferay/accessibility/menu/web/internal/product/navigation/personal/menu/AccessibilityMenuPersonalMenuEntry.java
+++ b/modules/apps/accessibility/accessibility-menu-web/src/main/java/com/liferay/accessibility/menu/web/internal/product/navigation/personal/menu/AccessibilityMenuPersonalMenuEntry.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.accessibility.menu.web.internal.product.navigation.personal.menu;
+
+import com.liferay.accessibility.menu.web.internal.constants.AccessibilityMenuPortletKeys;
+import com.liferay.accessibility.menu.web.internal.util.AccessibilitySettingsUtil;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.product.navigation.personal.menu.BasePersonalMenuEntry;
+import com.liferay.product.navigation.personal.menu.PersonalMenuEntry;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Thiago Buarque
+ */
+@Component(
+	property = {
+		"product.navigation.personal.menu.entry.order:Integer=0",
+		"product.navigation.personal.menu.group:Integer=300"
+	},
+	service = PersonalMenuEntry.class
+)
+public class AccessibilityMenuPersonalMenuEntry extends BasePersonalMenuEntry {
+
+	@Override
+	public String getOnClickJSModuleURL() {
+		return _npmResolver.resolveModuleName(
+			"@liferay/accessibility-menu-web/js/accessibilityMenuOpener");
+	}
+
+	@Override
+	public String getPortletId() {
+		return AccessibilityMenuPortletKeys.ACCESSIBILITY_MENU;
+	}
+
+	@Override
+	public String getPortletURL(HttpServletRequest httpServletRequest) {
+		return null;
+	}
+
+	@Override
+	public boolean isShow(
+		PortletRequest portletRequest, PermissionChecker permissionChecker) {
+
+		if (AccessibilitySettingsUtil.isAccessibilityMenuEnabled(
+				_portal.getHttpServletRequest(portletRequest),
+				_configurationProvider)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private NPMResolver _npmResolver;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/accessibility/accessibility-menu-web/src/main/java/com/liferay/accessibility/menu/web/internal/product/navigation/personal/menu/AccessibilityMenuPersonalMenuEntry.java
+++ b/modules/apps/accessibility/accessibility-menu-web/src/main/java/com/liferay/accessibility/menu/web/internal/product/navigation/personal/menu/AccessibilityMenuPersonalMenuEntry.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"product.navigation.personal.menu.entry.order:Integer=0",
+		"product.navigation.personal.menu.entry.order:Integer=50",
 		"product.navigation.personal.menu.group:Integer=300"
 	},
 	service = PersonalMenuEntry.class

--- a/modules/apps/accessibility/accessibility-menu-web/src/main/resources/META-INF/resources/js/accessibilityMenuOpener.ts
+++ b/modules/apps/accessibility/accessibility-menu-web/src/main/resources/META-INF/resources/js/accessibilityMenuOpener.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const openAccessibilityMenu = () => {
+	Liferay.fire('openAccessibilityMenu');
+};
+
+export default openAccessibilityMenu;

--- a/modules/apps/accessibility/accessibility-menu-web/types/src/main/resources/META-INF/resources/js/accessibilityMenuOpener.d.ts
+++ b/modules/apps/accessibility/accessibility-menu-web/types/src/main/resources/META-INF/resources/js/accessibilityMenuOpener.d.ts
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+declare const openAccessibilityMenu: () => void;
+export default openAccessibilityMenu;

--- a/modules/apps/product-navigation/product-navigation-personal-menu-api/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Product Navigation Personal Menu API
 Bundle-SymbolicName: com.liferay.product.navigation.personal.menu.api
-Bundle-Version: 4.1.4
+Bundle-Version: 4.2.0
 Export-Package:\
 	com.liferay.product.navigation.personal.menu,\
 	com.liferay.product.navigation.personal.menu.configuration,\

--- a/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/java/com/liferay/product/navigation/personal/menu/PersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/java/com/liferay/product/navigation/personal/menu/PersonalMenuEntry.java
@@ -57,6 +57,10 @@ public interface PersonalMenuEntry {
 	 */
 	public String getLabel(Locale locale);
 
+	public default String getOnClickJSModuleURL() {
+		return null;
+	}
+
 	/**
 	 * Returns the URL used to render a portlet based on the servlet request
 	 * attributes.

--- a/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/resources/com/liferay/product/navigation/personal/menu/packageinfo
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-api/src/main/resources/com/liferay/product/navigation/personal/menu/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -233,7 +233,11 @@ public class GetPersonalMenuItemsMVCResourceCommand
 					jsonObject.put(
 						"jsOnClickConfig",
 						personalMenuEntry.getJSOnClickConfigJSONObject(
-							_portal.getHttpServletRequest(portletRequest)));
+							_portal.getHttpServletRequest(portletRequest))
+					).put(
+						"onClickJSModuleURL",
+						personalMenuEntry.getOnClickJSModuleURL()
+					);
 				}
 			}
 			catch (PortalException portalException) {
@@ -242,8 +246,6 @@ public class GetPersonalMenuItemsMVCResourceCommand
 
 			jsonObject.put(
 				"label", personalMenuEntry.getLabel(themeDisplay.getLocale())
-			).put(
-				"onClickJSModuleURL", personalMenuEntry.getOnClickJSModuleURL()
 			).put(
 				"symbolRight", personalMenuEntry.getIcon(portletRequest)
 			);

--- a/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-personal-menu-web/src/main/java/com/liferay/product/navigation/personal/menu/web/internal/portlet/action/GetPersonalMenuItemsMVCResourceCommand.java
@@ -243,6 +243,8 @@ public class GetPersonalMenuItemsMVCResourceCommand
 			jsonObject.put(
 				"label", personalMenuEntry.getLabel(themeDisplay.getLocale())
 			).put(
+				"onClickJSModuleURL", personalMenuEntry.getOnClickJSModuleURL()
+			).put(
 				"symbolRight", personalMenuEntry.getIcon(portletRequest)
 			);
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-site-administration/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:application-list:application-list-taglib")
+	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")

--- a/modules/apps/product-navigation/product-navigation-site-administration/package.json
+++ b/modules/apps/product-navigation/product-navigation-site-administration/package.json
@@ -1,0 +1,13 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "@liferay/product-navigation-site-administration",
+	"private": true,
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "6.0.39"
+}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
@@ -5,6 +5,7 @@
 
 package com.liferay.product.navigation.site.administration.internal.menu;
 
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.ItemSelectorCriterion;
 import com.liferay.item.selector.criteria.URLItemSelectorReturnType;
@@ -86,6 +87,12 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 	}
 
 	@Override
+	public String getOnClickJSModuleURL() {
+		return _npmResolver.resolveModuleName(
+			"@liferay/product-navigation-site-administration/js/mySitesOpener");
+	}
+
+	@Override
 	public String getPortletURL(HttpServletRequest httpServletRequest) {
 		return null;
 	}
@@ -123,6 +130,9 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private NPMResolver _npmResolver;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/js/mySitesOpener.ts
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/js/mySitesOpener.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {navigate, openSelectionModal} from 'frontend-js-web';
+
+const openMySitesModal = (jsOnClickConfig) => {
+	const {selectEventName, title, url} = jsOnClickConfig;
+
+	openSelectionModal({
+		id: selectEventName,
+		onSelect(selectedItem) {
+			navigate(selectedItem.url);
+		},
+		selectEventName,
+		title,
+		url,
+	});
+};
+
+export default openMySitesModal;

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -8,7 +8,7 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
-import {fetch, navigate, openSelectionModal, sub} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
@@ -34,9 +34,9 @@ function getModuleAndFunctionNames(url) {
 	return [functionName, moduleName];
 }
 
-const callModuleFunction = (module, functionName) => {
+const callModuleFunction = (functionName, jsOnClickConfig, module) => {
 	if (module[functionName] && typeof module[functionName] === 'function') {
-		module[functionName]();
+		module[functionName](jsOnClickConfig);
 	}
 };
 
@@ -55,22 +55,6 @@ function mapItemsOnClick(items) {
 			newVal.items = mapItemsOnClick(nestedItems);
 		}
 
-		if (jsOnClickConfig) {
-			newVal.onClick = () => {
-				const {selectEventName, title, url} = jsOnClickConfig;
-
-				openSelectionModal({
-					id: selectEventName,
-					onSelect(selectedItem) {
-						navigate(selectedItem.url);
-					},
-					selectEventName,
-					title,
-					url,
-				});
-			};
-		}
-
 		if (onClickJSModuleURL) {
 			if (onClickJSModuleURL.includes(' from ')) {
 				newVal.onClick = async () => {
@@ -83,13 +67,13 @@ function mapItemsOnClick(items) {
 						/* webpackIgnore: true */ moduleName
 					);
 
-					callModuleFunction(module, functionName);
+					callModuleFunction(functionName, jsOnClickConfig, module);
 				};
 			}
 			else {
 				newVal.onClick = () => {
 					Liferay.Loader.require(onClickJSModuleURL, (module) =>
-						callModuleFunction(module, 'default')
+						callModuleFunction('default', jsOnClickConfig, module)
 					);
 				};
 			}

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -12,9 +12,42 @@ import {fetch, navigate, openSelectionModal, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
+function getModuleAndFunctionNames(url) {
+	const parts = url.split(' from ');
+
+	const moduleName = parts[1].trim();
+	let functionName = parts[0].trim();
+
+	if (
+		functionName !== 'default' &&
+		(!functionName.startsWith('{') || !functionName.endsWith('}'))
+	) {
+		throw new Error(`Invalid data renderer URL: ${url}`);
+	}
+
+	if (functionName.startsWith('{')) {
+		functionName = functionName
+			.substring(1, functionName.length - 1)
+			.trim();
+	}
+
+	return [functionName, moduleName];
+}
+
+const callModuleFunction = (module, functionName) => {
+	if (module[functionName] && typeof module[functionName] === 'function') {
+		module[functionName]();
+	}
+};
+
 function mapItemsOnClick(items) {
 	return items.map((item) => {
-		const {items: nestedItems, jsOnClickConfig, ...otherKeys} = item;
+		const {
+			items: nestedItems,
+			jsOnClickConfig,
+			onClickJSModuleURL,
+			...otherKeys
+		} = item;
 
 		const newVal = {...otherKeys};
 
@@ -36,6 +69,30 @@ function mapItemsOnClick(items) {
 					url,
 				});
 			};
+		}
+
+		if (onClickJSModuleURL) {
+			if (onClickJSModuleURL.includes(' from ')) {
+				newVal.onClick = async () => {
+					const [
+						functionName,
+						moduleName,
+					] = getModuleAndFunctionNames(onClickJSModuleURL);
+
+					const module = await import(
+						/* webpackIgnore: true */ moduleName
+					);
+
+					callModuleFunction(module, functionName);
+				};
+			}
+			else {
+				newVal.onClick = () => {
+					Liferay.Loader.require(onClickJSModuleURL, (module) =>
+						callModuleFunction(module, 'default')
+					);
+				};
+			}
 		}
 
 		return newVal;

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/personal_menu/js/PersonalMenu.es.js
@@ -8,37 +8,9 @@ import {ClayDropDownWithItems} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClaySticker from '@clayui/sticker';
-import {fetch, sub} from 'frontend-js-web';
+import {fetch, getRenderer, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
-
-function getModuleAndFunctionNames(url) {
-	const parts = url.split(' from ');
-
-	const moduleName = parts[1].trim();
-	let functionName = parts[0].trim();
-
-	if (
-		functionName !== 'default' &&
-		(!functionName.startsWith('{') || !functionName.endsWith('}'))
-	) {
-		throw new Error(`Invalid data renderer URL: ${url}`);
-	}
-
-	if (functionName.startsWith('{')) {
-		functionName = functionName
-			.substring(1, functionName.length - 1)
-			.trim();
-	}
-
-	return [functionName, moduleName];
-}
-
-const callModuleFunction = (functionName, jsOnClickConfig, module) => {
-	if (module[functionName] && typeof module[functionName] === 'function') {
-		module[functionName](jsOnClickConfig);
-	}
-};
 
 function mapItemsOnClick(items) {
 	return items.map((item) => {
@@ -56,27 +28,14 @@ function mapItemsOnClick(items) {
 		}
 
 		if (onClickJSModuleURL) {
-			if (onClickJSModuleURL.includes(' from ')) {
-				newVal.onClick = async () => {
-					const [
-						functionName,
-						moduleName,
-					] = getModuleAndFunctionNames(onClickJSModuleURL);
+			newVal.onClick = async () => {
+				const {component} = await getRenderer({
+					type: 'internal',
+					url: onClickJSModuleURL,
+				});
 
-					const module = await import(
-						/* webpackIgnore: true */ moduleName
-					);
-
-					callModuleFunction(functionName, jsOnClickConfig, module);
-				};
-			}
-			else {
-				newVal.onClick = () => {
-					Liferay.Loader.require(onClickJSModuleURL, (module) =>
-						callModuleFunction('default', jsOnClickConfig, module)
-					);
-				};
-			}
+				component(jsOnClickConfig);
+			};
 		}
 
 		return newVal;


### PR DESCRIPTION
Resent from https://github.com/liferay-platform-experience/liferay-portal/pull/328

@izaera & @bryceosterhaus I'm sending this here for your final review due it's use of useRenderer from frontend-js-web, based on the [discussion related to this in Slack](https://liferay.slack.com/archives/CNBG06JS3/p1696922917588729?thread_ts=1696531668.693209&cid=CNBG06JS3). 

Original Message:

Motivation
Not every customer knows how to open the accessibility menu using the keyboard. Because of that we want to provide easy access to the Accessibility Menu from the user Personal Menu.

Proposed Solution
Open the Accessibility Menu by firing the openAccessibilityMenu event on click.

I also generalized the usage of JSOnClickConfig in PersonalMenuEntry so it can be passed as parameter to the [dynamically import module approach I added to open the accessibility menu](https://github.com/liferay-peds/liferay-portal/pull/328/commits/4c489278c6fb528847d67eee57b1f777dfb9476d).

Threads
Additional info regarding the discussion prior taking the proposed approach can be found in the following slack channels, [here](https://liferay.atlassian.net/browse/LPS-194004) and [here](https://liferay.slack.com/archives/CNBG06JS3/p1696531668693209)

![image](https://github.com/liferay-frontend/liferay-portal/assets/1609196/c8900f42-3c13-433e-9f20-d6e96d19cfaa)
