### PR TITLE
LPS-202020 fixes error of incorrect positioning of the columns visibility button

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/FieldsSelectorDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/FieldsSelectorDropdown.js
@@ -57,7 +57,7 @@ const FieldsSelectorDropdown = ({fields}) => {
 						'component-action': Liferay.FeatureFlags['LPS-193005'],
 					})}
 					displayType="secondary"
-					size="xs"
+					size={Liferay.FeatureFlags['LPS-193005'] ? 'xs' : undefined}
 					symbol={active ? 'caret-top' : 'caret-bottom'}
 				/>
 			}


### PR DESCRIPTION
[LPS-202020](https://liferay.atlassian.net/browse/LPS-202020) Hey guys, this PR is a WIP to fix the behavior where the width of the FDS columns has some inconsistent sizes.

So far I'm still analyzing to investigate the real cause of the problem, I'm still not sure if the bug has occurred due to the changes https://github.com/liferay-platform-experience/liferay-portal/pull/228, like the changes they only affect when FF is enabled, it wouldn't make much sense, but as Markos did a test of reversing the commit and apparently that would solve it, but I'm not able to reproduce this behavior by reversing the commits and even removing the code manually in master, I still see the width with the wrong sizes.

My assumption is that as FDS takes the column size as soon as the table is rendered the first time, the sizes are already strange.

![Screenshot 2023-11-29 at 20 19 26](https://github.com/liferay-frontend/liferay-portal/assets/13750819/35351365-7811-466b-aa52-dc2c60885416)

My assumption is that this is more related to CSS because the table is already rendering with a strange size, I'm not sure if this is related to the rows having no content. I'll continue investigating.