### PR TITLE
LPS-203708 Instead of 'This filed is required', 'Please fill out this field' displays in modal when saving the field with blank in page templates

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -60,7 +60,7 @@ const SimpleInputModal = ({
 		}
 	};
 
-	const _handleSubmit = (event) => {
+	const handleSubmit = (event) => {
 		event.preventDefault();
 
 		const error = inputValue
@@ -132,7 +132,7 @@ const SimpleInputModal = ({
 				<ClayForm
 					id={`${namespace}form`}
 					noValidate
-					onSubmit={_handleSubmit}
+					onSubmit={handleSubmit}
 				>
 					<ClayModal.Body>
 						{alert && alert.message && alert.title && (

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -5,7 +5,7 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
-import {ClayCheckbox, ClayInput} from '@clayui/form';
+import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
@@ -63,6 +63,18 @@ const SimpleInputModal = ({
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 
+		const error = inputValue
+			? ''
+			: Liferay.Language.get('this-field-is-required');
+
+		if (error && required) {
+			setErrorMessage(error);
+
+			return;
+		}
+
+		setLoadingResponse(true);
+
 		const formData = new FormData(
 			document.querySelector(`#${namespace}form`)
 		);
@@ -102,8 +114,6 @@ const SimpleInputModal = ({
 			.catch((response) => {
 				handleFormError(response);
 			});
-
-		setLoadingResponse(true);
 	};
 
 	const {observer, onClose} = useModal({
@@ -119,7 +129,11 @@ const SimpleInputModal = ({
 			<ClayModal center={center} observer={observer} size={size}>
 				<ClayModal.Header>{dialogTitle}</ClayModal.Header>
 
-				<form id={`${namespace}form`} onSubmit={_handleSubmit}>
+				<ClayForm
+					id={`${namespace}form`}
+					noValidate
+					onSubmit={_handleSubmit}
+				>
 					<ClayModal.Body>
 						{alert && alert.message && alert.title && (
 							<ClayAlert
@@ -161,9 +175,19 @@ const SimpleInputModal = ({
 								disabled={loadingResponse}
 								id={`${namespace}${mainFieldName}`}
 								name={`${namespace}${mainFieldName}`}
-								onChange={(event) =>
-									setInputValue(event.target.value)
-								}
+								onChange={(event) => {
+									if (required) {
+										setErrorMessage(
+											event.target.value
+												? ''
+												: Liferay.Language.get(
+														'this-field-is-required'
+												  )
+										);
+									}
+
+									setInputValue(event.target.value);
+								}}
 								placeholder={placeholder}
 								ref={handleMainFieldRef}
 								required={required}
@@ -172,7 +196,10 @@ const SimpleInputModal = ({
 							/>
 
 							{errorMessage && (
-								<div className="form-feedback-item">
+								<div
+									className="form-feedback-item"
+									role="alert"
+								>
 									<ClayIcon
 										className="inline-item inline-item-before"
 										symbol="exclamation-full"
@@ -228,7 +255,7 @@ const SimpleInputModal = ({
 							</ClayButton.Group>
 						}
 					/>
-				</form>
+				</ClayForm>
 			</ClayModal>
 		)
 	);


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-203708)

## Test Scenario 1

> [!NOTE]
>Add feature.flag.LPS-189856=true into portal-ext.properties

1. Go to Design > Page Template > Display page templates
2. Add a folder with blank name
3. Save in the modal

## Test Scenario 2

1. Go to Design > Page Template > Masters
2. Add a master page template with blank name
3. Save in the modal

## Test Scenario 3

1. Go to Design > Page Template > Page templates
2. Add a page template set
3. Add a content/widget page template with blank name
4. Save in the modal

### Notes

**This solution creates a generic fix for all the places where we are using the OpneSimpleInputModal.** 

![image](https://github.com/liferay-echo/liferay-portal/assets/93203423/7624c83e-73ef-47cc-bbe3-01bd943b9b1e)
