### PR TITLE
LPS-201102 Unable to save client extensions that deploy portlets when database partitioning is on

### DIFF
--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java
@@ -13,6 +13,8 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -38,8 +40,6 @@ import java.util.Set;
 public abstract class BaseCETImpl implements CET {
 
 	public BaseCETImpl(ClientExtensionEntry clientExtensionEntry) {
-		_clientExtensionEntry = clientExtensionEntry;
-
 		if (clientExtensionEntry != null) {
 			_companyId = clientExtensionEntry.getCompanyId();
 			_createDate = clientExtensionEntry.getCreateDate();
@@ -47,6 +47,7 @@ public abstract class BaseCETImpl implements CET {
 			_externalReferenceCode =
 				clientExtensionEntry.getExternalReferenceCode();
 			_modifiedDate = clientExtensionEntry.getModifiedDate();
+			_name = clientExtensionEntry.getName();
 
 			try {
 				_properties = PropertiesUtil.load(
@@ -128,11 +129,9 @@ public abstract class BaseCETImpl implements CET {
 
 	@Override
 	public String getName(Locale locale) {
-		if (_clientExtensionEntry != null) {
-			return _clientExtensionEntry.getName(locale);
-		}
+		String languageId = LocaleUtil.toLanguageId(locale);
 
-		return _name;
+		return LocalizationUtil.getLocalization(_name, languageId);
 	}
 
 	@Override
@@ -238,7 +237,6 @@ public abstract class BaseCETImpl implements CET {
 	}
 
 	private String _baseURL = StringPool.BLANK;
-	private ClientExtensionEntry _clientExtensionEntry;
 	private long _companyId;
 	private Date _createDate;
 	private String _description = StringPool.BLANK;

--- a/modules/apps/client-extension/test.properties
+++ b/modules/apps/client-extension/test.properties
@@ -15,10 +15,10 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
-        (testray.component.names ~ "Remote Apps")
+        (testray.component.names ~ "Client Extensions")
 
 ##
 ## Testray
 ##
 
-    testray.main.component.name=Remote Apps
+    testray.main.component.name=Client Extensions


### PR DESCRIPTION
In this PR we are removing a ClientExtensionEntry model object reference in CET objects, which seems to be behind the exception we get when trying to edit an existing IFrame or a Custom-Element client extension entry, created from the UI. This situation happens when database partitioning feature is on.

Reference: https://liferay.atlassian.net/browse/LPS-201102 (see the LPS and linked LPP for in-depth explanations)

Exception excerpt:
```
com.liferay.portal.kernel.exception.SystemException: com.liferay.portal.kernel.dao.orm.ORMException: javax.persistence.OptimisticLockException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) :  [com.liferay.client.extension.model.impl.ClientExtensionEntryImpl#1869125]
com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl.processException(BasePersistenceImpl.java:640) ~[portal-kernel.jar:?]
com.liferay.client.extension.service.persistence.impl.ClientExtensionEntryPersistenceImpl.updateImpl(ClientExtensionEntryPersistenceImpl.java:4761) ~[?:?]
com.liferay.client.extension.service.persistence.impl.ClientExtensionEntryPersistenceImpl.updateImpl(ClientExtensionEntryPersistenceImpl.java:85) ~[?:?]
com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl.update(BasePersistenceImpl.java:787) ~[portal-kernel.jar:?]
com.liferay.client.extension.service.impl.ClientExtensionEntryLocalServiceImpl.updateStatus(ClientExtensionEntryLocalServiceImpl.java:360) ~[?:?]
jdk.internal.reflect.GeneratedMethodAccessor11121.invoke(Unknown Source) ~[?:?]
jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:41) ~[portal-impl.jar:?]
com.liferay.portal.spring.transaction.TransactionInterceptor.invoke(TransactionInterceptor.java:60) ~[portal-impl.jar:?]
com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:48) ~[portal-impl.jar:?]
com.liferay.portal.kernel.aop.ChainableMethodAdvice.invoke(ChainableMethodAdvice.java:55) ~[portal-kernel.jar:?]
com.liferay.portal.spring.aop.AopMethodInvocationImpl.proceed(AopMethodInvocationImpl.java:48) ~[portal-impl.jar:?]
com.liferay.portal.spring.aop.AopInvocationHandler.invoke(AopInvocationHandler.java:40) ~[portal-impl.jar:?]
com.sun.proxy.$Proxy453.updateStatus(Unknown Source) ~[?:?]
com.liferay.client.extension.internal.workflow.ClientExtensionEntryWorkflowHandler.updateStatus(ClientExtensionEntryWorkflowHandler.java:61) ~[?:?]
com.liferay.client.extension.internal.workflow.ClientExtensionEntryWorkflowHandler.updateStatus(ClientExtensionEntryWorkflowHandler.java:28) ~[?:?]
com.liferay.portal.kernel.workflow.WorkflowHandler.updateStatus(WorkflowHandler.java:117) ~[portal-kernel.jar:?]
com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil.startWorkflowInstance(WorkflowHandlerRegistryUtil.java:145) ~[portal-kernel.jar:?]
com.liferay.client.extension.service.impl.ClientExtensionEntryLocalServiceImpl._startWorkflowInstance(ClientExtensionEntryLocalServiceImpl.java:450) ~[?:?]
com.liferay.client.extension.service.impl.ClientExtensionEntryLocalServiceImpl.updateClientExtensionEntry(ClientExtensionEntryLocalServiceImpl.java:325) ~[?:?]
```

At the time of this writing, I don't have a full causal explanation of this. However, it seems related with how Entity cache works with and w/o database partitioning, and the fact that current CET portlet deployment process that is triggered when creating/updating these client extensions holds a reference to a ClientExtensionEntry object which is later updated, causing the above exception. 

More specifically:

- Some types of client extension entail the creation of a widget (see [iframe](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java#L138) and [custom-element](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java#L106-L107)) when deployed. When registering a new portlet service, it [holds a reference](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/BaseCETPortlet.java#L31) to the CET object. 

- In turn, CET object stores a [reference to the ClientExtensionEntry ](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java#L41)model object
 
- As a result, every time portlet service is registered, we make that ClientExtensionEntry reference to remain reachable
 
As keeping such a reference is not needed and can be seen as a code smell, I'm removing it here, yet providing equivalent feature for the `getName()` method where this reference was being used.

I've confirmed this PR fixes the issue, however there might be other considerations about this fix. I'm summoning @achaparro and @izaera in the hope we can ensure this is the right path to follow.