### PR TITLE
LPS-203834 Apply editor config contributor client extensions to CKEditor

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
@@ -73,13 +73,12 @@ public class CETEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		JSONArray jsonArray = jsonObject.getJSONArray(
-			"editorConfigTransformerURLs");
+		JSONArray jsonArray = jsonObject.getJSONArray("editorTransformerURLs");
 
 		if (jsonArray == null) {
 			jsonArray = JSONFactoryUtil.createJSONArray();
 
-			jsonObject.put("editorConfigTransformerURLs", jsonArray);
+			jsonObject.put("editorTransformerURLs", jsonArray);
 		}
 
 		jsonArray.put(_url);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/ClassicEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/ClassicEditorConfigContributor.java
@@ -37,18 +37,12 @@ public class ClassicEditorConfigContributor
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
 		jsonObject.put(
-			"disableNativeSpellChecker", false
-		).put(
-			"extraPlugins", "scayt"
-		).put(
 			"toolbar_liferay",
 			JSONUtil.putAll(
 				toJSONArray("['Undo', 'Redo']"),
 				toJSONArray("['Styles', 'Bold', 'Italic', 'Underline']"),
 				toJSONArray("['NumberedList', 'BulletedList']"),
-				toJSONArray("['Link', Unlink]"), toJSONArray("['Table']"),
-				toJSONArray("['Scayt']"))
-		);
+				toJSONArray("['Link', Unlink]"), toJSONArray("['Table']")));
 	}
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@clayui/loading-indicator": "3.106.1",
 		"@liferay/cookies-banner-web": "*",
 		"ckeditor4": "4.22.1",
 		"ckeditor4-react": "1.4.2",

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -430,11 +430,10 @@ name = HtmlUtil.escapeJS(name);
 	};
 
 	var createEditor = function () {
+		var editorContainer = A.one('#<%= name %>Container');
 		var editorNode = A.one('#<%= name %>');
 
 		if (!editorNode) {
-			var editorContainer = A.one('#<%= name %>Container');
-
 			editorContainer.setHTML('');
 
 			editorNode = A.Node.create('<%= HtmlUtil.escapeJS(editor) %>');
@@ -454,6 +453,8 @@ name = HtmlUtil.escapeJS(name);
 				ckEditorContent = getInitialContent();
 			}
 
+			var ckEditor = CKEDITOR.instances['<%= name %>'];
+
 			ckEditor.setData(ckEditorContent, () => {
 				ckEditor.resetDirty();
 
@@ -471,6 +472,247 @@ name = HtmlUtil.escapeJS(name);
 			});
 		}
 
