### PR TITLE
LPS-187309 Allow admins to configure editors through client extensions

### DIFF
--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/constants/ClientExtensionEntryConstants.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/constants/ClientExtensionEntryConstants.java
@@ -12,6 +12,9 @@ public class ClientExtensionEntryConstants {
 
 	public static final String TYPE_CUSTOM_ELEMENT = "customElement";
 
+	public static final String TYPE_EDITOR_CONFIGURATION =
+		"editorConfiguration";
+
 	public static final String TYPE_FDS_CELL_RENDERER = "fdsCellRenderer";
 
 	public static final String TYPE_FDS_FILTER = "fdsFilter";

--- a/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/EditorConfigurationCET.java
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/java/com/liferay/client/extension/type/EditorConfigurationCET.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.type;
+
+import com.liferay.client.extension.type.annotation.CETProperty;
+import com.liferay.client.extension.type.annotation.CETType;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Daniel Sanz
+ */
+@CETType(description = "This is a description.", name = "customElement")
+@ProviderType
+public interface EditorConfigurationCET extends CET {
+
+	@CETProperty(
+		defaultValue = "", label = "editor-config-keys",
+		name = "editorConfigKeys", type = CETProperty.Type.StringList
+	)
+	public String getEditorConfigKeys();
+
+	@CETProperty(
+		defaultValue = "", label = "editor-names", name = "editorNames",
+		type = CETProperty.Type.StringList
+	)
+	public String getEditorNames();
+
+	@CETProperty(
+		defaultValue = "", label = "portlet-names", name = "portletNames",
+		type = CETProperty.Type.StringList
+	)
+	public String getPortletNames();
+
+	@CETProperty(
+		defaultValue = "", label = "url", name = "url",
+		type = CETProperty.Type.URL
+	)
+	public String getURL();
+
+}

--- a/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/dependencies/client-extension-types.json
+++ b/modules/apps/client-extension/client-extension-type-api/src/main/resources/com/liferay/client/extension/type/dependencies/client-extension-types.json
@@ -59,6 +59,49 @@
 	},
 	{
 		"description": "This is a description.",
+		"name": "customElement",
+		"properties": [
+			{
+				"name": "description",
+				"type": "CETProperty.Type.String"
+			},
+			{
+				"name": "name",
+				"type": "CETProperty.Type.String"
+			},
+			{
+				"default": "https://www.liferay.com",
+				"name": "sourceCodeURL",
+				"type": "CETProperty.Type.String"
+			},
+			{
+				"name": "type",
+				"type": "CETProperty.Type.String"
+			},
+			{
+				"default": "",
+				"name": "editorNames",
+				"type": "CETProperty.Type.StringList"
+			},
+			{
+				"default": "",
+				"name": "portletNames",
+				"type": "CETProperty.Type.StringList"
+			},
+			{
+				"default": "",
+				"name": "editorConfigKeys",
+				"type": "CETProperty.Type.StringList"
+			},
+			{
+				"default": "",
+				"name": "url",
+				"type": "CETProperty.Type.URL"
+			}
+		]
+	},
+	{
+		"description": "This is a description.",
 		"name": "fdsCellRenderer",
 		"properties": [
 			{

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/EditorConfigurationCETImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/EditorConfigurationCETImpl.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.type.internal;
+
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntry;
+import com.liferay.client.extension.type.EditorConfigurationCET;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+
+import java.util.Properties;
+import java.util.Set;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Daniel Sanz
+ */
+public class EditorConfigurationCETImpl
+	extends BaseCETImpl implements EditorConfigurationCET {
+
+	public EditorConfigurationCETImpl(
+		ClientExtensionEntry clientExtensionEntry) {
+
+		super(clientExtensionEntry);
+	}
+
+	public EditorConfigurationCETImpl(PortletRequest portletRequest) {
+		this(
+			StringPool.BLANK,
+			UnicodePropertiesBuilder.create(
+				true
+			).put(
+				"editorConfigKeys",
+				StringUtil.merge(
+					ParamUtil.getStringValues(
+						portletRequest, "editorConfigKeys"),
+					StringPool.NEW_LINE)
+			).put(
+				"editorNames",
+				StringUtil.merge(
+					ParamUtil.getStringValues(portletRequest, "editorNames"),
+					StringPool.NEW_LINE)
+			).put(
+				"portletNames",
+				StringUtil.merge(
+					ParamUtil.getStringValues(portletRequest, "portletNames"),
+					StringPool.NEW_LINE)
+			).put(
+				"url", ParamUtil.getString(portletRequest, "url")
+			).build());
+	}
+
+	public EditorConfigurationCETImpl(
+		String baseURL, long companyId, String description,
+		String externalReferenceCode, String name, Properties properties,
+		String sourceCodeURL, UnicodeProperties typeSettingsUnicodeProperties) {
+
+		super(
+			baseURL, companyId, description, externalReferenceCode, name,
+			properties, sourceCodeURL, typeSettingsUnicodeProperties);
+	}
+
+	public EditorConfigurationCETImpl(
+		String baseURL, UnicodeProperties typeSettingsUnicodeProperties) {
+
+		super(baseURL, typeSettingsUnicodeProperties);
+	}
+
+	@Override
+	public String getEditJSP() {
+		return "/admin/edit_editor_configuration.jsp";
+	}
+
+	@Override
+	public String getEditorConfigKeys() {
+		return getString("editorConfigKeys");
+	}
+
+	@Override
+	public String getEditorNames() {
+		return getString("editorNames");
+	}
+
+	@Override
+	public String getPortletNames() {
+		return getString("portletNames");
+	}
+
+	@Override
+	public String getType() {
+		return ClientExtensionEntryConstants.TYPE_EDITOR_CONFIGURATION;
+	}
+
+	@Override
+	public String getURL() {
+		return getString("url");
+	}
+
+	@Override
+	public boolean hasProperties() {
+		return true;
+	}
+
+	@Override
+	protected boolean isURLCETPropertyName(String name) {
+		return _urlCETPropertyNames.contains(name);
+	}
+
+	private static final Set<String> _urlCETPropertyNames =
+		getURLCETPropertyNames(EditorConfigurationCET.class);
+
+}

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/CETFactoryImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/CETFactoryImpl.java
@@ -48,6 +48,9 @@ public class CETFactoryImpl implements CETFactory {
 			ClientExtensionEntryConstants.TYPE_CUSTOM_ELEMENT,
 			new CustomElementCETImplFactoryImpl()
 		).put(
+			ClientExtensionEntryConstants.TYPE_EDITOR_CONFIGURATION,
+			new EditorConfigurationCETImplFactoryImpl()
+		).put(
 			ClientExtensionEntryConstants.TYPE_FDS_CELL_RENDERER,
 			new FDSCellRendererCETImplFactoryImpl()
 		).put(

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/EditorConfigurationCETImplFactoryImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/EditorConfigurationCETImplFactoryImpl.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.type.internal.factory;
+
+import com.liferay.client.extension.exception.ClientExtensionEntryTypeSettingsException;
+import com.liferay.client.extension.model.ClientExtensionEntry;
+import com.liferay.client.extension.type.EditorConfigurationCET;
+import com.liferay.client.extension.type.factory.CETImplFactory;
+import com.liferay.client.extension.type.internal.EditorConfigurationCETImpl;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Properties;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Daniel Sanz
+ */
+public class EditorConfigurationCETImplFactoryImpl
+	implements CETImplFactory<EditorConfigurationCET> {
+
+	@Override
+	public EditorConfigurationCET create(
+			ClientExtensionEntry clientExtensionEntry)
+		throws PortalException {
+
+		return new EditorConfigurationCETImpl(clientExtensionEntry);
+	}
+
+	@Override
+	public EditorConfigurationCET create(PortletRequest portletRequest)
+		throws PortalException {
+
+		return new EditorConfigurationCETImpl(portletRequest);
+	}
+
+	@Override
+	public EditorConfigurationCET create(
+			String baseURL, long companyId, String description,
+			String externalReferenceCode, String name, Properties properties,
+			String sourceCodeURL, UnicodeProperties unicodeProperties)
+		throws PortalException {
+
+		return new EditorConfigurationCETImpl(
+			baseURL, companyId, description, externalReferenceCode, name,
+			properties, sourceCodeURL, unicodeProperties);
+	}
+
+	@Override
+	public void validate(
+			UnicodeProperties newTypeSettingsUnicodeProperties,
+			UnicodeProperties oldTypeSettingsUnicodeProperties)
+		throws PortalException {
+
+		EditorConfigurationCET editorConfigurationCET =
+			new EditorConfigurationCETImpl(
+				StringPool.BLANK, newTypeSettingsUnicodeProperties);
+
+		if (Validator.isNull(editorConfigurationCET.getURL())) {
+			throw new ClientExtensionEntryTypeSettingsException(
+				"At least one JavaScript URL is required",
+				"please-enter-at-least-one-javascript-url");
+		}
+	}
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.web.internal.portlet.editor.config.contributor;
+
+import com.liferay.client.extension.web.internal.type.deployer.Registrable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Dictionary;
+import java.util.Map;
+
+/**
+ * @author Daniel Sanz
+ */
+public class CETEditorConfigContributor
+	implements EditorConfigContributor, Registrable {
+
+	public CETEditorConfigContributor(
+		String editorConfigKeys, String editorNames, String portletNames,
+		String url) {
+
+		_editorConfigKeys = editorConfigKeys;
+		_editorNames = editorNames;
+		_portletNames = portletNames;
+		_url = url;
+	}
+
+	@Override
+	public Dictionary<String, Object> getDictionary() {
+		return HashMapDictionaryBuilder.<String, Object>put(
+			"editor.config.key",
+			() -> {
+				if (Validator.isNotNull(_editorConfigKeys)) {
+					return _editorConfigKeys.split(StringPool.NEW_LINE);
+				}
+
+				return null;
+			}
+		).put(
+			"editor.name",
+			() -> {
+				if (Validator.isNotNull(_editorNames)) {
+					return _editorNames.split(StringPool.NEW_LINE);
+				}
+
+				return null;
+			}
+		).put(
+			"javax.portlet.name",
+			() -> {
+				if (Validator.isNotNull(_portletNames)) {
+					return _portletNames.split(StringPool.NEW_LINE);
+				}
+
+				return null;
+			}
+		).build();
+	}
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		JSONArray urlsJSONArray = jsonObject.getJSONArray(
+			"CETConfigurationURLs");
+
+		if (urlsJSONArray == null) {
+			urlsJSONArray = JSONFactoryUtil.createJSONArray();
+			jsonObject.put("CETConfigurationURLs", urlsJSONArray);
+		}
+
+		urlsJSONArray.put("default from " + _url);
+	}
+
+	private final String _editorConfigKeys;
+	private final String _editorNames;
+	private final String _portletNames;
+	private final String _url;
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -8,6 +8,7 @@ package com.liferay.client.extension.web.internal.type.deployer;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.CustomElementCET;
+import com.liferay.client.extension.type.EditorConfigurationCET;
 import com.liferay.client.extension.type.IFrameCET;
 import com.liferay.client.extension.type.JSImportMapsEntryCET;
 import com.liferay.client.extension.type.deployer.CETDeployer;
@@ -16,11 +17,13 @@ import com.liferay.client.extension.web.internal.portlet.CETPortletFriendlyURLMa
 import com.liferay.client.extension.web.internal.portlet.CustomElementCETPortlet;
 import com.liferay.client.extension.web.internal.portlet.IFrameCETPortlet;
 import com.liferay.client.extension.web.internal.portlet.action.CETPortletConfigurationAction;
+import com.liferay.client.extension.web.internal.portlet.editor.config.contributor.CETEditorConfigContributor;
 import com.liferay.client.extension.web.internal.util.CETUtil;
 import com.liferay.frontend.js.importmaps.extender.JSImportMapsContributor;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
@@ -54,6 +57,12 @@ public class CETDeployerImpl implements CETDeployer {
 				ClientExtensionEntryConstants.TYPE_CUSTOM_ELEMENT)) {
 
 			return _deploy((CustomElementCET)cet);
+		}
+		else if (Objects.equals(
+					cet.getType(),
+					ClientExtensionEntryConstants.TYPE_EDITOR_CONFIGURATION)) {
+
+			return _deploy((EditorConfigurationCET)cet);
 		}
 		else if (Objects.equals(
 					cet.getType(), ClientExtensionEntryConstants.TYPE_IFRAME)) {
@@ -107,6 +116,19 @@ public class CETDeployerImpl implements CETDeployer {
 					customElementCET, _npmResolver, portletId)));
 
 		return serviceRegistrations;
+	}
+
+	private List<ServiceRegistration<?>> _deploy(
+		EditorConfigurationCET editorConfigurationCET) {
+
+		return Arrays.asList(
+			_register(
+				EditorConfigContributor.class,
+				new CETEditorConfigContributor(
+					editorConfigurationCET.getEditorConfigKeys(),
+					editorConfigurationCET.getEditorNames(),
+					editorConfigurationCET.getPortletNames(),
+					editorConfigurationCET.getURL())));
 	}
 
 	private List<ServiceRegistration<?>> _deploy(IFrameCET iFrameCET) {

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_editor_configuration.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/edit_editor_configuration.jsp
@@ -1,0 +1,108 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/admin/init.jsp" %>
+
+<%
+EditClientExtensionEntryDisplayContext<EditorConfigurationCET> editClientExtensionEntryDisplayContext = (EditClientExtensionEntryDisplayContext)renderRequest.getAttribute(ClientExtensionAdminWebKeys.EDIT_CLIENT_EXTENSION_ENTRY_DISPLAY_CONTEXT);
+
+EditorConfigurationCET editorConfigurationCET = editClientExtensionEntryDisplayContext.getCET();
+%>
+
+<aui:field-wrapper cssClass="form-group">
+	<aui:input label="js-url" name="url" required="<%= true %>" type="text" value="<%= editorConfigurationCET.getURL() %>" />
+
+	<div class="form-text">
+		<liferay-ui:message key="enter-the-url-of-the-javascript-file-to-provide-editor-configuration-json" />
+	</div>
+</aui:field-wrapper>
+
+<div class="lfr-form-rows" id="<portlet:namespace />_portletNames_field">
+
+	<%
+	for (String _portletName : editClientExtensionEntryDisplayContext.getStrings(editorConfigurationCET.getPortletNames())) {
+	%>
+
+		<div class="lfr-form-row">
+			<aui:field-wrapper cssClass="form-group">
+				<aui:input ignoreRequestValue="<%= true %>" label="portlet-names" name="portletNames" type="text" value="<%= _portletName %>" />
+
+				<div class="form-text form-text-repeat">
+					<liferay-ui:message key="enter-portlet-name-to-apply-this-editor-configuration" />
+				</div>
+			</aui:field-wrapper>
+		</div>
+
+	<%
+	}
+	%>
+
+</div>
+
+<div class="lfr-form-rows" id="<portlet:namespace />_editorNames_field">
+
+	<%
+	for (String editorName : editClientExtensionEntryDisplayContext.getStrings(editorConfigurationCET.getEditorNames())) {
+	%>
+
+		<div class="lfr-form-row">
+			<aui:field-wrapper cssClass="form-group">
+				<aui:input ignoreRequestValue="<%= true %>" label="editor-name" name="editorNames" type="text" value="<%= editorName %>" />
+
+				<div class="form-text form-text-repeat">
+					<liferay-ui:message key="enter-editor-name-to-apply-this-editor-configuration" />
+				</div>
+			</aui:field-wrapper>
+		</div>
+
+	<%
+	}
+	%>
+
+</div>
+
+<div class="lfr-form-rows" id="<portlet:namespace />_editorConfigKeys_field">
+
+	<%
+	for (String editorConfigKey : editClientExtensionEntryDisplayContext.getStrings(editorConfigurationCET.getEditorConfigKeys())) {
+	%>
+
+		<div class="lfr-form-row">
+			<aui:field-wrapper cssClass="form-group">
+				<aui:input ignoreRequestValue="<%= true %>" label="editor-config-key" name="editorConfigKeys" type="text" value="<%= editorConfigKey %>" />
+
+				<div class="form-text form-text-repeat">
+					<liferay-ui:message key="enter-editor-config-key-to-apply-this-editor-configuration" />
+				</div>
+			</aui:field-wrapper>
+		</div>
+
+	<%
+	}
+	%>
+
+</div>
+
+<aui:script use="liferay-auto-fields">
+	new Liferay.AutoFields({
+		contentBox: '#<portlet:namespace />_portletNames_field',
+		minimumRows: 1,
+		namespace: '<portlet:namespace />',
+	}).render();
+
+	new Liferay.AutoFields({
+		contentBox: '#<portlet:namespace />_editorNames_field',
+		minimumRows: 1,
+		namespace: '<portlet:namespace />',
+	}).render();
+
+	new Liferay.AutoFields({
+		contentBox: '#<portlet:namespace />_editorConfigKeys_field',
+		minimumRows: 1,
+		namespace: '<portlet:namespace />',
+	}).render();
+</aui:script>

--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -13,6 +13,7 @@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
 <%@ page import="com.liferay.client.extension.exception.ClientExtensionEntryNameException" %><%@
 page import="com.liferay.client.extension.exception.ClientExtensionEntryTypeSettingsException" %><%@
 page import="com.liferay.client.extension.type.CustomElementCET" %><%@
+page import="com.liferay.client.extension.type.EditorConfigurationCET" %><%@
 page import="com.liferay.client.extension.type.FDSCellRendererCET" %><%@
 page import="com.liferay.client.extension.type.FDSFilterCET" %><%@
 page import="com.liferay.client.extension.type.GlobalCSSCET" %><%@

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -140,6 +140,14 @@ if (showSource) {
 name = HtmlUtil.escapeJS(name);
 %>
 
+<aui:script require="frontend-js-web/index as frontendJsWeb">
+	var {getEditorConfigurationCX} = frontendJsWeb;
+
+	if (!Liferay.Util.getEditorConfigurationCX) {
+		Liferay.Util.getEditorConfigurationCX = getEditorConfigurationCX;
+	}
+</aui:script>
+
 <aui:script use="<%= modules %>">
 	var windowNode = A.getWin();
 
@@ -234,52 +242,56 @@ name = HtmlUtil.escapeJS(name);
 			plugins.push(A.Plugin.LiferayAlloyEditorSource);
 		</c:if>
 
-		alloyEditor = new A.LiferayAlloyEditor({
-			contents: '<%= HtmlUtil.escapeJS(contents) %>',
-			editorConfig: editorConfig,
-			editorPaths: [
-				'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_ALLOYEDITOR) %>',
-				'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR) %>',
-			],
-			namespace: '<%= name %>',
+		Liferay.Util.getEditorConfigurationCX(editorConfig).then((editorConfig) => {
+			alloyEditor = new A.LiferayAlloyEditor({
+				contents: '<%= HtmlUtil.escapeJS(contents) %>',
+				editorConfig: editorConfig,
+				editorPaths: [
+					'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_ALLOYEDITOR) %>',
+					'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR) %>',
+				],
+				namespace: '<%= name %>',
 
-			<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
-				onBlurMethod: '<%= HtmlUtil.escapeJS(namespace + onBlurMethod) %>',
-			</c:if>
+				<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
+					onBlurMethod: '<%= HtmlUtil.escapeJS(namespace + onBlurMethod) %>',
+				</c:if>
 
-			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-				onChangeMethod: '<%= HtmlUtil.escapeJS(namespace + onChangeMethod) %>',
-			</c:if>
+				<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+					onChangeMethod:
+						'<%= HtmlUtil.escapeJS(namespace + onChangeMethod) %>',
+				</c:if>
 
-			<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
-				onFocusMethod: '<%= HtmlUtil.escapeJS(namespace + onFocusMethod) %>',
-			</c:if>
+				<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
+					onFocusMethod:
+						'<%= HtmlUtil.escapeJS(namespace + onFocusMethod) %>',
+				</c:if>
 
-			<c:if test="<%= Validator.isNotNull(onInitMethod) %>">
-				onInitMethod: '<%= HtmlUtil.escapeJS(namespace + onInitMethod) %>',
-			</c:if>
+				<c:if test="<%= Validator.isNotNull(onInitMethod) %>">
+					onInitMethod: '<%= HtmlUtil.escapeJS(namespace + onInitMethod) %>',
+				</c:if>
 
-			plugins: plugins,
-			portletId: '<%= portletId %>',
-			textMode: <%= (editorOptions != null) ? editorOptions.isTextMode() : Boolean.FALSE.toString() %>,
+				plugins: plugins,
+				portletId: '<%= portletId %>',
+				textMode: <%= (editorOptions != null) ? editorOptions.isTextMode() : Boolean.FALSE.toString() %>,
 
-			useCustomDataProcessor: <%= (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor")) %>,
-		}).render();
+				useCustomDataProcessor: <%= (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor")) %>,
+			}).render();
 
-		CKEDITOR.dom.selection.prototype.selectElement = function (element) {
-			this.isLocked = 0;
+			CKEDITOR.dom.selection.prototype.selectElement = function (element) {
+				this.isLocked = 0;
 
-			var range = new CKEDITOR.dom.range(this.root);
+				var range = new CKEDITOR.dom.range(this.root);
 
-			range.setEndAfter(element);
-			range.setStartBefore(element);
+				range.setEndAfter(element);
+				range.setStartBefore(element);
 
-			this.selectRanges([range]);
-		};
+				this.selectRanges([range]);
+			};
 
-		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.alloyeditor.web#" + editorName + "#onEditorCreate" %>' />
+			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.alloyeditor.web#" + editorName + "#onEditorCreate" %>' />
 
-		Liferay.namespace('EDITORS').alloyEditor.addInstance();
+			Liferay.namespace('EDITORS').alloyEditor.addInstance();
+		});
 	};
 
 	var ignoreClass = ['ddm-options-target'];

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -129,6 +129,14 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 name = HtmlUtil.escapeJS(name);
 %>
 
+<aui:script require="frontend-js-web/index as frontendJsWeb">
+	var {getEditorConfigurationCX} = frontendJsWeb;
+
+	if (!Liferay.Util.getEditorConfigurationCX) {
+		Liferay.Util.getEditorConfigurationCX = getEditorConfigurationCX;
+	}
+</aui:script>
+
 <aui:script use="<%= modules %>">
 	var UA = A.UA;
 
@@ -486,238 +494,246 @@ name = HtmlUtil.escapeJS(name);
 
 		var config = A.merge(defaultConfig, editorConfig);
 
-		CKEDITOR.<%= inlineEdit ? "inline" : "replace" %>('<%= name %>', config);
+		Liferay.Util.getEditorConfigurationCX(config).then((config) => {
+			CKEDITOR.<%= inlineEdit ? "inline" : "replace" %>(
+				'<%= name %>',
+				config
+			);
 
-		Liferay.on('<%= name %>selectItem', (event) => {
-			CKEDITOR.tools.callFunction(event.ckeditorfuncnum, event.value);
-		});
-
-		var ckEditor = CKEDITOR.instances['<%= name %>'];
-
-		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.ckeditor.web#" + editorName + "#onEditorCreate" %>' />
-
-		Liferay.namespace('EDITORS').ckeditor.addInstance();
-
-		<c:if test="<%= inlineEdit && Validator.isNotNull(inlineEditSaveURL) %>">
-			inlineEditor = new Liferay.CKEditorInline({
-				editor: ckEditor,
-				editorName: '<%= name %>',
-				namespace: '<portlet:namespace />',
-				saveURL: '<%= inlineEditSaveURL %>',
+			Liferay.on('<%= name %>selectItem', (event) => {
+				CKEDITOR.tools.callFunction(event.ckeditorfuncnum, event.value);
 			});
-		</c:if>
 
-		var customDataProcessorLoaded = false;
+			var ckEditor = CKEDITOR.instances['<%= name %>'];
 
-		<%
-		boolean useCustomDataProcessor = (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor"));
-		%>
+			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.ckeditor.web#" + editorName + "#onEditorCreate" %>' />
 
-		<c:if test="<%= useCustomDataProcessor %>">
-			ckEditor.on('customDataProcessorLoaded', () => {
-				customDataProcessorLoaded = true;
+			Liferay.namespace('EDITORS').ckeditor.addInstance();
 
-				if (instanceReady) {
-					initData();
-				}
-
-				// LPS-118801
-
-				var editorPath =
-					'<%= HtmlUtil.escapeJS(PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR)) %>';
-
-				document
-					.querySelectorAll(
-						'link[href*="' +
-							editorPath +
-							'"],script[src*="' +
-							editorPath +
-							'"]'
-					)
-					.forEach((tag) => {
-						tag.setAttribute('data-senna-track', 'temporary');
-					});
-			});
-		</c:if>
-
-		var instanceReady = false;
-
-		ckEditor.on('instanceReady', () => {
-			<c:choose>
-				<c:when test="<%= useCustomDataProcessor %>">
-					instanceReady = true;
-
-					if (customDataProcessorLoaded) {
-						initData();
-					}
-				</c:when>
-				<c:otherwise>
-					initData();
-				</c:otherwise>
-			</c:choose>
-
-			window['<%= name %>'].instanceReady = true;
-
-			<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
-				CKEDITOR.instances['<%= name %>'].on(
-					'blur',
-					window['<%= name %>'].onBlurCallback
-				);
+			<c:if test="<%= inlineEdit && Validator.isNotNull(inlineEditSaveURL) %>">
+				inlineEditor = new Liferay.CKEditorInline({
+					editor: ckEditor,
+					editorName: '<%= name %>',
+					namespace: '<portlet:namespace />',
+					saveURL: '<%= inlineEditSaveURL %>',
+				});
 			</c:if>
 
-			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-				var contentChangeHandle = setInterval(() => {
-					try {
-						window['<%= name %>'].onChangeCallback();
+			var customDataProcessorLoaded = false;
+
+			<%
+			boolean useCustomDataProcessor = (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor"));
+			%>
+
+			<c:if test="<%= useCustomDataProcessor %>">
+				ckEditor.on('customDataProcessorLoaded', () => {
+					customDataProcessorLoaded = true;
+
+					if (instanceReady) {
+						initData();
 					}
-					catch (e) {}
-				}, 300);
 
-				var clearContentChangeHandle = function (event) {
-					if (event.portletId === '<%= portletId %>') {
-						clearInterval(contentChangeHandle);
+					// LPS-118801
 
-						Liferay.detach('destroyPortlet', clearContentChangeHandle);
+					var editorPath =
+						'<%= HtmlUtil.escapeJS(PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR)) %>';
+
+					document
+						.querySelectorAll(
+							'link[href*="' +
+								editorPath +
+								'"],script[src*="' +
+								editorPath +
+								'"]'
+						)
+						.forEach((tag) => {
+							tag.setAttribute('data-senna-track', 'temporary');
+						});
+				});
+			</c:if>
+
+			var instanceReady = false;
+
+			ckEditor.on('instanceReady', () => {
+				<c:choose>
+					<c:when test="<%= useCustomDataProcessor %>">
+						instanceReady = true;
+
+						if (customDataProcessorLoaded) {
+							initData();
+						}
+					</c:when>
+					<c:otherwise>
+						initData();
+					</c:otherwise>
+				</c:choose>
+
+				window['<%= name %>'].instanceReady = true;
+
+				<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
+					CKEDITOR.instances['<%= name %>'].on(
+						'blur',
+						window['<%= name %>'].onBlurCallback
+					);
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+					var contentChangeHandle = setInterval(() => {
+						try {
+							window['<%= name %>'].onChangeCallback();
+						}
+						catch (e) {}
+					}, 300);
+
+					var clearContentChangeHandle = function (event) {
+						if (event.portletId === '<%= portletId %>') {
+							clearInterval(contentChangeHandle);
+
+							Liferay.detach('destroyPortlet', clearContentChangeHandle);
+						}
+					};
+
+					Liferay.on('destroyPortlet', clearContentChangeHandle);
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
+					CKEDITOR.instances['<%= name %>'].on(
+						'focus',
+						window['<%= name %>'].onFocusCallback
+					);
+				</c:if>
+
+				<c:if test="<%= !(inlineEdit && Validator.isNotNull(inlineEditSaveURL)) %>">
+					var initialEditor = CKEDITOR.instances['<%= name %>'].id;
+
+					eventHandles.push(
+						A.getWin().on(
+							'resize',
+							A.debounce(() => {
+								if (
+									currentToolbarSet !=
+									getToolbarSet(initialToolbarSet)
+								) {
+									var ckeditorInstance =
+										CKEDITOR.instances['<%= name %>'];
+
+									if (ckeditorInstance) {
+										var currentEditor = ckeditorInstance.id;
+
+										if (currentEditor === initialEditor) {
+											var currentDialog = CKEDITOR.dialog.getCurrent();
+
+											if (currentDialog) {
+												currentDialog.hide();
+											}
+
+											ckEditorContent = ckeditorInstance.getData();
+
+											window['<%= name %>'].dispose();
+
+											window['<%= name %>'].create();
+
+											CKEDITOR.instances['<%= name %>'].setData(
+												ckEditorContent
+											);
+
+											initialEditor =
+												CKEDITOR.instances['<%= name %>'].id;
+										}
+									}
+								}
+							}, 250)
+						)
+					);
+				</c:if>
+			});
+
+			ckEditor.on('dataReady', (event) => {
+				if (instancePendingData !== null) {
+					var pendingData = instancePendingData;
+
+					instancePendingData = null;
+
+					ckEditor.setData(pendingData);
+				}
+				else {
+					instanceDataReady = true;
+				}
+
+				window['<%= name %>']._setStyles();
+			});
+
+			ckEditor.on('drop', function (event) {
+				var data = event.data.dataTransfer.getData('text/html');
+
+				if (data) {
+					var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
+
+					var element = fragment.children[0];
+
+					if (element.hasClass('cke_widget_image')) {
+						element = element.children[0];
+					}
+
+					if (this.pasteFilter && element.name) {
+						return this.pasteFilter.check(element.name);
+					}
+				}
+			});
+
+			ckEditor.on('setData', (event) => {
+				instanceDataReady = false;
+			});
+
+			if (UA.edge && parseInt(UA.edge, 10) >= 14) {
+				var resetActiveElementValidation = function (activeElement) {
+					activeElement = A.one(activeElement);
+
+					var activeElementAncestor = activeElement.ancestor();
+
+					if (
+						activeElementAncestor.hasClass('has-error') ||
+						activeElementAncestor.hasClass('has-success')
+					) {
+						activeElementAncestor.removeClass('has-error');
+						activeElementAncestor.removeClass('has-success');
+
+						var formValidatorStack = activeElementAncestor.one(
+							'.form-validator-stack'
+						);
+
+						if (formValidatorStack) {
+							formValidatorStack.remove();
+						}
 					}
 				};
 
-				Liferay.on('destroyPortlet', clearContentChangeHandle);
-			</c:if>
+				var onBlur = function (activeElement) {
+					resetActiveElementValidation(activeElement);
 
-			<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
-				CKEDITOR.instances['<%= name %>'].on(
-					'focus',
-					window['<%= name %>'].onFocusCallback
-				);
-			</c:if>
+					setTimeout(() => {
+						if (activeElement) {
+							ckEditor.focusManager.blur(true);
+							activeElement.focus();
+						}
+					}, 0);
+				};
 
-			<c:if test="<%= !(inlineEdit && Validator.isNotNull(inlineEditSaveURL)) %>">
-				var initialEditor = CKEDITOR.instances['<%= name %>'].id;
+				ckEditor.on('instanceReady', () => {
+					var editorWrapper = A.one('#cke_<%= name %>');
 
-				eventHandles.push(
-					A.getWin().on(
-						'resize',
-						A.debounce(() => {
-							if (currentToolbarSet != getToolbarSet(initialToolbarSet)) {
-								var ckeditorInstance =
-									CKEDITOR.instances['<%= name %>'];
-
-								if (ckeditorInstance) {
-									var currentEditor = ckeditorInstance.id;
-
-									if (currentEditor === initialEditor) {
-										var currentDialog = CKEDITOR.dialog.getCurrent();
-
-										if (currentDialog) {
-											currentDialog.hide();
-										}
-
-										ckEditorContent = ckeditorInstance.getData();
-
-										window['<%= name %>'].dispose();
-
-										window['<%= name %>'].create();
-
-										CKEDITOR.instances['<%= name %>'].setData(
-											ckEditorContent
-										);
-
-										initialEditor =
-											CKEDITOR.instances['<%= name %>'].id;
-									}
-								}
-							}
-						}, 250)
-					)
-				);
-			</c:if>
-		});
-
-		ckEditor.on('dataReady', (event) => {
-			if (instancePendingData !== null) {
-				var pendingData = instancePendingData;
-
-				instancePendingData = null;
-
-				ckEditor.setData(pendingData);
-			}
-			else {
-				instanceDataReady = true;
-			}
-
-			window['<%= name %>']._setStyles();
-		});
-
-		ckEditor.on('drop', function (event) {
-			var data = event.data.dataTransfer.getData('text/html');
-
-			if (data) {
-				var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
-
-				var element = fragment.children[0];
-
-				if (element.hasClass('cke_widget_image')) {
-					element = element.children[0];
-				}
-
-				if (this.pasteFilter && element.name) {
-					return this.pasteFilter.check(element.name);
-				}
-			}
-		});
-
-		ckEditor.on('setData', (event) => {
-			instanceDataReady = false;
-		});
-
-		if (UA.edge && parseInt(UA.edge, 10) >= 14) {
-			var resetActiveElementValidation = function (activeElement) {
-				activeElement = A.one(activeElement);
-
-				var activeElementAncestor = activeElement.ancestor();
-
-				if (
-					activeElementAncestor.hasClass('has-error') ||
-					activeElementAncestor.hasClass('has-success')
-				) {
-					activeElementAncestor.removeClass('has-error');
-					activeElementAncestor.removeClass('has-success');
-
-					var formValidatorStack = activeElementAncestor.one(
-						'.form-validator-stack'
-					);
-
-					if (formValidatorStack) {
-						formValidatorStack.remove();
+					if (editorWrapper) {
+						editorWrapper.once('mouseenter', function (event) {
+							ckEditor.once(
+								'focus',
+								onBlur.bind(this, document.activeElement)
+							);
+							ckEditor.focus();
+						});
 					}
-				}
-			};
-
-			var onBlur = function (activeElement) {
-				resetActiveElementValidation(activeElement);
-
-				setTimeout(() => {
-					if (activeElement) {
-						ckEditor.focusManager.blur(true);
-						activeElement.focus();
-					}
-				}, 0);
-			};
-
-			ckEditor.on('instanceReady', () => {
-				var editorWrapper = A.one('#cke_<%= name %>');
-
-				if (editorWrapper) {
-					editorWrapper.once('mouseenter', function (event) {
-						ckEditor.once(
-							'focus',
-							onBlur.bind(this, document.activeElement)
-						);
-						ckEditor.focus();
-					});
-				}
-			});
-		}
+				});
+			}
+		});
 	};
 
 	<%

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -5,8 +5,15 @@
 
 import {flipThirdPartyCookiesOff} from '@liferay/cookies-banner-web';
 import CKEditor from 'ckeditor4-react';
+import {getEditorConfigurationCX} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
+import React, {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
 
 import '../css/main.scss';
 
@@ -26,7 +33,10 @@ function createElementFromHTML(htmlString) {
  * DXP implementations of CKEditor. Please don't import it directly.
  */
 const BaseEditor = forwardRef(
-	({contents, name, onChange, onChangeMethodName, ...props}, ref) => {
+	({config, contents, name, onChange, onChangeMethodName, ...props}, ref) => {
+		const [editorConfiguration, setEditorConfiguration] = useState(config);
+		const [cxLoaded, setCXLoaded] = useState(false);
+
 		const editorRef = useRef();
 
 		useEffect(() => {
@@ -93,13 +103,26 @@ const BaseEditor = forwardRef(
 			};
 		}, [contents, getHTML, name]);
 
-		return (
+		useEffect(() => {
+			getEditorConfigurationCX(config).then((config) => {
+				setEditorConfiguration(config);
+				setCXLoaded(true);
+			});
+		}, [config]);
+
+		return cxLoaded ? (
 			<CKEditor
+				config={editorConfiguration}
 				name={name}
 				onChange={onChangeCallback}
 				onChangeMethodName={onChangeMethodName}
 				ref={editorRefsCallback}
 				{...props}
+			/>
+		) : (
+			<span
+				aria-hidden="true"
+				className="loading-animation loading-animation-sm"
 			/>
 		);
 	}
@@ -111,6 +134,7 @@ window.CKEDITOR_BASEPATH = CURRENT_PATH;
 BaseEditor.displayName = 'BaseEditor';
 
 BaseEditor.propTypes = {
+	config: PropTypes.object,
 	contents: PropTypes.string,
 	name: PropTypes.string.isRequired,
 	onChange: PropTypes.func,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -85,6 +85,7 @@ export {default as createResourceURL} from './liferay/util/portlet_url/create_re
 // Renderer API
 
 export {default as getRenderer} from './renderer/getRenderer';
+export {default as getEditorConfigurationCX} from './renderer/getEditorConfigurationCX';
 
 // Session API
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/getEditorConfigurationCX.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/renderer/getEditorConfigurationCX.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getRenderer from './getRenderer';
+import {IInternalRenderer, TRenderer} from './types';
+
+const getEditorConfigurationCX = async (config: Object) => {
+	const urls: string[] = (config as any)?.CETConfigurationURLs;
+
+	delete (config as any)?.CETConfigurationURLs;
+
+	if (!urls || !urls.length) {
+		return config;
+	}
+
+	return Promise.allSettled(
+		urls.map((url) => getRenderer({type: 'internal', url}))
+	)
+		.then((results: PromiseSettledResult<TRenderer>[]) => {
+			return results.reduce((cfg, result) => {
+				if (result.status === 'fulfilled') {
+
+					// @ts-ignore
+
+					return (result.value as IInternalRenderer).component(cfg);
+				}
+				else {
+					console.error(
+						`Unable to load editor configuration client extension: `,
+						result.reason
+					);
+
+					return cfg;
+				}
+			}, config);
+		})
+		.catch((error: string) => {
+			console.error(
+				`Unable to load editor configuration client extensions: `,
+				error
+			);
+
+			return config;
+		});
+};
+
+export default getEditorConfigurationCX;

--- a/modules/apps/frontend-js/frontend-js-web/tsconfig.json
+++ b/modules/apps/frontend-js/frontend-js-web/tsconfig.json
@@ -1,6 +1,12 @@
 {
-	"@generated": "e1cfacada806e3a4ae578071d90ce85a568d5ad2",
+	"@generated": "26ad6910ec8daa7a0cf7f868cf5afcb5b2f256f5",
 	"@overrides": {
+		"compilerOptions": {
+			"lib": [
+				"es2020",
+				"DOM"
+			]
+		}
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
 	"@see": "https://git.io/JY2EA",
@@ -9,6 +15,10 @@
 		"baseUrl": ".",
 		"composite": true,
 		"jsx": "react",
+		"lib": [
+			"es2020",
+			"DOM"
+		],
 		"module": "es6",
 		"moduleResolution": "node",
 		"outDir": "./types",

--- a/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/getEditorConfigurationCX.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/renderer/getEditorConfigurationCX.d.ts
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+declare const getEditorConfigurationCX: (config: Object) => Promise<Object>;
+export default getEditorConfigurationCX;


### PR DESCRIPTION
This is a WIP proposal aiming at covering the entire epic [LPS-186870](https://liferay.atlassian.net/browse/LPS-186870).

### Core idea

**Provide a CX to add editor configurations resembling how [EditorConfigContributor](https://help.liferay.com/hc/en-us/articles/360029848491-Modifying-an-Editor-s-Configuration) framework works**

Main concepts:

- **CX registration**: user provides the information as given in the java EditorConfigContributor class annotations: `portlet names`, `editor config keys` and `editor names`. 
- **CX deployment**: when the CX is deployed, a CETEditorConfigContributor service is registered in the system using the CX information. This way we mirror the CX entry into an equivalent EditorConfigContributor instance
- **CX at runtime, server side**: such contributor adds the CX instance JS URL to the editor config, for later processing in the frontend
- **CX at runtime, frontend side**: a small utility loads the JS and runs the default function, providing a placeholder to return a configuration object
  - Each JS may choose to merge/add/remove configuration items
  - Order of JS execution is the order of CETEditorConfigContributor services (or it shall be)
  - All backend EditorConfigContributors will have already run before the CX JS has a chance to kick in 
  - CX injection points include all ootb editors, both the react and JSP-based

### Still to do

- Handling errors: I've provided a basic error management, see commit messages
- Refactor getRenderers to accommodate loading of the JS. Current solution works well however it kinda forces the API to load the CX as "internal"
- Think about better naming for the utility function
- Provide types for the JS CX code to leverage typescript in a similar way as FDS Cell Renderers do
- Language translations
- CX UI design: I've provided a functional repeatable fields to mirror flexibility of EditorConfigContributor java class annotations. In fact none of the 3 values is required, but we need to provide proper explanations and review UI in general
- Integrate with other editor instances using the EditorConfigContributor, most notably, fragments in page editor
- Workspace samples
- FF
- consider validating the configuration before sending it to the editor

### To play around with this

- Upload the attached files to the D&M, please make sure to strip the .txt extension first (GH does not allow .js attachments):
   - [test-editor-configuration-cx2.js.txt](https://github.com/liferay-frontend/liferay-portal/files/13382486/test-editor-configuration-cx2.js.txt)
   - [test-alloyeditor-configuration-cx.js.txt](https://github.com/liferay-frontend/liferay-portal/files/13382484/test-alloyeditor-configuration-cx.js.txt)
   - [test-editor-configuration-cx.js.txt](https://github.com/liferay-frontend/liferay-portal/files/13382485/test-editor-configuration-cx.js.txt)
- Create several client extension entries as per the following screenshots
![image](https://github.com/liferay-frontend/liferay-portal/assets/861014/91f4f34e-dc0f-45b3-b621-020bafb52494)
![image](https://github.com/liferay-frontend/liferay-portal/assets/861014/c9debc4c-3e17-4597-8f78-8c4c9939e330)
![image](https://github.com/liferay-frontend/liferay-portal/assets/861014/499548c7-8d66-4242-b1f6-3c2a083ba50c)
![image](https://github.com/liferay-frontend/liferay-portal/assets/861014/ce3fe007-6eb9-462a-8cce-fffb09591490)
- Check different editors: blog content, web content description, etc

This PR is to test and validate the concept