### PR TITLE
LPS-200680 Rescale only if it's really needed

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -263,15 +263,25 @@
 						const editorContentHeight = editorContent.getBoundingClientRect()
 							.height;
 
-						let elementOuterHtml = `<img src="${imageSrc}" height="${editorContentHeight}">`;
+						const imgElement = new Image();
 
-						if (instance._isEmptySelection(editor)) {
-							elementOuterHtml += '<br />';
-						}
+						imgElement.src = imageSrc;
 
-						editor.insertHtml(elementOuterHtml);
+						imgElement.onload = function () {
+							if (imgElement.height > editorContentHeight) {
+								imgElement.height = editorContentHeight;
+							}
 
-						editor.focus();
+							let elementOuterHtml = imgElement.outerHTML;
+
+							if (instance._isEmptySelection(editor)) {
+								elementOuterHtml += '<br />';
+							}
+
+							editor.insertHtml(elementOuterHtml);
+
+							editor.focus();
+						};
 					}
 				}
 			}


### PR DESCRIPTION
Hey,

With the previous code we were always rescaling the image to the size of the editor, causing issues with small images.

With this change I'm only rescaling images larger than the editor. I had to change a little bit the way how we load the image to access its height.

Let me know if you have any question.