### PR TITLE
LPS-201903 DSM filter nested fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/package.json
@@ -15,6 +15,7 @@
 		"@clayui/link": "3.106.1",
 		"@clayui/list": "3.106.1",
 		"@clayui/loading-indicator": "3.106.1",
+		"@clayui/management-toolbar": "3.106.1",
 		"@clayui/modal": "3.106.1",
 		"@clayui/multi-select": "3.106.1",
 		"@clayui/navigation-bar": "3.106.1",

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -7,9 +7,11 @@ import ClayButton from '@clayui/button';
 import {TreeView} from '@clayui/core';
 import {ClayCheckbox} from '@clayui/form';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
-import ClayManagementToolbar from '@clayui/management-toolbar';
+import ClayManagementToolbar, {
+	ClayResultsBar,
+} from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
-import {fetch} from 'frontend-js-web';
+import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {FDSViewType} from '../../../FDSViews';
@@ -63,6 +65,28 @@ const applySavedFDSFields = ({
 	return [selectedKeys, fields];
 };
 
+function filterFields(fields: Array<IFieldTreeItem>, query: string) {
+	const filteredItems: Array<IFieldTreeItem> = [];
+	const regexp = new RegExp(query, 'i');
+
+	fields.forEach((field) => {
+		const match = field.label ? regexp.test(field.label) : false;
+
+		const filteredChildren = field.children?.length
+			? filterFields(field.children, query)
+			: [];
+
+		if (match || (field.children?.length && filteredChildren.length)) {
+			filteredItems.push({
+				...field,
+				children: filteredChildren,
+			});
+		}
+	});
+
+	return filteredItems;
+}
+
 const AddFieldsModalContent = ({
 	closeModal,
 	fdsView,
@@ -84,11 +108,14 @@ const AddFieldsModalContent = ({
 	saveFDSFieldsURL: string;
 	savedFDSFields: Array<IFDSField>;
 }) => {
-	const [fields, setFields] = useState<Array<IFieldTreeItem> | null>(null);
+	const [initialFields, setInitialFields] = useState<Array<
+		IFieldTreeItem
+	> | null>(null);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
 		new Set<React.Key>()
 	);
+	const [fields, setFields] = useState<Array<IField> | null>(initialFields);
 	const [query, setQuery] = useState<string>('');
 
 	const saveFDSFields = async () => {
@@ -97,7 +124,7 @@ const AddFieldsModalContent = ({
 		const creationData: Array<{name: string; type: string}> = [];
 		const deletionIds: Array<number> = [];
 
-		visit(fields || [], (field: IFieldTreeItem) => {
+		visit(initialFields || [], (field: IFieldTreeItem) => {
 			if (selectedKeys.has(field.name) && !field.savedId) {
 				creationData.push({name: field.name, type: field.type});
 			}
@@ -161,6 +188,7 @@ const AddFieldsModalContent = ({
 
 				setSelectedKeys(initialSelectedKeys);
 
+				setInitialFields(updatedFields);
 				setFields(updatedFields);
 			}
 		});
@@ -168,6 +196,8 @@ const AddFieldsModalContent = ({
 
 	const onSearch = (query: string) => {
 		setQuery(query);
+
+		setFields(filterFields(initialFields ?? [], query));
 	};
 
 	return (
@@ -187,13 +217,50 @@ const AddFieldsModalContent = ({
 							</ClayManagementToolbar.Search>
 						</ClayManagementToolbar>
 
+						{query && (
+							<ClayResultsBar>
+								<ClayResultsBar.Item expand>
+									<span className="component-text text-truncate-inline">
+										<span className="text-truncate">
+											{sub(
+												fields.length === 1
+													? Liferay.Language.get(
+															'x-result-for-x'
+													  )
+													: Liferay.Language.get(
+															'x-results-for-x'
+													  ),
+												fields.length,
+												query
+											)}
+										</span>
+									</span>
+								</ClayResultsBar.Item>
+
+								<ClayResultsBar.Item>
+									<ClayButton
+										className="component-link tbar-link"
+										displayType="unstyled"
+										onClick={() => {
+											setQuery('');
+											setFields(initialFields);
+										}}
+									>
+										{Liferay.Language.get('clear')}
+									</ClayButton>
+								</ClayResultsBar.Item>
+							</ClayResultsBar>
+						)}
+
 						<div className="container-fluid container-fluid-max-xl px-4 py-2">
 							<TreeView
 								className="bg-light"
 								items={fields}
 								nestedKey="children"
 								onItemsChange={(items) =>
-									setFields(items as Array<IFieldTreeItem>)
+									setInitialFields(
+										items as Array<IFieldTreeItem>
+									)
 								}
 								onSelectionChange={setSelectedKeys}
 								selectedKeys={selectedKeys}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -65,7 +65,11 @@ const applySavedFDSFields = ({
 	return [selectedKeys, fields];
 };
 
-function filterFields(fields: Array<IFieldTreeItem>, query: string) {
+function filterFields(
+	fields: Array<IFieldTreeItem>,
+	query: string,
+	onFilter?: Function
+) {
 	const filteredItems: Array<IFieldTreeItem> = [];
 	const regexp = new RegExp(query, 'i');
 
@@ -73,7 +77,7 @@ function filterFields(fields: Array<IFieldTreeItem>, query: string) {
 		const match = field.label ? regexp.test(field.label) : false;
 
 		const filteredChildren = field.children?.length
-			? filterFields(field.children, query)
+			? filterFields(field.children, query, onFilter)
 			: [];
 
 		if (match || (field.children?.length && filteredChildren.length)) {
@@ -81,10 +85,38 @@ function filterFields(fields: Array<IFieldTreeItem>, query: string) {
 				...field,
 				children: filteredChildren,
 			});
+
+			if (onFilter) {
+				onFilter(field);
+			}
 		}
 	});
 
 	return filteredItems;
+}
+
+function applyFilter({
+	fields,
+	query,
+}: {fields?: Array<IFieldTreeItem>; query?: string} = {}) {
+	if (!query || !fields) {
+		return {
+			filteredItems: fields ?? [],
+			filteredKeys: [],
+		};
+	}
+
+	const filteredKeys: Array<React.Key> = [];
+	const filteredItems = filterFields(fields, query, ({id}: IField) => {
+		if (id) {
+			filteredKeys.push(id);
+		}
+	});
+
+	return {
+		filteredItems,
+		filteredKeys,
+	};
 }
 
 const AddFieldsModalContent = ({
@@ -117,6 +149,7 @@ const AddFieldsModalContent = ({
 	);
 	const [fields, setFields] = useState<Array<IField> | null>(initialFields);
 	const [query, setQuery] = useState<string>('');
+	const [expandedKeys, setExpandedKeys] = useState<Array<React.Key>>([]);
 
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
@@ -197,7 +230,13 @@ const AddFieldsModalContent = ({
 	const onSearch = (query: string) => {
 		setQuery(query);
 
-		setFields(filterFields(initialFields ?? [], query));
+		const {filteredItems, filteredKeys} = applyFilter({
+			fields: initialFields ?? [],
+			query,
+		});
+
+		setFields(filteredItems);
+		setExpandedKeys(filteredKeys);
 	};
 
 	return (
@@ -255,8 +294,12 @@ const AddFieldsModalContent = ({
 						<div className="container-fluid container-fluid-max-xl px-4 py-2">
 							<TreeView
 								className="bg-light"
+								expandedKeys={new Set(expandedKeys)}
 								items={fields}
 								nestedKey="children"
+								onExpandedChange={(keys) => {
+									setExpandedKeys(Array.from(keys));
+								}}
 								onItemsChange={(items) =>
 									setInitialFields(
 										items as Array<IFieldTreeItem>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -7,12 +7,14 @@ import ClayButton from '@clayui/button';
 import {TreeView} from '@clayui/core';
 import {ClayCheckbox} from '@clayui/form';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import ClayManagementToolbar from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {FDSViewType} from '../../../FDSViews';
 import {getFields} from '../../../api';
+import Search from '../../../components/Search';
 import {IField} from '../../../types';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
@@ -87,6 +89,7 @@ const AddFieldsModalContent = ({
 	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
 		new Set<React.Key>()
 	);
+	const [query, setQuery] = useState<string>('');
 
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
@@ -163,44 +166,64 @@ const AddFieldsModalContent = ({
 		});
 	}, [savedFDSFields, fdsView]);
 
+	const onSearch = (query: string) => {
+		setQuery(query);
+	};
+
 	return (
 		<>
 			<ClayModal.Header>
 				{Liferay.Language.get('add-fields')}
 			</ClayModal.Header>
 
-			<ClayModal.Body className="bg-light m-4 p-0">
+			<ClayModal.Body className="pt-0 px-0">
 				{fields === null ? (
 					<ClayLoadingIndicator />
 				) : (
-					<div className="pb-2 pt-2">
-						<TreeView
-							defaultItems={fields}
-							nestedKey="children"
-							onSelectionChange={setSelectedKeys}
-							selectedKeys={selectedKeys}
-							selectionMode="multiple"
-						>
-							{({children, label}: IFieldTreeItem) => (
-								<TreeView.Item>
-									<TreeView.ItemStack>
-										<ClayCheckbox checked label={label} />
-									</TreeView.ItemStack>
+					<>
+						<ClayManagementToolbar>
+							<ClayManagementToolbar.Search>
+								<Search onSearch={onSearch} query={query} />
+							</ClayManagementToolbar.Search>
+						</ClayManagementToolbar>
 
-									<TreeView.Group items={children}>
-										{({label}: IFieldTreeItem) => (
-											<TreeView.Item>
-												<ClayCheckbox
-													checked
-													label={label}
-												/>
-											</TreeView.Item>
-										)}
-									</TreeView.Group>
-								</TreeView.Item>
-							)}
-						</TreeView>
-					</div>
+						<div className="container-fluid container-fluid-max-xl px-4 py-2">
+							<TreeView
+								className="bg-light"
+								items={fields}
+								nestedKey="children"
+								onItemsChange={(items) =>
+									setFields(items as Array<IFieldTreeItem>)
+								}
+								onSelectionChange={setSelectedKeys}
+								selectedKeys={selectedKeys}
+								selectionMode="multiple"
+								showExpanderOnHover={false}
+							>
+								{({children, label}: IFieldTreeItem) => (
+									<TreeView.Item>
+										<TreeView.ItemStack>
+											<ClayCheckbox
+												checked
+												label={label}
+											/>
+										</TreeView.ItemStack>
+
+										<TreeView.Group items={children}>
+											{({label}: IFieldTreeItem) => (
+												<TreeView.Item>
+													<ClayCheckbox
+														checked
+														label={label}
+													/>
+												</TreeView.Item>
+											)}
+										</TreeView.Group>
+									</TreeView.Item>
+								)}
+							</TreeView>
+						</div>
+					</>
 				)}
 			</ClayModal.Body>
 


### PR DESCRIPTION

### Issue 
- [LPS-201903](https://liferay.atlassian.net/browse/LPS-201903) Allow users to search for fields in a hierarchical list 
- under FF `feature.flag.LPS-186871=true`

### Search UI

The main concept is to provide a filtering option for hierarchical fields on DSM. Currently, the tree automatically expands the path of results to display the match.

https://github.com/liferay-frontend/liferay-portal/assets/67901/b0e98b7d-ba0b-4bee-86b5-239322e7330c


### Questions

- I've updated the `saveFDSFields` function to save all fields, not just the filtered ones. However, I'm uncertain. @markocikos, could you please review it? 🥺
- I attempted to limit the modal width to size `xl`, but I lost the full height. Any ideas on how to maintain both full height and max-width?

### Still TODO
- Limit the width of the modal
- Highlight the match in the results 

