### PR TITLE
LPS-199725 - PoC. Implement root model for Dataset Manager

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -16,6 +16,7 @@ import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.field.util.ObjectFieldUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectField;
+import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
@@ -202,25 +203,39 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_language.get(locale, "title"), "title", fdsActionObjectDefinition,
 			userId);
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsActionObjectDefinition.getObjectDefinitionId());
+		ObjectRelationship fdsViewFDSCreationActionRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsActionObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSCreationAction Relationship"),
+				"fdsViewFDSCreationActionRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsActionObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(
-				"FDSView FDSCreationAction Relationship"),
-			"fdsViewFDSCreationActionRelationship", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsActionObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(
-				"FDSView FDSItemAction Relationship"),
-			"fdsViewFDSItemActionRelationship", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		long[] relationshipId1 = new long[1];
+
+		relationshipId1[0] =
+			fdsViewFDSCreationActionRelationship.getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId1);
+
+		ObjectRelationship fdsViewFDSItemActionRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsActionObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSItemAction Relationship"),
+				"fdsViewFDSItemActionRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+
+		long[] relationshipId2 = new long[1];
+
+		relationshipId2[0] =
+			fdsViewFDSItemActionRelationship.getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId2);
 	}
 
 	private void _createFDSClientExtensionFilterObjectDefintion(
@@ -256,18 +271,24 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_language.get(locale, "label"), "label",
 			fdsClientExtensionFilterObjectDefinition, userId);
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId,
-			fdsClientExtensionFilterObjectDefinition.getObjectDefinitionId());
+		ObjectRelationship fdsViewFDSClientExtensionFilterRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsClientExtensionFilterObjectDefinition.
+					getObjectDefinitionId(),
+				0, ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSClientExtensionFilter"),
+				"fdsViewFDSClientExtensionFilter", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsClientExtensionFilterObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(
-				"FDSView FDSClientExtensionFilter"),
-			"fdsViewFDSClientExtensionFilter", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		long[] relationshipId = new long[1];
+
+		relationshipId[0] =
+			fdsViewFDSClientExtensionFilterRelationship.
+				getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId);
 	}
 
 	private void _createFDSDateFilterObjectDefinition(
@@ -307,17 +328,22 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_language.get(locale, "label"), "label",
 			fdsDateFilterObjectDefinition, userId);
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsDateFilterObjectDefinition.getObjectDefinitionId());
+		ObjectRelationship fdsViewFDSDateFilterRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsDateFilterObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSDateFilter Relationship"),
+				"fdsViewFDSDateFilterRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsDateFilterObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(
-				"FDSView FDSDateFilter Relationship"),
-			"fdsViewFDSDateFilterRelationship", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		long[] relationshipId = new long[1];
+
+		relationshipId[0] =
+			fdsViewFDSDateFilterRelationship.getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId);
 	}
 
 	private void _createFDSDynamicFilterObjectDefintion(
@@ -364,17 +390,22 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_language.get(locale, "label"), "label",
 			fdsDynamicFilterObjectDefinition, userId);
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsDynamicFilterObjectDefinition.getObjectDefinitionId());
+		ObjectRelationship fdsViewFDSDynamicFilterRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsDynamicFilterObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSDynamicFilter Relationship"),
+				"fdsViewFDSDynamicFilterRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsDynamicFilterObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap(
-				"FDSView FDSDynamicFilter Relationship"),
-			"fdsViewFDSDynamicFilterRelationship", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		long[] relationshipId = new long[1];
+
+		relationshipId[0] =
+			fdsViewFDSDynamicFilterRelationship.getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId);
 	}
 
 	private ObjectDefinition _createFDSEntryObjectDefinition(
@@ -458,16 +489,22 @@ public class FDSViewsPortlet extends MVCPortlet {
 			_language.get(locale, "column-label"), "label",
 			fdsFieldObjectDefinition, userId);
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsFieldObjectDefinition.getObjectDefinitionId());
+		ObjectRelationship fdsViewFDSFieldRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsFieldObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSField Relationship"),
+				"fdsViewFDSFieldRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsFieldObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap("FDSView FDSField Relationship"),
-			"fdsViewFDSFieldRelationship", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		long[] relationshipId = new long[1];
+
+		relationshipId[0] =
+			fdsViewFDSFieldRelationship.getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId);
 	}
 
 	private void _createFDSSortObjectDefinition(
@@ -494,16 +531,22 @@ public class FDSViewsPortlet extends MVCPortlet {
 						_language.get(locale, "sorting"), "sortingDirection",
 						true)));
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsSortObjectDefinition.getObjectDefinitionId());
+		ObjectRelationship fdsViewFDSSortRelationship =
+			_objectRelationshipLocalService.addObjectRelationship(
+				userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+				fdsSortObjectDefinition.getObjectDefinitionId(), 0,
+				ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+				LocalizedMapUtil.getLocalizedMap(
+					"FDSView FDSSort Relationship"),
+				"fdsViewFDSSortRelationship", false,
+				ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
 
-		_objectRelationshipLocalService.addObjectRelationship(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId(),
-			fdsSortObjectDefinition.getObjectDefinitionId(), 0,
-			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
-			LocalizedMapUtil.getLocalizedMap("FDSView FDSSort Relationship"),
-			"fdsViewFDSSortRelationship", false,
-			ObjectRelationshipConstants.TYPE_ONE_TO_MANY);
+		long[] relationshipId = new long[1];
+
+		relationshipId[0] =
+			fdsViewFDSSortRelationship.getObjectRelationshipId();
+
+		_objectDefinitionLocalService.bindObjectDefinitions(relationshipId);
 	}
 
 	private ObjectDefinition _createFDSViewObjectDefinition(
@@ -576,9 +619,6 @@ public class FDSViewsPortlet extends MVCPortlet {
 			fdsViewObjectDefinition.getObjectDefinitionId(),
 			labelObjectField.getObjectFieldId());
 
-		_objectDefinitionLocalService.publishSystemObjectDefinition(
-			userId, fdsViewObjectDefinition.getObjectDefinitionId());
-
 		_objectRelationshipLocalService.addObjectRelationship(
 			userId, fdsEntryObjectDefinition.getObjectDefinitionId(),
 			fdsViewObjectDefinition.getObjectDefinitionId(), 0,
@@ -626,6 +666,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 		_createFDSFieldObjectDefinition(
 			fdsViewObjectDefinition, locale, userId);
 		_createFDSSortObjectDefinition(fdsViewObjectDefinition, locale, userId);
+
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
+			userId, fdsViewObjectDefinition.getObjectDefinitionId());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
## Story / Task
- https://liferay.atlassian.net/browse/LPS-199725 - Technical research on Root Model implications
- FF needed `feature.flag.LPS-187142=true`

## Goal of PoC

We are trying to implement the root model in the Dataset Manager. The idea is having a couple of first level objects: Entries (datasets) and Views. Views have a relationship with Entries but do not need to be under the root model. 
Views object will be the root for DSM Actions, Fields, Filters & Sortings.

To achieve this, we create the objects, relationships and bind Actions, Fields, Filters & Sortings objects to the Views object using the Java API provided in the ObjectDefinition service (`objectDefinitionLocalService.bindObjectDefinitions`). As all objects need to be in draft mode while binding, we delay the publication of the Views object till the end. Basically, publishing the root object will publish its binded objects in cascade (**not working**).

## UI binding custom objects
Creating custom objects, binding child to root and publish the root. Both objects published.

[custom-object-binding.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/369f2312-1960-4882-a2be-cd8f5e1192e5)

## UI binding DSM objects
Creating DSM objects and binding them to Views (via Java API) only publish the root.

[DSM-auto-binding.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/c94685a9-13eb-421a-af02-4ab9f1747052)

It seems that the binding has been successful, as from the item actions menu the _Unbinding_ option is available but the object is not _Approved_/_Published_.  When we try to access the details of one of the children (Actions) it is not possible to _Publish_ it. The reason to hide the button seems to be that the `isRootDescendantNode` is true (successful binding).

[child-not-published.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/c149bd44-97b0-4cfc-8caf-65f1a377c499)

## Alternatives

As a workaround we tried to publish all objects via API after publishing the Views object. However, this kind of publication does not fully respect the root model as all endpoints are created in the same level.

![api](https://github.com/liferay-frontend/liferay-portal/assets/132653342/355141ee-19bc-4e4b-af4d-c3d29ed2d993)

In this case the expected result should show all objects binded to Views with the endpoint prefixed with `/data-set-manager/views/`

```
/data-set-manager/entries
/data-set-manager/views
/data-set-manager/views/actions
/data-set-manager/views/fields
```

One possible cause for this is that only the Custom Objects publishing considers the root model [publishCustomObjectDefinition](https://github.com/liferay/liferay-portal/blob/master/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java#L820), something that System Object publishing [publishSystemObjectDefinition](https://github.com/liferay/liferay-portal/blob/master/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java#L856) does not.



