### PR TITLE
LPS-202565 Don't cache CSP configuration

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/configuration/ContentSecurityPolicyConfigurationUtil.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/configuration/ContentSecurityPolicyConfigurationUtil.java
@@ -22,15 +22,10 @@ public class ContentSecurityPolicyConfigurationUtil {
 			ConfigurationProvider configurationProvider,
 			HttpServletRequest httpServletRequest, Portal portal) {
 
-		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
-			(ContentSecurityPolicyConfiguration)httpServletRequest.getAttribute(
-				ContentSecurityPolicyConfigurationUtil.class.getName());
-
-		if (contentSecurityPolicyConfiguration != null) {
-			return contentSecurityPolicyConfiguration;
-		}
-
 		try {
+			ContentSecurityPolicyConfiguration
+				contentSecurityPolicyConfiguration;
+
 			long groupId = portal.getScopeGroupId(httpServletRequest);
 
 			if (groupId > 0) {
@@ -44,16 +39,12 @@ public class ContentSecurityPolicyConfigurationUtil {
 						ContentSecurityPolicyConfiguration.class,
 						portal.getCompanyId(httpServletRequest));
 			}
+
+			return contentSecurityPolicyConfiguration;
 		}
 		catch (PortalException portalException) {
 			return ReflectionUtil.throwException(portalException);
 		}
-
-		httpServletRequest.setAttribute(
-			ContentSecurityPolicyConfigurationUtil.class.getName(),
-			contentSecurityPolicyConfiguration);
-
-		return contentSecurityPolicyConfiguration;
 	}
 
 }


### PR DESCRIPTION
We cannot cache CSP configuration per request because some parts of DXP forward/include requests wrapping the original request, thus sometimes values as group, company, etc. may differ from those of the original request.