### PR TITLE
LPS-203827 Fix small prop

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -658,6 +658,8 @@ AUI.add(
 					);
 
 					if (languageStatusNode) {
+						Liferay.fire('inputLocalized:updateTranslationStatus');
+
 						languageStatusNode.setHTML(
 							A.Lang.sub(instance.TRANSLATION_STATUS_TEMPLATE, {
 								languageId: languageId.replaceAll(/_/g, '-'),

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -263,9 +263,9 @@ AUI.add(
 								fieldNamePrefix,
 								fieldNameSuffix,
 								id,
+								languageId,
 								name: A.Lang.String.escapeHTML(name),
 								namespace,
-								value: languageId,
 							})
 						);
 
@@ -701,7 +701,7 @@ AUI.add(
 				},
 
 				INPUT_HIDDEN_TEMPLATE:
-					'<input id="{namespace}{id}_{value}" name="{namespace}{fieldNamePrefix}{name}_{value}{fieldNameSuffix}" type="hidden" value="" />',
+					'<input data-field-name={name} data-language-id={languageId} id="{namespace}{id}_{languageId}" name="{namespace}{fieldNamePrefix}{name}_{languageId}{fieldNameSuffix}" type="hidden" value="" />',
 
 				TRANSLATION_STATUS_TEMPLATE:
 					'<span aria-label="{translationAriaLabel}" role="button" tabindex="0"> {languageId} <span class="dropdown-item-indicator-end w-auto"><span class="label label-{translationStatusCssClass}">{translationStatus}</span></span></span>',

--- a/modules/apps/frontend-js/frontend-js-components-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-components-web/package.json
@@ -3,6 +3,7 @@
 		"@clayui/alert": "3.106.1",
 		"@clayui/button": "3.107.0",
 		"@clayui/card": "3.107.1",
+		"@clayui/core": "3.107.1",
 		"@clayui/drop-down": "3.107.1",
 		"@clayui/form": "3.107.0",
 		"@clayui/icon": "3.106.1",

--- a/modules/apps/frontend-js/frontend-js-components-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-components-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@clayui/alert": "3.106.1",
 		"@clayui/button": "3.107.0",
 		"@clayui/card": "3.107.1",
 		"@clayui/drop-down": "3.107.1",

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
@@ -34,3 +34,4 @@ export {
 
 export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
 export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export {Locale} from './translation_manager/TranslationAdminContent';

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.tsx
@@ -14,13 +14,13 @@ import React, {useMemo, useState} from 'react';
 
 export interface Locale {
 	displayName: string;
-	id: string;
-	label: string;
+	id: Liferay.Language.Locale;
+	label: Liferay.Language.Locale;
 	symbol: string;
 }
 
 export interface Translations {
-	activeLanguageIds?: string[];
+	activeLanguageIds?: Liferay.Language.Locale[];
 	ariaLabels?: {
 		default?: string;
 		manageTranslations?: string;
@@ -29,15 +29,15 @@ export interface Translations {
 		translated?: string;
 	};
 	availableLocales: Locale[];
-	defaultLanguageId: string;
-	translations?: {[key: string]: unknown};
+	defaultLanguageId: Liferay.Language.Locale;
+	translations?: Record<Liferay.Language.Locale, string> | null;
 }
 
 interface IProps extends Translations {
-	onAddLocale?: (localeId: string) => void;
+	onAddLocale?: (localeId: Liferay.Language.Locale) => void;
 	onCancel?: React.MouseEventHandler<HTMLButtonElement>;
 	onDone?: React.MouseEventHandler<HTMLButtonElement>;
-	onRemoveLocale?: (localeId: string) => void;
+	onRemoveLocale?: (localeId: Liferay.Language.Locale) => void;
 }
 
 const noop = () => {};
@@ -57,7 +57,7 @@ export default function TranslationAdminContent({
 	onCancel = noop,
 	onDone = noop,
 	onRemoveLocale = noop,
-	translations = {},
+	translations = null,
 }: IProps) {
 	const [creationMenuActive, setCreationMenuActive] = useState(false);
 	const [searchValue, setSearchValue] = useState('');
@@ -183,7 +183,10 @@ export default function TranslationAdminContent({
 
 							const isDefaultLocale =
 								activeLocale.id === defaultLanguageId;
-							const localeValue = translations[label];
+
+							const localeValue = translations
+								? translations[label]
+								: null;
 
 							return (
 								<ClayTable.Row key={label}>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminItem.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminItem.tsx
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+import {Locale} from './TranslationAdminContent';
+import {TranslationProgress} from './TranslationAdminSelector';
+import TranslationAdminStatusLabel from './TranslationAdminStatusLabel';
+
+interface Props {
+	defaultLanguageId: Liferay.Language.Locale;
+	item: Locale;
+	labels?: {
+		default?: string;
+		notTranslated?: string;
+		translated?: string;
+	};
+	localeValue: string | null;
+	showOnlyFlags?: boolean;
+	translationProgress?: TranslationProgress | null;
+}
+
+export default function TranslationAdminItem({
+	defaultLanguageId,
+	item,
+	labels,
+	localeValue,
+	showOnlyFlags,
+	translationProgress = null,
+}: Props) {
+	return (
+		<ClayLayout.ContentRow containerElement="span">
+			<ClayLayout.ContentCol containerElement="span" expand>
+				<ClayLayout.ContentSection>
+					<ClayIcon
+						className="inline-item inline-item-before"
+						symbol={item.symbol}
+					/>
+
+					<span aria-hidden="true">{item.label}</span>
+				</ClayLayout.ContentSection>
+			</ClayLayout.ContentCol>
+
+			{!showOnlyFlags && (
+				<TranslationAdminStatusLabel
+					defaultLanguageId={defaultLanguageId}
+					labels={labels}
+					languageId={item.id}
+					languageName={item.displayName}
+					localeValue={localeValue}
+					translationProgress={translationProgress}
+				/>
+			)}
+		</ClayLayout.ContentRow>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal.tsx
@@ -9,7 +9,7 @@ import React, {useEffect, useState} from 'react';
 import TranslationAdminContent, {Translations} from './TranslationAdminContent';
 
 interface IProps extends Translations {
-	onClose: (languageIds: string[]) => void;
+	onClose: (languageIds: Liferay.Language.Locale[]) => void;
 	visible?: boolean;
 }
 
@@ -34,7 +34,7 @@ export default function TranslationAdminModal({
 	);
 	const [visible, setVisible] = useState(initialVisible);
 
-	const handleAddLocale = (localeId: string) => {
+	const handleAddLocale = (localeId: Liferay.Language.Locale) => {
 		setActiveLanguageIds([...activeLanguageIds, localeId]);
 	};
 
@@ -49,7 +49,7 @@ export default function TranslationAdminModal({
 		onClose([...activeLanguageIds]);
 	};
 
-	const handleRemoveLocale = (localeId: string) => {
+	const handleRemoveLocale = (localeId: Liferay.Language.Locale) => {
 		const newActiveLanguageIds = [...activeLanguageIds];
 		newActiveLanguageIds.splice(activeLanguageIds.indexOf(localeId), 1);
 		setActiveLanguageIds(newActiveLanguageIds);

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -220,6 +220,7 @@ export default function TranslationAdminSelector({
 
 			<ClayDropDown
 				active={selectorDropdownActive}
+				hasLeftSymbols
 				onActiveChange={setSelectorDropdownActive}
 				trigger={
 					<TriggerButton
@@ -231,13 +232,17 @@ export default function TranslationAdminSelector({
 			>
 				<ClayDropDown.ItemList>
 					{activeLocales.map((activeLocale) => {
+						const active = activeLocale.id === selectedLanguageId;
+
 						return (
 							<ClayDropDown.Item
+								active={active}
 								key={activeLocale.id}
 								onClick={() => {
 									setSelectedLanguageId(activeLocale.id);
 									setSelectorDropdownActive(false);
 								}}
+								symbolLeft={active ? 'check-small' : undefined}
 							>
 								<TranslationAdminItem
 									defaultLanguageId={defaultLanguageId}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -6,12 +6,12 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
-import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {Locale, Translations} from './TranslationAdminContent';
 import TranslationAdminModal from './TranslationAdminModal';
+import TranslationAdminStatusLabel from './TranslationAdminStatusLabel';
 
 const DISPLAY_TYPE = {
 	default: 'default',
@@ -39,10 +39,7 @@ export default function TranslationAdminSelector({
 	activeLanguageIds: initialActiveLanguageIds = [],
 	adminMode,
 	ariaLabels = {
-		default: Liferay.Language.get('default'),
 		manageTranslations: Liferay.Language.get('manage-translations'),
-		notTranslated: Liferay.Language.get('not-translated'),
-		translated: Liferay.Language.get('translated'),
 	},
 	availableLocales = [],
 	defaultLanguageId,
@@ -159,21 +156,12 @@ export default function TranslationAdminSelector({
 				}
 			>
 				<ClayDropDown.ItemList>
-					{activeLocales.map((activeLocale) => {
-						const label = activeLocale.label;
-
-						const isDefaultLocale =
-							activeLocale.id === defaultLanguageId;
-
-						const localeValue = translations
-							? translations[activeLocale.id]
-							: null;
-
+					{activeLocales.map(({id, label, symbol}) => {
 						return (
 							<ClayDropDown.Item
-								key={activeLocale.id}
+								key={id}
 								onClick={() => {
-									setSelectedLanguageId(activeLocale.id);
+									setSelectedLanguageId(id);
 									setSelectorDropdownActive(false);
 								}}
 							>
@@ -185,33 +173,32 @@ export default function TranslationAdminSelector({
 										<ClayLayout.ContentSection>
 											<ClayIcon
 												className="inline-item inline-item-before"
-												symbol={activeLocale.symbol}
+												symbol={symbol}
 											/>
 
-											{label}
+											<span>{label}</span>
 										</ClayLayout.ContentSection>
 									</ClayLayout.ContentCol>
 
 									{!showOnlyFlags && (
-										<ClayLayout.ContentCol containerElement="span">
-											<ClayLayout.ContentSection>
-												<ClayLabel
-													displayType={
-														isDefaultLocale
-															? 'info'
-															: localeValue
-															? 'success'
-															: 'warning'
-													}
-												>
-													{isDefaultLocale
-														? ariaLabels.default
-														: localeValue
-														? ariaLabels.translated
-														: ariaLabels.notTranslated}
-												</ClayLabel>
-											</ClayLayout.ContentSection>
-										</ClayLayout.ContentCol>
+										<TranslationAdminStatusLabel
+											defaultLanguageId={
+												defaultLanguageId
+											}
+											labels={{
+												default: ariaLabels.default,
+												notTranslated:
+													ariaLabels.notTranslated,
+												translated:
+													ariaLabels.translated,
+											}}
+											languageId={id}
+											localeValue={
+												translations
+													? translations[id]
+													: null
+											}
+										/>
 									)}
 								</ClayLayout.ContentRow>
 							</ClayDropDown.Item>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -28,6 +28,12 @@ interface IProps extends Translations {
 	selectedLanguageId: Liferay.Language.Locale;
 	showOnlyFlags?: boolean;
 	small?: boolean;
+	translationProgress?: TranslationProgress | null;
+}
+
+export interface TranslationProgress {
+	totalItems: number;
+	translatedItems: Record<string, number>;
 }
 
 // These variables are defined here, out of the component, to avoid
@@ -50,6 +56,7 @@ export default function TranslationAdminSelector({
 	showOnlyFlags,
 	small = false,
 	translations = null,
+	translationProgress = null,
 }: IProps) {
 	const [activeLanguageIds, setActiveLanguageIds] = useState<
 		Liferay.Language.Locale[]
@@ -198,6 +205,9 @@ export default function TranslationAdminSelector({
 												translations
 													? translations[id]
 													: null
+											}
+											translationProgress={
+												translationProgress
 											}
 										/>
 									)}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -7,7 +7,8 @@ import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import React, {useEffect, useMemo, useState} from 'react';
+import {sub} from 'frontend-js-web';
+import React, {Ref, useEffect, useMemo, useState} from 'react';
 
 import {Locale, Translations} from './TranslationAdminContent';
 import TranslationAdminModal from './TranslationAdminModal';
@@ -18,9 +19,11 @@ const DISPLAY_TYPE = {
 	horizontal: 'horizontal',
 } as const;
 
+type DisplayType = 'default' | 'horizontal';
+
 interface IProps extends Translations {
 	adminMode?: boolean;
-	displayType?: 'default' | 'horizontal';
+	displayType?: DisplayType;
 	onActiveLanguageIdsChange?: (
 		languageIds: Liferay.Language.Locale[]
 	) => void;
@@ -36,10 +39,64 @@ export interface TranslationProgress {
 	translatedItems: Record<string, number>;
 }
 
+interface TriggerButtonProps {
+	displayType: DisplayType;
+	selectedItem: Locale;
+	small: boolean;
+}
+
 // These variables are defined here, out of the component, to avoid
 // unexpected re-renders
 
 const noop = () => {};
+
+const TriggerButton = React.forwardRef(
+	(
+		{displayType, selectedItem, small, ...props}: TriggerButtonProps,
+		ref: Ref<HTMLButtonElement>
+	) => {
+		const ariaLabelButton = sub(
+			Liferay.Language.get('select-a-language.-current-language-x'),
+			selectedItem.displayName
+		);
+
+		return Liferay.FeatureFlags['LPS-114700'] &&
+			displayType === DISPLAY_TYPE.horizontal ? (
+			<ClayButton
+				{...props}
+				aria-label={ariaLabelButton}
+				className="btn-block form-control-select"
+				displayType="secondary"
+				ref={ref}
+				size="sm"
+			>
+				<span className="inline-item-before">
+					<ClayIcon symbol={selectedItem.symbol} />
+				</span>
+
+				<span aria-hidden="true">{selectedItem.label}</span>
+			</ClayButton>
+		) : (
+			<ClayButton
+				{...props}
+				aria-label={ariaLabelButton}
+				displayType="secondary"
+				monospaced
+				ref={ref}
+				small={small}
+				title={Liferay.Language.get('select-language')}
+			>
+				<span className="inline-item">
+					<ClayIcon symbol={selectedItem.symbol} />
+				</span>
+
+				<span aria-hidden="true" className="btn-section">
+					{selectedItem.label}
+				</span>
+			</ClayButton>
+		);
+	}
+);
 
 export default function TranslationAdminSelector({
 	activeLanguageIds: initialActiveLanguageIds = [],
@@ -129,37 +186,11 @@ export default function TranslationAdminSelector({
 				active={selectorDropdownActive}
 				onActiveChange={setSelectorDropdownActive}
 				trigger={
-					Liferay.FeatureFlags['LPS-114700'] &&
-					displayType === DISPLAY_TYPE.horizontal ? (
-						<ClayButton
-							className="btn-block form-control-select"
-							displayType="secondary"
-							size="sm"
-						>
-							<span className="inline-item-before">
-								<ClayIcon symbol={selectedLocale.symbol} />
-							</span>
-
-							{selectedLocale.label}
-						</ClayButton>
-					) : (
-						<ClayButton
-							displayType="secondary"
-							monospaced
-							small={small}
-							title={Liferay.Language.get(
-								'select-translation-language'
-							)}
-						>
-							<span className="inline-item">
-								<ClayIcon symbol={selectedLocale.symbol} />
-							</span>
-
-							<span className="btn-section">
-								{selectedLocale.label}
-							</span>
-						</ClayButton>
-					)
+					<TriggerButton
+						displayType={displayType}
+						selectedItem={selectedLocale}
+						small={small}
+					/>
 				}
 			>
 				<ClayDropDown.ItemList>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -15,9 +15,11 @@ import TranslationAdminModal from './TranslationAdminModal';
 
 interface IProps extends Translations {
 	adminMode?: boolean;
-	onActiveLanguageIdsChange?: (languageIds: string[]) => void;
-	onSelectedLanguageIdChange?: (languageId: string) => void;
-	selectedLanguageId: string;
+	onActiveLanguageIdsChange?: (
+		languageIds: Liferay.Language.Locale[]
+	) => void;
+	onSelectedLanguageIdChange?: (languageId: Liferay.Language.Locale) => void;
+	selectedLanguageId: Liferay.Language.Locale;
 	showOnlyFlags?: boolean;
 	small?: boolean;
 }
@@ -43,20 +45,22 @@ export default function TranslationAdminSelector({
 	selectedLanguageId: initialSelectedLanguageId,
 	showOnlyFlags,
 	small = false,
-	translations = {},
+	translations = null,
 }: IProps) {
-	const [activeLanguageIds, setActiveLanguageIds] = useState(
-		initialActiveLanguageIds
-	);
-	const [selectedLanguageId, setSelectedLanguageId] = useState(
-		initialSelectedLanguageId
-	);
+	const [activeLanguageIds, setActiveLanguageIds] = useState<
+		Liferay.Language.Locale[]
+	>(initialActiveLanguageIds);
+	const [selectedLanguageId, setSelectedLanguageId] = useState<
+		Liferay.Language.Locale
+	>(initialSelectedLanguageId);
 	const [selectorDropdownActive, setSelectorDropdownActive] = useState(false);
 	const [translationModalVisible, setTranslationModalVisible] = useState(
 		false
 	);
 
-	const handleCloseTranslationModal = (activeLanguageIds: string[]) => {
+	const handleCloseTranslationModal = (
+		activeLanguageIds: Liferay.Language.Locale[]
+	) => {
 		setActiveLanguageIds(activeLanguageIds);
 
 		if (!activeLanguageIds.includes(selectedLanguageId)) {
@@ -139,7 +143,9 @@ export default function TranslationAdminSelector({
 						const isDefaultLocale =
 							activeLocale.id === defaultLanguageId;
 
-						const localeValue = translations[activeLocale.id];
+						const localeValue = translations
+							? translations[activeLocale.id]
+							: null;
 
 						return (
 							<ClayDropDown.Item

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -9,7 +9,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
-import React, {Ref, useEffect, useMemo, useState} from 'react';
+import React, {Ref, useEffect, useMemo, useRef, useState} from 'react';
 
 import useId from '../hooks/useId';
 import {Locale, Translations} from './TranslationAdminContent';
@@ -128,6 +128,7 @@ export default function TranslationAdminSelector({
 	const [translationModalVisible, setTranslationModalVisible] = useState(
 		false
 	);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
 
 	const handleCloseTranslationModal = (
 		activeLanguageIds: Liferay.Language.Locale[]
@@ -225,6 +226,9 @@ export default function TranslationAdminSelector({
 				trigger={
 					<TriggerButton
 						displayType={displayType}
+						ref={(node) => {
+							triggerRef.current = node;
+						}}
 						selectedItem={selectedLocale}
 						small={small}
 					/>
@@ -241,6 +245,8 @@ export default function TranslationAdminSelector({
 								onClick={() => {
 									setSelectedLanguageId(activeLocale.id);
 									setSelectorDropdownActive(false);
+
+									triggerRef.current?.focus();
 								}}
 								symbolLeft={active ? 'check-small' : undefined}
 							>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -156,7 +156,7 @@ export default function TranslationAdminSelector({
 				}
 			>
 				<ClayDropDown.ItemList>
-					{activeLocales.map(({id, label, symbol}) => {
+					{activeLocales.map(({displayName, id, label, symbol}) => {
 						return (
 							<ClayDropDown.Item
 								key={id}
@@ -193,6 +193,7 @@ export default function TranslationAdminSelector({
 													ariaLabels.translated,
 											}}
 											languageId={id}
+											languageName={displayName}
 											localeValue={
 												translations
 													? translations[id]

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -4,12 +4,14 @@
  */
 
 import ClayButton from '@clayui/button';
+import {Option, Picker} from '@clayui/core';
 import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
 import React, {Ref, useEffect, useMemo, useState} from 'react';
 
+import useId from '../hooks/useId';
 import {Locale, Translations} from './TranslationAdminContent';
 import TranslationAdminModal from './TranslationAdminModal';
 import TranslationAdminStatusLabel from './TranslationAdminStatusLabel';
@@ -122,6 +124,7 @@ export default function TranslationAdminSelector({
 		Liferay.Language.Locale
 	>(initialSelectedLanguageId);
 	const [selectorDropdownActive, setSelectorDropdownActive] = useState(false);
+	const selectorId = useId();
 	const [translationModalVisible, setTranslationModalVisible] = useState(
 		false
 	);
@@ -169,6 +172,44 @@ export default function TranslationAdminSelector({
 	useEffect(() => {
 		setSelectedLanguageId(initialSelectedLanguageId);
 	}, [initialSelectedLanguageId]);
+
+	if (Liferay.FeatureFlags['LPS-114700'] && !adminMode) {
+		return (
+			<Picker
+				as={TriggerButton}
+				displayType={displayType}
+				id={selectorId}
+				items={activeLocales}
+				onSelectionChange={(id: React.Key) => {
+					setSelectedLanguageId(id as Liferay.Language.Locale);
+				}}
+				selectedItem={activeLocales.find(
+					(locale) => locale.id === selectedLanguageId
+				)}
+				selectedKey={selectedLanguageId}
+			>
+				{(item) => (
+					<Option key={item.id} textValue={item.label}>
+						<ClayLayout.ContentRow containerElement="span">
+							<ClayLayout.ContentCol
+								containerElement="span"
+								expand
+							>
+								<ClayLayout.ContentSection>
+									<ClayIcon
+										className="inline-item-before"
+										symbol={item.symbol}
+									/>
+
+									{item.label}
+								</ClayLayout.ContentSection>
+							</ClayLayout.ContentCol>
+						</ClayLayout.ContentRow>
+					</Option>
+				)}
+			</Picker>
+		);
+	}
 
 	return (
 		<>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -13,8 +13,8 @@ import React, {Ref, useEffect, useMemo, useState} from 'react';
 
 import useId from '../hooks/useId';
 import {Locale, Translations} from './TranslationAdminContent';
+import TranslationAdminItem from './TranslationAdminItem';
 import TranslationAdminModal from './TranslationAdminModal';
-import TranslationAdminStatusLabel from './TranslationAdminStatusLabel';
 
 const DISPLAY_TYPE = {
 	default: 'default',
@@ -190,21 +190,16 @@ export default function TranslationAdminSelector({
 			>
 				{(item) => (
 					<Option key={item.id} textValue={item.label}>
-						<ClayLayout.ContentRow containerElement="span">
-							<ClayLayout.ContentCol
-								containerElement="span"
-								expand
-							>
-								<ClayLayout.ContentSection>
-									<ClayIcon
-										className="inline-item-before"
-										symbol={item.symbol}
-									/>
-
-									{item.label}
-								</ClayLayout.ContentSection>
-							</ClayLayout.ContentCol>
-						</ClayLayout.ContentRow>
+						<TranslationAdminItem
+							defaultLanguageId={defaultLanguageId}
+							item={item}
+							labels={ariaLabels}
+							localeValue={
+								translations ? translations[item.id] : null
+							}
+							showOnlyFlags={showOnlyFlags}
+							translationProgress={translationProgress}
+						/>
 					</Option>
 				)}
 			</Picker>
@@ -235,55 +230,27 @@ export default function TranslationAdminSelector({
 				}
 			>
 				<ClayDropDown.ItemList>
-					{activeLocales.map(({displayName, id, label, symbol}) => {
+					{activeLocales.map((activeLocale) => {
 						return (
 							<ClayDropDown.Item
-								key={id}
+								key={activeLocale.id}
 								onClick={() => {
-									setSelectedLanguageId(id);
+									setSelectedLanguageId(activeLocale.id);
 									setSelectorDropdownActive(false);
 								}}
 							>
-								<ClayLayout.ContentRow containerElement="span">
-									<ClayLayout.ContentCol
-										containerElement="span"
-										expand
-									>
-										<ClayLayout.ContentSection>
-											<ClayIcon
-												className="inline-item inline-item-before"
-												symbol={symbol}
-											/>
-
-											<span>{label}</span>
-										</ClayLayout.ContentSection>
-									</ClayLayout.ContentCol>
-
-									{!showOnlyFlags && (
-										<TranslationAdminStatusLabel
-											defaultLanguageId={
-												defaultLanguageId
-											}
-											labels={{
-												default: ariaLabels.default,
-												notTranslated:
-													ariaLabels.notTranslated,
-												translated:
-													ariaLabels.translated,
-											}}
-											languageId={id}
-											languageName={displayName}
-											localeValue={
-												translations
-													? translations[id]
-													: null
-											}
-											translationProgress={
-												translationProgress
-											}
-										/>
-									)}
-								</ClayLayout.ContentRow>
+								<TranslationAdminItem
+									defaultLanguageId={defaultLanguageId}
+									item={activeLocale}
+									labels={ariaLabels}
+									localeValue={
+										translations
+											? translations[activeLocale.id]
+											: null
+									}
+									showOnlyFlags={showOnlyFlags}
+									translationProgress={translationProgress}
+								/>
 							</ClayDropDown.Item>
 						);
 					})}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -13,8 +13,14 @@ import React, {useEffect, useMemo, useState} from 'react';
 import {Locale, Translations} from './TranslationAdminContent';
 import TranslationAdminModal from './TranslationAdminModal';
 
+const DISPLAY_TYPE = {
+	default: 'default',
+	horizontal: 'horizontal',
+} as const;
+
 interface IProps extends Translations {
 	adminMode?: boolean;
+	displayType?: 'default' | 'horizontal';
 	onActiveLanguageIdsChange?: (
 		languageIds: Liferay.Language.Locale[]
 	) => void;
@@ -40,6 +46,7 @@ export default function TranslationAdminSelector({
 	},
 	availableLocales = [],
 	defaultLanguageId,
+	displayType = DISPLAY_TYPE.default,
 	onActiveLanguageIdsChange = noop,
 	onSelectedLanguageIdChange = noop,
 	selectedLanguageId: initialSelectedLanguageId,
@@ -118,22 +125,37 @@ export default function TranslationAdminSelector({
 				active={selectorDropdownActive}
 				onActiveChange={setSelectorDropdownActive}
 				trigger={
-					<ClayButton
-						displayType="secondary"
-						monospaced
-						small={small}
-						title={Liferay.Language.get(
-							'select-translation-language'
-						)}
-					>
-						<span className="inline-item">
-							<ClayIcon symbol={selectedLocale.symbol} />
-						</span>
+					Liferay.FeatureFlags['LPS-114700'] &&
+					displayType === DISPLAY_TYPE.horizontal ? (
+						<ClayButton
+							className="btn-block form-control-select"
+							displayType="secondary"
+							size="sm"
+						>
+							<span className="inline-item-before">
+								<ClayIcon symbol={selectedLocale.symbol} />
+							</span>
 
-						<span className="btn-section">
 							{selectedLocale.label}
-						</span>
-					</ClayButton>
+						</ClayButton>
+					) : (
+						<ClayButton
+							displayType="secondary"
+							monospaced
+							small={small}
+							title={Liferay.Language.get(
+								'select-translation-language'
+							)}
+						>
+							<span className="inline-item">
+								<ClayIcon symbol={selectedLocale.symbol} />
+							</span>
+
+							<span className="btn-section">
+								{selectedLocale.label}
+							</span>
+						</ClayButton>
+					)
 				}
 			>
 				<ClayDropDown.ItemList>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -85,7 +85,7 @@ const TriggerButton = React.forwardRef(
 				displayType="secondary"
 				monospaced
 				ref={ref}
-				small={small}
+				size={small ? 'sm' : undefined}
 				title={Liferay.Language.get('select-language')}
 			>
 				<span className="inline-item">

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.tsx
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {DisplayType} from '@clayui/alert';
+import ClayLabel from '@clayui/label';
+import ClayLayout from '@clayui/layout';
+import React from 'react';
+
+interface Props {
+	defaultLanguageId: Liferay.Language.Locale;
+	labels?: {
+		default?: string;
+		notTranslated?: string;
+		translated?: string;
+	};
+	languageId: Liferay.Language.Locale;
+	localeValue: string | null;
+}
+
+interface Status {
+	displayType: DisplayType;
+	label: string;
+}
+
+export default function TranslationAdminStatusLabel({
+	defaultLanguageId,
+	labels,
+	languageId,
+	localeValue,
+}: Props) {
+	const status = {
+		default: {
+			displayType: 'info',
+			label: labels?.default || Liferay.Language.get('default'),
+		},
+		notTranslated: {
+			displayType: 'warning',
+			label:
+				labels?.notTranslated || Liferay.Language.get('not-translated'),
+		},
+		translated: {
+			displayType: 'success',
+			label: labels?.translated || Liferay.Language.get('translated'),
+		},
+	} as const;
+
+	let statusLabel: Status = status.notTranslated;
+
+	if (languageId === defaultLanguageId) {
+		statusLabel = status.default;
+	}
+	else if (localeValue) {
+		statusLabel = status.translated;
+	}
+
+	return (
+		<ClayLayout.ContentCol containerElement="span">
+			<ClayLayout.ContentSection>
+				<ClayLabel displayType={statusLabel.displayType}>
+					{statusLabel.label}
+				</ClayLabel>
+			</ClayLayout.ContentSection>
+		</ClayLayout.ContentCol>
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.tsx
@@ -6,6 +6,7 @@
 import {DisplayType} from '@clayui/alert';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
+import {sub} from 'frontend-js-web';
 import React from 'react';
 
 interface Props {
@@ -16,6 +17,7 @@ interface Props {
 		translated?: string;
 	};
 	languageId: Liferay.Language.Locale;
+	languageName: string;
 	localeValue: string | null;
 }
 
@@ -28,6 +30,7 @@ export default function TranslationAdminStatusLabel({
 	defaultLanguageId,
 	labels,
 	languageId,
+	languageName,
 	localeValue,
 }: Props) {
 	const status = {
@@ -57,8 +60,19 @@ export default function TranslationAdminStatusLabel({
 
 	return (
 		<ClayLayout.ContentCol containerElement="span">
+			<span className="sr-only">
+				{sub(
+					Liferay.Language.get('x-language-x'),
+					languageName,
+					statusLabel.label
+				)}
+			</span>
+
 			<ClayLayout.ContentSection>
-				<ClayLabel displayType={statusLabel.displayType}>
+				<ClayLabel
+					aria-hidden="true"
+					displayType={statusLabel.displayType}
+				>
 					{statusLabel.label}
 				</ClayLabel>
 			</ClayLayout.ContentSection>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.tsx
@@ -9,6 +9,8 @@ import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
 import React from 'react';
 
+import {TranslationProgress} from './TranslationAdminSelector';
+
 interface Props {
 	defaultLanguageId: Liferay.Language.Locale;
 	labels?: {
@@ -19,6 +21,7 @@ interface Props {
 	languageId: Liferay.Language.Locale;
 	languageName: string;
 	localeValue: string | null;
+	translationProgress: TranslationProgress | null;
 }
 
 interface Status {
@@ -32,6 +35,7 @@ export default function TranslationAdminStatusLabel({
 	languageId,
 	languageName,
 	localeValue,
+	translationProgress = null,
 }: Props) {
 	const status = {
 		default: {
@@ -56,6 +60,23 @@ export default function TranslationAdminStatusLabel({
 	}
 	else if (localeValue) {
 		statusLabel = status.translated;
+	}
+	else if (
+		Liferay.FeatureFlags['LPS-114700'] &&
+		translationProgress?.translatedItems[languageId]
+	) {
+		const {totalItems, translatedItems} = translationProgress;
+
+		statusLabel =
+			totalItems === translatedItems[languageId]
+				? status.translated
+				: {
+						displayType: 'secondary',
+						label: sub(Liferay.Language.get('translating-x-x'), [
+							translatedItems[languageId],
+							totalItems,
+						]),
+				  };
 	}
 
 	return (

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -27,3 +27,4 @@ export {
 } from './translation_manager/state';
 export {default as TranslationAdminModal} from './translation_manager/TranslationAdminModal';
 export {default as TranslationAdminSelector} from './translation_manager/TranslationAdminSelector';
+export {Locale} from './translation_manager/TranslationAdminContent';

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminContent.d.ts
@@ -6,12 +6,12 @@
 import React from 'react';
 export interface Locale {
 	displayName: string;
-	id: string;
-	label: string;
+	id: Liferay.Language.Locale;
+	label: Liferay.Language.Locale;
 	symbol: string;
 }
 export interface Translations {
-	activeLanguageIds?: string[];
+	activeLanguageIds?: Liferay.Language.Locale[];
 	ariaLabels?: {
 		default?: string;
 		manageTranslations?: string;
@@ -20,16 +20,14 @@ export interface Translations {
 		translated?: string;
 	};
 	availableLocales: Locale[];
-	defaultLanguageId: string;
-	translations?: {
-		[key: string]: unknown;
-	};
+	defaultLanguageId: Liferay.Language.Locale;
+	translations?: Record<Liferay.Language.Locale, string> | null;
 }
 interface IProps extends Translations {
-	onAddLocale?: (localeId: string) => void;
+	onAddLocale?: (localeId: Liferay.Language.Locale) => void;
 	onCancel?: React.MouseEventHandler<HTMLButtonElement>;
 	onDone?: React.MouseEventHandler<HTMLButtonElement>;
-	onRemoveLocale?: (localeId: string) => void;
+	onRemoveLocale?: (localeId: Liferay.Language.Locale) => void;
 }
 export default function TranslationAdminContent({
 	ariaLabels,

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminItem.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminItem.d.ts
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+import {Locale} from './TranslationAdminContent';
+import {TranslationProgress} from './TranslationAdminSelector';
+interface Props {
+	defaultLanguageId: Liferay.Language.Locale;
+	item: Locale;
+	labels?: {
+		default?: string;
+		notTranslated?: string;
+		translated?: string;
+	};
+	localeValue: string | null;
+	showOnlyFlags?: boolean;
+	translationProgress?: TranslationProgress | null;
+}
+export default function TranslationAdminItem({
+	defaultLanguageId,
+	item,
+	labels,
+	localeValue,
+	showOnlyFlags,
+	translationProgress,
+}: Props): JSX.Element;
+export {};

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminModal.d.ts
@@ -7,7 +7,7 @@
 
 import {Translations} from './TranslationAdminContent';
 interface IProps extends Translations {
-	onClose: (languageIds: string[]) => void;
+	onClose: (languageIds: Liferay.Language.Locale[]) => void;
 	visible?: boolean;
 }
 export default function TranslationAdminModal({

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
@@ -8,9 +8,11 @@
 import {Translations} from './TranslationAdminContent';
 interface IProps extends Translations {
 	adminMode?: boolean;
-	onActiveLanguageIdsChange?: (languageIds: string[]) => void;
-	onSelectedLanguageIdChange?: (languageId: string) => void;
-	selectedLanguageId: string;
+	onActiveLanguageIdsChange?: (
+		languageIds: Liferay.Language.Locale[]
+	) => void;
+	onSelectedLanguageIdChange?: (languageId: Liferay.Language.Locale) => void;
+	selectedLanguageId: Liferay.Language.Locale;
 	showOnlyFlags?: boolean;
 	small?: boolean;
 }

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
@@ -6,9 +6,10 @@
 /// <reference types="react" />
 
 import {Translations} from './TranslationAdminContent';
+declare type DisplayType = 'default' | 'horizontal';
 interface IProps extends Translations {
 	adminMode?: boolean;
-	displayType?: 'default' | 'horizontal';
+	displayType?: DisplayType;
 	onActiveLanguageIdsChange?: (
 		languageIds: Liferay.Language.Locale[]
 	) => void;

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
@@ -16,6 +16,11 @@ interface IProps extends Translations {
 	selectedLanguageId: Liferay.Language.Locale;
 	showOnlyFlags?: boolean;
 	small?: boolean;
+	translationProgress?: TranslationProgress | null;
+}
+export interface TranslationProgress {
+	totalItems: number;
+	translatedItems: Record<string, number>;
 }
 export default function TranslationAdminSelector({
 	activeLanguageIds: initialActiveLanguageIds,
@@ -30,5 +35,6 @@ export default function TranslationAdminSelector({
 	showOnlyFlags,
 	small,
 	translations,
+	translationProgress,
 }: IProps): JSX.Element;
 export {};

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
@@ -8,6 +8,7 @@
 import {Translations} from './TranslationAdminContent';
 interface IProps extends Translations {
 	adminMode?: boolean;
+	displayType?: 'default' | 'horizontal';
 	onActiveLanguageIdsChange?: (
 		languageIds: Liferay.Language.Locale[]
 	) => void;
@@ -22,6 +23,7 @@ export default function TranslationAdminSelector({
 	ariaLabels,
 	availableLocales,
 	defaultLanguageId,
+	displayType,
 	onActiveLanguageIdsChange,
 	onSelectedLanguageIdChange,
 	selectedLanguageId: initialSelectedLanguageId,

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.d.ts
@@ -13,12 +13,14 @@ interface Props {
 		translated?: string;
 	};
 	languageId: Liferay.Language.Locale;
+	languageName: string;
 	localeValue: string | null;
 }
 export default function TranslationAdminStatusLabel({
 	defaultLanguageId,
 	labels,
 	languageId,
+	languageName,
 	localeValue,
 }: Props): JSX.Element;
 export {};

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.d.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+interface Props {
+	defaultLanguageId: Liferay.Language.Locale;
+	labels?: {
+		default?: string;
+		notTranslated?: string;
+		translated?: string;
+	};
+	languageId: Liferay.Language.Locale;
+	localeValue: string | null;
+}
+export default function TranslationAdminStatusLabel({
+	defaultLanguageId,
+	labels,
+	languageId,
+	localeValue,
+}: Props): JSX.Element;
+export {};

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminStatusLabel.d.ts
@@ -5,6 +5,7 @@
 
 /// <reference types="react" />
 
+import {TranslationProgress} from './TranslationAdminSelector';
 interface Props {
 	defaultLanguageId: Liferay.Language.Locale;
 	labels?: {
@@ -15,6 +16,7 @@ interface Props {
 	languageId: Liferay.Language.Locale;
 	languageName: string;
 	localeValue: string | null;
+	translationProgress: TranslationProgress | null;
 }
 export default function TranslationAdminStatusLabel({
 	defaultLanguageId,
@@ -22,5 +24,6 @@ export default function TranslationAdminStatusLabel({
 	languageId,
 	languageName,
 	localeValue,
+	translationProgress,
 }: Props): JSX.Element;
 export {};


### PR DESCRIPTION
Hi guys!

In Echo team we are making improvements for the `TranslationAdminSelector` component and `input localized` according to this story https://liferay.atlassian.net/browse/LPS-200663. In this story several improvements are proposed:

_Selector_: A new horizontal design for the translation selector

<img src="https://github.com/liferay-frontend/liferay-portal/assets/9701095/e4b73150-d9d0-4ab0-b148-e497f4e2c9bb" width="500">

_Dropdown_: A new status for translations, indicating the number of fields that have been translated.

<img src="https://github.com/liferay-frontend/liferay-portal/assets/9701095/441fcc7f-06fb-44d5-97bd-f0570b66e266" width="300">

Therefore the following has been done:

**For TranslationAdminSelector.tsx**

- The possibility to display the `TranslationAdminSelector` component with a horizontal design. For this reason, a new prop has been added to this component: `displayType`, with two options, `default` and `horizontal`.

- A new `translationProgress` prop has been included. This prop is used to indicate how many fields are translated in the translation status (see second image from above). It has the following structure:
```
TranslationProgress {
	totalItems: number;
	translatedItems: Record<string, number>;
}
```
- Accessibility improvements
        - Context improvements adding `aria-*`
        - When the selector doesn't show the Translation Manager button it must be a `picker`, and otherwise a `dropdown`
        - For the `dropdown`, when an option is selected the focus will return to the trigger


**For input_localized.js**
- Two attributes have been added to the hidden inputs of the localized input: `data-language-id="{languageId}"` and `data-field-name="{fieldName}"` to make it easier to search from outside the component
- It's necessary to know when the translations are updated, so a `Liferay.fire('inputLocalized:updateTranslationStatus')` is added in the localized input.

Thanks in advance! :slightly_smiling_face: 