### PR TITLE
LPS 201348 BUG FI inputLocalized translations keys

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
@@ -30,7 +30,11 @@ interface InputLocalizedProps {
 	resultFormatter?: (value: string) => React.ReactNode;
 	selectedLocale?: Liferay.Language.Locale;
 	tooltip?: string;
-	translations: Liferay.Language.LocalizedValue<string>;
+	translations: Liferay.Language.LocalizedValue<string> &
+		Partial<{
+			zh_Hans_CN: string;
+			zh_Hant_TW: string;
+		}>;
 }
 
 interface InputLocale {
@@ -48,8 +52,12 @@ const availableLocales = Object.keys(Liferay.Language.available)
 	}));
 
 const translationsNormalizer = (
-	translations: any
-) => {
+	translations: Liferay.Language.LocalizedValue<string> &
+		Partial<{
+			zh_Hans_CN: string;
+			zh_Hant_TW: string;
+		}>
+): Liferay.Language.LocalizedValue<string> => {
 	const {zh_Hans_CN, zh_Hant_TW, ...normalizedTranslations} = translations;
 
 	if (zh_Hans_CN) {

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
@@ -47,6 +47,22 @@ const availableLocales = Object.keys(Liferay.Language.available)
 		symbol: language.replace(/_/g, '-').toLowerCase(),
 	}));
 
+const translationsNormalizer = (
+	translations: any
+) => {
+	const {zh_Hans_CN, zh_Hant_TW, ...normalizedTranslations} = translations;
+
+	if (zh_Hans_CN) {
+		normalizedTranslations['zh_CN'] = zh_Hans_CN;
+	}
+
+	if (zh_Hant_TW) {
+		normalizedTranslations['zh_TW'] = zh_Hant_TW;
+	}
+
+	return normalizedTranslations;
+};
+
 export default function InputLocalized({
 	disableFlag,
 	disabled,
@@ -62,10 +78,11 @@ export default function InputLocalized({
 	resultFormatter = () => null,
 	selectedLocale,
 	tooltip,
-	translations,
+	translations: initialTranslations,
 	...otherProps
 }: InputLocalizedProps) {
 	const [locale, setLocale] = useState<InputLocale>(availableLocales[0]);
+	const translations = translationsNormalizer(initialTranslations);
 
 	useEffect(() => {
 		if (disableFlag) {

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
@@ -24,7 +24,11 @@ interface InputLocalizedProps {
 	resultFormatter?: (value: string) => React.ReactNode;
 	selectedLocale?: Liferay.Language.Locale;
 	tooltip?: string;
-	translations: Liferay.Language.LocalizedValue<string>;
+	translations: Liferay.Language.LocalizedValue<string> &
+		Partial<{
+			zh_Hans_CN: string;
+			zh_Hant_TW: string;
+		}>;
 }
 interface InputLocale {
 	label: Liferay.Language.Locale;

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
@@ -45,7 +45,7 @@ export default function InputLocalized({
 	resultFormatter,
 	selectedLocale,
 	tooltip,
-	translations,
+	translations: initialTranslations,
 	...otherProps
 }: InputLocalizedProps): JSX.Element;
 export {};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/liferay.d.ts
@@ -42,7 +42,8 @@ declare module Liferay {
 			| 'ja_JP'
 			| 'pt_BR'
 			| 'sv_SE'
-			| 'zh_CN';
+			| 'zh_CN'
+			| 'zh_TW';
 
 		type FullyLocalizedValue<T> = {[key in Locale]: T};
 		type LocalizedValue<T> = Partial<FullyLocalizedValue<T>>;


### PR DESCRIPTION
# Issue [LPS-201348](https://liferay.atlassian.net/browse/LPS-201348) / [LPP-51597](https://liferay.atlassian.net/browse/LPP-51597)

## How to test it

1. Open Applications Menu
2. Control Panel > Objects > Picklist
3. Create new Picklist
4. add a name
5. add a translation in es_ES for example
6. add a translation in zh_CN
7. Save
8. Open the new picklist

❌ the translation in zh_CN is lost

---

## Problem 
We have a Language entries, send the next format:

```js
"name_i18n": {
	"en_US": "test-1-en",
	"es_ES": "test-1-es",
	"zh_CN": "test-1-zh"
}
```



Saved in DB in the following XML:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<root available-locales="en_US,zh_CN,es_ES," default-locale="en_US">
	<Name language-id="en_US">list-1</Name>
	<Name language-id="zh_CN">list-1-zh</Name>
	<Name language-id="es_ES">list-1-es</Name>
</root>
```

![Pasted image 20231221123700](https://github.com/liferay-frontend/liferay-portal/assets/67901/c3d29f1a-ef41-4ec9-9d5e-31a82aba0a31)


But when we get the formats, the formats are mutating into this:

```js
"name_i18n" : {
    "zh-Hans-CN" : "test-1-zh",
    "en-US" : "test-1-en",
    "es-ES" : "test-1-es"
},
```

![Pasted image 20231221124200](https://github.com/liferay-frontend/liferay-portal/assets/67901/1b8f6a1f-4d2d-4734-8f71-a8c322926361)

---

## Solution

At first, I thought a better solution was fixing the API, instead of adding an extra step for normalization, but we decided to apply the normalization on the frontend side avoiding breaking changes.



