### PR TITLE
LPS-201345 - Filter actions that do not appear as item actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -28,7 +28,10 @@ const formatActions = (actions, itemData) => {
 	return actions
 		? actions.reduce((actions, action) => {
 				if (action.data?.permissionKey) {
-					if (itemData.actions[action.data.permissionKey]) {
+					if (
+						itemData.actions &&
+						itemData.actions[action.data.permissionKey]
+					) {
 						if (action.target === 'headless') {
 							return [
 								...actions,


### PR DESCRIPTION
## Related
:bug: https://liferay.atlassian.net/browse/LPS-201345

## Issue description
When an admin user creates a new Dataset and a new custom view for a headless endpoint (x.e. `/headless-admin-address/v1.0/countries/Country`) and define item actions of type Link that includes a `Headless Action Key` value, the fragment that displays the dataset breaks.

We've found that the headless endpoint used in the example does not provide a list of actions for each item, so trying to check the action created in the Dataset Manager with the actions provided (not provided in this case) throws an error.

## Fix
In the method that checks for the `permissionKey` we first need to ensure that there is available an item actions property, otherwise we could filter out the action.

## UI
We create a couple of datasets, one from a custom object and one from a headless endpoint to test both cases.

[Screencast from 2023-11-10 14-06-30.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/33a75b69-438a-43ca-af3c-b1edd7c8e13b)


