### PR TITLE
LPS-187626 Remove no needed CSS

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -6,12 +6,14 @@
 import ClayTabs from '@clayui/tabs';
 import React, {useEffect, useRef} from 'react';
 
-const Panel = ({children}) => {
+const Panel = ({children: tabPanel}) => {
 	const ref = useRef();
 
 	useEffect(() => {
-		ref.current.appendChild(children);
-	}, [children]);
+		while (tabPanel.firstChild) {
+			ref.current.appendChild(tabPanel.firstChild);
+		}
+	}, [tabPanel]);
 
 	return <div ref={ref}></div>;
 };

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -250,8 +250,4 @@ $productMenuWidth: 320px;
 			}
 		}
 	}
-
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 0.5rem;
-	}
 }

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -23,8 +23,4 @@
 	.add-layout-form .sheet-footer {
 		position: absolute;
 	}
-
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
 }

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -13,8 +13,4 @@
 	.dialog-footer {
 		position: fixed;
 	}
-
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
@@ -67,7 +67,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-communities",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/site_memberships_admin.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,5 +1,0 @@
-.portlet-communities {
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
-}

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/portlet/TrashPortlet.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/portlet/TrashPortlet.java
@@ -59,7 +59,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.css-class-wrapper=portlet-trash",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/trash.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,5 +1,0 @@
-.portlet-trash {
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
-}


### PR DESCRIPTION
Hi guys! I'm sending this as a fix of [LPS-187626](https://liferay.atlassian.net/browse/LPS-187626).

## Context
Currently, when using `clay:tabs` taglib, the correct usage is adding a `clay:tabs-panel` inside it for each tab content.

However, using it that way causes a double tabs panel, as the `clay:tabs` taglib is rendering a `ClayTabs.Panel` for each child, and then we are also rendering the same markup inside the `clay:tabs-panel` taglib.

## Solution
What I did is just removing the tabs panel markup from `clay:tabs-panel`, and let `clay:tabs` manage it, as this is needed for the `active` state to work properly. After doing this, I thought if we actually need the `clay:tabs-panel` taglib, but I think it's a good idea to leave it so the use of the taglib is more clear.

### Note
Only https://github.com/liferay-frontend/liferay-portal/pull/3915/commits/e1aff87eb1b37cff30a739f41edc24f192c501cc needs to be reviewed, as https://github.com/liferay-frontend/liferay-portal/pull/3915/commits/66cde1b3381096135f64503ca2b9cfdbfbb8da13 only adapts some CSS and all that code belongs to us in the Echo team.


Please let me know your thoughts, thanks!