### PR TITLE
LPS-193516 Add handleKeyDown to navigate dropdown menu with the keyboard

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown.tsx
@@ -39,43 +39,49 @@ const LocalesDropdown = ({
 
 	const [dropdownActive, setDropdownActive] = useState(false);
 
-	const handleKeyDown = (event: React.KeyboardEvent) => {
-		if (!dropdownActive || !dropdownMenuRef.current) return;
-
-		const items = dropdownMenuRef.current.querySelectorAll('[role="menuitem"]');
-
-		if (!items || items.length === 0) return;
-
-		const activeElement = document.activeElement as Element;
-
-		const currentIndex = activeElement
-			? Array.from(items).indexOf(activeElement)
-			: -1;
-
-		if (event.key === 'ArrowDown') {
-			event.preventDefault();
-			const nextIndex = (currentIndex + 1) % items.length;
-			(items[nextIndex] as HTMLElement)?.focus();
-		} else if (event.key === 'ArrowUp') {
-			event.preventDefault();
-			const prevIndex = (currentIndex - 1 + items.length) % items.length;
-			(items[prevIndex] as HTMLElement)?.focus();
-		}
-	};
-
 	useEffect(() => {
-		const onKeyDown = (event: KeyboardEvent) => {
-			handleKeyDown(event as unknown as React.KeyboardEvent);
-		};
-	  
-		document.addEventListener('keydown', onKeyDown);
-	  
-		return () => {
-		  document.removeEventListener('keydown', onKeyDown);
-		};
-	  }, [dropdownActive]);
-	  
+		const handleKeyDown = (event: React.KeyboardEvent) => {
+			if (!dropdownActive || !dropdownMenuRef.current) {
+				return;
+			}
 
+			const items = dropdownMenuRef.current.querySelectorAll(
+				'[role="menuitem"]'
+			);
+
+			if (!items || !items.length) {
+				return;
+			}
+
+			const activeElement = document.activeElement as Element;
+
+			const currentIndex = activeElement
+				? Array.from(items).indexOf(activeElement)
+				: -1;
+
+			if (event.key === 'ArrowDown') {
+				event.preventDefault();
+				const nextIndex = (currentIndex + 1) % items.length;
+				(items[nextIndex] as HTMLElement)?.focus();
+			}
+			else if (event.key === 'ArrowUp') {
+				event.preventDefault();
+				const prevIndex =
+					(currentIndex - 1 + items.length) % items.length;
+				(items[prevIndex] as HTMLElement)?.focus();
+			}
+		};
+
+		const onKeyDown = (event: KeyboardEvent) => {
+			handleKeyDown((event as unknown) as React.KeyboardEvent);
+		};
+
+		document.addEventListener('keydown', onKeyDown);
+
+		return () => {
+			document.removeEventListener('keydown', onKeyDown);
+		};
+	}, [dropdownActive]);
 
 	return (
 		<div>
@@ -133,12 +139,12 @@ const LocalesDropdown = ({
 												if (
 													field.localizable &&
 													fieldName !==
-													field.fieldName
+														field.fieldName
 												) {
 													document
 														.getElementsByName(
 															field.fieldName +
-															localeId
+																localeId
 														)[0]
 														.click();
 												}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown.tsx
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/util/localizable/LocalesDropdown.tsx
@@ -8,7 +8,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {PagesVisitor, useFormState} from 'data-engine-js-components-web';
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import AvailableLocaleLabel from './AvailableLocaleLabel';
 
@@ -35,9 +35,47 @@ const LocalesDropdown = ({
 	const {pages} = useFormState();
 
 	const alignElementRef = useRef(null);
-	const dropdownMenuRef = useRef(null);
+	const dropdownMenuRef = useRef<HTMLDivElement | null>(null);
 
 	const [dropdownActive, setDropdownActive] = useState(false);
+
+	const handleKeyDown = (event: React.KeyboardEvent) => {
+		if (!dropdownActive || !dropdownMenuRef.current) return;
+
+		const items = dropdownMenuRef.current.querySelectorAll('[role="menuitem"]');
+
+		if (!items || items.length === 0) return;
+
+		const activeElement = document.activeElement as Element;
+
+		const currentIndex = activeElement
+			? Array.from(items).indexOf(activeElement)
+			: -1;
+
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			const nextIndex = (currentIndex + 1) % items.length;
+			(items[nextIndex] as HTMLElement)?.focus();
+		} else if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			const prevIndex = (currentIndex - 1 + items.length) % items.length;
+			(items[prevIndex] as HTMLElement)?.focus();
+		}
+	};
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			handleKeyDown(event as unknown as React.KeyboardEvent);
+		};
+	  
+		document.addEventListener('keydown', onKeyDown);
+	  
+		return () => {
+		  document.removeEventListener('keydown', onKeyDown);
+		};
+	  }, [dropdownActive]);
+	  
+
 
 	return (
 		<div>
@@ -95,12 +133,12 @@ const LocalesDropdown = ({
 												if (
 													field.localizable &&
 													fieldName !==
-														field.fieldName
+													field.fieldName
 												) {
 													document
 														.getElementsByName(
 															field.fieldName +
-																localeId
+															localeId
 														)[0]
 														.click();
 												}


### PR DESCRIPTION
Added TSX code to be able to navigate the dropdown menu with arrow keys.

### References

- [LPS-193516 Add handleKeyDown to navigate dropdown menu with the keyboard](https://issues.liferay.com/browse/LPS-193516)

### What is the goal of this PR?
Be able to navigate the dropdown menu with keyboard keys.
### What does it look like?

#### Before PR
[LPS-193516-before.webm](https://github.com/liferay-frontend/liferay-portal/assets/75842844/022cdd12-eac7-403a-ae03-4a996f42cbb5)


#### After PR

[LPS-193516-after.webm](https://github.com/liferay-frontend/liferay-portal/assets/75842844/178536b7-ff76-411c-a86b-69f8a4148694)


### Steps to reproduce
_Requirements:_

Add feature.flag.LPS-146755=true to portal.ext.properties
Add feature.flag.LPS-172017=true to portal.ext.properties

- Create an object
- Configure the Panel Link to Control Panel > Object
- Activate the Entry Translation
- Add a field with Type 'Text' 
- Activate the Enable Entry Translation
- Save and publish the object
- Go to the newly created object
- Add a new entry and save it
- Try to add a translation to this new entry using the keyboard keys (change the field default language to another one using the keyboard keys
