### PR TITLE
LPS-205373 - Add missing dependency, aui-component.

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -786,6 +786,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['array-invoke', 'aui-debounce', 'aui-node'],
+		requires: ['aui-component', 'array-invoke', 'aui-debounce', 'aui-node'],
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-205373

Adds missing dependency in menu.js which causes errors to be thrown when quickly clicking on an instance of liferay-ui:icon-menu. This was discovered while playing around with playwright.

![Screenshot 2024-01-09 at 4 12 33 PM](https://github.com/liferay/liferay-portal/assets/1609196/3ddfbd65-d63c-41fb-a27c-59201584332e)
