### PR TITLE
LPS-194387 LPS-200809 Migrate FDS Show View Options Select to Clay Picker

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/package.json
@@ -3,6 +3,7 @@
 		"@clayui/autocomplete": "3.106.1",
 		"@clayui/button": "3.106.1",
 		"@clayui/card": "3.106.1",
+		"@clayui/core": "3.106.1",
 		"@clayui/drop-down": "3.106.1",
 		"@clayui/empty-state": "3.106.1",
 		"@clayui/form": "3.106.1",

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/ActiveViewSelector.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/ActiveViewSelector.js
@@ -4,57 +4,59 @@
  */
 
 import {ClayButtonWithIcon} from '@clayui/button';
-import ClayDropDown from '@clayui/drop-down';
+import {Option, Picker} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import persistActiveView from '../../thunks/persistActiveView';
 import ViewsContext from '../../views/ViewsContext';
 
+const ActiveViewSelectorTrigger = React.forwardRef(
+	({symbol, ...otherProps}, ref) => (
+		<ClayButtonWithIcon
+			{...otherProps}
+			aria-label={Liferay.Language.get('show-view-options')}
+			className="nav-link nav-link-monospaced"
+			displayType="unstyled"
+			ref={ref}
+			symbol={symbol}
+			title={Liferay.Language.get('show-view-options')}
+		/>
+	)
+);
+
 function ActiveViewSelector({views}) {
 	const {appURL, id, portletId} = useContext(FrontendDataSetContext);
 	const [{activeView}, viewsDispatch] = useContext(ViewsContext);
 
-	const [active, setActive] = useState(false);
+	const handleSelectionChange = (value) => {
+		viewsDispatch(
+			persistActiveView({
+				activeViewName: value,
+				appURL,
+				id,
+				portletId,
+			})
+		);
+	};
 
 	return (
-		<ClayDropDown
-			active={active}
-			onActiveChange={setActive}
-			trigger={
-				<ClayButtonWithIcon
-					className="nav-link nav-link-monospaced"
-					displayType="unstyled"
-					symbol={activeView.thumbnail}
-					title={Liferay.Language.get('show-view-options')}
-				/>
-			}
+		<Picker
+			as={ActiveViewSelectorTrigger}
+			items={views}
+			onSelectionChange={handleSelectionChange}
+			selectedKey={activeView.name}
+			symbol={activeView.thumbnail}
 		>
-			<ClayDropDown.ItemList>
-				{views.map(({label, name, thumbnail}) => (
-					<ClayDropDown.Item
-						key={name}
-						onClick={(event) => {
-							event.preventDefault();
-							setActive(false);
-							viewsDispatch(
-								persistActiveView({
-									activeViewName: name,
-									appURL,
-									id,
-									portletId,
-								})
-							);
-						}}
-					>
-						<ClayIcon className="mr-3" symbol={thumbnail} />
+			{({label, name, thumbnail}) => (
+				<Option key={name} textValue={name}>
+					<ClayIcon className="mr-3" symbol={thumbnail} />
 
-						{label}
-					</ClayDropDown.Item>
-				))}
-			</ClayDropDown.ItemList>
-		</ClayDropDown>
+					{label}
+				</Option>
+			)}
+		</Picker>
 	);
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/saveViewSettings.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/saveViewSettings.js
@@ -8,6 +8,10 @@ import {fetch, openToast} from 'frontend-js-web';
 import {logError} from './logError';
 
 export function saveViewSettings({appURL, id, portletId, settings}) {
+	if (!appURL) {
+		return;
+	}
+
 	const url = new URL(`${appURL}/data-set/${id}/save-active-view-settings`);
 
 	url.searchParams.append('groupId', themeDisplay.getScopeGroupId());


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPS-194387
**Subtask:** https://liferay.atlassian.net/browse/LPS-200809

## Details

This migrates the use of `ClayDropDown` to `Picker` for the "Show View Options" button.

<p><img width="454" alt="Screenshot 2023-11-08 at 12 02 33 PM" src="https://github.com/liferay-frontend/liferay-portal/assets/4496722/fff77157-268f-476f-9139-d3f0a49edc5e"></p>


**Things to note:**
- To pass the active view's symbol to the custom trigger `ActiveViewSelectorTrigger`, I added a custom prop to `Picker` named `symbol`.
- `ActiveViewSelector` was always trying to persist the value and throwing an error with an invalid URL, so I added an extra check for to skip it if `appURL` wasn't defined.


## Demo

I didn't find any FDS with multiple view options being currently used in Portal so below is an example of adding a list view in the Data Set Manager. (Code I added for this demo: https://github.com/thektan/liferay-portal/commit/f3b55b37919ed9f9a465fcc0e83466de617406ba)

### Before

https://github.com/liferay-frontend/liferay-portal/assets/4496722/d5c0e857-74e8-4542-a078-251dbf216444

### After

The tooltip always appears after selecting an option, which feels a bit annoying to me, but I'm not sure if anything can be done since the focus goes back to the trigger.

https://github.com/liferay-frontend/liferay-portal/assets/4496722/a982249b-1f09-401e-a0e1-bfbf5fd2df00
