### PR TITLE
LPS-202697 Add new parameter for input localized to hide the translation manager

### DIFF
--- a/portal-web/docroot/html/taglib/aui/input/init.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/init.jsp
@@ -42,6 +42,7 @@ java.lang.String label = GetterUtil.getString((java.lang.String)request.getAttri
 java.lang.String labelCssClass = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:labelCssClass"));
 java.lang.String languageId = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:languageId"));
 java.lang.String languagesDropdownDirection = GetterUtil.getString((java.lang.String)request.getAttribute("aui:input:languagesDropdownDirection"));
+boolean languagesDropdownVisible = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:languagesDropdownVisible")));
 boolean last = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:last")));
 boolean localized = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:localized")));
 boolean localizeLabel = GetterUtil.getBoolean(String.valueOf(request.getAttribute("aui:input:localizeLabel")), true);

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -288,6 +288,7 @@ boolean choiceField = checkboxField || radioField;
 					ignoreRequestValue="<%= ignoreRequestValue %>"
 					languageId="<%= languageId %>"
 					languagesDropdownDirection="<%= languagesDropdownDirection %>"
+					languagesDropdownVisible="<%= languagesDropdownVisible %>"
 					name="<%= name %>"
 					onChange="<%= onChange %>"
 					onClick="<%= onClick %>"

--- a/portal-web/docroot/html/taglib/ui/input_localized/init.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/init.jsp
@@ -31,6 +31,7 @@ boolean ignoreRequestValue = GetterUtil.getBoolean((String)request.getAttribute(
 String inputAddon = (String)request.getAttribute("liferay-ui:input-localized:inputAddon");
 String languageId = (String)request.getAttribute("liferay-ui:input-localized:languageId");
 String languagesDropdownDirection = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-localized:languagesDropdownDirection"));
+boolean languagesDropdownVisible = GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:input-localized:languagesDropdownVisible"));
 String maxLength = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-localized:maxLength"));
 String name = (String)request.getAttribute("liferay-ui:input-localized:name");
 String placeholder = (String)request.getAttribute("liferay-ui:input-localized:placeholder");

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -128,7 +128,7 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 		}
 		%>
 
-		<div class="input-group-item input-group-item-shrink input-localized-content">
+		<div class="input-group-item input-group-item-shrink input-localized-content <%= languagesDropdownVisible ? "" : "hide" %>">
 
 			<%
 			String normalizedSelectedLanguageId = StringUtil.replace(selectedLanguageId, '_', '-');

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 21.0.1
+Bundle-Version: 21.1.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-aui.tld
+++ b/util-taglib/src/META-INF/liferay-aui.tld
@@ -807,6 +807,13 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>Whether to make visible the languages dropdown. The default value is <![CDATA[<code>true</code>]]></description>
+			<name>languagesDropdownVisible</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
 			<description>Whether the component should be the last element of the form.</description>
 			<name>last</name>
 			<required>false</required>

--- a/util-taglib/src/META-INF/liferay-ui.tld
+++ b/util-taglib/src/META-INF/liferay-ui.tld
@@ -1157,6 +1157,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>languagesDropdownVisible</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>maxLength</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/util-taglib/src/com/liferay/taglib/aui/base/BaseInputTag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/base/BaseInputTag.java
@@ -111,6 +111,10 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		return _helpTextCssClass;
 	}
 
+	public boolean getLanguagesDropdownVisible() {
+		return _languagesDropdownVisible;
+	}
+
 	public java.lang.String getIconOff() {
 		return _iconOff;
 	}
@@ -335,6 +339,10 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		_helpTextCssClass = helpTextCssClass;
 	}
 
+	public void setLanguagesDropdownVisible(boolean languagesDropdownVisible) {
+		_languagesDropdownVisible = languagesDropdownVisible;
+	}
+
 	public void setIconOff(java.lang.String iconOff) {
 		_iconOff = iconOff;
 	}
@@ -503,6 +511,7 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		_labelCssClass = null;
 		_languageId = null;
 		_languagesDropdownDirection = null;
