### PR TITLE
LPS-204019 Repeatable fields are not saved for editor configuration client extensions

### DIFF
--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/EditorConfigContributorCETImplFactoryImpl.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/factory/EditorConfigContributorCETImplFactoryImpl.java
@@ -8,8 +8,10 @@ package com.liferay.client.extension.type.internal.factory;
 import com.liferay.client.extension.exception.ClientExtensionEntryTypeSettingsException;
 import com.liferay.client.extension.type.EditorConfigContributorCET;
 import com.liferay.client.extension.type.internal.EditorConfigContributorCETImpl;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -50,11 +52,19 @@ public class EditorConfigContributorCETImplFactoryImpl
 			true
 		).put(
 			"editorConfigKeys",
-			ParamUtil.getString(portletRequest, "editorConfigKeys")
+			StringUtil.merge(
+				ParamUtil.getStringValues(portletRequest, "editorConfigKeys"),
+				StringPool.NEW_LINE)
 		).put(
-			"editorNames", ParamUtil.getString(portletRequest, "editorNames")
+			"editorNames",
+			StringUtil.merge(
+				ParamUtil.getStringValues(portletRequest, "editorNames"),
+				StringPool.NEW_LINE)
 		).put(
-			"portletNames", ParamUtil.getString(portletRequest, "portletNames")
+			"portletNames",
+			StringUtil.merge(
+				ParamUtil.getStringValues(portletRequest, "portletNames"),
+				StringPool.NEW_LINE)
 		).put(
 			"url", ParamUtil.getString(portletRequest, "url")
 		).build();


### PR DESCRIPTION
### References

- [LPS-204019 Repeatable fields are not saved for editor configuration client extensions](https://issues.liferay.com/browse/LPS-204019)

### What is the goal of this PR?

A bugfix. We are treating repeatable fields as strings in backend.

cc @boton

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/5435511/95f79f3c-864a-4bda-858e-7420fc525f7d


### Steps to reproduce

See JIRA ticket