### PR TITLE
LPS-191958 When you rename a Data Set entry, it's possible to leave the name field blank

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -764,7 +764,9 @@ const RenameFDSEntryModalContent = ({
 		})
 			.then((response) => {
 				if (!response.ok) {
-					throw Error();
+					openDefaultFailureToast();
+
+					setSaveButtonDisabled(false);
 				}
 
 				closeModal();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -746,8 +746,11 @@ const RenameFDSEntryModalContent = ({
 }) => {
 	const [fdsEntryLabel, setFDSEntryLabel] = useState(itemData.label);
 	const [labelValidationError, setLabelValidationError] = useState(false);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
 	function saveFDSEntryRename() {
+		setSaveButtonDisabled(true);
+
 		fetch(itemData.actions.update.href, {
 			body: JSON.stringify({
 				externalReferenceCode: itemData.externalReferenceCode,
@@ -770,7 +773,11 @@ const RenameFDSEntryModalContent = ({
 
 				loadData();
 			})
-			.catch(openDefaultFailureToast);
+			.catch(() => {
+				openDefaultFailureToast();
+
+				setSaveButtonDisabled(false);
+			});
 	}
 
 	return (
@@ -795,7 +802,7 @@ const RenameFDSEntryModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={!fdsEntryLabel}
+							disabled={!fdsEntryLabel || saveButtonDisabled}
 							onClick={saveFDSEntryRename}
 						>
 							{Liferay.Language.get('save')}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -759,7 +759,11 @@ const RenameFDSEntryModalContent = ({
 			},
 			method: itemData.actions.update.method,
 		})
-			.then(() => {
+			.then((response) => {
+				if (!response.ok) {
+					throw Error();
+				}
+
 				closeModal();
 
 				openDefaultSuccessToast();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -749,8 +749,6 @@ const RenameFDSEntryModalContent = ({
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
 	function saveFDSEntryRename() {
-		setSaveButtonDisabled(true);
-
 		fetch(itemData.actions.update.href, {
 			body: JSON.stringify({
 				externalReferenceCode: itemData.externalReferenceCode,
@@ -782,6 +780,16 @@ const RenameFDSEntryModalContent = ({
 			});
 	}
 
+	const validate = () => {
+		if (!fdsEntryLabel) {
+			setLabelValidationError(true);
+
+			return false;
+		}
+
+		return true;
+	};
+
 	return (
 		<>
 			<ClayModal.Header>
@@ -804,8 +812,19 @@ const RenameFDSEntryModalContent = ({
 				last={
 					<ClayButton.Group spaced>
 						<ClayButton
-							disabled={!fdsEntryLabel || saveButtonDisabled}
-							onClick={saveFDSEntryRename}
+							disabled={saveButtonDisabled}
+							onClick={() => {
+								setSaveButtonDisabled(true);
+
+								const success = validate();
+
+								if (success) {
+									saveFDSEntryRename();
+								}
+								else {
+									setSaveButtonDisabled(false);
+								}
+							}}
 						>
 							{Liferay.Language.get('save')}
 						</ClayButton>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -258,15 +258,15 @@ const RestEndpointDropdownMenu = ({
 };
 
 const FDSEntryLabelInput = ({
-	handleOnBlur,
 	labelValidationError,
 	namespace,
+	onBlur,
 	onChange,
 	value,
 }: {
-	handleOnBlur: () => void;
 	labelValidationError: boolean;
 	namespace: string;
+	onBlur: () => void;
 	onChange: Function;
 	value: string;
 }) => (
@@ -283,7 +283,7 @@ const FDSEntryLabelInput = ({
 
 		<ClayInput
 			id={`${namespace}fdsEntryLabelInput`}
-			onBlur={handleOnBlur}
+			onBlur={onBlur}
 			onChange={(event) => onChange(event.target.value)}
 			type="text"
 			value={value}
@@ -614,11 +614,11 @@ const AddFDSEntryModalContent = ({
 
 			<ClayModal.Body>
 				<FDSEntryLabelInput
-					handleOnBlur={() => {
-						setLabelValidationError(!fdsEntryLabel);
-					}}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
+					onBlur={() => {
+						setLabelValidationError(!fdsEntryLabel);
+					}}
 					onChange={setFDSEntryLabel}
 					value={fdsEntryLabel}
 				/>
@@ -788,11 +788,11 @@ const RenameFDSEntryModalContent = ({
 
 			<ClayModal.Body>
 				<FDSEntryLabelInput
-					handleOnBlur={() => {
-						setLabelValidationError(!fdsEntryLabel);
-					}}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
+					onBlur={() => {
+						setLabelValidationError(!fdsEntryLabel);
+					}}
 					onChange={setFDSEntryLabel}
 					value={fdsEntryLabel}
 				/>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -794,7 +794,10 @@ const RenameFDSEntryModalContent = ({
 			<ClayModal.Footer
 				last={
 					<ClayButton.Group spaced>
-						<ClayButton onClick={saveFDSEntryRename}>
+						<ClayButton
+							disabled={!fdsEntryLabel}
+							onClick={saveFDSEntryRename}
+						>
 							{Liferay.Language.get('save')}
 						</ClayButton>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191958

**Rename Data Set Entry Modal:**
- Disables save when input is blank AND while saving
- Added an additional `!response.ok` check in case the response errors
- Renamed `handleOnBlur` -> `onBlur` for consistency. 

## Demo

https://github.com/liferay-frontend/liferay-portal/assets/4496722/94c97d85-9c1c-4194-9f59-661deeb39bf9

