### PR TITLE
LPS-205940 Add functional tests for editor config contributor CET FF functionality

### DIFF
--- a/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
+++ b/modules/test/playwright/pages/export-import-web/exportImportFrame.page.ts
@@ -5,7 +5,7 @@
 
 // @ts-ignore
 
-import {expect, Page} from '@playwright/test';
+import {Page, expect} from '@playwright/test';
 
 import {zipFolder} from '../../utils/util';
 

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -8,6 +8,7 @@ import {Locator, Page} from '@playwright/test';
 export class ApplicationsMenuPage {
 	readonly applicationMenuButton: Locator;
 	readonly applicationsMenuTabButton: Locator;
+	readonly clientExtensionsLink: Locator;
 	readonly controlPanelButton: Locator;
 	readonly dataMigrationCenterMenuItem: Locator;
 	readonly instanceSettingsLink: Locator;
@@ -23,6 +24,9 @@ export class ApplicationsMenuPage {
 		);
 		this.applicationsMenuTabButton = page.getByRole('tab', {
 			name: 'Applications',
+		});
+		this.clientExtensionsLink = page.getByRole('menuitem', {
+			name: 'Client Extensions',
 		});
 		this.controlPanelButton = page.getByRole('tab', {
 			name: 'Control Panel',
@@ -54,6 +58,12 @@ export class ApplicationsMenuPage {
 		await this.goto();
 		await this.applicationMenuButton.click();
 		await this.applicationsMenuTabButton.click();
+	}
+
+	async goToClientExtensions() {
+		await this.goto();
+		await this.applicationMenuButton.click();
+		await this.clientExtensionsLink.click();
 	}
 
 	async goToDataMigrationCenter() {

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -5,16 +5,25 @@
 
 import {defineConfig} from '@playwright/test';
 
-import {config as exportImportWeb} from './tests/export-import-web/config';
-import {config as batchPlanner} from './tests/batch-planner/config';
-import {config as setup} from './tests/global.setup.config';
-import {config as object} from './tests/object-web/config';
-import {config as portalWeb} from './tests/portal-web/config';
-import {config as usersAdminWeb} from './tests/users-admin-web/config';
+import {config as batchPlannerConfig} from './tests/batch-planner/config';
+import {config as clientExtensionWebConfig} from './tests/client-extension-web/config';
+import {config as exportImportWebConfig} from './tests/export-import-web/config';
+import {config as setupConfig} from './tests/global.setup.config';
+import {config as objectWebConfig} from './tests/object-web/config';
+import {config as portalWebConfig} from './tests/portal-web/config';
+import {config as usersAdminWebConfig} from './tests/users-admin-web/config';
 
 export default defineConfig({
 	forbidOnly: !!process.env.CI,
-	projects: [batchPlanner, exportImportWeb, object, portalWeb, setup, usersAdminWeb],
+	projects: [
+		batchPlannerConfig,
+		clientExtensionWebConfig,
+		exportImportWebConfig,
+		objectWebConfig,
+		portalWebConfig,
+		setupConfig,
+		usersAdminWebConfig,
+	],
 	reporter: [
 		[
 			'html',

--- a/modules/test/playwright/tests/batch-planner/import.spec.ts
+++ b/modules/test/playwright/tests/batch-planner/import.spec.ts
@@ -318,7 +318,10 @@ test('can import CSV file with an unexisting field', async ({
 
 	await dataMigrationCenterPage.importFile(
 		OBJECT_ENTRY_ENTITY_TYPE,
-		path.join(__dirname, '/dependencies/non_existing_field_object_entries.csv'),
+		path.join(
+			__dirname,
+			'/dependencies/non_existing_field_object_entries.csv'
+		),
 		'UPSERT',
 		'UPDATE'
 	);
@@ -913,7 +916,10 @@ test('cannot import CSV file with empty headers row', async ({
 	await dataMigrationCenterPage.goToImportFile();
 
 	await dataMigrationCenterPage.selectFile(
-		path.join(__dirname, '/dependencies/empty_header_values_object_entries.csv')
+		path.join(
+			__dirname,
+			'/dependencies/empty_header_values_object_entries.csv'
+		)
 	);
 
 	await dataMigrationCenterPage.selectImportEntityType(

--- a/modules/test/playwright/tests/client-extension-web/config.ts
+++ b/modules/test/playwright/tests/client-extension-web/config.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	dependencies: ['setup'],
+	name: 'clientExtension',
+	testDir: 'tests/client-extension-web',
+	use: {
+		...devices['Desktop Chrome'],
+		storageState: 'tmp/.auth/user.json',
+	},
+};

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {clientExtensionsPageTest} from './fixtures/clientExtensionsPageTest';
+import {newEditorConfigContributorPageTest} from './fixtures/newEditorConfigContributorPageTest';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	clientExtensionsPageTest,
+	newEditorConfigContributorPageTest
+);
+
+test('Editor config contributor client extension is disabled if FF is set to false', async ({
+	apiHelpers,
+	clientExtensionsPage,
+}) => {
+	await apiHelpers.featureFlag.updateFeatureFlag('LPS-186870', false);
+
+	await clientExtensionsPage.goto();
+
+	await clientExtensionsPage.newClientExtensionButton.click();
+
+	await expect(
+		clientExtensionsPage.editorConfigContributorMenuItem
+	).not.toBeAttached();
+});
+
+test('Create, edit and delete editor config contributor client extension', async ({
+	apiHelpers,
+	clientExtensionsPage,
+	newEditorConfigContributorPage,
+}) => {
+	await apiHelpers.featureFlag.updateFeatureFlag('LPS-186870', true);
+
+	await clientExtensionsPage.goto();
+
+	await clientExtensionsPage.newClientExtensionButton.click();
+
+	await clientExtensionsPage.editorConfigContributorMenuItem.click();
+
+	const sampleName1 = 'Sample Name 1';
+
+	await newEditorConfigContributorPage.nameInput.fill(sampleName1);
+
+	await newEditorConfigContributorPage.descriptionEditable.isEditable();
+
+	await newEditorConfigContributorPage.descriptionEditable.fill(
+		'Sample Description'
+	);
+
+	await newEditorConfigContributorPage.urlInput.fill(
+		'https://www.liferay.com'
+	);
+
+	await newEditorConfigContributorPage.portletNamesInput.fill(
+		'Sample Portlet Name'
+	);
+
+	await newEditorConfigContributorPage.editorNamesInput.fill(
+		'Sample Editor Names'
+	);
+
+	await newEditorConfigContributorPage.editorConfigKeysInput.fill(
+		'Sample Editor Config Keys'
+	);
+
+	await newEditorConfigContributorPage.publishButton.click();
+
+	await expect(
+		clientExtensionsPage.page.getByText(sampleName1)
+	).toBeVisible();
+
+	await clientExtensionsPage.itemActionsToggleButton.click();
+
+	await clientExtensionsPage.itemEditButton.click();
+
+	const sampleName2 = 'Sample Name 2';
+
+	await newEditorConfigContributorPage.nameInput.fill(sampleName2);
+
+	await newEditorConfigContributorPage.publishButton.click();
+
+	await expect(
+		clientExtensionsPage.page.getByText(sampleName2)
+	).toBeVisible();
+
+	await clientExtensionsPage.itemActionsToggleButton.click();
+
+	clientExtensionsPage.page.on('dialog', (dialog) => dialog.accept());
+
+	await clientExtensionsPage.itemDeleteButton.click();
+});

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -81,6 +81,8 @@ test('Create, edit and delete editor config contributor client extension', async
 
 	const sampleName2 = 'Sample Name 2';
 
+	await newEditorConfigContributorPage.nameInput.click();
+
 	await newEditorConfigContributorPage.nameInput.fill(sampleName2);
 
 	await newEditorConfigContributorPage.publishButton.click();

--- a/modules/test/playwright/tests/client-extension-web/fixtures/clientExtensionsPageTest.ts
+++ b/modules/test/playwright/tests/client-extension-web/fixtures/clientExtensionsPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ClientExtensionsPage} from '../pages/ClientExtensionsPage';
+
+const clientExtensionsPageTest = test.extend<{
+	clientExtensionsPage: ClientExtensionsPage;
+}>({
+	clientExtensionsPage: async ({page}, use) => {
+		await use(new ClientExtensionsPage(page));
+	},
+});
+
+export {clientExtensionsPageTest};

--- a/modules/test/playwright/tests/client-extension-web/fixtures/newEditorConfigContributorPageTest.ts
+++ b/modules/test/playwright/tests/client-extension-web/fixtures/newEditorConfigContributorPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {NewEditorConfigContributorPage} from '../pages/NewEditorConfigContributorPage';
+
+const newEditorConfigContributorPageTest = test.extend<{
+	newEditorConfigContributorPage: NewEditorConfigContributorPage;
+}>({
+	newEditorConfigContributorPage: async ({page}, use) => {
+		await use(new NewEditorConfigContributorPage(page));
+	},
+});
+
+export {newEditorConfigContributorPageTest};

--- a/modules/test/playwright/tests/client-extension-web/pages/ClientExtensionsPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/ClientExtensionsPage.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ApplicationsMenuPage} from '../../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+
+export class ClientExtensionsPage {
+	readonly applicationsMenuPage: ApplicationsMenuPage;
+	readonly itemActionsToggleButton: Locator;
+	readonly itemDeleteButton: Locator;
+	readonly itemEditButton: Locator;
+	readonly newClientExtensionButton: Locator;
+	readonly editorConfigContributorMenuItem: Locator;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+		this.page = page;
+
+		this.newClientExtensionButton = page
+			.getByRole('button')
+			.and(page.getByTitle('New'));
+
+		this.editorConfigContributorMenuItem = page.getByRole('menuitem', {
+			name: 'Add Editor Config Contributor',
+		});
+
+		this.itemActionsToggleButton = page.getByRole('button', {
+			name: 'Actions',
+		});
+
+		this.itemDeleteButton = page.getByRole('menuitem', {
+			name: 'Delete',
+		});
+		this.itemEditButton = page.getByRole('menuitem', {
+			name: 'Edit',
+		});
+	}
+
+	async goto() {
+		await this.applicationsMenuPage.goToClientExtensions();
+	}
+}

--- a/modules/test/playwright/tests/client-extension-web/pages/NewEditorConfigContributorPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/NewEditorConfigContributorPage.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+export class NewEditorConfigContributorPage {
+	readonly descriptionEditable: Locator;
+	readonly editorConfigKeysInput: Locator;
+	readonly editorNamesInput: Locator;
+	readonly nameInput: Locator;
+	readonly portletNamesInput: Locator;
+	readonly publishButton: Locator;
+	readonly page: Page;
+	readonly urlInput: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		const portletId =
+			'_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet';
+
+		this.nameInput = page.locator(`#${portletId}_name`);
+
+		const descriptionIframe = page.frameLocator(
+			`#cke_${portletId}_description iframe`
+		);
+
+		this.descriptionEditable = descriptionIframe.locator('.cke_editable');
+
+		this.urlInput = page.locator(`#${portletId}_url`);
+		this.portletNamesInput = page.locator(
+			`[name=${portletId}_portletNames]`
+		);
+		this.editorNamesInput = page.locator(`[name=${portletId}_editorNames]`);
+		this.editorConfigKeysInput = page.locator(
+			`[name=${portletId}_editorConfigKeys]`
+		);
+
+		this.publishButton = page.getByRole('button', {name: 'Publish'});
+	}
+}


### PR DESCRIPTION
### References

- [LPS-187309 Apply editor config contributor client extensions to CKEditor](https://issues.liferay.com/browse/LPS-187309)

### What is the goal of this PR?

My initial go at Playwright. This PR is just a simple test on how FF affects option in CET menu. In a followups, we should be able to reasonably easily test creation of new CET, edit and delete. Application using a workflow sample will be a challenge.

Technical notes in comments.

### What does it look like?

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/85f3b51d-226a-482d-a8cb-c0526dad67a6)

