### PR TITLE
[TS] LPS-200609 

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/build.gradle
@@ -13,8 +13,10 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:frontend-js:frontend-js-components-web")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")

--- a/modules/apps/oauth2-provider/oauth2-provider-web/package.json
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/package.json
@@ -1,7 +1,16 @@
 {
 	"dependencies": {
+		"@clayui/alert": "3.106.1",
+		"@clayui/button": "3.107.0",
+		"@clayui/form": "3.107.0",
+		"@clayui/icon": "3.106.1",
+		"@clayui/modal": "3.107.0",
+		"@liferay/frontend-icons-web": "*",
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
-		"pkce-challenge": "^3.0.0"
+		"pkce-challenge": "^3.0.0",
+		"react": "16.12.0",
+		"react-dom": "16.12.0"
 	},
 	"main": "js/liferay.js",
 	"name": "@liferay/oauth2-provider-web",

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -84,23 +84,22 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 
 					<aui:model-context bean="<%= oAuth2Application %>" model="<%= OAuth2Application.class %>" />
 
+					<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" var="baseResourceURL" />
+
 					<c:if test="<%= oAuth2Application != null %>">
-						<aui:fieldset style="border-bottom: 2px solid #F0F0F0; margin-bottom: 1em;">
-							<div class="pencil-wrapper">
-								<aui:button href="" onClick='<%= liferayPortletResponse.getNamespace() + "showEditClientIdModal();" %>' value="edit" />
-
-								<aui:input helpMessage="client-id-help[oauth2]" name="clientId" readonly="true" required="<%= true %>" type="text" />
-							</div>
-
-							<aui:input name="originalClientId" type="hidden" value="<%= clientId %>" />
-
-							<div class="pencil-wrapper">
-								<aui:button href="" onClick='<%= liferayPortletResponse.getNamespace() + "showEditClientSecretModal();" %>' value="edit" />
-
-								<aui:input helpMessage="client-secret-help[oauth2]" name="clientSecret" readonly="true" type="password" value="<%= clientSecret %>" />
-							</div>
-
-							<aui:input name="originalClientSecret" type="hidden" value="<%= clientSecret %>" />
+						<aui:fieldset cssClass="mb-3" style="border-bottom: 2px solid #F0F0F0;">
+							<react:component
+								module="admin/js/components/EditClientDetails"
+								props='<%=
+									HashMapBuilder.<String, Object>put(
+										"baseResourceURL", String.valueOf(baseResourceURL)
+									).put(
+										"clientId", clientId
+									).put(
+										"clientSecret", clientSecret
+									).build()
+								%>'
+							/>
 						</aui:fieldset>
 					</c:if>
 				</clay:col>
@@ -164,70 +163,6 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 	</clay:container-fluid>
 </aui:form>
 
-<div class="hidden">
-	<div id="<portlet:namespace />edit-client-id-modal">
-		<div>
-			<div class="portlet-msg-error">
-				<clay:icon
-					symbol="info-panel-open"
-				/>
-
-				<b><liferay-ui:message key="warning" />:</b>
-
-				<liferay-ui:message key="if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details" />
-			</div>
-
-			<div class="padlock" id="<portlet:namespace />clientIdPadlock">
-				<div class="open" style="display: none;">
-					<clay:icon symbol="unlock" /><liferay-ui:message key="changed" />
-				</div>
-
-				<div class="closed">
-					<clay:icon symbol="lock" /><liferay-ui:message key="unchanged" />
-				</div>
-			</div>
-
-			<aui:input helpMessage="client-id-help[oauth2]" label="client-id" name="newClientId" onKeyup='<%= liferayPortletResponse.getNamespace() + "updatePadlock('clientIdPadlock', this.value, '" + HtmlUtil.escapeJS(clientId) + "')" %>' type="text" value="<%= clientId %>" />
-
-			<aui:button-row>
-				<aui:button href="" icon="icon-undo" onClick='<%= liferayPortletResponse.getNamespace() + "setControlEqualTo('newClientId', 'originalClientId')" %>' value="revert" />
-			</aui:button-row>
-		</div>
-	</div>
-
-	<div id="<portlet:namespace />edit-client-secret-modal">
-		<div>
-			<div class="portlet-msg-error">
-				<clay:icon
-					symbol="info-panel-open"
-				/>
-
-				<b><liferay-ui:message key="warning" />:</b>
-
-				<liferay-ui:message key="if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details" />
-			</div>
-
-			<div class="padlock" id="<portlet:namespace />clientSecretPadlock">
-				<div class="open" style="display: none;">
-					<clay:icon symbol="unlock" /><liferay-ui:message key="changed" />
-				</div>
-
-				<div class="closed">
-					<clay:icon symbol="lock" /><liferay-ui:message key="unchanged" />
-				</div>
-			</div>
-
-			<aui:input helpMessage="client-secret-id" label="client-secret" name="newClientSecret" onKeyup='<%= liferayPortletResponse.getNamespace() + "updatePadlock('clientSecretPadlock', this.value, '" + HtmlUtil.escapeJS(clientSecret) + "')" %>' type="text" value="<%= clientSecret %>" />
-
-			<aui:button-row>
-				<aui:button href="" icon="icon-plus" onClick='<%= liferayPortletResponse.getNamespace() + "generateRandomSecret()" %>' value="generate-new-secret" />
-
-				<aui:button href="" icon="icon-undo" onClick='<%= liferayPortletResponse.getNamespace() + "setControlEqualTo('newClientSecret', 'originalClientSecret')" %>' value="revert" />
-			</aui:button-row>
-		</div>
-	</div>
-</div>
-
 <aui:script use="aui-modal,liferay-form,node,node-event-simulate">
 	window.<portlet:namespace />areAdminApplicationSectionsRequired = function () {
 		var selectedClientProfile = <portlet:namespace />getSelectedClientProfile();
@@ -243,28 +178,6 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 					' input:checked[name=<%= liferayPortletResponse.getNamespace() %>grant-<%= GrantType.AUTHORIZATION_CODE_PKCE.name() %>]'
 			).size() > 0
 		);
