### PR TITLE
LPS-164321

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PanelGroupTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PanelGroupTag.java
@@ -21,7 +21,7 @@ public class PanelGroupTag extends BaseContainerTag {
 	@Override
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
-		setDynamicAttribute(StringPool.BLANK, "aria-orentation", "vertical");
+		setDynamicAttribute(StringPool.BLANK, "aria-orientation", "vertical");
 		setDynamicAttribute(StringPool.BLANK, "role", "tablist");
 
 		return super.doStartTag();


### PR DESCRIPTION
Sending based on the conversation in this slack thread:
https://liferay.slack.com/archives/CNBG06JS3/p1699435276057189

There was a typo where it was `aria-orentation` instead of `aria-orientation`.

## Steps to reproduce

1. Navigate to Control Panel > Password Policies
2. Edit the default password policy
3. Run a check for the incorrect attribute in the Developer Tools console:
```
document.querySelectorAll('.panel-group[aria-orentation]')
```
4. Run a check for the correct attribute in the Developer Tools console:
```
document.querySelectorAll('.panel-group[aria-orientation]')
```