### PR TITLE
LPS-184328 - Add aria-label to checkbox

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Fields.tsx
@@ -19,7 +19,7 @@ import {
 	openModal,
 } from 'frontend-js-web';
 import fuzzy from 'fuzzy';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../Constants';
 import {IFDSViewSectionProps} from '../FDSView';
@@ -241,19 +241,24 @@ const SaveFDSFieldsModalContent = ({
 		});
 	}, [fdsFields, fdsView]);
 
-	const isSelectAllChecked = () => {
+	const visibleFields = fields?.filter((field) => field.visible) ?? [];
+
+	const isSelectAllChecked = useMemo(() => {
 		if (!fields) {
 			return false;
 		}
 
-		const selectedFields = fields.filter((field) => field.selected);
+		const isSelectAllSelectedFields = fields.filter(
+			(field) => field.selected
+		);
 
-		const selectedFieldsCount = selectedFields?.length || 0;
+		const isSelectAllSelectedFieldsCount =
+			isSelectAllSelectedFields?.length || 0;
 
-		return selectedFieldsCount === fields.length;
-	};
+		return isSelectAllSelectedFieldsCount === fields.length;
+	}, [fields]);
 
-	const isSelectAllIndeterminate = () => {
+	const isSelectAllIndeterminate = useMemo(() => {
 		if (!fields) {
 			return false;
 		}
@@ -262,16 +267,13 @@ const SaveFDSFieldsModalContent = ({
 			fields.filter((field) => field.selected)?.length || 0;
 
 		return selectedFieldsCount > 0 && selectedFieldsCount < fields.length;
-	};
-
-	const visibleFields = fields?.filter((field) => field.visible) ?? [];
+	}, [fields]);
 
 	return (
 		<>
 			<ClayModal.Header>
 				{Liferay.Language.get('add-fields')}
 			</ClayModal.Header>
-
 			<ClayModal.Body>
 				{fields === null ? (
 					<ClayLoadingIndicator />
@@ -281,8 +283,17 @@ const SaveFDSFieldsModalContent = ({
 							<ManagementToolbar.ItemList expand>
 								<ManagementToolbar.Item className="pr-2">
 									<ClayCheckbox
-										checked={isSelectAllChecked()}
-										indeterminate={isSelectAllIndeterminate()}
+										aria-label={
+											!isSelectAllChecked
+												? Liferay.Language.get(
+														'select-all'
+												  )
+												: Liferay.Language.get(
+														'deselect-all'
+												  )
+										}
+										checked={isSelectAllChecked}
+										indeterminate={isSelectAllIndeterminate}
 										onChange={({target: {checked}}) =>
 											setFields(
 												fields.map((field) => ({


### PR DESCRIPTION
### References

- [LPS-184328 Form elements don't have labels on Fields tab](https://liferay.atlassian.net/browse/LPS-184328)
- [LPS-183320 Checkbox from Add Fields modal of Dataset view doesn't have a label](https://liferay.atlassian.net/browse/LPS-183320)

### What is the goal of this PR?

The goal of this PR is to add a missing aria-label to the dataset field addition checkbox.

### What does it look like?

#### Before PR
![image (46)](https://github.com/liferay-frontend/liferay-portal/assets/141816816/806ce7c3-f855-494e-83a8-4eee387a95e1)

#### After PR
![image (47)](https://github.com/liferay-frontend/liferay-portal/assets/141816816/5874f8cf-19bd-460c-bfe4-e97b9e79e69c)


