### PR TITLE
LPS-202271 DSM highlight filtered nested fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -119,6 +119,24 @@ function applyFilter({
 	};
 }
 
+const Highlight = ({query, text}: {query?: string; text?: string}) => {
+	if (!query || !text) {
+		return <>{text ?? ''}</>;
+	}
+
+	const indexMatch = text.search(RegExp(query, 'i'));
+
+	return indexMatch > -1 ? (
+		<>
+			{text.substring(0, indexMatch)}
+			<mark>{text.substring(indexMatch, indexMatch + query.length)}</mark>
+			{text.substring(indexMatch + query.length)}
+		</>
+	) : (
+		<>{text}</>
+	);
+};
+
 const AddFieldsModalContent = ({
 	closeModal,
 	fdsView,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -24,6 +24,7 @@ import {IFDSField} from '../Fields';
 
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
+	query?: string;
 	savedId?: number;
 	selected?: boolean;
 }
@@ -84,6 +85,7 @@ function filterFields(
 			filteredItems.push({
 				...field,
 				children: filteredChildren,
+				query,
 			});
 
 			if (onFilter) {
@@ -328,7 +330,7 @@ const AddFieldsModalContent = ({
 								selectionMode="multiple"
 								showExpanderOnHover={false}
 							>
-								{({children, label}: IFieldTreeItem) => (
+								{({children, label, query}: IFieldTreeItem) => (
 									<TreeView.Item>
 										<TreeView.ItemStack>
 											<ClayCheckbox checked>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -66,11 +66,17 @@ const applySavedFDSFields = ({
 	return [selectedKeys, fields];
 };
 
-function filterFields(
-	fields: Array<IFieldTreeItem>,
-	query: string,
-	onFilter?: Function
-) {
+function filterFields({
+	fields,
+	onFilter,
+	onMatch,
+	query,
+}: {
+	fields: Array<IFieldTreeItem>;
+	onFilter?: Function;
+	onMatch?: Function;
+	query: string;
+}) {
 	const filteredItems: Array<IFieldTreeItem> = [];
 	const regexp = new RegExp(query, 'i');
 
@@ -78,7 +84,7 @@ function filterFields(
 		const match = field.label ? regexp.test(field.label) : false;
 
 		const filteredChildren = field.children?.length
-			? filterFields(field.children, query, onFilter)
+			? filterFields({fields: field.children, onFilter, onMatch, query})
 			: [];
 
 		if (match || (field.children?.length && filteredChildren.length)) {
@@ -92,6 +98,10 @@ function filterFields(
 				onFilter(field);
 			}
 		}
+
+		if (match && onMatch) {
+			onMatch(field);
+		}
 	});
 
 	return filteredItems;
@@ -103,19 +113,27 @@ function applyFilter({
 }: {fields?: Array<IFieldTreeItem>; query?: string} = {}) {
 	if (!query || !fields) {
 		return {
+			counter: 0,
 			filteredItems: fields ?? [],
 			filteredKeys: [],
 		};
 	}
 
+	let counter = 0;
 	const filteredKeys: Array<React.Key> = [];
-	const filteredItems = filterFields(fields, query, ({id}: IField) => {
-		if (id) {
-			filteredKeys.push(id);
-		}
+	const filteredItems = filterFields({
+		fields,
+		onFilter: ({id}: IField) => {
+			if (id) {
+				filteredKeys.push(id);
+			}
+		},
+		onMatch: () => counter++,
+		query,
 	});
 
 	return {
+		counter,
 		filteredItems,
 		filteredKeys,
 	};
@@ -172,6 +190,7 @@ const AddFieldsModalContent = ({
 	const [fields, setFields] = useState<Array<IField> | null>(initialFields);
 	const [query, setQuery] = useState<string>('');
 	const [expandedKeys, setExpandedKeys] = useState<Array<React.Key>>([]);
+	const [searchCounter, setSearchCounter] = useState<number>(0);
 
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
@@ -252,13 +271,14 @@ const AddFieldsModalContent = ({
 	const onSearch = (query: string) => {
 		setQuery(query);
 
-		const {filteredItems, filteredKeys} = applyFilter({
+		const {counter, filteredItems, filteredKeys} = applyFilter({
 			fields: initialFields ?? [],
 			query,
 		});
 
 		setFields(filteredItems);
 		setExpandedKeys(filteredKeys);
+		setSearchCounter(counter);
 	};
 
 	return (
@@ -284,14 +304,14 @@ const AddFieldsModalContent = ({
 									<span className="component-text text-truncate-inline">
 										<span className="text-truncate">
 											{sub(
-												fields.length === 1
+												searchCounter === 1
 													? Liferay.Language.get(
 															'x-result-for-x'
 													  )
 													: Liferay.Language.get(
 															'x-results-for-x'
 													  ),
-												fields.length,
+												searchCounter,
 												query
 											)}
 										</span>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -131,7 +131,9 @@ const Highlight = ({query, text}: {query?: string; text?: string}) => {
 	return indexMatch > -1 ? (
 		<>
 			{text.substring(0, indexMatch)}
-			<mark>{text.substring(indexMatch, indexMatch + query.length)}</mark>
+			<mark className="bg-transparent border-0 font-weight-bold p-0 shadow-none">
+				{text.substring(indexMatch, indexMatch + query.length)}
+			</mark>
 			{text.substring(indexMatch + query.length)}
 		</>
 	) : (

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -334,10 +334,12 @@ const AddFieldsModalContent = ({
 									<TreeView.Item>
 										<TreeView.ItemStack>
 											<ClayCheckbox checked>
-												<Highlight
-													query={query}
-													text={label}
-												/>
+												<span className="font-weight-normal pl-1 text-3">
+													<Highlight
+														query={query}
+														text={label}
+													/>
+												</span>
 											</ClayCheckbox>
 										</TreeView.ItemStack>
 
@@ -345,10 +347,12 @@ const AddFieldsModalContent = ({
 											{({label}: IFieldTreeItem) => (
 												<TreeView.Item>
 													<ClayCheckbox checked>
-														<Highlight
-															query={query}
-															text={label}
-														/>
+														<span className="font-weight-normal pl-1 text-3">
+															<Highlight
+																query={query}
+																text={label}
+															/>
+														</span>
 													</ClayCheckbox>
 												</TreeView.Item>
 											)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -331,19 +331,23 @@ const AddFieldsModalContent = ({
 								{({children, label}: IFieldTreeItem) => (
 									<TreeView.Item>
 										<TreeView.ItemStack>
-											<ClayCheckbox
-												checked
-												label={label}
-											/>
+											<ClayCheckbox checked>
+												<Highlight
+													query={query}
+													text={label}
+												/>
+											</ClayCheckbox>
 										</TreeView.ItemStack>
 
 										<TreeView.Group items={children}>
 											{({label}: IFieldTreeItem) => (
 												<TreeView.Item>
-													<ClayCheckbox
-														checked
-														label={label}
-													/>
+													<ClayCheckbox checked>
+														<Highlight
+															query={query}
+															text={label}
+														/>
+													</ClayCheckbox>
 												</TreeView.Item>
 											)}
 										</TreeView.Group>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/fields/modal_content/AddFieldsModalContent.tsx
@@ -73,8 +73,8 @@ function filterFields({
 	query,
 }: {
 	fields: Array<IFieldTreeItem>;
-	onFilter?: Function;
-	onMatch?: Function;
+	onFilter?: (field: IFieldTreeItem) => void;
+	onMatch?: (field: IFieldTreeItem) => void;
 	query: string;
 }) {
 	const filteredItems: Array<IFieldTreeItem> = [];
@@ -123,7 +123,7 @@ function applyFilter({
 	const filteredKeys: Array<React.Key> = [];
 	const filteredItems = filterFields({
 		fields,
-		onFilter: ({id}: IField) => {
+		onFilter: ({id}: IFieldTreeItem) => {
 			if (id) {
 				filteredKeys.push(id);
 			}
@@ -187,7 +187,9 @@ const AddFieldsModalContent = ({
 	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
 		new Set<React.Key>()
 	);
-	const [fields, setFields] = useState<Array<IField> | null>(initialFields);
+	const [fields, setFields] = useState<Array<IFieldTreeItem> | null>(
+		initialFields
+	);
 	const [query, setQuery] = useState<string>('');
 	const [expandedKeys, setExpandedKeys] = useState<Array<React.Key>>([]);
 	const [searchCounter, setSearchCounter] = useState<number>(0);


### PR DESCRIPTION
## How it works
This PR Highlights the coincidences in nested fields search on the DSM

![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/f75974e9-e927-4663-a9a0-01219ceae789)

As discussed I  implemented a naif component for the highlight instead of using the fuzzy. 
Later we can use this component in other places or update it to use the fuzzy search.

## Decision making

I need to use workarounds to implement the highlighting mechanism as soon as I can:

1. **Pass the query to each field** e562bc823678201e62c661abe65aeb250f999dcd
I need to add the query params inside each child because the `query` state isn't accessible on `<TreeView.Group items={children}>`. An alternative could be to ask Clay to allow us to pass some kind of context to all the children `<TreeView.Group items={children} data={{ query }}>`

Before  | After
:----:|:----:
![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/1774fbac-0350-4bc2-921b-2b3980a02d5f) | ![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/db4ea72e-9ed6-47fe-8b58-7b4c70553f79)

2. **Style the ClayCheckbox pseudo label with utilities** 1b82e5bdecff80fe477c968b888f82ea02d5199a
Trying to emulate the **label** style because the `Checkout` `label` properly only allows plain text.

Before  | After
:----:|:----:
![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/db4ea72e-9ed6-47fe-8b58-7b4c70553f79) | ![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/c5c17d7c-61af-4e16-99ce-9dd3b1abbd8c)


3. **Style the mark tag with utilities** b9e94f77d2007c755dfe953bc3185728232c554f
I think it is more semantically correct to use the `<mark>` tag [^1] [^2] so I use it instead of `<strong>`. I abused the CSS utilities to reset and style it.

Before  | After
:----:|:----:
![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/c5c17d7c-61af-4e16-99ce-9dd3b1abbd8c) | ![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/468e1965-11f4-405f-b90c-fc65d9a95595)


## Extra ball
I fixed a bug that I introduced some days ago because I'm using the `fields. length` to show the number or the search result and it is wrong. 

I added proper support on 2923ee7df4cd55836162eeb06d5d5494ae3561ce.

It can be split on a separate PR if needed.


Before  | After
:----:|:----:
![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/34cbf9be-19f9-428e-8520-0a33a9b2fbcb) |  ![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/6bddef6d-7955-4401-a90d-504496dcba02)


[^1]: https://www.w3.org/TR/2011/WD-html5-author-20110809/the-mark-element.html
[^2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark