### PR TITLE
LPS-201144 Export ILearnResourceContext Interface

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts
@@ -16,6 +16,7 @@ export {default as useSessionState} from './hooks/useSessionState';
 
 export {
 	default as LearnMessage,
+	ILearnResourceContext,
 	LearnResourcesContext,
 } from './learn_message/LearnMessage';
 

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -24,7 +24,7 @@ interface ILearnResourceItem {
 	[resourceKey: string]: ILearnResourceKeyItem;
 }
 
-interface ILearnResourceContext {
+export interface ILearnResourceContext {
 	[learnResourceName: string]: ILearnResourceItem;
 }
 

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/index.d.ts
@@ -13,6 +13,7 @@ export {default as useId} from './hooks/useId';
 export {default as useSessionState} from './hooks/useSessionState';
 export {
 	default as LearnMessage,
+	ILearnResourceContext,
 	LearnResourcesContext,
 } from './learn_message/LearnMessage';
 export {default as Treeview} from './treeview/Treeview';

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/learn_message/LearnMessage.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/learn_message/LearnMessage.d.ts
@@ -18,7 +18,7 @@ interface ILearnResourceKeyItem {
 interface ILearnResourceItem {
 	[resourceKey: string]: ILearnResourceKeyItem;
 }
-interface ILearnResourceContext {
+export interface ILearnResourceContext {
 	[learnResourceName: string]: ILearnResourceItem;
 }
 declare type ClayLinkProps = React.ComponentProps<typeof ClayLink>;


### PR DESCRIPTION
Motivation:

I'm using `LearnMessage` in `object-web` and would like to import the `ILearnResourceContext` interface to avoid code duplication.