### PR TITLE
LPS-203655 Predefined values table fields are not rendered when selecting a system object definition

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.js
@@ -7,7 +7,7 @@ import ClayTable from '@clayui/table';
 import classNames from 'classnames';
 import {throttle} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useContext, useLayoutEffect, useMemo, useRef} from 'react';
+import React, {useContext, useEffect, useMemo, useRef} from 'react';
 
 import ViewsContext from '../../ViewsContext';
 import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
@@ -34,7 +34,7 @@ function Cell({
 	const cellRef = useRef();
 	const clientXRef = useRef({current: null});
 
-	useLayoutEffect(() => {
+	useEffect(() => {
 		if (columnName && heading && !isFixed) {
 			const boundingClientRect = cellRef.current.getBoundingClientRect();
 


### PR DESCRIPTION
### References

- [LPS-203655 Predefined values table fields are not rendered when selecting a system object definition](https://issues.liferay.com/browse/LPS-203655)
- Related to https://github.com/liferay-frontend/liferay-portal/pull/3887

### What is the goal of this PR?

A bugfix. The root cause of this issue is the use of thunk dispatch in a `useLayoutEffect`. Since `useThunk` [checks](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useThunk.ts#L27) `isMounted`, and `useIsMounted` [is implemented with useLayoutEffect](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/hooks/useIsMounted.ts#L30-L36), this results in a race condition. `isMounted` can turn out true or false depending on uncertain order of execution. There is a typical order, that's why this issue isn't noticeable everywhere, but for some reason this order flips on the objects actions page. The end result is `false` value of `isMounted`, resulting in no dispatching. This means that width calculations never worked on this page. It also means that this is not a regression from https://github.com/liferay-frontend/liferay-portal/pull/3887, but new styles did highlight the wrong behavior. 

In PR, we are changing `useLayoutEffect` to `useEffect`, to sidestep the problem. `useLayoutEffect` will always happen before, so the component will always be mounted on the check. A better solution than this would be to remove `useThunk` from FDS and use normal reducer, but that would be a much large tech debt task.


### What does it look like?


https://github.com/liferay-frontend/liferay-portal/assets/5435511/29712c37-ee14-41fc-a48e-b563c3d8de48


