### PR TITLE
LPS-187626 clay:tabs taglib is adding additional tabs panel

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -4,7 +4,7 @@
  */
 
 import ClayTabs from '@clayui/tabs';
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 const Panel = ({children: tabPanel}) => {
 	const ref = useRef();
@@ -37,20 +37,26 @@ export default function Tabs({
 	tabsItems,
 	...otherProps
 }) {
+	const activeIndex = tabsItems.findIndex((item) => item.active);
+
+	const [active, setActive] = useState(activeIndex === -1 ? 0 : activeIndex);
+
 	return (
 		<>
 			<ClayTabs
 				activation={activation}
+				active={active}
 				className={cssClass}
 				displayType={displayType}
 				fade={fade}
 				justified={justified}
+				onActiveChange={setActive}
 				{...otherProps}
 			>
 				<ClayTabs.List>
-					{tabsItems.map(({active, disabled, href, label}, i) => (
+					{tabsItems.map(({disabled, href, label}, i) => (
 						<ClayTabs.Item
-							active={active}
+							active={i === active}
 							disabled={disabled}
 							href={href}
 							key={i}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -6,12 +6,14 @@
 import ClayTabs from '@clayui/tabs';
 import React, {useEffect, useRef} from 'react';
 
-const Panel = ({children}) => {
+const Panel = ({children: tabPanel}) => {
 	const ref = useRef();
 
 	useEffect(() => {
-		ref.current.appendChild(children);
-	}, [children]);
+		while (tabPanel.firstChild) {
+			ref.current.appendChild(tabPanel.firstChild);
+		}
+	}, [tabPanel]);
 
 	return <div ref={ref}></div>;
 };

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -10,9 +10,13 @@ const Panel = ({children: tabPanel}) => {
 	const ref = useRef();
 
 	useEffect(() => {
+		const fragment = document.createDocumentFragment();
+
 		while (tabPanel.firstChild) {
-			ref.current.appendChild(tabPanel.firstChild);
+			fragment.appendChild(tabPanel.firstChild);
 		}
+
+		ref.current.appendChild(fragment);
 	}, [tabPanel]);
 
 	return <div ref={ref}></div>;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -250,8 +250,4 @@ $productMenuWidth: 320px;
 			}
 		}
 	}
-
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 0.5rem;
-	}
 }

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -23,8 +23,4 @@
 	.add-layout-form .sheet-footer {
 		position: absolute;
 	}
-
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
 }

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -13,8 +13,4 @@
 	.dialog-footer {
 		position: fixed;
 	}
-
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
 }

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/portlet/SiteMembershipsPortlet.java
@@ -67,7 +67,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-communities",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/site_memberships_admin.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,5 +1,0 @@
-.portlet-communities {
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
-}

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/portlet/TrashPortlet.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/portlet/TrashPortlet.java
@@ -59,7 +59,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.css-class-wrapper=portlet-trash",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.icon=/icons/trash.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
 		"com.liferay.portlet.private-request-attributes=false",

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,5 +1,0 @@
-.portlet-trash {
-	.nav-tabs + .tab-content .tab-pane {
-		padding: 1rem;
-	}
-}


### PR DESCRIPTION
This supersedes https://github.com/liferay-frontend/liferay-portal/pull/3915. There, 
* We removed an extra `<div>` panel coming from the taglib-generated SSR markup (see [LPS-187626](https://liferay.atlassian.net/browse/LPS-187626) for details), which was redundant when React clay tabs component takes control.
* In doing so we chose to `appendChild()` all panel child nodes (using [firstChild](https://developer.mozilla.org/en-US/docs/Web/API/Node/firstChild) as we do in our [build_fragment utility](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/build_fragment.js#L15-L17), not just `firstElementChild`)
* This way, some artificial styles DXP apps must add to handle this dual markup can be deleted

In addition, this new PR:
* Improves the above by adding the panels into a `documentFragment` to avoid browser reflows that could be caused if child nodes are added to the markup one by one in the active tab
* Manages the `active` value from the DXP Tabs component, so that now taglib works fine when active tab is not the first tab. Before this, there was a flicker while rendering, where first tab was visible for some milliseconds between the SSR and the react rendering.

Note there's still an extra `<div>` produced by the `Panel` component, which proved specially hard to remove from markup. That can be a future improvement if it happens to cause any issue we don't see at this moment.

cc @sandrodw3 @markocikos 

fyi, in case you guys are curious about this part of the frontend architecture @kresimir-coko @chestofwonders @juanjofgliferay 

