### PR TITLE
LPS 174379 - Frontend Data Set Sample Tab Elements | Critical Accessibility Issue - Ensure elements with an ARIA role that require parent roles are contained by them

### DIFF
--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -125,7 +125,7 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs
 						</c:if>
 		</c:when>
 		<c:otherwise>
-			<ul class="lfr-nav mb-3 mb-lg-4 nav nav-<%= type %> <%= cssClass %>" data-tabs-namespace="<%= namespace + param %>">
+			<ul class="lfr-nav mb-3 mb-lg-4 nav nav-<%= type %> <%= cssClass %>" data-tabs-namespace="<%= namespace + param %>" role="tablist">
 		</c:otherwise>
 	</c:choose>
 
@@ -192,7 +192,7 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs
 		}
 	%>
 
-		<li class="nav-item" data-tab-name="<%= names[i] %>" id="<%= namespace %><%= param %><%= StringUtil.toCharCode(values[i]) %>TabsId">
+		<li class="nav-item" data-tab-name="<%= names[i] %>" id="<%= namespace %><%= param %><%= StringUtil.toCharCode(values[i]) %>TabsId" role="none">
 			<a class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" onClick="<%= Validator.isNotNull(curOnClick) ? curOnClick : StringPool.BLANK %>" role="tab">
 				<liferay-ui:message key="<%= HtmlUtil.escape(names[i]) %>" />
 			</a>


### PR DESCRIPTION
**References**
[LPS-174379 : Frontend Data Set Sample Tab Elements | Critical Accessibility Issue - Ensure elements with an ARIA role that require parent roles are contained by them](https://liferay.atlassian.net/browse/LPS-174379)

**What is the goal of this PR?**
The goal of this PR is to add an attribute role to the elements lists to fix the accessibility issue.

**### Before PR**
![image](https://github.com/liferay-frontend/liferay-portal/assets/100470089/9bbf2962-b935-427d-96d1-2de83b7a2dfc)

**### After PR**
![image](https://github.com/liferay-frontend/liferay-portal/assets/100470089/04f50f8e-490c-4c19-b844-716960842d11)