+		function initEditor(config) {
+			CKEDITOR.<%= inlineEdit ? "inline" : "replace" %>(
+				'<%= name %>',
+				config
+			);
+
+			Liferay.on('<%= name %>selectItem', (event) => {
+				CKEDITOR.tools.callFunction(event.ckeditorfuncnum, event.value);
+			});
+
+			var ckEditor = CKEDITOR.instances['<%= name %>'];
+
+			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.ckeditor.web#" + editorName + "#onEditorCreate" %>' />
+
+			Liferay.namespace('EDITORS').ckeditor.addInstance();
+
+			<c:if test="<%= inlineEdit && Validator.isNotNull(inlineEditSaveURL) %>">
+				inlineEditor = new Liferay.CKEditorInline({
+					editor: ckEditor,
+					editorName: '<%= name %>',
+					namespace: '<portlet:namespace />',
+					saveURL: '<%= inlineEditSaveURL %>',
+				});
+			</c:if>
+
+			var customDataProcessorLoaded = false;
+
+			<%
+			boolean useCustomDataProcessor = (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor"));
+			%>
+
+			<c:if test="<%= useCustomDataProcessor %>">
+				ckEditor.on('customDataProcessorLoaded', () => {
+					customDataProcessorLoaded = true;
+
+					if (instanceReady) {
+						initData();
+					}
+
+					// LPS-118801
+
+					var editorPath =
+						'<%= HtmlUtil.escapeJS(PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR)) %>';
+
+					document
+						.querySelectorAll(
+							'link[href*="' +
+								editorPath +
+								'"],script[src*="' +
+								editorPath +
+								'"]'
+						)
+						.forEach((tag) => {
+							tag.setAttribute('data-senna-track', 'temporary');
+						});
+				});
+			</c:if>
+
+			var instanceReady = false;
+
+			ckEditor.on('instanceReady', () => {
+				<c:choose>
+					<c:when test="<%= useCustomDataProcessor %>">
+						instanceReady = true;
+
+						if (customDataProcessorLoaded) {
+							initData();
+						}
+					</c:when>
+					<c:otherwise>
+						initData();
+					</c:otherwise>
+				</c:choose>
+
+				window['<%= name %>'].instanceReady = true;
+
+				<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
+					CKEDITOR.instances['<%= name %>'].on(
+						'blur',
+						window['<%= name %>'].onBlurCallback
+					);
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+					var contentChangeHandle = setInterval(() => {
+						try {
+							window['<%= name %>'].onChangeCallback();
+						}
+						catch (e) {}
+					}, 300);
+
+					var clearContentChangeHandle = function (event) {
+						if (event.portletId === '<%= portletId %>') {
+							clearInterval(contentChangeHandle);
+
+							Liferay.detach('destroyPortlet', clearContentChangeHandle);
+						}
+					};
+
+					Liferay.on('destroyPortlet', clearContentChangeHandle);
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
+					CKEDITOR.instances['<%= name %>'].on(
+						'focus',
+						window['<%= name %>'].onFocusCallback
+					);
+				</c:if>
+
+				<c:if test="<%= !(inlineEdit && Validator.isNotNull(inlineEditSaveURL)) %>">
+					var initialEditor = CKEDITOR.instances['<%= name %>'].id;
+
+					eventHandles.push(
+						A.getWin().on(
+							'resize',
+							A.debounce(() => {
+								if (
+									currentToolbarSet !=
+									getToolbarSet(initialToolbarSet)
+								) {
+									var ckeditorInstance =
+										CKEDITOR.instances['<%= name %>'];
+
+									if (ckeditorInstance) {
+										var currentEditor = ckeditorInstance.id;
+
+										if (currentEditor === initialEditor) {
+											var currentDialog = CKEDITOR.dialog.getCurrent();
+
+											if (currentDialog) {
+												currentDialog.hide();
+											}
+
+											ckEditorContent = ckeditorInstance.getData();
+
+											window['<%= name %>'].dispose();
+
+											window['<%= name %>'].create();
+
+											CKEDITOR.instances['<%= name %>'].setData(
+												ckEditorContent
+											);
+
+											initialEditor =
+												CKEDITOR.instances['<%= name %>'].id;
+										}
+									}
+								}
+							}, 250)
+						)
+					);
+				</c:if>
+			});
+
+			ckEditor.on('dataReady', (event) => {
+				if (instancePendingData !== null) {
+					var pendingData = instancePendingData;
+
+					instancePendingData = null;
+
+					ckEditor.setData(pendingData);
+				}
+				else {
+					instanceDataReady = true;
+				}
+
+				window['<%= name %>']._setStyles();
+			});
+
+			ckEditor.on('drop', function (event) {
+				var data = event.data.dataTransfer.getData('text/html');
+
+				if (data) {
+					var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
+
+					var element = fragment.children[0];
+
+					if (element.hasClass('cke_widget_image')) {
+						element = element.children[0];
+					}
+
+					if (this.pasteFilter && element.name) {
+						return this.pasteFilter.check(element.name);
+					}
+				}
+			});
+
+			ckEditor.on('setData', (event) => {
+				instanceDataReady = false;
+			});
+
+			if (UA.edge && parseInt(UA.edge, 10) >= 14) {
+				var resetActiveElementValidation = function (activeElement) {
+					activeElement = A.one(activeElement);
+
+					var activeElementAncestor = activeElement.ancestor();
+
+					if (
+						activeElementAncestor.hasClass('has-error') ||
+						activeElementAncestor.hasClass('has-success')
+					) {
+						activeElementAncestor.removeClass('has-error');
+						activeElementAncestor.removeClass('has-success');
+
+						var formValidatorStack = activeElementAncestor.one(
+							'.form-validator-stack'
+						);
+
+						if (formValidatorStack) {
+							formValidatorStack.remove();
+						}
+					}
+				};
+
+				var onBlur = function (activeElement) {
+					resetActiveElementValidation(activeElement);
+
+					setTimeout(() => {
+						if (activeElement) {
+							ckEditor.focusManager.blur(true);
+							activeElement.focus();
+						}
+					}, 0);
+				};
+
+				ckEditor.on('instanceReady', () => {
+					var editorWrapper = A.one('#cke_<%= name %>');
+
+					if (editorWrapper) {
+						editorWrapper.once('mouseenter', function (event) {
+							ckEditor.once(
+								'focus',
+								onBlur.bind(this, document.activeElement)
+							);
+							ckEditor.focus();
+						});
+					}
+				});
+			}
+		}
+
 		currentToolbarSet = getToolbarSet(initialToolbarSet);
 
 		var defaultConfig = {
@@ -486,237 +728,54 @@ name = HtmlUtil.escapeJS(name);
 
 		var config = A.merge(defaultConfig, editorConfig);
 
-		CKEDITOR.<%= inlineEdit ? "inline" : "replace" %>('<%= name %>', config);
+		var editorTransformerURLs = config.editorTransformerURLs;
 
-		Liferay.on('<%= name %>selectItem', (event) => {
-			CKEDITOR.tools.callFunction(event.ckeditorfuncnum, event.value);
-		});
+		if (Liferay.FeatureFlags['LPS-186870'] && editorTransformerURLs) {
+			var loadingIndicator = document.createElement('span');
 
-		var ckEditor = CKEDITOR.instances['<%= name %>'];
+			loadingIndicator.classList.add('loading-animation');
+			loadingIndicator.setAttribute('aria-hidden', true);
 
-		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.ckeditor.web#" + editorName + "#onEditorCreate" %>' />
+			editorContainer.appendChild(loadingIndicator);
 
-		Liferay.namespace('EDITORS').ckeditor.addInstance();
+			Liferay.Util.loadClientExtensions([
+				{
+					clientExtensionDefinitions: editorTransformerURLs.map(
+						(url) => ({
+							importDeclaration: 'default from ' + url,
+						})
+					),
+					onLoad: (bindingContexts) => {
+						var transformedConfig = config;
 
-		<c:if test="<%= inlineEdit && Validator.isNotNull(inlineEditSaveURL) %>">
-			inlineEditor = new Liferay.CKEditorInline({
-				editor: ckEditor,
-				editorName: '<%= name %>',
-				namespace: '<portlet:namespace />',
-				saveURL: '<%= inlineEditSaveURL %>',
-			});
-		</c:if>
+						bindingContexts.forEach(
+							({binding: editorTransformer, error}) => {
+								if (error) {
+									console.error(error);
+								}
 
-		var customDataProcessorLoaded = false;
-
-		<%
-		boolean useCustomDataProcessor = (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor"));
-		%>
-
-		<c:if test="<%= useCustomDataProcessor %>">
-			ckEditor.on('customDataProcessorLoaded', () => {
-				customDataProcessorLoaded = true;
-
-				if (instanceReady) {
-					initData();
-				}
-
-				// LPS-118801
-
-				var editorPath =
-					'<%= HtmlUtil.escapeJS(PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR)) %>';
-
-				document
-					.querySelectorAll(
-						'link[href*="' +
-							editorPath +
-							'"],script[src*="' +
-							editorPath +
-							'"]'
-					)
-					.forEach((tag) => {
-						tag.setAttribute('data-senna-track', 'temporary');
-					});
-			});
-		</c:if>
-
-		var instanceReady = false;
-
-		ckEditor.on('instanceReady', () => {
-			<c:choose>
-				<c:when test="<%= useCustomDataProcessor %>">
-					instanceReady = true;
-
-					if (customDataProcessorLoaded) {
-						initData();
-					}
-				</c:when>
-				<c:otherwise>
-					initData();
-				</c:otherwise>
-			</c:choose>
-
-			window['<%= name %>'].instanceReady = true;
-
-			<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
-				CKEDITOR.instances['<%= name %>'].on(
-					'blur',
-					window['<%= name %>'].onBlurCallback
-				);
-			</c:if>
-
-			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-				var contentChangeHandle = setInterval(() => {
-					try {
-						window['<%= name %>'].onChangeCallback();
-					}
-					catch (e) {}
-				}, 300);
-
-				var clearContentChangeHandle = function (event) {
-					if (event.portletId === '<%= portletId %>') {
-						clearInterval(contentChangeHandle);
-
-						Liferay.detach('destroyPortlet', clearContentChangeHandle);
-					}
-				};
-
-				Liferay.on('destroyPortlet', clearContentChangeHandle);
-			</c:if>
-
-			<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
-				CKEDITOR.instances['<%= name %>'].on(
-					'focus',
-					window['<%= name %>'].onFocusCallback
-				);
-			</c:if>
-
-			<c:if test="<%= !(inlineEdit && Validator.isNotNull(inlineEditSaveURL)) %>">
-				var initialEditor = CKEDITOR.instances['<%= name %>'].id;
-
-				eventHandles.push(
-					A.getWin().on(
-						'resize',
-						A.debounce(() => {
-							if (currentToolbarSet != getToolbarSet(initialToolbarSet)) {
-								var ckeditorInstance =
-									CKEDITOR.instances['<%= name %>'];
-
-								if (ckeditorInstance) {
-									var currentEditor = ckeditorInstance.id;
-
-									if (currentEditor === initialEditor) {
-										var currentDialog = CKEDITOR.dialog.getCurrent();
-
-										if (currentDialog) {
-											currentDialog.hide();
-										}
-
-										ckEditorContent = ckeditorInstance.getData();
-
-										window['<%= name %>'].dispose();
-
-										window['<%= name %>'].create();
-
-										CKEDITOR.instances['<%= name %>'].setData(
-											ckEditorContent
-										);
-
-										initialEditor =
-											CKEDITOR.instances['<%= name %>'].id;
-									}
+								if (
+									editorTransformer &&
+									editorTransformer.editorConfigTransformer
+								) {
+									transformedConfig = editorTransformer.editorConfigTransformer(
+										transformedConfig
+									);
 								}
 							}
-						}, 250)
-					)
-				);
-			</c:if>
-		});
-
-		ckEditor.on('dataReady', (event) => {
-			if (instancePendingData !== null) {
-				var pendingData = instancePendingData;
-
-				instancePendingData = null;
-
-				ckEditor.setData(pendingData);
-			}
-			else {
-				instanceDataReady = true;
-			}
-
-			window['<%= name %>']._setStyles();
-		});
-
-		ckEditor.on('drop', function (event) {
-			var data = event.data.dataTransfer.getData('text/html');
-
-			if (data) {
-				var fragment = CKEDITOR.htmlParser.fragment.fromHtml(data);
-
-				var element = fragment.children[0];
-
-				if (element.hasClass('cke_widget_image')) {
-					element = element.children[0];
-				}
-
-				if (this.pasteFilter && element.name) {
-					return this.pasteFilter.check(element.name);
-				}
-			}
-		});
-
-		ckEditor.on('setData', (event) => {
-			instanceDataReady = false;
-		});
-
-		if (UA.edge && parseInt(UA.edge, 10) >= 14) {
-			var resetActiveElementValidation = function (activeElement) {
-				activeElement = A.one(activeElement);
-
-				var activeElementAncestor = activeElement.ancestor();
-
-				if (
-					activeElementAncestor.hasClass('has-error') ||
-					activeElementAncestor.hasClass('has-success')
-				) {
-					activeElementAncestor.removeClass('has-error');
-					activeElementAncestor.removeClass('has-success');
-
-					var formValidatorStack = activeElementAncestor.one(
-						'.form-validator-stack'
-					);
-
-					if (formValidatorStack) {
-						formValidatorStack.remove();
-					}
-				}
-			};
-
-			var onBlur = function (activeElement) {
-				resetActiveElementValidation(activeElement);
-
-				setTimeout(() => {
-					if (activeElement) {
-						ckEditor.focusManager.blur(true);
-						activeElement.focus();
-					}
-				}, 0);
-			};
-
-			ckEditor.on('instanceReady', () => {
-				var editorWrapper = A.one('#cke_<%= name %>');
-
-				if (editorWrapper) {
-					editorWrapper.once('mouseenter', function (event) {
-						ckEditor.once(
-							'focus',
-							onBlur.bind(this, document.activeElement)
 						);
-						ckEditor.focus();
-					});
-				}
-			});
+
+						if (loadingIndicator) {
+							loadingIndicator.remove();
+						}
+
+						initEditor(transformedConfig);
+					},
+				},
+			]);
+		}
+		else {
+			initEditor(config);
 		}
 	};
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -3,10 +3,18 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {flipThirdPartyCookiesOff} from '@liferay/cookies-banner-web';
 import CKEditor from 'ckeditor4-react';
+import {loadClientExtensions} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {forwardRef, useCallback, useEffect, useRef} from 'react';
+import React, {
+	forwardRef,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react';
 
 import '../css/main.scss';
 
@@ -26,7 +34,22 @@ function createElementFromHTML(htmlString) {
  * DXP implementations of CKEditor. Please don't import it directly.
  */
 const BaseEditor = forwardRef(
-	({contents, name, onChange, onChangeMethodName, ...props}, ref) => {
+	(
+		{
+			config: initialConfig,
+			contents,
+			name,
+			onChange,
+			onChangeMethodName,
+			...props
+		},
+		ref
+	) => {
+		const [config, setConfig] = useState(initialConfig);
+		const [loading, setLoading] = useState(
+			Boolean(initialConfig.editorConfigTransformerURLs)
+		);
+
 		const editorRef = useRef();
 
 		useEffect(() => {
@@ -39,6 +62,37 @@ const BaseEditor = forwardRef(
 				}
 			});
 		}, []);
+
+		useEffect(() => {
+			if (!config.editorConfigTransformerURLs) {
+				return;
+			}
+
+			loadClientExtensions([
+				{
+					clientExtensionDefinitions: config.editorConfigTransformerURLs.map(
+						(url) => ({
+							importDeclaration: `default from ${url}`,
+						})
+					),
+					onLoad: (bindingContexts) => {
+						let transformedConfig = config;
+
+						bindingContexts.forEach(
+							({binding: editorConfigTransformer}) => {
+								transformedConfig = editorConfigTransformer(
+									transformedConfig
+								);
+							}
+						);
+
+						setConfig(transformedConfig);
+
+						setLoading(false);
+					},
+				},
+			]);
+		}, [config]);
 
 		const getHTML = useCallback(() => {
 			let data = contents;
@@ -93,8 +147,11 @@ const BaseEditor = forwardRef(
 			};
 		}, [contents, getHTML, name]);
 
-		return (
+		return loading ? (
+			<ClayLoadingIndicator />
+		) : (
 			<CKEditor
+				config={config}
 				name={name}
 				onChange={onChangeCallback}
 				onChangeMethodName={onChangeMethodName}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -46,9 +46,7 @@ const BaseEditor = forwardRef(
 		ref
 	) => {
 		const [config, setConfig] = useState(initialConfig);
-		const [loading, setLoading] = useState(
-			Boolean(initialConfig.editorTransformerURLs)
-		);
+		const [loading, setLoading] = useState(false);
 
 		const editorRef = useRef();
 
@@ -64,9 +62,14 @@ const BaseEditor = forwardRef(
 		}, []);
 
 		useEffect(() => {
-			if (!initialConfig.editorTransformerURLs) {
+			if (
+				!Liferay.FeatureFlags['LPS-186870'] ||
+				!initialConfig.editorTransformerURLs
+			) {
 				return;
 			}
+
+			setLoading(true);
 
 			loadClientExtensions([
 				{

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -64,25 +64,34 @@ const BaseEditor = forwardRef(
 		}, []);
 
 		useEffect(() => {
-			if (!config.editorConfigTransformerURLs) {
+			if (!initialConfig.editorConfigTransformerURLs) {
 				return;
 			}
 
 			loadClientExtensions([
 				{
-					clientExtensionDefinitions: config.editorConfigTransformerURLs.map(
+					clientExtensionDefinitions: initialConfig.editorConfigTransformerURLs.map(
 						(url) => ({
 							importDeclaration: `default from ${url}`,
 						})
 					),
 					onLoad: (bindingContexts) => {
-						let transformedConfig = config;
+						let transformedConfig = initialConfig;
 
 						bindingContexts.forEach(
-							({binding: editorConfigTransformer}) => {
-								transformedConfig = editorConfigTransformer(
-									transformedConfig
-								);
+							({binding: editorConfigTransformer, error}) => {
+								if (
+									process.env.NODE_ENV === 'development' &&
+									error
+								) {
+									console.error(error);
+								}
+
+								if (editorConfigTransformer) {
+									transformedConfig = editorConfigTransformer(
+										transformedConfig
+									);
+								}
 							}
 						);
 
@@ -92,7 +101,7 @@ const BaseEditor = forwardRef(
 					},
 				},
 			]);
-		}, [config]);
+		}, [initialConfig]);
 
 		const getHTML = useCallback(() => {
 			let data = contents;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -47,7 +47,7 @@ const BaseEditor = forwardRef(
 	) => {
 		const [config, setConfig] = useState(initialConfig);
 		const [loading, setLoading] = useState(
-			Boolean(initialConfig.editorConfigTransformerURLs)
+			Boolean(initialConfig.editorTransformerURLs)
 		);
 
 		const editorRef = useRef();
@@ -64,13 +64,13 @@ const BaseEditor = forwardRef(
 		}, []);
 
 		useEffect(() => {
-			if (!initialConfig.editorConfigTransformerURLs) {
+			if (!initialConfig.editorTransformerURLs) {
 				return;
 			}
 
 			loadClientExtensions([
 				{
-					clientExtensionDefinitions: initialConfig.editorConfigTransformerURLs.map(
+					clientExtensionDefinitions: initialConfig.editorTransformerURLs.map(
 						(url) => ({
 							importDeclaration: `default from ${url}`,
 						})
@@ -79,13 +79,16 @@ const BaseEditor = forwardRef(
 						let transformedConfig = initialConfig;
 
 						bindingContexts.forEach(
-							({binding: editorConfigTransformer, error}) => {
+							({binding: editorTransformer, error}) => {
 								if (
 									process.env.NODE_ENV === 'development' &&
 									error
 								) {
 									console.error(error);
 								}
+
+								const editorConfigTransformer =
+									editorTransformer?.editorConfigTransformer;
 
 								if (editorConfigTransformer) {
 									transformedConfig = editorConfigTransformer(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -6,6 +6,7 @@
 import groupBy from 'lodash.groupby';
 import isEqual from 'lodash.isequal';
 
+import loadClientExtensions from '../utils/client_extensions/loadClientExtensions';
 import DynamicSelect from './DynamicSelect';
 import BREAKPOINTS from './breakpoints';
 import {
@@ -243,6 +244,7 @@ Liferay.Util.getPortletConfigurationIconAction = getPortletConfigurationIconActi
 Liferay.Util.getPortletId = getPortletId;
 
 Liferay.Util.getPortletNamespace = getPortletNamespace;
+Liferay.Util.getSelectedOptionValues = getSelectedOptionValues;
 Liferay.Util.getTop = getTop;
 Liferay.Util.getURLWithSessionId = getURLWithSessionId;
 Liferay.Util.getWindow = getWindow;
@@ -265,8 +267,7 @@ Liferay.Util.isPhone = isPhone;
  */
 Liferay.Util.isTablet = isTablet;
 
-Liferay.Util.getSelectedOptionValues = getSelectedOptionValues;
-
+Liferay.Util.loadClientExtensions = loadClientExtensions;
 Liferay.Util.navigate = navigate;
 Liferay.Util.ns = ns;
 Liferay.Util.objectToFormData = objectToFormData;


### PR DESCRIPTION
### References

- [LPS-187309 Apply editor config contributor client extensions to CKEditor](https://issues.liferay.com/browse/LPS-187309)
- PoC: https://github.com/liferay-frontend/liferay-portal/pull/3835
- public API: https://github.com/liferay/liferay-frontend-projects/pull/1185

### What is the goal of this PR?

This is the third part of the editor config contributor CET implementation, where we apply CETs in frontend. In addition, we are adding a workspace sample. 

See technical notes in inline comments.

### What does it look like?

![screen](https://github.com/liferay-frontend/liferay-portal/assets/5435511/7c2e318a-26a2-428e-b772-2cdd8289963e)

### Steps to reproduce

Setting up workspace updates locally is quite complex, see [Slack discussion](https://liferay.slack.com/archives/C3JBR21HA/p1702572438634679). Once CET is deployed, you can see on `frontend-editor-ckeditor-web`, Classic tab. 