### PR TITLE
LPS-203659 Integrate Editor Config Contributor CET with ConfigContributor framework

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.web.internal.portlet.editor.config.contributor;
+
+import com.liferay.client.extension.web.internal.type.deployer.Registrable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Dictionary;
+import java.util.Map;
+
+/**
+ * @author Daniel Sanz
+ */
+public class CETEditorConfigContributor
+	implements EditorConfigContributor, Registrable {
+
+	public CETEditorConfigContributor(
+		String editorConfigKeys, String editorNames, String portletNames,
+		String url) {
+
+		_editorConfigKeys = editorConfigKeys;
+		_editorNames = editorNames;
+		_portletNames = portletNames;
+		_url = url;
+	}
+
+	@Override
+	public Dictionary<String, Object> getDictionary() {
+		return HashMapDictionaryBuilder.<String, Object>put(
+			"editor.config.key",
+			() -> {
+				if (Validator.isNotNull(_editorConfigKeys)) {
+					return _editorConfigKeys.split(StringPool.NEW_LINE);
+				}
+
+				return null;
+			}
+		).put(
+			"editor.name",
+			() -> {
+				if (Validator.isNotNull(_editorNames)) {
+					return _editorNames.split(StringPool.NEW_LINE);
+				}
+
+				return null;
+			}
+		).put(
+			"javax.portlet.name",
+			() -> {
+				if (Validator.isNotNull(_portletNames)) {
+					return _portletNames.split(StringPool.NEW_LINE);
+				}
+
+				return null;
+			}
+		).build();
+	}
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		JSONArray urlsJSONArray = jsonObject.getJSONArray(
+			"CETConfigurationURLs");
+
+		if (urlsJSONArray == null) {
+			urlsJSONArray = JSONFactoryUtil.createJSONArray();
+			jsonObject.put("CETConfigurationURLs", urlsJSONArray);
+		}
+
+		urlsJSONArray.put("default from " + _url);
+	}
+
+	private final String _editorConfigKeys;
+	private final String _editorNames;
+	private final String _portletNames;
+	private final String _url;
+
+}

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -73,15 +73,16 @@ public class CETEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		JSONArray urlsJSONArray = jsonObject.getJSONArray(
-			"CETConfigurationURLs");
+		JSONArray jsonArray = jsonObject.getJSONArray(
+			"editorConfigTransformerURLs");
 
-		if (urlsJSONArray == null) {
-			urlsJSONArray = JSONFactoryUtil.createJSONArray();
-			jsonObject.put("CETConfigurationURLs", urlsJSONArray);
+		if (jsonArray == null) {
+			jsonArray = JSONFactoryUtil.createJSONArray();
+
+			jsonObject.put("editorConfigTransformerURLs", jsonArray);
 		}
 
-		urlsJSONArray.put("default from " + _url);
+		jsonArray.put(_url);
 	}
 
 	private final String _editorConfigKeys;

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -8,6 +8,7 @@ package com.liferay.client.extension.web.internal.type.deployer;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.CustomElementCET;
+import com.liferay.client.extension.type.EditorConfigurationCET;
 import com.liferay.client.extension.type.IFrameCET;
 import com.liferay.client.extension.type.JSImportMapsEntryCET;
 import com.liferay.client.extension.type.deployer.CETDeployer;
@@ -17,10 +18,13 @@ import com.liferay.client.extension.web.internal.portlet.CETPortletFriendlyURLMa
 import com.liferay.client.extension.web.internal.portlet.CustomElementCETPortlet;
 import com.liferay.client.extension.web.internal.portlet.IFrameCETPortlet;
 import com.liferay.client.extension.web.internal.portlet.action.CETPortletConfigurationAction;
+import com.liferay.client.extension.web.internal.portlet.editor.config.contributor.CETEditorConfigContributor;
+import com.liferay.client.extension.web.internal.util.CETUtil;
 import com.liferay.frontend.js.importmaps.extender.JSImportMapsContributor;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
@@ -54,6 +58,12 @@ public class CETDeployerImpl implements CETDeployer {
 				ClientExtensionEntryConstants.TYPE_CUSTOM_ELEMENT)) {
 
 			return _deploy((CustomElementCET)cet);
+		}
+		else if (Objects.equals(
+					cet.getType(),
+					ClientExtensionEntryConstants.TYPE_EDITOR_CONFIGURATION)) {
+
+			return _deploy((EditorConfigurationCET)cet);
 		}
 		else if (Objects.equals(
 					cet.getType(), ClientExtensionEntryConstants.TYPE_IFRAME)) {
@@ -107,6 +117,19 @@ public class CETDeployerImpl implements CETDeployer {
 					customElementCET, _npmResolver, portletId)));
 
 		return serviceRegistrations;
