### PR TITLE
LPS-202133 - Add missing action properties

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -665,9 +665,15 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 						"confirmationMessage",
 						properties.get("confirmationMessage")
 					).put(
+						"errorMessage", properties.get("errorMessage")
+					).put(
+						"method", properties.get("method")
+					).put(
 						"permissionKey", properties.get("permissionKey")
 					).put(
 						"status", properties.get("confirmationMessageType")
+					).put(
+						"successMessage", properties.get("successMessage")
 					).put(
 						"title", properties.get("label")
 					)

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
@@ -550,6 +550,11 @@ const ActionForm = ({
 									onChange={(event) =>
 										setActionData({
 											...actionData,
+											method:
+												event.target.value ===
+												ACTION_TYPE.ASYNC
+													? ACTION_METHOD.DELETE
+													: '',
 											type: event.target.value,
 										})
 									}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
@@ -550,11 +550,6 @@ const ActionForm = ({
 									onChange={(event) =>
 										setActionData({
 											...actionData,
-											method:
-												event.target.value ===
-												ACTION_TYPE.ASYNC
-													? ACTION_METHOD.DELETE
-													: '',
 											type: event.target.value,
 										})
 									}
@@ -594,7 +589,10 @@ const ActionForm = ({
 										placeholder={Liferay.Language.get(
 											'please-select-an-option'
 										)}
-										value={actionData.method}
+										value={
+											actionData.method ||
+											ACTION_METHOD.DELETE
+										}
 									/>
 								</ClayForm.Group>
 							</ClayLayout.Col>


### PR DESCRIPTION
Story / Bug: [LPS-191489](https://liferay.atlassian.net/browse/LPS-191489) / [LPS-201133](https://liferay.atlassian.net/browse/LPS-202133)

## Issue
Admin user can define async actions for dataset items. Some properties of the async action were not set properly, like `method` or `errorMessage` and `successMessage`.

## Solution
Set `DELETE` as default method when selecting _async_ action type.
Send `method`, `errorMessage` and `successMessage` to the dataset.

## UI
[Screencast from 2023-12-05 08-56-02.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/ee702c7b-99d3-4a9a-bb1d-577e04dba760)
