### PR TITLE
LPS-201541 Don't add CSP nonces to site initializer FTL templates

### DIFF
--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-get-app-button/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-get-app-button/ddm-template.ftl
@@ -1,3 +1,3 @@
-<script ${nonceAttribute}>
+<script>
 	Liferay.MarketplaceCustomerFlow = {appId:${CPDefinition_cProductId.getData()}};
 </script>

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-share-link/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-share-link/ddm-template.ftl
@@ -4,7 +4,7 @@
 	<svg class="link-arrow" style="margin-left:auto;" width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><mask id="arrow" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="5" y="4" width="6" height="8"><path d="m6 10.584 2.587-2.587L6 5.41a.664.664 0 1 1 .94-.94L10 7.53c.26.26.26.68 0 .94l-3.06 3.06c-.26.26-.68.26-.94 0a.678.678 0 0 1 0-.946Z" fill="#000"></path></mask><g mask="url(#arrow)"><path fill="#858c94" d="M0 0h16v16H0z"></path></g></svg>
 </a>
 
-<script ${nonceAttribute} type="">
+<script type="">
 	var target = document.querySelector('[href="#copy-share-link"]');
 
 	function copyToClipboard(text) {

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-tabs-license/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-tabs-license/ddm-template.ftl
@@ -4,7 +4,7 @@
 	</#if>
 </div>
 
-<script ${nonceAttribute}>
+<script>
 	var contentEl = document.querySelector('#mpLicense');
 	var tabPanel = contentEl.closest('.tab-panel-item');
 	var tabTarget = tabPanel.getAttribute('aria-labelledby');

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-tabs-profile/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-tabs-profile/ddm-template.ftl
@@ -4,7 +4,7 @@
 	</#if>
 </div>
 
-<script ${nonceAttribute}>
+<script>
 	var contentEl = document.querySelector('#mpProfile');
 	var tabPanel = contentEl.closest('.tab-panel-item');
 	var tabTarget = tabPanel.getAttribute('aria-labelledby');

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-tabs-release/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/ddm-templates/marketplace-tabs-release/ddm-template.ftl
@@ -4,7 +4,7 @@
 	</#if>
 </div>
 
-<script ${nonceAttribute}>
+<script>
 	var contentEl = document.querySelector('#mpRelease');
 	var tabPanel = contentEl.closest('.tab-panel-item');
 	var tabTarget = tabPanel.getAttribute('aria-labelledby');

--- a/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/ddm-templates/tip-card/ddm-template.ftl
+++ b/modules/apps/site-initializer/site-initializer-raylife-d2c/src/main/resources/site-initializer/ddm-templates/tip-card/ddm-template.ftl
@@ -90,7 +90,7 @@
 
 <#assign applicationNameSpace = randomNamespace />
 
-<script ${nonceAttribute}>
+<script>
 	function ${applicationNameSpace}backToEdit() {
 		let siteName = '';
 

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/ddm-templates/news-entries/ddm-template.ftl
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/ddm-templates/news-entries/ddm-template.ftl
@@ -80,7 +80,7 @@
 	</#if>
 </div>
 
-<script ${nonceAttribute}>
+<script>
 	function handleClick(title){
 		const text = title.nextElementSibling.innerHTML;
 

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/ddm-templates/announcements-entries/ddm-template.ftl
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/ddm-templates/announcements-entries/ddm-template.ftl
@@ -72,7 +72,7 @@
 	</#if>
 </div>
 
-<script ${nonceAttribute}>
+<script>
 	function handleClick(title){
 		const text = title.nextElementSibling.innerHTML;
 


### PR DESCRIPTION
Apparently these FTL templates are not routed through the standard template engine we use in portal (which makes sense because they are site initializers, not real content generators). Thus I'm rolling back my previous change.

Note that the content generated by these templates won't be CSP compatible when a policy based on nonces is configured, but fixing that is out of the scope of this LPS.