### PR TITLE
LPS-197208 Adding a class name to the clay checkbox 

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/CheckboxMultiSelect.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/CheckboxMultiSelect.tsx
@@ -78,6 +78,7 @@ function CheckboxMultiSelect({
 							<ClayCheckbox
 								aria-label={item.label}
 								checked={isChecked(items, item)}
+								className="invisible"
 								onClick={(event: any) => {
 									event.stopPropagation();
 


### PR DESCRIPTION
### References
[LPS-197208 Interactive controls are nested in preselected values field](https://liferay.atlassian.net/browse/LPS-197208)

### What is the goal of this PR?
The goal of this PR is to add a class name to the clay checkbox  to fix the accessibility issue.

### Before PR
![before](https://github.com/liferay-frontend/liferay-portal/assets/107557710/4c37debd-a31d-439e-a912-4407994ff34c)

### After PR
![after](https://github.com/liferay-frontend/liferay-portal/assets/107557710/76e81cdf-c0d2-44b8-8d46-5f1b89826cf9)
