### PR TITLE
LPS-164321 - Fix Typo in aria-orientation

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PanelGroupTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PanelGroupTag.java
@@ -21,7 +21,7 @@ public class PanelGroupTag extends BaseContainerTag {
 	@Override
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
-		setDynamicAttribute(StringPool.BLANK, "aria-orentation", "vertical");
+		setDynamicAttribute(StringPool.BLANK, "aria-orientation", "vertical");
 		setDynamicAttribute(StringPool.BLANK, "role", "tablist");
 
 		return super.doStartTag();


### PR DESCRIPTION
### References

- [LPS-164321 Remote Apps Critical Accessibility Bugs](https://liferay.atlassian.net/browse/LPS-164321)

### What is the goal of this PR?

The goal of this PR is to fix the critical accessibility issues detected through AxeDev Tools when creating a Custom Element.

The first issue and the one that this PR is targeted at, is fixing the typo that triggers the "ARIA attributes must conform to valid names" error from "aria-orentation" to "aria-orientation".

The second one is related to the clay component as demonstrated by [this ticket](https://liferay.atlassian.net/browse/LPS-201300) and requires a PR of it's own.

### What does it look like?

#### Before PR
![image (50)](https://github.com/liferay-frontend/liferay-portal/assets/141816816/0bba88b1-2f39-44ca-aca3-b30813f50468)


#### After PR
![image (51)](https://github.com/liferay-frontend/liferay-portal/assets/141816816/c2c478eb-4cbc-466c-8acc-f7260f589667)

