### PR TITLE
LPS-197124 - Cookies PreAction setup

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
@@ -36,17 +36,7 @@ export default function ({
 
 		toggleSwitch.addEventListener('click', notifyCookiePreferenceUpdate);
 
-		// NOTE: this check prevents loading stored cookie information
-		// when check/uncheck the Preference handling (Enable) checkbox
-
-		// if (getCookie(userConfigCookieName)) {
-
 		toggleSwitch.checked = getCookie(cookieKey) === 'true';
-
-		// }
-		// else {
-		// 	toggleSwitch.checked = toggleSwitch.dataset.prechecked === 'true';
-		// }
 
 		notifyCookiePreferenceUpdate();
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
@@ -11,7 +11,6 @@ import {
 	getCookie,
 	setCookie,
 	setUserConfigCookie,
-	userConfigCookieName,
 } from '../../js/CookiesUtil';
 
 export default function ({
@@ -37,12 +36,17 @@ export default function ({
 
 		toggleSwitch.addEventListener('click', notifyCookiePreferenceUpdate);
 
-		if (getCookie(userConfigCookieName)) {
-			toggleSwitch.checked = getCookie(cookieKey) === 'true';
-		}
-		else {
-			toggleSwitch.checked = toggleSwitch.dataset.prechecked === 'true';
-		}
+		// NOTE: this check prevents loading stored cookie information
+		// when check/uncheck the Preference handling (Enable) checkbox
+
+		// if (getCookie(userConfigCookieName)) {
+
+		toggleSwitch.checked = getCookie(cookieKey) === 'true';
+
+		// }
+		// else {
+		// 	toggleSwitch.checked = toggleSwitch.dataset.prechecked === 'true';
+		// }
 
 		notifyCookiePreferenceUpdate();
 

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
@@ -95,6 +95,9 @@ public class CookiesPreAction extends Action {
 				httpServletRequest, httpServletResponse,
 				CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
 		}
+
+		CookiesManagerUtil.addNecessaryCookies(
+			httpServletRequest, httpServletResponse);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -199,7 +199,10 @@ public class CookiesManagerImpl implements CookiesManager {
 			cookiesPreferenceHandlingConfiguration =
 				_getCookiesPreferenceHandlingConfiguration(httpServletRequest);
 
-		if (!cookiesPreferenceHandlingConfiguration.enabled()) {
+		boolean cookiesHandlingEnabled =
+			cookiesPreferenceHandlingConfiguration.enabled();
+
+		if (!cookiesHandlingEnabled) {
 			_deleteCookieConsentCookies(
 				httpServletRequest, httpServletResponse);
 		}

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -136,23 +136,11 @@ public class CookiesManagerImpl implements CookiesManager {
 		int consentType, Cookie cookie, HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse, boolean secure) {
 
-		if (!_SESSION_ENABLE_PERSISTENT_COOKIES) {
+		if (!_SESSION_ENABLE_PERSISTENT_COOKIES ||
+			((cookie.getMaxAge() != 0) &&
+			 !hasConsentType(consentType, httpServletRequest))) {
+
 			return false;
-		}
-
-		if (cookie.getMaxAge() != 0) {
-			CookiesPreferenceHandlingConfiguration
-				cookiesPreferenceHandlingConfiguration =
-					_getCookiesPreferenceHandlingConfiguration(
-						httpServletRequest);
-
-			if (!cookiesPreferenceHandlingConfiguration.enabled()) {
-				_deleteCookieConsentCookies(
-					httpServletRequest, httpServletResponse);
-			}
-			else if (!hasConsentType(consentType, httpServletRequest)) {
-				return false;
-			}
 		}
 
 		// LEP-5175
@@ -211,19 +199,10 @@ public class CookiesManagerImpl implements CookiesManager {
 			cookiesPreferenceHandlingConfiguration =
 				_getCookiesPreferenceHandlingConfiguration(httpServletRequest);
 
-		// Get Preference handling checkbox state
-
-		boolean cookiesHandlingEnabled =
-			cookiesPreferenceHandlingConfiguration.enabled();
-
-		// Remove cookie that stores information about the cookies banner configuration
-
-		if (!cookiesHandlingEnabled) {
+		if (!cookiesPreferenceHandlingConfiguration.enabled()) {
 			_deleteCookieConsentCookies(
 				httpServletRequest, httpServletResponse);
 		}
-
-		// Get Explicit consent mode checkbox state
 
 		boolean explicitConsentMode =
 			cookiesPreferenceHandlingConfiguration.explicitConsentMode();
@@ -245,14 +224,7 @@ public class CookiesManagerImpl implements CookiesManager {
 				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
 				httpServletRequest, true));
 
-		// NOTE: for each necessary cookie, create the placeholder: cookie value = false
-		// except for the NAME_CONSENT_TYPE_NECESSARY one
-
 		if (!necessaryConsentCookie) {
-
-			// NOTE: Need to manually create the cookie to avoid duplication due to
-			// different paths
-
 			Cookie necessaryCookie = new Cookie(
 				CookiesConstants.NAME_CONSENT_TYPE_NECESSARY, "true");
 
@@ -264,11 +236,6 @@ public class CookiesManagerImpl implements CookiesManager {
 		}
 
 		String cookieValue = "false";
-
-		// NOTE: for each necessary cookie, create the placeholder (value = false)
-		// Control the case that configuration modal is disabled & explicit mode enabled to reset
-		// Otherwise, keep cookie information if there is any
-		// This will help us, reopen configuration modal with store information
 
 		if (!functionalConsentCookie ||
 			(!cookiesHandlingEnabled && explicitConsentMode)) {
@@ -565,23 +532,6 @@ public class CookiesManagerImpl implements CookiesManager {
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
-		boolean hasConsentTypeFunctionalCookie = Validator.isNotNull(
-			getCookieValue(
-				CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
-				httpServletRequest));
-		boolean hasConsentTypePerformanceCookie = Validator.isNotNull(
-			getCookieValue(
-				CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
-				httpServletRequest));
-		boolean hasConsentTypePersonalizationCookie = Validator.isNotNull(
-			getCookieValue(
-				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
-				httpServletRequest));
-
-		// NOTE: could remove previous, as we don't want to remove necessary
-		// cookies just the one that reminds if the user had used the
-		// configuration modal
-
 		boolean hasUserConsentConfiguredCookie = Validator.isNotNull(
 			getCookieValue(
 				CookiesConstants.NAME_USER_CONSENT_CONFIGURED,
@@ -591,9 +541,6 @@ public class CookiesManagerImpl implements CookiesManager {
 			return deleteCookies(
 				getDomain(httpServletRequest), httpServletRequest,
 				httpServletResponse,
-				// CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
-				// CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
-				// CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
 				CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
 		}
 

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -577,21 +577,23 @@ public class CookiesManagerImpl implements CookiesManager {
 			getCookieValue(
 				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
 				httpServletRequest));
+
+		// NOTE: could remove previous, as we don't want to remove necessary
+		// cookies just the one that reminds if the user had used the
+		// configuration modal
+
 		boolean hasUserConsentConfiguredCookie = Validator.isNotNull(
 			getCookieValue(
 				CookiesConstants.NAME_USER_CONSENT_CONFIGURED,
 				httpServletRequest));
 
-		if (hasConsentTypeFunctionalCookie || hasConsentTypePerformanceCookie ||
-			hasConsentTypePersonalizationCookie ||
-			hasUserConsentConfiguredCookie) {
-
+		if (hasUserConsentConfiguredCookie) {
 			return deleteCookies(
 				getDomain(httpServletRequest), httpServletRequest,
 				httpServletResponse,
-				CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
-				CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
-				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+				// CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
+				// CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+				// CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
 				CookiesConstants.NAME_USER_CONSENT_CONFIGURED);
 		}
 

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -203,6 +203,115 @@ public class CookiesManagerImpl implements CookiesManager {
 	}
 
 	@Override
+	public void addNecessaryCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		CookiesPreferenceHandlingConfiguration
+			cookiesPreferenceHandlingConfiguration =
+				_getCookiesPreferenceHandlingConfiguration(httpServletRequest);
+
+		// Get Preference handling checkbox state
+
+		boolean cookiesHandlingEnabled =
+			cookiesPreferenceHandlingConfiguration.enabled();
+
+		// Remove cookie that stores information about the cookies banner configuration
+
+		if (!cookiesHandlingEnabled) {
+			_deleteCookieConsentCookies(
+				httpServletRequest, httpServletResponse);
+		}
+
+		// Get Explicit consent mode checkbox state
+
+		boolean explicitConsentMode =
+			cookiesPreferenceHandlingConfiguration.explicitConsentMode();
+
+		boolean functionalConsentCookie = Validator.isNotNull(
+			_getCookieValue(
+				CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
+				httpServletRequest, true));
+		boolean necessaryConsentCookie = Validator.isNotNull(
+			_getCookieValue(
+				CookiesConstants.NAME_CONSENT_TYPE_NECESSARY,
+				httpServletRequest, true));
+		boolean performanceConsentCookie = Validator.isNotNull(
+			_getCookieValue(
+				CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
+				httpServletRequest, true));
+		boolean personalizationConsentCookie = Validator.isNotNull(
+			_getCookieValue(
+				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+				httpServletRequest, true));
+
+		// NOTE: for each necessary cookie, create the placeholder: cookie value = false
+		// except for the NAME_CONSENT_TYPE_NECESSARY one
+
+		if (!necessaryConsentCookie) {
+
+			// NOTE: Need to manually create the cookie to avoid duplication due to
+			// different paths
+
+			Cookie necessaryCookie = new Cookie(
+				CookiesConstants.NAME_CONSENT_TYPE_NECESSARY, "true");
+
+			necessaryCookie.setPath(StringPool.SLASH);
+
+			addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, necessaryCookie,
+				httpServletRequest, httpServletResponse);
+		}
+
+		String cookieValue = "false";
+
+		// NOTE: for each necessary cookie, create the placeholder (value = false)
+		// Control the case that configuration modal is disabled & explicit mode enabled to reset
+		// Otherwise, keep cookie information if there is any
+		// This will help us, reopen configuration modal with store information
+
+		if (!functionalConsentCookie ||
+			(!cookiesHandlingEnabled && explicitConsentMode)) {
+
+			Cookie functionalCookie = new Cookie(
+				CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL, cookieValue);
+
+			functionalCookie.setPath(StringPool.SLASH);
+
+			addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, functionalCookie,
+				httpServletRequest, httpServletResponse);
+		}
+
+		if (!performanceConsentCookie ||
+			(!cookiesHandlingEnabled && explicitConsentMode)) {
+
+			Cookie performanceCookie = new Cookie(
+				CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE, cookieValue);
+
+			performanceCookie.setPath(StringPool.SLASH);
+
+			addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, performanceCookie,
+				httpServletRequest, httpServletResponse);
+		}
+
+		if (!personalizationConsentCookie ||
+			(!cookiesHandlingEnabled && explicitConsentMode)) {
+
+			Cookie personalizationCookie = new Cookie(
+				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
+				cookieValue);
+
+			personalizationCookie.setPath(StringPool.SLASH);
+
+			addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, personalizationCookie,
+				httpServletRequest, httpServletResponse);
+		}
+	}
+
+	@Override
 	public boolean addSupportCookie(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {

--- a/portal-kernel/src/com/liferay/portal/kernel/cookies/CookiesManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cookies/CookiesManager.java
@@ -34,6 +34,10 @@ public interface CookiesManager {
 		int consentType, Cookie cookie, HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse, boolean secure);
 
+	public void addNecessaryCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse);
+
 	public boolean addSupportCookie(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse);

--- a/portal-kernel/src/com/liferay/portal/kernel/cookies/CookiesManagerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cookies/CookiesManagerUtil.java
@@ -57,6 +57,16 @@ public class CookiesManagerUtil {
 			secure);
 	}
 
+	public static void addNecessaryCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		CookiesManager cookiesManager = _cookiesManagerSnapshot.get();
+
+		cookiesManager.addNecessaryCookies(
+			httpServletRequest, httpServletResponse);
+	}
+
 	public static boolean addSupportCookie(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {

--- a/portal-kernel/src/com/liferay/portal/kernel/cookies/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/cookies/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0


### PR DESCRIPTION
**On hold**: https://github.com/liferay-frontend/liferay-portal/pull/3892#issuecomment-2284000118

----

## Issue
Liferay allows users to configure how they want to handle their cookies preferences, letting the platform to store information based on 4 different cookie groups: Necessary, Functional, Performance and Personalization cookies. However, Liferay uses cookies to store the  cookie information :shrug: . Actually, those cookies, considered Necessary, are not created until the users confirm their preferences.

We need to setup those basic cookies no matter when a user confirms (or not) cookie preferences. To setup the basic cookies we need to consider some scenarios:

**1 - First access**
Setup basic cookies configuration. 
```
NECESSARY_COOKIES = true
FUNCTIONAL_COOKIES = false
PERFORMANCE_COOKIES = true
PERSONALIZATION_COOKIES = true
```
**2 - Based on Cookies Preference handling options**
![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/bc0b22ad-7e98-4e01-9dba-5c976caab6a4)

**2a - Both options enabled**
Setup basic cookies configuration (1) or load stored cookie preferences

**2b - Preference handling enabled / Explicit consent mode disabled**
Setup basic cookies configuration (1) or load stored cookie preferences

**2c - Preference handling disabled / Explicit consent mode enabled**
Setup basic cookies configuration (1),  remove stored cookie preferences if any

**2d - Both options disabled**
Setup basic cookies configuration (1) or load stored cookie preferences 
