### PR TITLE
LPS-194385 LPS-201251 Migrate CustomViewsControls.js to Clay Picker

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/components/CustomViewsControls.js
@@ -4,6 +4,7 @@
  */
 
 import ClayButton from '@clayui/button';
+import {Option, Picker} from '@clayui/core';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
@@ -14,6 +15,30 @@ import React, {useContext, useRef, useState} from 'react';
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import ViewsContext from '../../views/ViewsContext';
 import {VIEWS_ACTION_TYPES} from '../../views/viewsReducer';
+
+const DEFAULT_VIEW_ID = 'DEFAULT_VIEW';
+
+const CustomViewsControlsTrigger = React.forwardRef(
+	({triggerLabel, viewUpdated, ...otherProps}, ref) => (
+		<ClayButton
+			{...otherProps}
+			aria-label={Liferay.Language.get('views')}
+			className="custom-views-selection dropdown-toggle"
+			displayType="unstyled"
+			ref={ref}
+		>
+			<span className="navbar-text-truncate">{triggerLabel}</span>
+
+			{viewUpdated && (
+				<span className="inline-item-after reference-mark view-updated-mark">
+					<ClayIcon symbol="asterisk" />
+				</span>
+			)}
+
+			<ClayIcon className="ml-2" symbol="caret-bottom" />
+		</ClayButton>
+	)
+);
 
 const CustomViewsControls = () => {
 	const {appURL, id: fdsName, namespace, portletId} = useContext(
@@ -33,7 +58,6 @@ const CustomViewsControls = () => {
 		viewsDispatch,
 	] = useContext(ViewsContext);
 
-	const [viewsDropdownActive, setViewsDropdownActive] = useState(false);
 	const [actionsDropdownActive, setActionsDropdownActive] = useState(false);
 
 	const customViewLabelInputRef = useRef();
@@ -306,69 +330,43 @@ const CustomViewsControls = () => {
 		});
 	};
 