+		_languagesDropdownVisible = true;
 		_last = false;
 		_localized = false;
 		_localizeLabel = true;
@@ -557,6 +566,7 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 		setNamespacedAttribute(request, "formName", _formName);
 		setNamespacedAttribute(request, "helpMessage", _helpMessage);
 		setNamespacedAttribute(request, "helpTextCssClass", _helpTextCssClass);
+		setNamespacedAttribute(request, "languagesDropdownVisible", _languagesDropdownVisible);
 		setNamespacedAttribute(request, "iconOff", _iconOff);
 		setNamespacedAttribute(request, "iconOn", _iconOn);
 		setNamespacedAttribute(request, "id", _id);
@@ -619,6 +629,7 @@ public abstract class BaseInputTag extends com.liferay.taglib.BaseValidatorTagSu
 	private java.lang.String _formName = null;
 	private java.lang.String _helpMessage = null;
 	private java.lang.String _helpTextCssClass = "input-group-addon";
+	private boolean _languagesDropdownVisible = true;
 	private java.lang.String _iconOff = null;
 	private java.lang.String _iconOn = null;
 	private java.lang.String _id = null;

--- a/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/base/packageinfo
@@ -1,1 +1,1 @@
-version 15.1.0
+version 15.2.0

--- a/util-taglib/src/com/liferay/taglib/aui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/aui/packageinfo
@@ -1,1 +1,1 @@
-version 15.1.0
+version 15.2.0

--- a/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/InputLocalizedTag.java
@@ -82,6 +82,10 @@ public class InputLocalizedTag extends IncludeTag {
 		return _languagesDropdownDirection;
 	}
 
+	public boolean getLanguagesDropdownVisible() {
+		return _languagesDropdownVisible;
+	}
+
 	public String getMaxLength() {
 		return _maxLength;
 	}
@@ -208,6 +212,10 @@ public class InputLocalizedTag extends IncludeTag {
 		_languagesDropdownDirection = languagesDropdownDirection;
 	}
 
+	public void setLanguagesDropdownVisible(boolean languagesDropdownVisible) {
+		_languagesDropdownVisible = languagesDropdownVisible;
+	}
+
 	public void setMaxLength(String maxLength) {
 		_maxLength = maxLength;
 	}
@@ -259,6 +267,7 @@ public class InputLocalizedTag extends IncludeTag {
 		_inputAddon = null;
 		_languageId = null;
 		_languagesDropdownDirection = null;
+		_languagesDropdownVisible = true;
 		_maxLength = null;
 		_name = null;
 		_placeholder = null;
@@ -342,6 +351,9 @@ public class InputLocalizedTag extends IncludeTag {
 			"liferay-ui:input-localized:languagesDropdownDirection",
 			_languagesDropdownDirection);
 		httpServletRequest.setAttribute(
+			"liferay-ui:input-localized:languagesDropdownVisible",
+			String.valueOf(_languagesDropdownVisible));
+		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:maxLength", _maxLength);
 		httpServletRequest.setAttribute(
 			"liferay-ui:input-localized:name", _name);
@@ -382,6 +394,7 @@ public class InputLocalizedTag extends IncludeTag {
 	private String _inputAddon;
 	private String _languageId;
 	private String _languagesDropdownDirection;
+	private boolean _languagesDropdownVisible = true;
 	private String _maxLength;
 	private String _name;
 	private String _placeholder;

--- a/util-taglib/src/com/liferay/taglib/ui/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/ui/packageinfo
@@ -1,1 +1,1 @@
-version 22.0.0
+version 22.1.0


### PR DESCRIPTION
Hi guys!

In the echo team we are developing this new story https://liferay.atlassian.net/browse/LPS-200663. To meet the requirements of this story we need to hide the button of the translation manager from the localized input. For this reason we have added a new `hideTranslationManager` param to the `aui:input` and `ui:input-localized` taglibs to have the possibility of hiding this element. Can you review the implemented solution? 

Thanks in advance! :slightly_smiling_face: 