### PR TITLE
LPS-196982 Use of library with known vulnerability: Webpack 5.70.0 (modules)

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -21,7 +21,7 @@
 		"@types/html-minifier-terser": "5.1.0",
 		"html-webpack-plugin": "5.5.0",
 		"ua-parser-js": "^0.7.30",
-		"webpack": "5.70.0"
+		"webpack": "5.89.0"
 	},
 	"scripts": {
 		"cacheClean": "liferay-npm-scripts cache --clean",


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPS-196982

The goal is to remove the dependency on Webpack 5.70.0 which has known vulnerabilities.

However, as modules uses @liferay/npm-scripts to build, Webpack is no longer needed, so this PR gets completely rid of it.