+	const handleSelectionChange = (id) => {
+		if (id === DEFAULT_VIEW_ID) {
+			viewsDispatch({
+				type: VIEWS_ACTION_TYPES.RESET_TO_DEFAULT_VIEW,
+			});
+		}
+		else {
+			viewsDispatch({
+				type: VIEWS_ACTION_TYPES.UPDATE_ACTIVE_CUSTOM_VIEW,
+				value: id,
+			});
+		}
+	};
+
 	return (
 		<>
 			<ManagementToolbar.Item>
-				<ClayDropDown
-					active={viewsDropdownActive}
-					className="custom-views-selection"
-					hasLeftSymbols
-					onActiveChange={setViewsDropdownActive}
-					trigger={
-						<ClayButton displayType="unstyled">
-							<span className="navbar-text-truncate">
-								{activeCustomViewId
-									? customViews[activeCustomViewId]
-											.customViewLabel
-									: Liferay.Language.get('default-view')}
-							</span>
-
-							{viewUpdated && (
-								<span className="inline-item-after reference-mark view-updated-mark">
-									<ClayIcon symbol="asterisk" />
-								</span>
-							)}
-
-							<ClayIcon className="ml-2" symbol="caret-bottom" />
-						</ClayButton>
+				<Picker
+					as={CustomViewsControlsTrigger}
+					items={[...Object.keys(customViews), DEFAULT_VIEW_ID]}
+					onSelectionChange={handleSelectionChange}
+					selectedKey={activeCustomViewId ?? DEFAULT_VIEW_ID}
+					triggerLabel={
+						activeCustomViewId
+							? customViews[activeCustomViewId].customViewLabel
+							: Liferay.Language.get('default-view')
 					}
+					viewUpdated={viewUpdated}
 				>
-					<ClayDropDown.ItemList>
-						{Object.keys(customViews).map((id) => (
-							<ClayDropDown.Item
-								key={id}
-								onClick={() => {
-									viewsDispatch({
-										type:
-											VIEWS_ACTION_TYPES.UPDATE_ACTIVE_CUSTOM_VIEW,
-										value: id,
-									});
-
-									setViewsDropdownActive(false);
-								}}
-								symbolLeft={
-									id === activeCustomViewId && 'check'
-								}
-							>
-								{customViews[id].customViewLabel}
-							</ClayDropDown.Item>
-						))}
-
-						<ClayDropDown.Item
-							onClick={() => {
-								viewsDispatch({
-									type:
-										VIEWS_ACTION_TYPES.RESET_TO_DEFAULT_VIEW,
-								});
-
-								setViewsDropdownActive(false);
-							}}
-							symbolLeft={!activeCustomViewId && 'check'}
-						>
-							{Liferay.Language.get('default-view')}
-						</ClayDropDown.Item>
-					</ClayDropDown.ItemList>
-				</ClayDropDown>
+					{(id) => (
+						<Option key={id}>
+							{id === DEFAULT_VIEW_ID
+								? Liferay.Language.get('default-view')
+								: customViews[id].customViewLabel}
+						</Option>
+					)}
+				</Picker>
 			</ManagementToolbar.Item>
 
 			<ManagementToolbar.Item>
@@ -379,6 +377,9 @@ const CustomViewsControls = () => {
 					onActiveChange={setActionsDropdownActive}
 					trigger={
 						<ClayButton
+							aria-label={Liferay.Language.get(
+								'show-view-actions'
+							)}
 							displayType="unstyled"
 							title={Liferay.Language.get('show-view-actions')}
 						>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/FrontendDataSetCustomView.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/FrontendDataSetCustomView.macro
@@ -15,13 +15,6 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro assertCustomViewName(key_nameCustomView = null) {
-		AssertElementPresent(
-			locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-			value1 = ${key_nameCustomView});
-	}
-
-	@summary = "Default summary"
 	macro assertFilterSummaryLabel(key_filter = null) {
 		AssertElementPresent(
 			locator1 = "FrontendDataSet#FILTER_SUMMARY_LABEL",
@@ -39,9 +32,7 @@ definition {
 	macro changeCustomView(key_itemName = null) {
 		Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
-		Click(
-			key_optionName = ${key_itemName},
-			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW");
+		MenuItem.click(menuItem = ${key_itemName});
 	}
 
 	@summary = "Default summary"
@@ -157,9 +148,7 @@ definition {
 
 	@summary = "Default summary"
 	macro selectView(key_itemName = null) {
-		Click(
-			locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
-			value1 = ${key_itemName});
+		MenuItem.click(menuItem = ${key_itemName});
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/FrontendDataSet.path
@@ -223,7 +223,7 @@
 
 <tr>
 	<td>SELECT_CUSTOM_VIEW</td>
-	<td>//div[contains(@class,'custom-views-selection')]</td>
+	<td>//span[contains(@class,'navbar-text-truncate') and contains(text(),'${key_name}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetCustomView.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/frontenddataset/FrontendDataSetCustomView.testcase
@@ -50,7 +50,7 @@ definition {
 	@priority = 5
 	test CanBeDeleted {
 		task ("Given A custom view is created") {
-			FrontendDataSetCustomView.createNewView(key_nameView = "New View");
+			FrontendDataSetCustomView.createNewView(entryName = "New View");
 		}
 
 		task ("When Deleting the custom view") {
@@ -58,7 +58,9 @@ definition {
 		}
 
 		task ("Then Assert the custom view no longer exists") {
-			FrontendDataSetCustomView.assertCustomViewName(key_nameCustomView = "New View");
+			AssertElementNotPresent(
+				key_name = "New View",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 		}
 	}
 
@@ -66,7 +68,7 @@ definition {
 	@priority = 4
 	test CanBeEdited {
 		task ("And Given a custom view is created and selected") {
-			FrontendDataSetCustomView.createNewView(key_nameView = "New View");
+			FrontendDataSetCustomView.createNewView(entryName = "New View");
 		}
 
 		task ("When make edits to the view settings") {
@@ -89,7 +91,9 @@ definition {
 		}
 
 		task ("And Then edits are not applied to default view") {
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+			Click(
+				key_name = "New View",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
 			FrontendDataSetCustomView.selectView(key_itemName = "Default View");
 
@@ -124,7 +128,7 @@ definition {
 		}
 
 		task ("And When Save As the custom view") {
-			FrontendDataSetCustomView.createNewView(entryName = "TEST");
+			FrontendDataSetCustomView.createNewView(entryName = "New View");
 
 			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 
@@ -134,7 +138,9 @@ definition {
 		}
 
 		task ("Then A new custom view is created and selected as current view") {
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+			Click(
+				key_name = "New View",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
 			FrontendDataSetCustomView.selectView(key_itemName = "Default View");
 
@@ -142,9 +148,11 @@ definition {
 				columnName = "Description",
 				locator1 = "FrontendDataSet#COLUMN_NAME");
 
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+			Click(
+				key_name = "Default View",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
-			FrontendDataSetCustomView.selectView(key_itemName = "TEST");
+			FrontendDataSetCustomView.selectView(key_itemName = "New View");
 
 			AssertElementNotPresent(
 				key_columnName = "Description",
@@ -167,11 +175,13 @@ definition {
 				key_enableFilters = "Red",
 				key_filter = "Color");
 
-			FrontendDataSetCustomView.createNewView(entryName = "Custom View Name");
+			FrontendDataSetCustomView.createNewView(entryName = "New View");
 		}
 
 		task ("When open menu to select created custom view") {
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+			Click(
+				key_name = "New View",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 		}
 
 		task ("Then option to select default view is available") {
@@ -183,7 +193,7 @@ definition {
 		task ("And Then option to select created custom view is available") {
 			AssertTextPresent(
 				locator1 = "FrontendDataSet#SELECT_OPTION_CUSTOM_VIEW",
-				value1 = "Custom View Name");
+				value1 = "New View");
 		}
 	}
 
@@ -218,15 +228,21 @@ definition {
 		}
 
 		task ("Then A new custom view is created, and selected as current view") {
-			FrontendDataSetCustomView.assertCustomViewName(key_nameCustomView = "FrontendDataSet View 2");
+			AssertElementPresent(
+				key_name = "FrontendDataSet View 2",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
-			FrontendDataSetCustomView.changeCustomView(key_itemName = "FrontendDataSet View");
+			FrontendDataSetCustomView.changeCustomView(
+				key_itemName = "FrontendDataSet View",
+				key_name = "FrontendDataSet View");
 
 			FrontendDataSetCustomView.assertFilterSummaryLabel(key_filter = "Color: Blue, Green, Yellow");
 
 			FrontendDataSetCustomView.assertColumnPresent(key_field = "Description");
 
-			FrontendDataSetCustomView.changeCustomView(key_itemName = "FrontendDataSet View 2");
+			FrontendDataSetCustomView.changeCustomView(
+				key_itemName = "FrontendDataSet View 2",
+				key_name = "FrontendDataSet View");
 
 			Pagination.viewResults(results = "Showing 1 to 4 of 25 entries.");
 
@@ -263,7 +279,7 @@ definition {
 	@priority = 3
 	test HasActionsOnlyOnEllipsis {
 		task ("And Given created custom view") {
-			FrontendDataSetCustomView.createNewView(key_nameView = "New View");
+			FrontendDataSetCustomView.createNewView(entryName = "New View");
 		}
 
 		task ("When open ellipsis next to custom view") {
@@ -277,7 +293,9 @@ definition {
 		}
 
 		task ("When open select custom view button") {
-			FrontendDataSetCustomView.changeCustomView(key_itemName = "Default View");
+			FrontendDataSetCustomView.changeCustomView(
+				key_itemName = "Default View",
+				key_name = "New View");
 
 			Click(locator1 = "FrontendDataSet#SELECT_OPTION_HEADER");
 		}
@@ -297,7 +315,7 @@ definition {
 	@priority = 4
 	test HasOptionToEditName {
 		task ("And Given created custom view") {
-			FrontendDataSetCustomView.createNewView(key_nameView = "TEST");
+			FrontendDataSetCustomView.createNewView(entryName = "TEST");
 		}
 
 		task ("When open ellisis next to custom view") {
@@ -341,11 +359,13 @@ definition {
 		}
 
 		task ("And Then Custom Views dropdown items are localized") {
-			Click(locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
+			Click(
+				key_name = "Vista por defecto",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 
-			AssertTextEquals(
-				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW",
-				value1 = "Vista por defecto");
+			AssertElementPresent(
+				key_name = "Vista por defecto",
+				locator1 = "FrontendDataSet#SELECT_CUSTOM_VIEW");
 		}
 
 		task ("And Then Ellipsis dropdown 'Save' is localized") {


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPS-194385
**Subtask:** https://liferay.atlassian.net/browse/LPS-201251

This updates the Custom Views selector to use Clay Picker.

**Dev Note:**
- I introduced a new constant `DEFAULT_VIEW_ID` in order to be used for the Clay Picker `<Option>` `key` prop and the `selectedKey` to show which option was active.

## Demo

https://github.com/liferay-frontend/liferay-portal/assets/4496722/b5a9082b-7944-4976-81c3-1bc85775c0a5