+	}
+
+	private List<ServiceRegistration<?>> _deploy(
+		EditorConfigurationCET editorConfigurationCET) {
+
+		return Arrays.asList(
+			_register(
+				EditorConfigContributor.class,
+				new CETEditorConfigContributor(
+					editorConfigurationCET.getEditorConfigKeys(),
+					editorConfigurationCET.getEditorNames(),
+					editorConfigurationCET.getPortletNames(),
+					editorConfigurationCET.getURL())));
 	}
 
 	private List<ServiceRegistration<?>> _deploy(IFrameCET iFrameCET) {

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -8,7 +8,7 @@ package com.liferay.client.extension.web.internal.type.deployer;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.CustomElementCET;
-import com.liferay.client.extension.type.EditorConfigurationCET;
+import com.liferay.client.extension.type.EditorConfigContributorCET;
 import com.liferay.client.extension.type.IFrameCET;
 import com.liferay.client.extension.type.JSImportMapsEntryCET;
 import com.liferay.client.extension.type.deployer.CETDeployer;
@@ -19,7 +19,6 @@ import com.liferay.client.extension.web.internal.portlet.CustomElementCETPortlet
 import com.liferay.client.extension.web.internal.portlet.IFrameCETPortlet;
 import com.liferay.client.extension.web.internal.portlet.action.CETPortletConfigurationAction;
 import com.liferay.client.extension.web.internal.portlet.editor.config.contributor.CETEditorConfigContributor;
-import com.liferay.client.extension.web.internal.util.CETUtil;
 import com.liferay.frontend.js.importmaps.extender.JSImportMapsContributor;
 import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringBundler;
@@ -61,9 +60,10 @@ public class CETDeployerImpl implements CETDeployer {
 		}
 		else if (Objects.equals(
 					cet.getType(),
-					ClientExtensionEntryConstants.TYPE_EDITOR_CONFIGURATION)) {
+					ClientExtensionEntryConstants.
+						TYPE_EDITOR_CONFIG_CONTRIBUTOR)) {
 
-			return _deploy((EditorConfigurationCET)cet);
+			return _deploy((EditorConfigContributorCET)cet);
 		}
 		else if (Objects.equals(
 					cet.getType(), ClientExtensionEntryConstants.TYPE_IFRAME)) {
@@ -120,16 +120,16 @@ public class CETDeployerImpl implements CETDeployer {
 	}
 
 	private List<ServiceRegistration<?>> _deploy(
-		EditorConfigurationCET editorConfigurationCET) {
+		EditorConfigContributorCET editorConfigContributorCET) {
 
 		return Arrays.asList(
 			_register(
 				EditorConfigContributor.class,
 				new CETEditorConfigContributor(
-					editorConfigurationCET.getEditorConfigKeys(),
-					editorConfigurationCET.getEditorNames(),
-					editorConfigurationCET.getPortletNames(),
-					editorConfigurationCET.getURL())));
+					editorConfigContributorCET.getEditorConfigKeys(),
+					editorConfigContributorCET.getEditorNames(),
+					editorConfigContributorCET.getPortletNames(),
+					editorConfigContributorCET.getURL())));
 	}
 
 	private List<ServiceRegistration<?>> _deploy(IFrameCET iFrameCET) {


### PR DESCRIPTION
### References

- [LPS-203555 Integrate Editor Config Contributor CET with ConfigContributor framework](https://issues.liferay.com/browse/LPS-203555)
- Epic PoC: https://github.com/liferay-frontend/liferay-portal/pull/3835

### What is the goal of this PR?

The second part of editor CETs implementation. We are forwarding CET URLs to configuration of matching editors. We don't do anything with URLs, this will be in a followup story.

The logic is mostly the same as in the PoC. Changes:
- Naming updates, to match previously merged CET objects.
- A notable naming tweak is to call final prop `editorConfigTransformerURLs`. This is to foreshadow my future suggestion of new entry in public api, which will be `interface EditorConfigTransformer`. We can decide final form of this in upcoming PR, we can easily update naming in `CETEditorConfigContributor` later on.
- We are sending raw URL to frontend, instead of `default from url`. I think this logic belongs in a frontend utility, to be added in upcoming PR.

### What does it look like?

No effect in UI. To test:
1. Create one or more Editor Config Contributor CETs
2. Debug configuration passed to the editor. It should include `editorConfigTransformerURLs` prop, an array of URLs set in CETs.