### PR TITLE
LPS-200372 Create a sample CKEditor with spell checker plugin enabled

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/constants/CKEditorSampleWebKeys.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/constants/CKEditorSampleWebKeys.java
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.constants;
+
+/**
+ * @author Marko Cikos
+ */
+public class CKEditorSampleWebKeys {
+
+	public static final String CKEDITOR_SAMPLE_DISPLAY_CONTEXT =
+		"CKEDITOR_SAMPLE_DISPLAY_CONTEXT";
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/display/context/CKEditorSampleDisplayContext.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/display/context/CKEditorSampleDisplayContext.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.display.context;
+
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
+
+import java.util.List;
+
+/**
+ * @author Marko Cikos
+ */
+public class CKEditorSampleDisplayContext {
+
+	public List<TabsItem> getTabsItems() {
+		if (_tabsItems != null) {
+			return _tabsItems;
+		}
+
+		_tabsItems = TabsItemListBuilder.add(
+			tabsItem -> {
+				tabsItem.setActive(true);
+				tabsItem.setLabel("Balloon");
+				tabsItem.setPanelId("balloon");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Classic");
+				tabsItem.setPanelId("classic");
+			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("Legacy");
+				tabsItem.setPanelId("legacy");
+			}
+		).build();
+
+		return _tabsItems;
+	}
+
+	private List<TabsItem> _tabsItems;
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/BalloonEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/BalloonEditorConfigContributor.java
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.Component;
 	},
 	service = EditorConfigContributor.class
 )
-public class CKEditorSampleEditorConfigContributor
+public class BalloonEditorConfigContributor
 	extends BaseEditorConfigContributor {
 
 	@Override

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/ClassicEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/ClassicEditorConfigContributor.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.editor.configuration;
+
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	property = {
+		"editor.config.key=sampleClassicEditor",
+		"javax.portlet.name=" + CKEditorSamplePortletKeys.CKEDITOR_SAMPLE
+	},
+	service = EditorConfigContributor.class
+)
+public class ClassicEditorConfigContributor
+	extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		jsonObject.put(
+			"disableNativeSpellChecker", false
+		).put(
+			"extraPlugins", "scayt"
+		).put(
+			"toolbar_liferay",
+			JSONUtil.putAll(
+				toJSONArray("['Undo', 'Redo']"),
+				toJSONArray("['Styles', 'Bold', 'Italic', 'Underline']"),
+				toJSONArray("['NumberedList', 'BulletedList']"),
+				toJSONArray("['Link', Unlink]"), toJSONArray("['Table']"),
+				toJSONArray("['Scayt']"))
+		);
+	}
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/LegacyEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/LegacyEditorConfigContributor.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.editor.configuration;
+
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	property = {
+		"editor.config.key=sampleLegacyEditor",
+		"javax.portlet.name=" + CKEditorSamplePortletKeys.CKEDITOR_SAMPLE
+	},
+	service = EditorConfigContributor.class
+)
+public class LegacyEditorConfigContributor extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		jsonObject.put(
+			"toolbar_liferay",
+			JSONUtil.putAll(
+				toJSONArray("['Styles', 'Bold', 'Italic', 'Underline']"),
+				toJSONArray("['NumberedList', 'BulletedList']"),
+				toJSONArray("['Link', Unlink]")));
+	}
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
@@ -6,9 +6,16 @@
 package com.liferay.frontend.editor.ckeditor.sample.web.internal.portlet;
 
 import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSampleWebKeys;
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.display.context.CKEditorSampleDisplayContext;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 
+import java.io.IOException;
+
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -37,4 +44,17 @@ import org.osgi.service.component.annotations.Component;
 	service = Portlet.class
 )
 public class CKEditorSamplePortlet extends MVCPortlet {
+
+	@Override
+	public void doDispatch(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		renderRequest.setAttribute(
+			CKEditorSampleWebKeys.CKEDITOR_SAMPLE_DISPLAY_CONTEXT,
+			new CKEditorSampleDisplayContext());
+
+		super.doDispatch(renderRequest, renderResponse);
+	}
+
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -5,8 +5,19 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
+<%@ page import="com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSampleWebKeys" %><%@
+page import="com.liferay.frontend.editor.ckeditor.sample.web.internal.display.context.CKEditorSampleDisplayContext" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem" %>
+
+<%@ page import="java.util.List" %>
+
 <liferay-theme:defineObjects />
+
+<portlet:defineObjects />

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/balloon.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/balloon.jsp
@@ -1,0 +1,31 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="contents"
+>
+	<h1>Balloon Editor</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		This paragraph contains a <a href="https://example.com">link</a>.
+	</p>
+
+	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= contents %>"
+	editorName="ballooneditor"
+	name="sampleBalloonEditor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/classic.jsp
@@ -1,0 +1,25 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="contents"
+>
+	<h1>Classic Editor</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= contents %>"
+	editorName="ckeditor_classic"
+	name="sampleClassicEditor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/legacy.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/legacy.jsp
@@ -1,0 +1,25 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="contents"
+>
+	<h1>Legacy Editor</h1>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= contents %>"
+	editorName="ckeditor"
+	name="sampleLegacyEditor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -7,25 +7,26 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-util:buffer
-	var="sampleEditorContents"
+<%
+CKEditorSampleDisplayContext ckEditorSampleDisplayContext = (CKEditorSampleDisplayContext)request.getAttribute(CKEditorSampleWebKeys.CKEDITOR_SAMPLE_DISPLAY_CONTEXT);
+
+List<TabsItem> tabsItems = ckEditorSampleDisplayContext.getTabsItems();
+%>
+
+<clay:tabs
+	tabsItems="<%= tabsItems %>"
 >
-	<h1>Balloon Editor</h1>
 
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
-	</p>
+	<%
+	for (TabsItem tabsItem : tabsItems) {
+	%>
 
-	<p>
-		This paragraph contains a <a href="https://example.com">link</a>.
-	</p>
+		<clay:tabs-panel>
+			<liferay-util:include page='<%= "/partials/" + tabsItem.get("panelId") + ".jsp" %>' servletContext="<%= application %>" />
+		</clay:tabs-panel>
 
-	<img src="https://images.unsplash.com/photo-1539037116277-4db20889f2d4?fit=crop&w=300" />
-</liferay-util:buffer>
+	<%
+	}
+	%>
 
-<liferay-editor:editor
-	contents="<%= sampleEditorContents %>"
-	editorName="ballooneditor"
-	name="sampleBalloonEditor"
-	placeholder="content"
-/>
+</clay:tabs>


### PR DESCRIPTION
### References

- [LPS-199900 PoC Test spell checker plugin for Liferay DXP](https://issues.liferay.com/browse/LPS-199900)
- Official CKEditor docs for spellcheking: [Proofreading, Spelling and Grammar Checking](https://ckeditor.com/docs/ckeditor4/latest/examples/spellchecker.html)

### What is the goal of this PR?

The goal of the spike was to make a PoC for a spellchecker plugin. This does not necessarily mean code that needs to be merged. But, I figured this was a good opportunity to show some care for CKEditor sample module, adding samples for Classic and Legacy versions. I added two spellchecking solutions to the Classic version:
1. Native browser spellchecker, enabled by the `disableNativeSpellChecker` config property.
2. SCAYT plugin, enabled by `extraPlugins` and addition of a toolbar button.

The third solution from official docs, WProofreader, is a paid solution, based on the SCAYT plugin. These are their [docs on how it would integrate with CKeditor](https://demos.webspellchecker.com/wproofreader-ckeditor4.html).

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/5435511/f4245d1c-e0f3-43cc-a8b6-d1840e6aa70a


