### PR TITLE
LPS-201409 - Consider permissionKey case

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -28,7 +28,12 @@ const formatActions = (actions, itemData) => {
 	return actions
 		? actions.reduce((actions, action) => {
 				if (action.data?.permissionKey) {
-					if (itemData.actions?.[action.data.permissionKey]) {
+					if (
+						itemData.actions &&
+						Object.keys(itemData.actions)
+							.map((itemAction) => itemAction.toLowerCase())
+							.includes(action.data.permissionKey.toLowerCase())
+					) {
 						if (action.target === 'headless') {
 							return [
 								...actions,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.js
@@ -30,9 +30,11 @@ const formatActions = (actions, itemData) => {
 				if (action.data?.permissionKey) {
 					if (
 						itemData.actions &&
-						Object.keys(itemData.actions)
-							.map((itemAction) => itemAction.toLowerCase())
-							.includes(action.data.permissionKey.toLowerCase())
+						Object.keys(itemData.actions).some(
+							(itemAction) =>
+								itemAction.toLowerCase() ===
+								action.data.permissionKey.toLowerCase()
+						)
 					) {
 						if (action.target === 'headless') {
 							return [

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterCreationActions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterCreationActions.ts
@@ -16,9 +16,14 @@ const filterCreationActions = ({
 		if (
 			!action.data?.permissionKey ||
 			(action.data?.permissionKey &&
-				Object.keys(globalCollectionActions)
-					.map((globalAction) => globalAction.toLowerCase())
-					.includes(action.data.permissionKey.toLowerCase()))
+				Object.keys(globalCollectionActions).some((globalAction) => {
+					if (action.data?.permissionKey) {
+						return (
+							globalAction.toLowerCase() ===
+							action.data.permissionKey.toLowerCase()
+						);
+					}
+				}))
 		) {
 			return action;
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterCreationActions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterCreationActions.ts
@@ -16,7 +16,9 @@ const filterCreationActions = ({
 		if (
 			!action.data?.permissionKey ||
 			(action.data?.permissionKey &&
-				globalCollectionActions[action.data.permissionKey])
+				Object.keys(globalCollectionActions)
+					.map((globalAction) => globalAction.toLowerCase())
+					.includes(action.data.permissionKey.toLowerCase()))
 		) {
 			return action;
 		}


### PR DESCRIPTION
## Related
:bug: https://liferay.atlassian.net/browse/LPS-201409

## Issue
When we define an action (item action or creation action) we could add a permissionKey value. This key should match the one that is provided by the endpoint that feeds the frontend data set, otherwise the action won't be displayed.

x.e. adding a `DELETE` permissionKey will not match with the `delete` action that comes in the api response.

## Proposed solution
Compare both permission key values using the same letter case. Usually, item actions have lowerCase keys (`delete`, `replace`, `update`) but for the global actions there are also camelCase usages (`create`, `createBatch`, `updateBatch`)