### PR TITLE
LPS-197657 Removing server info from spritemaps

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -259,7 +259,7 @@ public class ButtonTag extends BaseContainerTag {
 		jspWriter.write("\"><svg class=\"lexicon-icon lexicon-icon-");
 		jspWriter.write(_icon);
 		jspWriter.write("\" role=\"presentation\" viewBox=\"0 0 512 ");
-		jspWriter.write("512\"><use xlink:href=\"");
+		jspWriter.write("512\"><use href=\"");
 
 		HttpServletRequest httpServletRequest = getRequest();
 
@@ -267,7 +267,15 @@ public class ButtonTag extends BaseContainerTag {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		jspWriter.write(themeDisplay.getPathThemeSpritemap());
+		String spritemap = themeDisplay.getPathThemeSpritemap();
+
+		int path = spritemap.indexOf("/o/");
+
+		if (path != -1) {
+			spritemap = spritemap.substring(path);
+		}
+
+		jspWriter.write(spritemap);
 
 		jspWriter.write("#");
 		jspWriter.write(_icon);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/IconTag.java
@@ -38,6 +38,10 @@ public class IconTag extends BaseContainerTag {
 
 		_spritemap = themeDisplay.getPathThemeSpritemap();
 
+		int path = _spritemap.indexOf("/o/");
+
+		_spritemap = _spritemap.substring(path);
+
 		return super.doStartTag();
 	}
 
@@ -71,7 +75,7 @@ public class IconTag extends BaseContainerTag {
 
 		JspWriter jspWriter = pageContext.getOut();
 
-		jspWriter.write("<use xlink:href=\"");
+		jspWriter.write("<use href=\"");
 		jspWriter.write(_spritemap);
 		jspWriter.write("#");
 		jspWriter.write(_symbol);

--- a/modules/apps/user/user-taglib/src/main/java/com/liferay/user/taglib/servlet/taglib/UserPortraitTag.java
+++ b/modules/apps/user/user-taglib/src/main/java/com/liferay/user/taglib/servlet/taglib/UserPortraitTag.java
@@ -43,12 +43,20 @@ public class UserPortraitTag extends IncludeTag {
 				sb.append(CharPool.SPACE);
 			}
 
+			String spritemap = themeDisplay.getPathThemeSpritemap();
+
+			int path = spritemap.indexOf("/o/");
+
+			if (path != -1) {
+				spritemap = spritemap.substring(path);
+			}
+
 			sb.append("user-icon-color-");
 			sb.append((user == null) ? 0 : (user.getUserId() % 10));
 			sb.append("\"><span class=\"inline-item\">");
 			sb.append("<svg class=\"lexicon-icon\">");
 			sb.append("<use href=\"");
-			sb.append(themeDisplay.getPathThemeSpritemap());
+			sb.append(spritemap);
 			sb.append("#user\" /></svg>");
 			sb.append("</span></span>");
 

--- a/util-taglib/src/com/liferay/taglib/aui/ATag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ATag.java
@@ -49,11 +49,19 @@ public class ATag extends BaseATag {
 					(ThemeDisplay)httpServletRequest.getAttribute(
 						WebKeys.THEME_DISPLAY);
 
+				String spritemap = themeDisplay.getPathThemeSpritemap();
+
+				int path = spritemap.indexOf("/o/");
+
+				if (path != -1) {
+					spritemap = spritemap.substring(path);
+				}
+
 				jspWriter.write(StringPool.SPACE);
 				jspWriter.write("<svg class=\"lexicon-icon ");
 				jspWriter.write("lexicon-icon-shortcut\" focusable=\"false\" ");
 				jspWriter.write("role=\"img\"><use href=\"");
-				jspWriter.write(themeDisplay.getPathThemeSpritemap());
+				jspWriter.write(spritemap);
 				jspWriter.write("#shortcut\" /><span ");
 				jspWriter.write("class=\"sr-only\">");
 

--- a/util-taglib/src/com/liferay/taglib/aui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/IconTag.java
@@ -139,6 +139,12 @@ public class IconTag extends BaseIconTag {
 						WebKeys.THEME_DISPLAY);
 
 				src = themeDisplay.getPathThemeSpritemap();
+
+				int path = src.indexOf("/o/");
+
+				if (path != -1) {
+					src = src.substring(path);
+				}
 			}
 
 			jspWriter.write(src);

--- a/util-taglib/src/com/liferay/taglib/ui/IconTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconTag.java
@@ -544,6 +544,12 @@ public class IconTag extends IncludeTag {
 		if (isAUIImage()) {
 			String pathThemeImages = themeDisplay.getPathThemeImages();
 
+			int path = pathThemeImages.indexOf("/o/");
+
+			if (path != -1) {
+				pathThemeImages = pathThemeImages.substring(path);
+			}
+
 			return pathThemeImages.concat("/spacer.png");
 		}
 		else if (Validator.isNotNull(_image)) {

--- a/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/UserPortraitTag.java
@@ -47,6 +47,14 @@ public class UserPortraitTag extends IncludeTag {
 				sb.append(CharPool.SPACE);
 			}
 
+			String spritemap = themeDisplay.getPathThemeSpritemap();
+
+			int path = spritemap.indexOf("/o/");
+
+			if (path != -1) {
+				spritemap = spritemap.substring(path);
+			}
+
 			sb.append("user-icon-color-");
 			sb.append((user == null) ? 0 : (user.getUserId() % 10));
 			sb.append(CharPool.SPACE);
@@ -54,7 +62,7 @@ public class UserPortraitTag extends IncludeTag {
 			sb.append("\"><span class=\"inline-item\">");
 			sb.append("<svg class=\"lexicon-icon\">");
 			sb.append("<use href=\"");
-			sb.append(themeDisplay.getPathThemeSpritemap());
+			sb.append(spritemap);
 			sb.append("#user\" /></svg>");
 			sb.append("</span></span>");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197657

When CDN is enabled, there are error messages in the logs due to SVG links not containing the correct protocol.
I removed the server info and left the path to the svg so that there is no longer any issue with the protocol.

Please let me know if there are any questions or comments about this.
Thank you!