### PR TITLE
LPS-206101 - Remove side panel duplicated close button 

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_side_panel.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_side_panel.scss
@@ -101,7 +101,7 @@
 		top: 0;
 		transition: top ease-in-out 0.1s, right ease-in-out 0.1s,
 			opacity ease-in 0.2s;
-		z-index: 10;
+		z-index: 1;
 
 		&.fds-side-panel-close-menu {
 			opacity: 1;


### PR DESCRIPTION
## Related tasks
https://liferay.atlassian.net/browse/LPS-206101

## Issue
Side panel opened from FDS components is displaying the close button twice. The problem was detected in Commerce and Objects modules. The side panel component has its own close button and is clashing with the one provided by these modules.

The issue appears after applying a fix for the Item Actions created from the Data Set Manager [LPS-204436](https://liferay.atlassian.net/browse/LPS-204436). As this feature (side panel actions) are still under a development FF, we are going to revert the previous change and look for a stable solution.

## UI before
![Screenshot 2024-01-11 at 15 40 57](https://github.com/liferay-frontend/liferay-portal/assets/132653342/f1313b88-75df-4818-a112-3a92267e9a91)

## UI after
![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/5c397194-9dc3-476f-915b-1b120af36207)
