### PR TITLE
LPS-201102 Do not flush the Hibernate session if we do not change companyId context since that causes to increase the mvccVersion in the middle of the process and StaleObjectException is thrown

### DIFF
--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java
@@ -13,6 +13,8 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -38,8 +40,6 @@ import java.util.Set;
 public abstract class BaseCETImpl implements CET {
 
 	public BaseCETImpl(ClientExtensionEntry clientExtensionEntry) {
-		_clientExtensionEntry = clientExtensionEntry;
-
 		if (clientExtensionEntry != null) {
 			_companyId = clientExtensionEntry.getCompanyId();
 			_createDate = clientExtensionEntry.getCreateDate();
@@ -47,6 +47,7 @@ public abstract class BaseCETImpl implements CET {
 			_externalReferenceCode =
 				clientExtensionEntry.getExternalReferenceCode();
 			_modifiedDate = clientExtensionEntry.getModifiedDate();
+			_name = clientExtensionEntry.getName();
 
 			try {
 				_properties = PropertiesUtil.load(
@@ -128,11 +129,9 @@ public abstract class BaseCETImpl implements CET {
 
 	@Override
 	public String getName(Locale locale) {
-		if (_clientExtensionEntry != null) {
-			return _clientExtensionEntry.getName(locale);
-		}
+		String languageId = LocaleUtil.toLanguageId(locale);
 
-		return _name;
+		return LocalizationUtil.getLocalization(_name, languageId);
 	}
 
 	@Override
@@ -238,7 +237,6 @@ public abstract class BaseCETImpl implements CET {
 	}
 
 	private String _baseURL = StringPool.BLANK;
-	private ClientExtensionEntry _clientExtensionEntry;
 	private long _companyId;
 	private Date _createDate;
 	private String _description = StringPool.BLANK;

--- a/modules/apps/client-extension/test.properties
+++ b/modules/apps/client-extension/test.properties
@@ -15,10 +15,10 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
-        (testray.component.names ~ "Remote Apps")
+        (testray.component.names ~ "Client Extensions")
 
 ##
 ## Testray
 ##
 
-    testray.main.component.name=Remote Apps
+    testray.main.component.name=Client Extensions

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -100,18 +100,24 @@ public class CompanyThreadLocal {
 	}
 
 	public static SafeCloseable lock(long companyId) {
-		if (isLocked()) {
-			Long currentCompanyId = _companyId.get();
+		long currentCompanyId = _companyId.get();
 
-			if (companyId == currentCompanyId.longValue()) {
+		if (companyId == currentCompanyId) {
+			if (isLocked()) {
 				return () -> {
 				};
 			}
 
+			_locked.set(true);
+
+			return () -> _locked.set(false);
+		}
+
+		if (isLocked()) {
 			throw new UnsupportedOperationException(
 				StringBundler.concat(
 					"Company ID ", companyId, " and company ID ",
-					currentCompanyId.longValue(), " are different"));
+					currentCompanyId, " are different"));
 		}
 
 		_syncLastDBPartitionSessionState();


### PR DESCRIPTION
Hi,

When DB Partitioning is enabled, we flush the Hibernate session when we change the company context so we make Hibernate aware of the correct partition for the previous modifications.

In this case with Client Extensions, the flush is executed even when there are no change of company and the _mvccVersion_ is increased (due to the flush) in the middle of the process, when we have already got the entity from the cache. Due to we have an old version of the entity, we got and StaleObjectException later on.

This fix solves the issue  in my environment. I have kept Daniel's changes since they are beneficial and does not harm.

Let me know if you need anything else.

cc/ @dsanz @CarlosBrichete 
