### PR TITLE
LPS-200583 - Add a portal property to limit the amount of files that can be requested at once by the ComboServlet (II)

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -307,6 +307,23 @@ public class ComboServlet extends HttpServlet {
 			if (cacheEnabled && (modulePathsString != null) &&
 				!PropsValues.COMBO_CHECK_TIMESTAMP) {
 
+				if (PropsValues.COMBO_MAX_FILES != -1) {
+					int totalFilesCount = 0;
+
+					List<String> keys = _bytesArrayPortalCache.getKeys();
+
+					for (String key : keys) {
+						byte[][] curBytesArray = _bytesArrayPortalCache.get(
+							key);
+
+						totalFilesCount += curBytesArray.length;
+
+						if (totalFilesCount > PropsValues.COMBO_MAX_FILES) {
+							return;
+						}
+					}
+				}
+
 				_bytesArrayPortalCache.put(modulePathsString, bytesArray);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -307,7 +307,7 @@ public class ComboServlet extends HttpServlet {
 			if (cacheEnabled && (modulePathsString != null) &&
 				!PropsValues.COMBO_CHECK_TIMESTAMP) {
 
-				if (PropsValues.COMBO_MAX_FILES != -1) {
+				if (modulePaths.length <= PropsValues.COMBO_MAX_FILES) {
 					int totalFilesCount = 0;
 
 					List<String> keys = _bytesArrayPortalCache.getKeys();
@@ -322,6 +322,21 @@ public class ComboServlet extends HttpServlet {
 							return;
 						}
 					}
+				}
+				else {
+					httpServletResponse.setHeader(
+						HttpHeaders.CACHE_CONTROL,
+						HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
+
+					httpServletResponse.setStatus(
+						HttpServletResponse.SC_BAD_REQUEST);
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"ComboServlet request exceeded maximum file count")
+					}
+
+					return;
 				}
 
 				_bytesArrayPortalCache.put(modulePathsString, bytesArray);

--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -307,23 +307,9 @@ public class ComboServlet extends HttpServlet {
 			if (cacheEnabled && (modulePathsString != null) &&
 				!PropsValues.COMBO_CHECK_TIMESTAMP) {
 
-				if (modulePaths.length <= PropsValues.COMBO_MAX_FILES) {
-					int totalFilesCount = 0;
+				if (PropsValues.COMBO_MAX_FILES > 0 &&
+					modulePaths.length > PropsValues.COMBO_MAX_FILES) {
 
-					List<String> keys = _bytesArrayPortalCache.getKeys();
-
-					for (String key : keys) {
-						byte[][] curBytesArray = _bytesArrayPortalCache.get(
-							key);
-
-						totalFilesCount += curBytesArray.length;
-
-						if (totalFilesCount > PropsValues.COMBO_MAX_FILES) {
-							return;
-						}
-					}
-				}
-				else {
 					httpServletResponse.setHeader(
 						HttpHeaders.CACHE_CONTROL,
 						HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
@@ -333,7 +319,7 @@ public class ComboServlet extends HttpServlet {
 
 					if (_log.isWarnEnabled()) {
 						_log.warn(
-							"ComboServlet request exceeded maximum file count")
+							"ComboServlet request exceeded maximum file count");
 					}
 
 					return;

--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -185,6 +185,21 @@ public class ComboServlet extends HttpServlet {
 			return;
 		}
 
+		if ((PropsValues.COMBO_MAX_FILES > 0) &&
+			(modulePathsSet.size() > PropsValues.COMBO_MAX_FILES)) {
+
+			httpServletResponse.setHeader(
+				HttpHeaders.CACHE_CONTROL,
+				HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
+			httpServletResponse.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+
+			if (_log.isWarnEnabled()) {
+				_log.warn("ComboServlet request exceeded maximum file count");
+			}
+
+			return;
+		}
+
 		String[] modulePaths = modulePathsSet.toArray(new String[0]);
 
 		String extension = StringPool.BLANK;
@@ -306,24 +321,6 @@ public class ComboServlet extends HttpServlet {
 
 			if (cacheEnabled && (modulePathsString != null) &&
 				!PropsValues.COMBO_CHECK_TIMESTAMP) {
-
-				if (PropsValues.COMBO_MAX_FILES > 0 &&
-					modulePaths.length > PropsValues.COMBO_MAX_FILES) {
-
-					httpServletResponse.setHeader(
-						HttpHeaders.CACHE_CONTROL,
-						HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
-
-					httpServletResponse.setStatus(
-						HttpServletResponse.SC_BAD_REQUEST);
-
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"ComboServlet request exceeded maximum file count");
-					}
-
-					return;
-				}
 
 				_bytesArrayPortalCache.put(modulePathsString, bytesArray);
 			}

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -338,6 +338,9 @@ public class PropsValues {
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.COMBO_CHECK_TIMESTAMP_INTERVAL));
 
+	public static final int COMBO_MAX_FILES = GetterUtil.getInteger(
+		PropsUtil.get(PropsKeys.COMBO_MAX_FILES), -1);
+
 	public static final String COMPANY_DEFAULT_HOME_URL = PropsUtil.get(
 		PropsKeys.COMPANY_DEFAULT_HOME_URL);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6105,7 +6105,7 @@
     combo.check.timestamp.interval=1000
 
     #
-    # Set the maximum number of files allowed in the cache.
+    # Set the maximum number of files allowed per combo request
     #
     # Env: LIFERAY_COMBO_PERIOD_MAX_PERIOD_FILES
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6104,6 +6104,13 @@
     #
     combo.check.timestamp.interval=1000
 
+    #
+    # Set the maximum number of files allowed in the cache.
+    #
+    # Env: LIFERAY_COMBO_PERIOD_MAX_PERIOD_FILES
+    #
+    combo.max.files=100
+
 ##
 ## Content Delivery Network
 ##

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -6105,7 +6105,7 @@
     combo.check.timestamp.interval=1000
 
     #
-    # Set the maximum number of files allowed per combo request
+    # Set the Maximum Number of Files Allowed per Combo Request
     #
     # Env: LIFERAY_COMBO_PERIOD_MAX_PERIOD_FILES
     #

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
@@ -306,9 +306,6 @@ public class ComboServletTest {
 			HttpServletResponse.SC_BAD_REQUEST,
 			mockHttpServletResponse.getStatus());
 
-		Assert.assertEquals(
-			"ComboServlet request exceeded maximum file count",
-			mockHttpServletResponse.getErrorMessage());
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
@@ -274,6 +274,39 @@ public class ComboServletTest {
 	}
 
 	@Test
+	public void testTooManyComboServletRequests() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < 101; i++) {
+			sb.append("/js/javascript");
+			sb.append(i);
+			sb.append(".js");
+
+			if (i != 100) {
+				sb.append(StringPool.AMPERSAND);
+			}
+		}
+
+		mockHttpServletRequest.setQueryString(sb.toString());
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		_comboServlet.service(mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_BAD_REQUEST,
+			mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(
+			"ComboServlet request exceeded maximum file count",
+			mockHttpServletResponse.getErrorMessage());
+	}
+
+	@Test
 	public void testValidateInValidModuleExtension() throws Exception {
 		boolean valid = _comboServlet.validateModuleExtension(
 			_TEST_PORTLET_ID +

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
@@ -275,9 +275,6 @@ public class ComboServletTest {
 
 	@Test
 	public void testTooManyComboServletRequests() throws Exception {
-		MockHttpServletRequest mockHttpServletRequest =
-			new MockHttpServletRequest();
-
 		int comboMaxFiles = 10;
 
 		ReflectionTestUtil.setFieldValue(
@@ -289,11 +286,14 @@ public class ComboServletTest {
 			if (i > 0) {
 				sb.append(StringPool.AMPERSAND);
 			}
+
 			sb.append("/js/javascript");
 			sb.append(i);
 			sb.append(".js");
-
 		}
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
 
 		mockHttpServletRequest.setQueryString(sb.toString());
 
@@ -303,9 +303,22 @@ public class ComboServletTest {
 		_comboServlet.service(mockHttpServletRequest, mockHttpServletResponse);
 
 		Assert.assertEquals(
+			HttpServletResponse.SC_OK, mockHttpServletResponse.getStatus());
+
+		sb.append(StringPool.AMPERSAND);
+		sb.append("/js/another_one.js");
+
+		mockHttpServletRequest = new MockHttpServletRequest();
+
+		mockHttpServletRequest.setQueryString(sb.toString());
+
+		mockHttpServletResponse = new MockHttpServletResponse();
+
+		_comboServlet.service(mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
 			HttpServletResponse.SC_BAD_REQUEST,
 			mockHttpServletResponse.getStatus());
-
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
@@ -278,16 +278,21 @@ public class ComboServletTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
+		int comboMaxFiles = 10;
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "COMBO_MAX_FILES", comboMaxFiles);
+
 		StringBuilder sb = new StringBuilder();
 
-		for (int i = 0; i < 101; i++) {
+		for (int i = 0; i < comboMaxFiles; i++) {
+			if (i > 0) {
+				sb.append(StringPool.AMPERSAND);
+			}
 			sb.append("/js/javascript");
 			sb.append(i);
 			sb.append(".js");
 
-			if (i != 100) {
-				sb.append(StringPool.AMPERSAND);
-			}
 		}
 
 		mockHttpServletRequest.setQueryString(sb.toString());

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -410,6 +410,8 @@ public interface PropsKeys {
 	public static final String COMBO_CHECK_TIMESTAMP_INTERVAL =
 		"combo.check.timestamp.interval";
 
+	public static final String COMBO_MAX_FILES = "combo.max.files";
+
 	public static final String COMMUNITIES_CONTROL_PANEL_MEMBERS_VISIBLE =
 		"communities.control.panel.members.visible";
 


### PR DESCRIPTION
This is a followup from https://github.com/liferay-frontend/liferay-portal/pull/3899 where some optimizations are made:

- We enforce `combo.max.files` only on the current request. There is no need to do so also in the cached responses as long as we are not caching responses that are requesting more files than allowed. Also, there is no need to check the global amount of cached files exceeds the limit as we want to enforce it on a per-request basis.
- Enforcement is made as soon as possible to avoid useless processing

cc @kresimir-coko @izaera 