-	};
-
-	window.<portlet:namespace />generateRandomSecret = function () {
-		Liferay.Util.fetch(
-			'<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/oauth2_provider/generate_random_secret" />',
-			{
-				method: 'POST',
-			}
-		)
-			.then((response) => {
-				return response.text();
-			})
-			.then((response) => {
-				var newClientSecretField = A.one(
-					'#<portlet:namespace />newClientSecret'
-				);
-
-				<portlet:namespace />updateComponent(
-					newClientSecretField,
-					response
-				);
-			});
 	};
 
 	window.<portlet:namespace />getSelectedClientProfile = function () {
@@ -351,95 +264,6 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 		<portlet:namespace />updateComponent(targetControl, srcControl.val());
 	};
 
-	window.<portlet:namespace />showEditClientIdModal = function () {
-		var bodyContentDiv = A.one('#<portlet:namespace />edit-client-id-modal');
-		var clientIdPadlock = A.one('#<portlet:namespace />clientIdPadlock');
-		var applyField = A.one('#<portlet:namespace />newClientId');
-		var populateFieldClientId = A.one('#<portlet:namespace />clientId');
-
-		<portlet:namespace />showModal(
-			'<%= UnicodeLanguageUtil.get(request, "edit-client-id") %>',
-			bodyContentDiv,
-			clientIdPadlock,
-			applyField,
-			populateFieldClientId
-		);
-	};
-
-	window.<portlet:namespace />showEditClientSecretModal = function () {
-		var bodyContentDiv = A.one(
-			'#<portlet:namespace />edit-client-secret-modal'
-		);
-		var clientSecretPadlock = A.one(
-			'#<portlet:namespace />clientSecretPadlock'
-		);
-		var applyField = A.one('#<portlet:namespace />newClientSecret');
-		var populateFieldClientSecret = A.one('#<portlet:namespace />clientSecret');
-
-		<portlet:namespace />showModal(
-			'<%= UnicodeLanguageUtil.get(request, "edit-client-secret") %>',
-			bodyContentDiv,
-			clientSecretPadlock,
-			applyField,
-			populateFieldClientSecret
-		);
-	};
-
-	window.<portlet:namespace />showModal = function (
-		title,
-		bodyContent,
-		footerContent,
-		applyField,
-		populateField
-	) {
-		var modal = new A.Modal({
-			bodyContent: bodyContent,
-			centered: true,
-			cssClass: 'edit-client-credentials-modal',
-			destroyOnHide: false,
-			footerContent: footerContent,
-			headerContent: title,
-			modal: true,
-			plugins: [Liferay.WidgetZIndex],
-		}).render();
-
-		modal.on('render', (event) => {
-			<portlet:namespace />updateComponent(applyField, populateField.val());
-		});
-
-		modal.addToolbar([
-			{
-				label: '<liferay-ui:message key="cancel" />',
-				on: {
-					click: function () {
-						<portlet:namespace />updateComponent(
-							applyField,
-							populateField.val()
-						);
-
-						modal.hide();
-					},
-				},
-			},
-			{
-				cssClass: 'btn-primary',
-				label: '<liferay-ui:message key="apply" />',
-				on: {
-					click: function () {
-						<portlet:namespace />updateComponent(
-							populateField,
-							applyField.val()
-						);
-
-						modal.hide();
-					},
-				},
-			},
-		]);
-
-		modal.show();
-	};
-
 	window.<portlet:namespace />updateAdminOptionsApplicationSection = function () {
 		var rememberApplicationSection = A.one(
 			'#<portlet:namespace />rememberDeviceSection'
@@ -505,22 +329,6 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 		component.val(newValue);
 		component.simulate('keyup');
 		component.simulate('change');
-	};
-
-	window.<portlet:namespace />updatePadlock = function (
-		padlockId,
-		newValue,
-		originalValue
-	) {
-		var padlock = A.one('#<portlet:namespace />' + padlockId);
-		if (newValue != originalValue) {
-			padlock.one('div.closed').hide();
-			padlock.one('div.open').show();
-		}
-		else {
-			padlock.one('div.open').hide();
-			padlock.one('div.closed').show();
-		}
 	};
 
 	window.<portlet:namespace />updateRedirectURIs = function (required) {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -7,6 +7,8 @@
 
 <%@ include file="/init.jsp" %>
 
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+
 <%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.criteria.UUIDItemSelectorReturnType" %><%@

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/components/EditClientDetails.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/components/EditClientDetails.tsx
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+import ReadOnlyInput from './ReadOnlyInput';
+
+interface IEditClientDetailsProps extends React.HTMLAttributes<HTMLElement> {
+	baseResourceURL: string;
+	clientId: string;
+	clientSecret: string;
+	portletNamespace: string;
+}
+
+const EditClientDetails: React.FC<IEditClientDetailsProps> = (props) => {
+	return (
+		<>
+			<ReadOnlyInput
+				alertText={Liferay.Language.get(
+					'if-changed-clients-with-the-old-client-id-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details'
+				)}
+				id={`${props.portletNamespace}clientId`}
+				initialValue={props.clientId}
+				label={Liferay.Language.get('client-id')}
+				title={Liferay.Language.get('edit-client-id')}
+				tooltip={Liferay.Language.get('client-id-help[oauth2]')}
+			/>
+
+			<ReadOnlyInput
+				alertText={Liferay.Language.get(
+					'if-changed-clients-with-the-old-client-secret-will-no-longer-be-able-to-request-new-tokens-after-you-save-the-application-details'
+				)}
+				baseResourceURL={props.baseResourceURL}
+				id={`${props.portletNamespace}clientSecret`}
+				initialValue={props.clientSecret}
+				isSecret={true}
+				label={Liferay.Language.get('client-secret')}
+				title={Liferay.Language.get('edit-client-secret')}
+				tooltip={Liferay.Language.get('client-secret-help[oauth2]')}
+				type="password"
+			/>
+		</>
+	);
+};
+
+export default EditClientDetails;

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/components/ReadOnlyInput.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/components/ReadOnlyInput.tsx
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {ClayInput} from '@clayui/form';
+import {FieldBase} from 'frontend-js-components-web';
+import {openModal} from 'frontend-js-web';
+import React, {useState} from 'react';
+
+import {EditClientOAuth2ModalContent} from './modals/EditClientOAuth2ModalContent';
+
+interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
+	alertText: string;
+	baseResourceURL?: string;
+	id: string;
+	initialValue: string;
+	isSecret?: boolean;
+	label: string;
+	title: string;
+	tooltip: string;
+	type?: string;
+}
+
+const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
+	const {
+		alertText,
+		baseResourceURL = '',
+		id,
+		initialValue,
+		isSecret = false,
+		label,
+		title,
+		tooltip,
+		type = 'text',
+	} = props;
+
+	const [value, setValue] = useState(initialValue);
+
+	const handleSetInputValue = (newInputValue: string) => {
+		setValue(newInputValue);
+	};
+
+	return (
+		<>
+			<FieldBase id={id} label={label} required={true} tooltip={tooltip}>
+				<ClayInput.Group>
+					<ClayInput.GroupItem prepend>
+						<ClayInput
+							id={id}
+							name={id}
+							readOnly
+							type={type}
+							value={value}
+						/>
+					</ClayInput.GroupItem>
+
+					<ClayInput.GroupItem append shrink>
+						<ClayButton
+							displayType="secondary"
+							onClick={() =>
+								openModal({
+									center: true,
+									contentComponent: ({
+										closeModal,
+									}: {
+										closeModal: () => void;
+									}) =>
+										EditClientOAuth2ModalContent({
+											alertText,
+											baseResourceURL,
+											closeModal,
+											handleSetInputValue,
+											id,
+											initialValue,
+											isSecret,
+											label,
+											title,
+											tooltip,
+										}),
+									id: 'editClientOAuth2Modal',
+									size: 'md',
+									status: 'warning',
+								})
+							}
+						>
+							{Liferay.Language.get('edit')}
+						</ClayButton>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</FieldBase>
+		</>
+	);
+};
+
+export default ReadOnlyInput;

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/components/modals/EditClientOAuth2ModalContent.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/js/components/modals/EditClientOAuth2ModalContent.tsx
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
+import {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayModal from '@clayui/modal';
+import {FieldBase} from 'frontend-js-components-web';
+import {createResourceURL, fetch} from 'frontend-js-web';
+import React, {useState} from 'react';
+
+export function EditClientOAuth2ModalContent({
+	alertText,
+	baseResourceURL,
+	closeModal,
+	handleSetInputValue,
+	id,
+	initialValue,
+	isSecret = false,
+	label,
+	title,
+	tooltip,
+}: {
+	alertText: string;
+	baseResourceURL: string;
+	closeModal: () => void;
+	handleSetInputValue: (newInputValue: string) => void;
+	id: string;
+	initialValue: string;
+	isSecret: boolean;
+	label: string;
+	title: string;
+	tooltip: string;
+}) {
+	const [modalValue, setModalValue] = useState(initialValue);
+
+	const modalId = `${id}modal`;
+	const valueChanged = modalValue !== initialValue;
+
+	const resourceURL = createResourceURL(baseResourceURL, {
+		p_p_id:
+			'com_liferay_oauth2_provider_web_internal_portlet_OAuth2AdminPortlet',
+		p_p_resource_id: '/oauth2_provider/generate_random_secret',
+	}).href;
+
+	const generateRandomSecret = async () => {
+		const response = await fetch(resourceURL, {
+			method: 'POST',
+		});
+
+		const responseText = (await response.text()) as string;
+
+		setModalValue(responseText);
+	};
+
+	return (
+		<>
+			<ClayModal.Header>{title}</ClayModal.Header>
+
+			<div className="modal-body">
+				<ClayAlert
+					displayType="warning"
+					title={Liferay.Language.get('warning')}
+				>
+					{alertText}
+				</ClayAlert>
+
+				<FieldBase id={modalId} label={label} tooltip={tooltip}>
+					<ClayInput.Group>
+						<ClayInput.GroupItem prepend>
+							<ClayInput
+								id={modalId}
+								name={modalId}
+								onChange={({target: {value}}) =>
+									setModalValue(value)
+								}
+								type="text"
+								value={modalValue}
+							/>
+						</ClayInput.GroupItem>
+
+						<ClayInput.GroupItem append shrink>
+							<ClayButton
+								disabled={!valueChanged}
+								displayType="secondary"
+								onClick={() => setModalValue(initialValue)}
+							>
+								{Liferay.Language.get('revert')}
+							</ClayButton>
+
+							{isSecret && (
+								<ClayButton
+									displayType="secondary"
+									onClick={() => generateRandomSecret()}
+								>
+									{Liferay.Language.get(
+										'generate-new-secret'
+									)}
+								</ClayButton>
+							)}
+						</ClayInput.GroupItem>
+					</ClayInput.Group>
+				</FieldBase>
+			</div>
+
+			<ClayModal.Footer
+				first={
+					valueChanged ? (
+						<span>
+							<ClayIcon symbol="unlock" />
+
+							{Liferay.Language.get('changed')}
+						</span>
+					) : (
+						<span>
+							<ClayIcon symbol="lock" />
+
+							{Liferay.Language.get('unchanged')}
+						</span>
+					)
+				}
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							displayType="secondary"
+							onClick={() => {
+								setModalValue(initialValue);
+								closeModal();
+							}}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+
+						<ClayButton
+							onClick={() => {
+								handleSetInputValue(modalValue);
+								closeModal();
+							}}
+						>
+							{Liferay.Language.get('apply')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</>
+	);
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/tsconfig.json
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "ef1cd2c35d9ff2d6f173ecd8973f049606ee42cd",
+	"@generated": "8fa34c9a5545d173c6404a6da541465a65c18dab",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,6 +13,12 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
+			"@liferay/frontend-icons-web": [
+				"../../frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
+			"frontend-js-components-web": [
+				"../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -35,6 +41,12 @@
 		"../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../frontend-icons/frontend-icons-web"
+		},
+		{
+			"path": "../../frontend-js/frontend-js-components-web"
+		},
 		{
 			"path": "../../frontend-js/frontend-js-web"
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/admin/js/components/EditClientDetails.d.ts
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/admin/js/components/EditClientDetails.d.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+interface IEditClientDetailsProps extends React.HTMLAttributes<HTMLElement> {
+	baseResourceURL: string;
+	clientId: string;
+	clientSecret: string;
+	portletNamespace: string;
+}
+declare const EditClientDetails: React.FC<IEditClientDetailsProps>;
+export default EditClientDetails;

--- a/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/admin/js/components/ReadOnlyInput.d.ts
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/admin/js/components/ReadOnlyInput.d.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
+	alertText: string;
+	baseResourceURL?: string;
+	id: string;
+	initialValue: string;
+	isSecret?: boolean;
+	label: string;
+	title: string;
+	tooltip: string;
+	type?: string;
+}
+declare const ReadOnlyInput: React.FC<IReadOnlyInputProps>;
+export default ReadOnlyInput;

--- a/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/admin/js/components/modals/EditClientOAuth2ModalContent.d.ts
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/types/src/main/resources/META-INF/resources/admin/js/components/modals/EditClientOAuth2ModalContent.d.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+export declare function EditClientOAuth2ModalContent({
+	alertText,
+	baseResourceURL,
+	closeModal,
+	handleSetInputValue,
+	id,
+	initialValue,
+	isSecret,
+	label,
+	title,
+	tooltip,
+}: {
+	alertText: string;
+	baseResourceURL: string;
+	closeModal: () => void;
+	handleSetInputValue: (newInputValue: string) => void;
+	id: string;
+	initialValue: string;
+	isSecret: boolean;
+	label: string;
+	title: string;
+	tooltip: string;
+}): JSX.Element;


### PR DESCRIPTION
### Context:
[LPS-200609 - Edit client credentials modal causes blank space above page and collapses screen](https://liferay.atlassian.net/browse/LPS-200609)

### Steps to reproduce:

1. Go to Control Panel > Security > OAuth 2 Administration
2. Select any "OAuth 2 Administration"
3. Click "Edit" button on "Client ID" or "Client Secret"

Actual result: An unnecessary blank space appears at the top of the screen.
Expected result: Unnecessary blank space is not displayed.

### Implementation details:
 The best long term solution would be to migrate away from new `A.Modal`. The amount of logic that’s being handled by javascript in the jsp could be handled much more simply if more of it is migrated to React. We would then be using the Clay Modal and not have to worry about things being as fragile in the future.