### PR TITLE
LPS-170366 Improve accessibility in pagination, SF fixed

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalTaglibsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/IllegalTaglibsCheck.java
@@ -37,7 +37,9 @@ public class IllegalTaglibsCheck extends BaseFileCheck {
 		SourceFormatterArgs sourceFormatterArgs =
 			sourceProcessor.getSourceFormatterArgs();
 
-		if (!sourceFormatterArgs.isFormatCurrentBranch()) {
+		if (!sourceFormatterArgs.isFormatCurrentBranch() ||
+			absolutePath.contains("/portal-web/")) {
+
 			return content;
 		}
 

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.markdown
@@ -111,7 +111,7 @@ HTMLEmptyLinesCheck | [Styling](styling_checks.markdown#styling-checks) | .html 
 HTMLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | .html or .path | Finds missing and unnecessary whitespace in `.html` files. |
 [IfStatementCheck](check/if_statement_check.markdown#ifstatementcheck) | [Styling](styling_checks.markdown#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds empty if-statements and consecutive if-statements with identical bodies |
 IllegalImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain classes. |
-IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain taglibs. |
+IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 [IncorrectFileLocationCheck](check/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | | Checks that `/src/*/java/` only contains `.java` files. |
 IncorrectFilePathCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | | Checks that file path contains illegal characters. |
 [InstanceInitializerCheck](check/instance_initializer_check.markdown#instanceinitializercheck) | [Styling](styling_checks.markdown#styling-checks) | .java | Performs several checks on class instance initializer. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.markdown
@@ -47,7 +47,7 @@ GradleProvidedDependenciesCheck | .gradle | Validates the scope of dependencies 
 GradleTestDependencyVersionCheck | .gradle | Checks the version for dependencies in gradle build files. |
 GradleTestUtilDeployDirCheck | .gradle | Checks for incorrect use of `deployDir`. |
 IllegalImportsCheck | .java, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain classes. |
-IllegalTaglibsCheck | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain taglibs. |
+IllegalTaglibsCheck | .ftl, .jsp, .jspf, .jspx, .tag, .tpl or .vm | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 [IncorrectFileLocationCheck](check/incorrect_file_location_check.markdown#incorrectfilelocationcheck) | | Checks that `/src/*/java/` only contains `.java` files. |
 IncorrectFilePathCheck | | Checks that file path contains illegal characters. |
 JSCompatibilityCheck | | Checks for JavaScript compatibility. |

--- a/modules/util/source-formatter/src/main/resources/documentation/ftl_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/ftl_source_processor_checks.markdown
@@ -11,4 +11,4 @@ FTLStylingCheck | [Styling](styling_checks.markdown#styling-checks) | Applies ru
 FTLTagAttributesCheck | [Styling](styling_checks.markdown#styling-checks) | Sorts and formats attributes values in tags. |
 FTLTagCheck | [Styling](styling_checks.markdown#styling-checks) | Finds cases where consecutive `#assign` can be combined. |
 FTLWhitespaceCheck | [Styling](styling_checks.markdown#styling-checks) | Finds missing and unnecessary whitespace in `.ftl` files. |
-IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain taglibs. |
+IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain deprecated taglibs in modules. |

--- a/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
+++ b/modules/util/source-formatter/src/main/resources/documentation/jsp_source_processor_checks.markdown
@@ -22,7 +22,7 @@ FactoryCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-ch
 [GetterUtilCheck](check/getter_util_check.markdown#getterutilcheck) | [Styling](styling_checks.markdown#styling-checks) | Finds cases where the default value is passed to `GetterUtil.get*` or `ParamUtil.get*`. |
 [IfStatementCheck](check/if_statement_check.markdown#ifstatementcheck) | [Styling](styling_checks.markdown#styling-checks) | Finds empty if-statements and consecutive if-statements with identical bodies |
 IllegalImportsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain classes. |
-IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain taglibs. |
+IllegalTaglibsCheck | [Bug Prevention](bug_prevention_checks.markdown#bug-prevention-checks) | Finds cases of incorrect use of certain deprecated taglibs in modules. |
 InstanceofOrderCheck | [Styling](styling_checks.markdown#styling-checks) | Check the order of `instanceof` calls. |
 JSONNamingCheck | [Naming Conventions](naming_conventions_checks.markdown#naming-conventions-checks) | Checks if variable names follow naming conventions. |
 [JSONUtilCheck](check/json_util_check.markdown#jsonutilcheck) | [Styling](styling_checks.markdown#styling-checks) | Checks for utilization of class `JSONUtil`. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -245,7 +245,7 @@
 		</check>
 		<check name="IllegalTaglibsCheck">
 			<category name="Bug Prevention" />
-			<description name="Finds cases of incorrect use of certain taglibs." />
+			<description name="Finds cases of incorrect use of certain deprecated taglibs in modules." />
 		</check>
 	</source-processor>
 	<source-processor name="GradleSourceProcessor">

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -196,253 +196,253 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 		</p>
 
 		<nav aria-label="pagination">
-		<ul class="pagination">
-			<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
+			<ul class="pagination">
+				<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
+					<c:choose>
+						<c:when test="<%= cur > 1 %>">
+							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
+						</c:when>
+						<c:otherwise>
+							<div class="page-link">
+						</c:otherwise>
+					</c:choose>
+
+						<liferay-ui:icon
+							icon='<%= PortalUtil.isRightToLeft(request) ? "angle-right" : "angle-left" %>'
+							markupView="lexicon"
+						/>
+
+					<c:choose>
+						<c:when test="<%= cur > 1 %>">
+							</a>
+						</c:when>
+						<c:otherwise>
+							</div>
+						</c:otherwise>
+					</c:choose>
+				</li>
+
 				<c:choose>
-					<c:when test="<%= cur > 1 %>">
-						<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
+					<c:when test="<%= pages <= 5 %>">
+
+						<%
+						for (int i = 1; i <= pages; i++) {
+						%>
+
+							<li class="page-item <%= (i == cur) ? "active" : StringPool.BLANK %>">
+								<c:choose>
+									<c:when test="<%= i == cur %>">
+										<a aria-current="page" class="page-link" tabindex="0">
+									</c:when>
+									<c:otherwise>
+										<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
+									</c:otherwise>
+								</c:choose>
+
+								<span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+							</li>
+
+						<%
+						}
+						%>
+
 					</c:when>
-					<c:otherwise>
-						<div class="page-link">
-					</c:otherwise>
-				</c:choose>
-
-					<liferay-ui:icon
-						icon='<%= PortalUtil.isRightToLeft(request) ? "angle-right" : "angle-left" %>'
-						markupView="lexicon"
-					/>
-
-				<c:choose>
-					<c:when test="<%= cur > 1 %>">
-						</a>
-					</c:when>
-					<c:otherwise>
-						</div>
-					</c:otherwise>
-				</c:choose>
-			</li>
-
-			<c:choose>
-				<c:when test="<%= pages <= 5 %>">
-
-					<%
-					for (int i = 1; i <= pages; i++) {
-					%>
-
-						<li class="page-item <%= (i == cur) ? "active" : StringPool.BLANK %>">
-							<c:choose>
-								<c:when test="<%= i == cur %>">
-									<a aria-current="page" class="page-link" tabindex="0">
-								</c:when>
-								<c:otherwise>
-									<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
-								</c:otherwise>
-							</c:choose>
-
-							<span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+					<c:when test="<%= cur == 1 %>">
+						<li class="active page-item">
+							<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 						</li>
+						<li class="page-item">
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
+						</li>
+						<li class="page-item">
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
+						</li>
+						<li class="dropdown page-item">
+							<button aria-controls="dropdown-pages-1" aria-haspopup="true" class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown">
+								<span aria-hidden="true">...</span>
 
-					<%
-					}
-					%>
+								<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
+							</button>
 
-				</c:when>
-				<c:when test="<%= cur == 1 %>">
-					<li class="active page-item">
-						<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
-					</li>
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
-					</li>
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
-					</li>
-					<li class="dropdown page-item">
-						<button aria-haspopup="true" class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-1">
-							<span aria-hidden="true">...</span>
+							<div class="dropdown-menu dropdown-menu-top-center">
+								<ul aria-expanded="false" class="inline-scroller link-list" id="dropdown-pages-1">
 
-							<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
-						</button>
+									<%
+									for (int i = 4; i < initialPages; i++) {
+										if (i >= pages) {
+											break;
+										}
+									%>
 
-						<div class="dropdown-menu dropdown-menu-top-center">
-							<ul class="inline-scroller link-list" id="dropdown-pages-1" aria-expanded="false">
+										<li>
+											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+										</li>
 
-								<%
-								for (int i = 4; i < initialPages; i++) {
-									if (i >= pages) {
-										break;
+									<%
 									}
-								%>
+									%>
 
-									<li>
-										<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
-									</li>
-
-								<%
-								}
-								%>
-
-							</ul>
-						</div>
-					</li>
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
-					</li>
-				</c:when>
-				<c:when test="<%= cur == pages %>">
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
-					</li>
-					<li class="dropdown page-item">
-						<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-2">
-							<span aria-hidden="true">...</span>
-
-							<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
-						</button>
-
-						<div class="dropdown-menu dropdown-menu-top-center">
-							<ul class="inline-scroller link-list" data-max-index="<%= pages - 2 %>" id="dropdown-pages-2" aria-expanded="false">
-
-								<%
-								for (int i = 2; i < ((initialPages > (cur - 2)) ? cur - 2 : initialPages); i++) {
-								%>
-
-									<li>
-										<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
-									</li>
-
-								<%
-								}
-								%>
-
-							</ul>
-						</div>
-					</li>
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 2 %></a>
-					</li>
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
-					</li>
-					<li class="active page-item">
-						<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
-					</li>
-				</c:when>
-				<c:otherwise>
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
-					</li>
-
-					<c:if test="<%= (cur - 3) > 1 %>">
+								</ul>
+							</div>
+						</li>
+						<li class="page-item">
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+						</li>
+					</c:when>
+					<c:when test="<%= cur == pages %>">
+						<li class="page-item">
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+						</li>
 						<li class="dropdown page-item">
-							<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-3">
+							<button aria-controls="dropdown-pages-2" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
 								<span aria-hidden="true">...</span>
 
 								<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
 							</button>
 
 							<div class="dropdown-menu dropdown-menu-top-center">
-								<ul class="inline-scroller link-list" data-max-index="<%= cur - 1 %>" id="dropdown-pages-3" aria-expanded="false">
-					</c:if>
+								<ul aria-expanded="false" class="inline-scroller link-list" data-max-index="<%= pages - 2 %>" id="dropdown-pages-2">
 
-					<%
-					for (int i = 2; i < ((initialPages > (cur - 1)) ? cur - 1 : initialPages); i++) {
-					%>
+									<%
+									for (int i = 2; i < ((initialPages > (cur - 2)) ? cur - 2 : initialPages); i++) {
+									%>
 
-						<li class="<%= ((cur - 3) > 1) ? "" : "page-item" %>">
-							<a class="<%= ((cur - 3) > 1) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
-						</li>
+										<li>
+											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+										</li>
 
-					<%
-					}
-					%>
+									<%
+									}
+									%>
 
-					<c:if test="<%= (cur - 3) > 1 %>">
 								</ul>
 							</div>
 						</li>
-					</c:if>
-
-					<c:if test="<%= (cur - 1) > 1 %>">
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur - 1 %></a>
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 2 %></a>
 						</li>
-					</c:if>
-
-					<li class="active page-item">
-						<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur %></a>
-					</li>
-
-					<c:if test="<%= (cur + 1) < pages %>">
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur + 1 %></a>
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
 						</li>
-					</c:if>
-
-					<c:if test="<%= (cur + 3) < pages %>">
-						<li class="dropdown page-item">
-							<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-4">
-								<span aria-hidden="true">...</span>
-
-								<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
-							</button>
-
-							<div class="dropdown-menu dropdown-menu-top-center">
-								<ul class="inline-scroller link-list" data-current-index="<%= cur + 2 %>" id="dropdown-pages-4" aria-expanded="false">
-					</c:if>
-
-					<%
-					int remainingPages = ((pages - (cur + 2)) < initialPages) ? (pages - (cur + 2)) : initialPages;
-
-					for (int i = cur + 2; i < ((cur + 2) + remainingPages); i++) {
-					%>
-
-						<li class="<%= ((cur + 3) < pages) ? "" : "page-item" %>">
-							<a class="<%= ((cur + 3) < pages) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+						<li class="active page-item">
+							<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+						</li>
+					</c:when>
+					<c:otherwise>
+						<li class="page-item">
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 						</li>
 
-					<%
-					}
-					%>
+						<c:if test="<%= (cur - 3) > 1 %>">
+							<li class="dropdown page-item">
+								<button aria-controls="dropdown-pages-3" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
+									<span aria-hidden="true">...</span>
 
-					<c:if test="<%= (cur + 3) < pages %>">
-								</ul>
+									<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
+								</button>
+
+								<div class="dropdown-menu dropdown-menu-top-center">
+									<ul aria-expanded="false" class="inline-scroller link-list" data-max-index="<%= cur - 1 %>" id="dropdown-pages-3">
+						</c:if>
+
+						<%
+						for (int i = 2; i < ((initialPages > (cur - 1)) ? cur - 1 : initialPages); i++) {
+						%>
+
+							<li class="<%= ((cur - 3) > 1) ? "" : "page-item" %>">
+								<a class="<%= ((cur - 3) > 1) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+							</li>
+
+						<%
+						}
+						%>
+
+						<c:if test="<%= (cur - 3) > 1 %>">
+									</ul>
+								</div>
+							</li>
+						</c:if>
+
+						<c:if test="<%= (cur - 1) > 1 %>">
+							<li class="page-item">
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur - 1 %></a>
+							</li>
+						</c:if>
+
+						<li class="active page-item">
+							<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur %></a>
+						</li>
+
+						<c:if test="<%= (cur + 1) < pages %>">
+							<li class="page-item">
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur + 1 %></a>
+							</li>
+						</c:if>
+
+						<c:if test="<%= (cur + 3) < pages %>">
+							<li class="dropdown page-item">
+								<button aria-controls="dropdown-pages-4" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
+									<span aria-hidden="true">...</span>
+
+									<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
+								</button>
+
+								<div class="dropdown-menu dropdown-menu-top-center">
+									<ul aria-expanded="false" class="inline-scroller link-list" data-current-index="<%= cur + 2 %>" id="dropdown-pages-4">
+						</c:if>
+
+						<%
+						int remainingPages = ((pages - (cur + 2)) < initialPages) ? (pages - (cur + 2)) : initialPages;
+
+						for (int i = cur + 2; i < ((cur + 2) + remainingPages); i++) {
+						%>
+
+							<li class="<%= ((cur + 3) < pages) ? "" : "page-item" %>">
+								<a class="<%= ((cur + 3) < pages) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+							</li>
+
+						<%
+						}
+						%>
+
+						<c:if test="<%= (cur + 3) < pages %>">
+									</ul>
+								</div>
+							</li>
+						</c:if>
+
+						<li class="page-item">
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+						</li>
+					</c:otherwise>
+				</c:choose>
+
+				<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
+					<c:choose>
+						<c:when test="<%= cur < pages %>">
+							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
+						</c:when>
+						<c:otherwise>
+							<div class="page-link">
+						</c:otherwise>
+					</c:choose>
+
+						<liferay-ui:icon
+							icon='<%= PortalUtil.isRightToLeft(request) ? "angle-left" : "angle-right" %>'
+							markupView="lexicon"
+						/>
+
+					<c:choose>
+						<c:when test="<%= cur < pages %>">
+							</a>
+						</c:when>
+						<c:otherwise>
 							</div>
-						</li>
-					</c:if>
-
-					<li class="page-item">
-						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
-					</li>
-				</c:otherwise>
-			</c:choose>
-
-			<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
-				<c:choose>
-					<c:when test="<%= cur < pages %>">
-						<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
-					</c:when>
-					<c:otherwise>
-						<div class="page-link">
-					</c:otherwise>
-				</c:choose>
-
-					<liferay-ui:icon
-						icon='<%= PortalUtil.isRightToLeft(request) ? "angle-left" : "angle-right" %>'
-						markupView="lexicon"
-					/>
-
-				<c:choose>
-					<c:when test="<%= cur < pages %>">
-						</a>
-					</c:when>
-					<c:otherwise>
-						</div>
-					</c:otherwise>
-				</c:choose>
-			</li>
-		</ul>
-	</nav>
+						</c:otherwise>
+					</c:choose>
+				</li>
+			</ul>
+		</nav>
 	</div>
 </c:if>
 

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -197,7 +197,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 		<nav aria-label="pagination">
 		<ul class="pagination">
-			<span class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
+			<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
 				<c:choose>
 					<c:when test="<%= cur > 1 %>">
 						<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
@@ -220,7 +220,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</div>
 					</c:otherwise>
 				</c:choose>
-			</span>
+			</li>
 
 			<c:choose>
 				<c:when test="<%= pages <= 5 %>">
@@ -258,14 +258,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
 					</li>
 					<li class="dropdown page-item">
-						<button aria-haspopup="true" class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown">
+						<button aria-haspopup="true" class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-1">
 							<span aria-hidden="true">...</span>
 
 							<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
 						</button>
 
 						<div class="dropdown-menu dropdown-menu-top-center">
-							<ul class="inline-scroller link-list">
+							<ul class="inline-scroller link-list" id="dropdown-pages-1" aria-expanded="false">
 
 								<%
 								for (int i = 4; i < initialPages; i++) {
@@ -294,14 +294,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 					</li>
 					<li class="dropdown page-item">
-						<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
+						<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-2">
 							<span aria-hidden="true">...</span>
 
 							<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
 						</button>
 
 						<div class="dropdown-menu dropdown-menu-top-center">
-							<ul class="inline-scroller link-list" data-max-index="<%= pages - 2 %>">
+							<ul class="inline-scroller link-list" data-max-index="<%= pages - 2 %>" id="dropdown-pages-2" aria-expanded="false">
 
 								<%
 								for (int i = 2; i < ((initialPages > (cur - 2)) ? cur - 2 : initialPages); i++) {
@@ -335,14 +335,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 					<c:if test="<%= (cur - 3) > 1 %>">
 						<li class="dropdown page-item">
-							<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
+							<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-3">
 								<span aria-hidden="true">...</span>
 
 								<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
 							</button>
 
 							<div class="dropdown-menu dropdown-menu-top-center">
-								<ul class="inline-scroller link-list" data-max-index="<%= cur - 1 %>">
+								<ul class="inline-scroller link-list" data-max-index="<%= cur - 1 %>" id="dropdown-pages-3" aria-expanded="false">
 					</c:if>
 
 					<%
@@ -381,14 +381,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 					<c:if test="<%= (cur + 3) < pages %>">
 						<li class="dropdown page-item">
-							<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
+							<button aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown" aria-controls="dropdown-pages-4">
 								<span aria-hidden="true">...</span>
 
 								<span class="sr-only"><liferay-ui:message key="intermediate-pages" />&nbsp;<liferay-ui:message key="use-tab-to-navigate" /></span>
 							</button>
 
 							<div class="dropdown-menu dropdown-menu-top-center">
-								<ul class="inline-scroller link-list" data-current-index="<%= cur + 2 %>">
+								<ul class="inline-scroller link-list" data-current-index="<%= cur + 2 %>" id="dropdown-pages-4" aria-expanded="false">
 					</c:if>
 
 					<%
@@ -417,7 +417,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				</c:otherwise>
 			</c:choose>
 
-			<span class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
+			<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
 				<c:choose>
 					<c:when test="<%= cur < pages %>">
 						<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
@@ -440,7 +440,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</div>
 					</c:otherwise>
 				</c:choose>
-			</span>
+			</li>
 		</ul>
 	</nav>
 	</div>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -195,8 +195,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 			<liferay-ui:message arguments="<%= new Object[] {numberFormat.format(start + 1), numberFormat.format(end), numberFormat.format(total)} %>" key="showing-x-to-x-of-x-entries" />
 		</p>
 
+		<nav aria-label="pagination">
 		<ul class="pagination">
-			<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
+			<span class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
 				<c:choose>
 					<c:when test="<%= cur > 1 %>">
 						<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
@@ -219,7 +220,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</div>
 					</c:otherwise>
 				</c:choose>
-			</li>
+			</span>
 
 			<c:choose>
 				<c:when test="<%= pages <= 5 %>">
@@ -416,7 +417,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				</c:otherwise>
 			</c:choose>
 
-			<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
+			<span class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
 				<c:choose>
 					<c:when test="<%= cur < pages %>">
 						<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
@@ -439,8 +440,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</div>
 					</c:otherwise>
 				</c:choose>
-			</li>
+			</span>
 		</ul>
+	</nav>
 	</div>
 </c:if>
 

--- a/portal-web/source-formatter-suppressions.xml
+++ b/portal-web/source-formatter-suppressions.xml
@@ -3,5 +3,6 @@
 <suppressions>
 	<source-check>
 		<suppress checks="IllegalTaglibsCheck" files="docroot/html/taglib/ui/icon/page\.jsp" />
+		<suppress checks="IllegalTaglibsCheck" files="docroot/html/taglib/ui/page_iterator/start\.jsp" />
 	</source-check>
 </suppressions>

--- a/portal-web/source-formatter-suppressions.xml
+++ b/portal-web/source-formatter-suppressions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-
-<suppressions>
-	<source-check>
-		<suppress checks="IllegalTaglibsCheck" files="docroot/html/taglib/ui/icon/page\.jsp" />
-		<suppress checks="IllegalTaglibsCheck" files="docroot/html/taglib/ui/page_iterator/start\.jsp" />
-	</source-check>
-</suppressions>


### PR DESCRIPTION
This is a continuation of https://github.com/liferay-frontend/liferay-portal/pull/3851, which was [rejected by BChan](https://github.com/brianchandotcom/liferay-portal/pull/144497) due to it was adding a SF supression.

In this PR, we fix `IllegalTaglibsCheck` rule to prevent it from reporting errors in case old taglibs are used in `portal-web`. Reason is that there, we can't use newer clay tags. Ideally, this situation will become less and less frequent, but still there are some DXP bits making use of old tags which haven't been modernized yet.

@ling-alan-huang as we talked privately, please take a look to the last 3 commits

cc @markocikos @smailbiala  