### PR TITLE
LPS-203203 Fix NPE if CSP configuration has not been set

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/taglib/ContentSecurityPolicyTopHeadDynamicInclude.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/taglib/ContentSecurityPolicyTopHeadDynamicInclude.java
@@ -55,7 +55,9 @@ public class ContentSecurityPolicyTopHeadDynamicInclude
 			ContentSecurityPolicyConfigurationUtil.
 				getContentSecurityPolicyConfiguration(httpServletRequest);
 
-		if (contentSecurityPolicyConfiguration.enabled()) {
+		if ((contentSecurityPolicyConfiguration != null) &&
+			contentSecurityPolicyConfiguration.enabled()) {
+
 			String policy = contentSecurityPolicyConfiguration.policy();
 
 			if (!policy.contains("'strict-dynamic'")) {


### PR DESCRIPTION
Some of the requests won't pass through the CSP filter and the CSP configuration won't be stored in the request. For those, we set the nonce to '' as if CSP hadn't been configured.