### PR TITLE
LPS-200511 Implement saving of hierarchical object fields in DSM

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -61,7 +61,7 @@ function getValidFields({
 			return;
 		}
 
-		if (type === EFieldType.OBJECT && propertyValue.$ref) {
+		if (propertyValue.$ref) {
 			if (Liferay.FeatureFlags['LPS-186871']) {
 				fields.push({
 					children: getValidFields({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -32,9 +32,11 @@ interface ISchemas {
 }
 
 function getValidFields({
+	contextPath,
 	schemaName,
 	schemas,
 }: {
+	contextPath: string;
 	schemaName: string;
 	schemas: ISchemas;
 }): Array<IField> {
@@ -63,11 +65,12 @@ function getValidFields({
 			if (Liferay.FeatureFlags['LPS-186871']) {
 				fields.push({
 					children: getValidFields({
+						contextPath: `${contextPath}${propertyKey}.`,
 						schemaName: propertyValue.$ref.replace(/^.*\//, ''),
 						schemas,
 					}),
 					label: propertyKey,
-					name: propertyKey,
+					name: `${contextPath}${propertyKey}`,
 					type,
 				});
 			}
@@ -78,7 +81,7 @@ function getValidFields({
 		fields.push({
 			format: propertyValue.format,
 			label: propertyKey,
-			name: propertyKey,
+			name: `${contextPath}${propertyKey}`,
 			type,
 		});
 	});
@@ -109,7 +112,11 @@ export async function getFields(fdsView: FDSViewType) {
 		return [];
 	}
 
-	return getValidFields({schemaName: restSchema, schemas});
+	return getValidFields({
+		contextPath: '',
+		schemaName: restSchema,
+		schemas,
+	});
 }
 
 export async function getAllPicklists(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/Fields.tsx
@@ -37,6 +37,7 @@ const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 
 export interface IFDSField {
+	contextPath: string;
 	externalReferenceCode: string;
 	id: number;
 	label: string;
@@ -158,7 +159,7 @@ const SaveFDSFieldsModalContent = ({
 		setSaveButtonDisabled(true);
 
 		const creationData: Array<{name: string; type: string}> = [];
-		const deletionIds: Array<number> = [];
+		const deletionIds: Array<string> = [];
 
 		fields?.forEach((field) => {
 			if (field.selected && !field.id) {
@@ -224,7 +225,7 @@ const SaveFDSFieldsModalContent = ({
 					);
 
 					return {
-						id: fdsField?.id,
+						id: fdsField ? String(fdsField.id) : undefined,
 						name: field.name,
 						selected: Boolean(fdsField),
 						type: field.type,
@@ -768,8 +769,33 @@ const Fields = ({
 				contentComponent: ({closeModal}: {closeModal: Function}) => (
 					<AddFieldsModalContent
 						closeModal={closeModal}
-						fdsFields={fdsFields || []}
 						fdsView={fdsView}
+						namespace={namespace}
+						onSave={({
+							createdFDSFields,
+							deletedFDSFieldsIds,
+						}: {
+							createdFDSFields: Array<IFDSField>;
+							deletedFDSFieldsIds: Array<number>;
+						}) => {
+							const newFDSFields: Array<IFDSField> = [];
+
+							fdsFields?.forEach((fdsField) => {
+								if (
+									!deletedFDSFieldsIds.includes(fdsField.id)
+								) {
+									newFDSFields.push(fdsField);
+								}
+							});
+
+							createdFDSFields.forEach((fdsField) => {
+								newFDSFields.push(fdsField);
+							});
+
+							setFDSFields(newFDSFields);
+						}}
+						saveFDSFieldsURL={saveFDSFieldsURL}
+						savedFDSFields={fdsFields || []}
 					/>
 				),
 				size: 'full-screen',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/Fields.tsx
@@ -54,7 +54,13 @@ interface ISaveFDSFieldsModalContentProps {
 	fdsFields: Array<IFDSField>;
 	fdsView: FDSViewType;
 	namespace: string;
-	onSave: Function;
+	onSave: ({
+		createdFDSFields,
+		deletedFDSFieldsIds,
+	}: {
+		createdFDSFields: Array<IFDSField>;
+		deletedFDSFieldsIds: Array<number>;
+	}) => void;
 	saveFDSFieldsURL: string;
 }
 
@@ -159,7 +165,7 @@ const SaveFDSFieldsModalContent = ({
 		setSaveButtonDisabled(true);
 
 		const creationData: Array<{name: string; type: string}> = [];
-		const deletionIds: Array<string> = [];
+		const deletionIds: Array<number> = [];
 
 		fields?.forEach((field) => {
 			if (field.selected && !field.id) {
@@ -167,7 +173,7 @@ const SaveFDSFieldsModalContent = ({
 			}
 
 			if (!field.selected && field.id) {
-				deletionIds.push(field.id);
+				deletionIds.push(Number(field.id));
 			}
 		});
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -8,48 +8,160 @@ import {TreeView} from '@clayui/core';
 import {ClayCheckbox} from '@clayui/form';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
+import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {FDSViewType} from '../../../FDSViews';
 import {getFields} from '../../../api';
 import {IField} from '../../../types';
+import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
+import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 import {IFDSField} from '../Fields';
+
+interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	savedId?: number;
+	selected?: boolean;
+}
+
+function visit(fields: Array<IFieldTreeItem>, callback: Function) {
+	fields.forEach((field) => {
+		callback(field);
+
+		if (field.children) {
+			visit(field.children, callback);
+		}
+	});
+}
+
+const applySavedFDSFields = ({
+	fields: initialFields,
+	savedFDSFields,
+}: {
+	fields: IField[];
+	savedFDSFields: Array<IFDSField>;
+}): [Set<React.Key>, Array<IFieldTreeItem>] => {
+	const selectedKeys = new Set<React.Key>();
+	const fields: IFieldTreeItem[] = Array.from(initialFields);
+
+	visit(fields, (field: IFieldTreeItem) => {
+		const savedFDSField = savedFDSFields.find(
+			(savedFDSField) => savedFDSField.name === field.name
+		);
+
+		if (savedFDSField) {
+			selectedKeys.add(savedFDSField.name);
+
+			field.savedId = savedFDSField.id;
+		}
+
+		field.id = field.name;
+	});
+
+	return [selectedKeys, fields];
+};
 
 const AddFieldsModalContent = ({
 	closeModal,
-	fdsFields,
 	fdsView,
+	namespace,
+	onSave,
+	saveFDSFieldsURL,
+	savedFDSFields,
 }: {
 	closeModal: Function;
-	fdsFields: Array<IFDSField>;
 	fdsView: FDSViewType;
+	namespace: string;
+	onSave: ({
+		createdFDSFields,
+		deletedFDSFieldsIds,
+	}: {
+		createdFDSFields: Array<IFDSField>;
+		deletedFDSFieldsIds: Array<number>;
+	}) => void;
+	saveFDSFieldsURL: string;
+	savedFDSFields: Array<IFDSField>;
 }) => {
-	const [fields, setFields] = useState<Array<IField> | null>(null);
+	const [fields, setFields] = useState<Array<IFieldTreeItem> | null>(null);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
+	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
+		new Set<React.Key>()
+	);
 
-	useEffect(() => {
-		getFields(fdsView).then((newFields) => {
-			if (!newFields) {
-				return;
+	const saveFDSFields = async () => {
+		setSaveButtonDisabled(true);
+
+		const creationData: Array<{name: string; type: string}> = [];
+		const deletionIds: Array<number> = [];
+
+		visit(fields || [], (field: IFieldTreeItem) => {
+			if (selectedKeys.has(field.name) && !field.savedId) {
+				creationData.push({name: field.name, type: field.type});
 			}
 
-			setFields(
-				newFields.map((field) => {
-					const fdsField = fdsFields.find(
-						(fdsField) => fdsField.name === field.name
-					);
-
-					return {
-						children: field.children,
-						id: fdsField?.id,
-						name: field.name,
-						selected: Boolean(fdsField),
-						type: field.type,
-						visible: true,
-					};
-				})
-			);
+			if (field.savedId && !selectedKeys.has(field.name)) {
+				deletionIds.push(field.savedId);
+			}
 		});
-	}, [fdsFields, fdsView]);
+
+		const formData = new FormData();
+
+		formData.append(
+			`${namespace}creationData`,
+			JSON.stringify(creationData)
+		);
+
+		deletionIds.forEach((id) => {
+			formData.append(`${namespace}deletionIds`, String(id));
+		});
+
+		formData.append(`${namespace}fdsViewId`, fdsView.id);
+
+		const response = await fetch(saveFDSFieldsURL, {
+			body: formData,
+			method: 'POST',
+		});
+
+		if (!response.ok) {
+			openDefaultFailureToast();
+
+			setSaveButtonDisabled(false);
+
+			return;
+		}
+
+		const createdFDSFields: Array<IFDSField> = await response.json();
+
+		closeModal();
+
+		openDefaultSuccessToast();
+
+		onSave({
+			createdFDSFields: createdFDSFields.map((fdsField) => ({
+				...fdsField,
+				id: Number(fdsField.id),
+			})),
+			deletedFDSFieldsIds: deletionIds,
+		});
+	};
+
+	useEffect(() => {
+		getFields(fdsView).then((fields) => {
+			if (fields) {
+				const [
+					initialSelectedKeys,
+					updatedFields,
+				] = applySavedFDSFields({
+					fields,
+					savedFDSFields,
+				});
+
+				setSelectedKeys(initialSelectedKeys);
+
+				setFields(updatedFields);
+			}
+		});
+	}, [savedFDSFields, fdsView]);
 
 	return (
 		<>
@@ -64,22 +176,24 @@ const AddFieldsModalContent = ({
 					<div className="pb-2 pt-2">
 						<TreeView
 							defaultItems={fields}
+							nestedKey="children"
+							onSelectionChange={setSelectedKeys}
+							selectedKeys={selectedKeys}
 							selectionMode="multiple"
 						>
-							{(field: IField) => (
+							{({children, label}: IFieldTreeItem) => (
 								<TreeView.Item>
 									<TreeView.ItemStack>
-										<ClayCheckbox checked={false} />
-
-										{field.name}
+										<ClayCheckbox checked label={label} />
 									</TreeView.ItemStack>
 
-									<TreeView.Group items={field.children}>
-										{(field: IField) => (
+									<TreeView.Group items={children}>
+										{({label}: IFieldTreeItem) => (
 											<TreeView.Item>
-												<ClayCheckbox checked={false} />
-
-												{field.name}
+												<ClayCheckbox
+													checked
+													label={label}
+												/>
 											</TreeView.Item>
 										)}
 									</TreeView.Group>
@@ -93,7 +207,12 @@ const AddFieldsModalContent = ({
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton>{Liferay.Language.get('save')}</ClayButton>
+						<ClayButton
+							disabled={saveButtonDisabled}
+							onClick={saveFDSFields}
+						>
+							{Liferay.Language.get('save')}
+						</ClayButton>
 
 						<ClayButton
 							displayType="secondary"

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/types.ts
@@ -27,7 +27,7 @@ export enum EFieldType {
 export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
-	id?: number;
+	id?: string;
 	label?: string;
 	name: string;
 	selected?: boolean;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/fields/Fields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/fields/Fields.d.ts
@@ -9,6 +9,7 @@ import {IFDSViewSectionProps} from '../../FDSView';
 import '../../../css/Fields.scss';
 declare type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 export interface IFDSField {
+	contextPath: string;
 	externalReferenceCode: string;
 	id: number;
 	label: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.d.ts
@@ -9,11 +9,23 @@ import {FDSViewType} from '../../../FDSViews';
 import {IFDSField} from '../Fields';
 declare const AddFieldsModalContent: ({
 	closeModal,
-	fdsFields,
 	fdsView,
+	namespace,
+	onSave,
+	saveFDSFieldsURL,
+	savedFDSFields,
 }: {
 	closeModal: Function;
-	fdsFields: Array<IFDSField>;
 	fdsView: FDSViewType;
+	namespace: string;
+	onSave: ({
+		createdFDSFields,
+		deletedFDSFieldsIds,
+	}: {
+		createdFDSFields: Array<IFDSField>;
+		deletedFDSFieldsIds: Array<number>;
+	}) => void;
+	saveFDSFieldsURL: string;
+	savedFDSFields: Array<IFDSField>;
 }) => JSX.Element;
 export default AddFieldsModalContent;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/types.d.ts
@@ -23,7 +23,7 @@ export declare enum EFieldType {
 export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
-	id?: number;
+	id?: string;
 	label?: string;
 	name: string;
 	selected?: boolean;


### PR DESCRIPTION
### References

- [LPS-195914 Allow users to save the mapped hierarchical object fields](https://issues.liferay.com/browse/LPS-195914)
- Requires: https://github.com/liferay-frontend/liferay-portal/pull/3770

### What is the goal of this PR?

In this PR, we are implementing saving of hierarchical object fields. The UI and handling is significantly more complex, as UI is based on `ClayTreeView`, with a matching tree data structure. This means recursive traversal for each action that modifies the tree. 

See technical notes in comments.

### What does it look like?

To showcase new behavior, I created two Objects, and a relationship between them:
- `Person`
- `City`
- `livesIn` relationship, 1:N `City`: `Person`. Multiple people live in a city, obviously :slightly_smiling_face: 

Note that the hierarchical fields in the end are empty, and that's expected. FDS doesn't yet support new format of names, and `livesIn` field is an objects, defaulting to an empty field.

https://github.com/liferay-frontend/liferay-portal/assets/5435511/41df899c-f010-45dc-b865-58511bcc6acb



