### PR TITLE
LPS-199022 CSRF bypass related to `p_l_back_url` in content page editor

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/SPATopHeadJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/SPATopHeadJSPDynamicInclude.java
@@ -60,6 +60,9 @@ public class SPATopHeadJSPDynamicInclude extends BaseJSPDynamicInclude {
 		).put(
 			"excludedPaths", spaHelper.getExcludedPathsJSONArray()
 		).put(
+			"excludedTargetPortlets",
+			spaHelper.getExcludedTargetPortletsJSONArray()
+		).put(
 			"loginRedirect",
 			HtmlUtil.escapeJS(spaHelper.getLoginRedirect(httpServletRequest))
 		).put(

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/helper/SPAHelper.java
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/helper/SPAHelper.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Time;
@@ -72,6 +73,10 @@ public class SPAHelper {
 
 	public JSONArray getExcludedPathsJSONArray() {
 		return _spaExcludedPathsJSONArray;
+	}
+
+	public JSONArray getExcludedTargetPortletsJSONArray() {
+		return _spaExcludedTargetPortletsJSONArray;
 	}
 
 	public ResourceBundle getLanguageResourceBundle(
@@ -172,6 +177,9 @@ public class SPAHelper {
 		_spaExcludedPathsJSONArray = _getExcludedPathsJSONArray(
 			_spaConfiguration);
 
+		_spaExcludedTargetPortletsJSONArray =
+			_getExcludedTargetPortletsJSONArray();
+
 		Collections.addAll(
 			_navigationExceptionSelectors,
 			_spaConfiguration.navigationExceptionSelectors());
@@ -206,6 +214,9 @@ public class SPAHelper {
 		_cacheExpirationTime = _getCacheExpirationTime(_spaConfiguration);
 		_spaExcludedPathsJSONArray = _getExcludedPathsJSONArray(
 			_spaConfiguration);
+
+		_spaExcludedTargetPortletsJSONArray =
+			_getExcludedTargetPortletsJSONArray();
 
 		Collections.addAll(
 			_navigationExceptionSelectors,
@@ -247,10 +258,19 @@ public class SPAHelper {
 		return jsonArray;
 	}
 
+	private JSONArray _getExcludedTargetPortletsJSONArray() {
+		return _jsonFactory.createJSONArray(
+			_SPA_DEFAULT_EXCLUDED_TARGET_PORTLETS);
+	}
+
 	private static final String _REDIRECT_PARAM_NAME;
 
 	private static final String[] _SPA_DEFAULT_EXCLUDED_PATHS = {
 		"/c/document_library", "/documents", "/image"
+	};
+
+	private static final String[] _SPA_DEFAULT_EXCLUDED_TARGET_PORTLETS = {
+		PortletKeys.USERS_ADMIN, PortletKeys.SERVER_ADMIN
 	};
 
 	private static final String _SPA_NAVIGATION_EXCEPTION_SELECTOR_KEY =
@@ -303,6 +323,7 @@ public class SPAHelper {
 
 	private volatile SPAConfiguration _spaConfiguration;
 	private volatile JSONArray _spaExcludedPathsJSONArray;
+	private volatile JSONArray _spaExcludedTargetPortletsJSONArray;
 
 	private static final class NavigationExceptionSelectorTrackerCustomizer
 		implements ServiceTrackerCustomizer<Object, Object> {

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
@@ -33,7 +33,11 @@ const initSPA = function (config) {
 				const host = loginRedirectURL.host || window.location.host;
 
 				if (app.isLinkSameOrigin_(host)) {
-					match = uri.searchParams.get('p_p_lifecycle') === '1';
+					match =
+						uri.searchParams.get('p_p_lifecycle') === '1' &&
+						!config.excludedTargetPortlets.some((item) =>
+							uri.searchParams.get('p_p_id')?.includes(item)
+						);
 				}
 
 				return match;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
@@ -33,11 +33,15 @@ const initSPA = function (config) {
 				const host = loginRedirectURL.host || window.location.host;
 
 				if (app.isLinkSameOrigin_(host)) {
-					match =
-						uri.searchParams.get('p_p_lifecycle') === '1' &&
-						!config.excludedTargetPortlets.some((item) =>
-							uri.searchParams.get('p_p_id')?.includes(item)
-						);
+					match = uri.searchParams.get('p_p_lifecycle') === '1';
+
+					if (match) {
+						const id = uri.searchParams.get('p_p_id');
+
+						if (id && config.excludedTargetPortlets) {
+							match = !config.excludedTargetPortlets.includes(id);
+						}
+					}
 				}
 
 				return match;


### PR DESCRIPTION
In this PR we're adding a new hardcoded parameter to handle the case where we don't want SPA to deal with links pointing to sensitive portlet action URLs

We might want to revert commerce PR that tried to solve this via java for some specific cases

@boton @bryceosterhaus pls take a look