### PR TITLE
LPS-197803 Delete aria-selected attribute

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/FiltersDropdown.js
@@ -83,7 +83,6 @@ const FiltersDropdown = () => {
 						<ClayDropDown.ItemList>
 							{filters.map((filter) => (
 								<ClayDropDown.Item
-									active={filter.value !== undefined}
 									key={filter.id}
 									onClick={() => {
 										setActiveFilter(filter);


### PR DESCRIPTION
### References

- [LPS-197803 Accessibility: Data Set Fragment - Elements must only use allowed ARIA attributes](https://liferay.atlassian.net/browse/LPS-197803)

### What is the goal of this PR?

- Removing the `aria-selected` attribute in order to fix the accessibility issue.

### What does it look like?

#### Before PR
![image (1)](https://github.com/liferay-frontend/liferay-portal/assets/60508076/59c20aa1-3659-47d1-90de-1239a649b63a)

#### After PR
![image (2)](https://github.com/liferay-frontend/liferay-portal/assets/60508076/a7b2c8fe-42fc-4ea6-b6fd-e8ffdc8f5e8e)
