### PR TITLE
LPS-204424 - Remove sorting direction for relevance column

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsManagementToolbarDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsManagementToolbarDisplayContext.java
@@ -170,8 +170,6 @@ public class BlogsManagementToolbarDisplayContext
 			ParamUtil.getString(httpServletRequest, "navigation", "entries")
 		).setParameter(
 			"orderByCol", "relevance"
-		).setParameter(
-			"orderByType", "desc"
 		).buildString();
 	}
 
@@ -185,10 +183,7 @@ public class BlogsManagementToolbarDisplayContext
 			sortingURL.setParameter(getOrderByColParam(), orderByCol);
 		}
 
-		if (Objects.equals(orderByCol, "relevance")) {
-			sortingURL.setParameter(getOrderByTypeParam(), "desc");
-		}
-		else {
+		if (!Objects.equals(orderByCol, "relevance")) {
 			sortingURL.setParameter(
 				getOrderByTypeParam(),
 				Objects.equals(getOrderByType(), "asc") ? "desc" : "asc");
@@ -267,8 +262,7 @@ public class BlogsManagementToolbarDisplayContext
 				dropdownItem.setActive(
 					Objects.equals(getOrderByCol(), "relevance"));
 				dropdownItem.setHref(
-					_getCurrentSortingURL(), "orderByCol", "relevance",
-					"orderByType", "desc");
+					_getCurrentSortingURL(), "orderByCol", "relevance");
 				dropdownItem.setLabel(
 					LanguageUtil.get(httpServletRequest, "relevance"));
 			}

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntriesDisplayContext.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/display/context/BlogsViewEntriesDisplayContext.java
@@ -167,7 +167,7 @@ public class BlogsViewEntriesDisplayContext {
 		}
 
 		if (_isOrderByColRelevance()) {
-			_orderByType = "desc";
+			_orderByType = "";
 		}
 		else {
 			_orderByType = SearchOrderByUtil.getOrderByType(

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -25,6 +25,22 @@ const FilterOrderControls = ({
 	const showOrderToggle =
 		!orderDropdownItems || orderDropdownItems.length <= 1;
 
+	const sortingDirectionOptions = [
+		{type: 'divider'},
+		{
+			active: sortingOrder === 'asc',
+			href: sortingOrder === 'asc' ? null : sortingURL,
+			label: Liferay.Language.get('ascending'),
+			type: 'item',
+		},
+		{
+			active: sortingOrder === 'desc',
+			href: sortingOrder === 'desc' ? null : sortingURL,
+			label: Liferay.Language.get('descending'),
+			type: 'item',
+		},
+	];
+
 	return (
 		<>
 			{filterDropdownItems && (
@@ -105,31 +121,20 @@ const FilterOrderControls = ({
 				<ManagementToolbar.Item>
 					<ClayDropDownWithItems
 						items={addActiveIcons([
-							...orderDropdownItems.map((item) => {
-								return {
-									...item,
-									onClick: (event) => {
-										onOrderDropdownItemClick(event, {
-											item,
-										});
-									},
-								};
-							}),
-							{type: 'divider'},
-							{
-								active: sortingOrder === 'asc',
-								href:
-									sortingOrder === 'asc' ? null : sortingURL,
-								label: Liferay.Language.get('ascending'),
-								type: 'item',
-							},
-							{
-								active: sortingOrder !== 'asc',
-								href:
-									sortingOrder !== 'asc' ? null : sortingURL,
-								label: Liferay.Language.get('descending'),
-								type: 'item',
-							},
+							...orderDropdownItems
+								.map((item) => {
+									return {
+										...item,
+										onClick: (event) => {
+											onOrderDropdownItemClick(event, {
+												item,
+											});
+										},
+									};
+								})
+								.concat(
+									sortingOrder ? sortingDirectionOptions : []
+								),
 						])}
 						trigger={
 							<ClayButton


### PR DESCRIPTION
## Related task
https://liferay.atlassian.net/browse/LPS-204424

## Issue
Changing sort direction (Ascending, Descending) when search results are ordered by "Relevance" is not working. This happens in Web Content and Blogs. 
Web Content does not return information about the sorting direction but Blogs does. However, neither of them work so  the idea is to remove this options if when the `sortingOrder` prop is null or empty in the ManagementToolbar component

## UI before
[sorting_with_direction.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/08738b3c-1bb2-44ce-8555-ec6e98c17cb7)

## UI after
[Screencast from 2024-01-16 08-39-43.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/d6689734-1fdf-4f9a-a07c-ffe51fba4551)

