### PR TITLE
LPS-201375 - Explicitly check 'true' from the cookie consent type

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/toggleThirdPartyCookies.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/toggleThirdPartyCookies.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {COOKIE_TYPES, checkConsent} from 'frontend-js-web';
+import {COOKIE_TYPES, getCookie} from 'frontend-js-web';
 
 export function flipThirdPartyCookiesOff(element) {
 	if (!Liferay.FeatureFlags['LPS-154290']) {
@@ -137,7 +137,7 @@ function flipThirdPartyCookie(type) {
  */
 export default function toggleThirdPartyCookies() {
 	Object.values(COOKIE_TYPES).forEach((type) => {
-		const typeConsent = checkConsent(type);
+		const typeConsent = getCookie(type) === 'true';
 
 		if (typeConsent) {
 			flipThirdPartyCookie(type);


### PR DESCRIPTION
Fixes a issue where if the cookie was undefined, it was still passing as truthy