### PR TITLE
LPS-201102 Unable to save client extensions that deploy portlets when database partitioning is on (all companies)

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryLocalServiceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryLocalServiceImpl.java
@@ -335,19 +335,10 @@ public class ClientExtensionEntryLocalServiceImpl
 			clientExtensionEntryPersistence.findByPrimaryKey(
 				clientExtensionEntryId);
 
-		if (status == clientExtensionEntry.getStatus()) {
+		int initialStatus = clientExtensionEntry.getStatus();
+
+		if (status == initialStatus) {
 			return clientExtensionEntry;
-		}
-
-		if (status == WorkflowConstants.STATUS_APPROVED) {
-			clientExtensionEntryLocalService.deployClientExtensionEntry(
-				clientExtensionEntry);
-		}
-		else if (clientExtensionEntry.getStatus() ==
-					WorkflowConstants.STATUS_APPROVED) {
-
-			clientExtensionEntryLocalService.undeployClientExtensionEntry(
-				clientExtensionEntry);
 		}
 
 		User user = _userLocalService.getUser(userId);
@@ -357,7 +348,19 @@ public class ClientExtensionEntryLocalServiceImpl
 		clientExtensionEntry.setStatusByUserName(user.getFullName());
 		clientExtensionEntry.setStatusDate(new Date());
 
-		return clientExtensionEntryPersistence.update(clientExtensionEntry);
+		clientExtensionEntry = clientExtensionEntryPersistence.update(
+			clientExtensionEntry);
+
+		if (status == WorkflowConstants.STATUS_APPROVED) {
+			clientExtensionEntryLocalService.deployClientExtensionEntry(
+				clientExtensionEntry);
+		}
+		else if (initialStatus == WorkflowConstants.STATUS_APPROVED) {
+			clientExtensionEntryLocalService.undeployClientExtensionEntry(
+				clientExtensionEntry);
+		}
+
+		return clientExtensionEntry;
 	}
 
 	private void _addResources(ClientExtensionEntry clientExtensionEntry)

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/BaseCETImpl.java
@@ -13,6 +13,8 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
@@ -38,8 +40,6 @@ import java.util.Set;
 public abstract class BaseCETImpl implements CET {
 
 	public BaseCETImpl(ClientExtensionEntry clientExtensionEntry) {
-		_clientExtensionEntry = clientExtensionEntry;
-
 		if (clientExtensionEntry != null) {
 			_companyId = clientExtensionEntry.getCompanyId();
 			_createDate = clientExtensionEntry.getCreateDate();
@@ -47,6 +47,7 @@ public abstract class BaseCETImpl implements CET {
 			_externalReferenceCode =
 				clientExtensionEntry.getExternalReferenceCode();
 			_modifiedDate = clientExtensionEntry.getModifiedDate();
+			_name = clientExtensionEntry.getName();
 
 			try {
 				_properties = PropertiesUtil.load(
@@ -128,11 +129,9 @@ public abstract class BaseCETImpl implements CET {
 
 	@Override
 	public String getName(Locale locale) {
-		if (_clientExtensionEntry != null) {
-			return _clientExtensionEntry.getName(locale);
-		}
+		String languageId = LocaleUtil.toLanguageId(locale);
 
-		return _name;
+		return LocalizationUtil.getLocalization(_name, languageId);
 	}
 
 	@Override
@@ -238,7 +237,6 @@ public abstract class BaseCETImpl implements CET {
 	}
 
 	private String _baseURL = StringPool.BLANK;
-	private ClientExtensionEntry _clientExtensionEntry;
 	private long _companyId;
 	private Date _createDate;
 	private String _description = StringPool.BLANK;

--- a/modules/apps/client-extension/test.properties
+++ b/modules/apps/client-extension/test.properties
@@ -15,10 +15,10 @@
 
     test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
         (portal.acceptance == true) AND \
-        (testray.component.names ~ "Remote Apps")
+        (testray.component.names ~ "Client Extensions")
 
 ##
 ## Testray
 ##
 
-    testray.main.component.name=Remote Apps
+    testray.main.component.name=Client Extensions

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -100,18 +100,24 @@ public class CompanyThreadLocal {
 	}
 
 	public static SafeCloseable lock(long companyId) {
-		if (isLocked()) {
-			Long currentCompanyId = _companyId.get();
+		long currentCompanyId = _companyId.get();
 
-			if (companyId == currentCompanyId.longValue()) {
+		if (companyId == currentCompanyId) {
+			if (isLocked()) {
 				return () -> {
 				};
 			}
 
+			_locked.set(true);
+
+			return () -> _locked.set(false);
+		}
+
+		if (isLocked()) {
 			throw new UnsupportedOperationException(
 				StringBundler.concat(
 					"Company ID ", companyId, " and company ID ",
-					currentCompanyId.longValue(), " are different"));
+					currentCompanyId, " are different"));
 		}
 
 		_syncLastDBPartitionSessionState();


### PR DESCRIPTION
This is a followup of https://github.com/liferay-frontend/liferay-portal/pull/3811 where we fix the issue for all companies. Previous fix was working in the default virtual instance, and only if there were no more virtual instances in the system.

When more than one virtual instance is created, DB partition executes some logic across all of them, which entails new flush operations, bringing back the faulty behavior when it comes to update a client extension. This happened on all companies, even the default one.

In this PR we are obeying the same order of things for all Client Extension service methods involving deployment, which is:

1. Persist the `ClientExtensionEntry` model
2. Deploy it

This natural order was being followed in the add/remove operations already, but not in the update one. With this change, updating a client extension entry via UI prevents the changes on the persistence layer caused by deployment from interfering with the client extension entry update itself.

Additional notes:
 * We discovered some potential optimizations while deploying the CET portlet as it should only apply to the current company, meaning there is no need to create portlet resources for all of them
 * A side effect of this change is that `CETFactory`  now takes an updated version of the `ClientExtensionEntry` model object, which is the right thing to expect. Prior to this, the model object used by the factory was not the one we ended up persisting. Probably, nobody noticed this because the affected model attributes (`status` and others) are not useful for the purposes of building a functional `CET` object
 * I'm keeping all the previous commits (both @achaparro and mine) because, even if they don't solve the issue entirely, they leave things in a better state and are still valuable

cc @achaparro @izaera @mateusralv @CarlosBrichete 