### PR TITLE
LPS-206315 Ensure startup scripts for chat providers are injected in the right place

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/chatwoot.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/chatwoot.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	if (!(window.$chatwoot && window.$chatwoot.hasLoaded)) {
 		(function (d, t) {
 			var BASE_URL = 'https://app.chatwoot.com';

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/crisp.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/crisp.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script type="text/javascript">
+<aui:script position="inline" type="text/javascript">
 	window.$crisp = [];
 	window.CRISP_WEBSITE_ID = '<%= clickToChatChatProviderAccountId %>';
 

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/hubspot.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/hubspot.jsp
@@ -52,7 +52,7 @@ if (themeDisplay.isSignedIn() && (parts.length > 1)) {
 	<c:when test="<%= themeDisplay.isSignedIn() && (parts.length > 1) %>">
 		<c:choose>
 			<c:when test="<%= Validator.isNull(identificationToken) %>">
-				<aui:script>
+				<aui:script position="inline">
 					Liferay.Util.openToast({
 						message:
 							'<%= (errorMessage != null) ? errorMessage : LanguageUtil.get(resourceBundle, "unable-to-connect-to-hubspot") %>',
@@ -61,7 +61,7 @@ if (themeDisplay.isSignedIn() && (parts.length > 1)) {
 				</aui:script>
 			</c:when>
 			<c:otherwise>
-				<aui:script type="text/javascript">
+				<aui:script position="inline" type="text/javascript">
 					window.hsConversationsSettings = {
 						identificationEmail: '<%= user.getEmailAddress() %>',
 						identificationToken: '<%= identificationToken %>',

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/intercom.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/intercom.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	var APP_ID = '<%= clickToChatChatProviderAccountId %>';
 
 	let intercomSettings = {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/jivochat.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/jivochat.jsp
@@ -10,7 +10,7 @@
 <aui:script async="<%= true %>" src='<%= "//code.jivosite.com/widget/" + clickToChatChatProviderAccountId %>'></aui:script>
 
 <c:if test="<%= themeDisplay.isSignedIn() %>">
-	<aui:script>
+	<aui:script position="inline">
 		function jivo_onOpen() {
 			jivo_api.setContactInfo({
 				email: '<%= user.getEmailAddress() %>',

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/livechat.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/livechat.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	window.__lc = window.__lc || {};
 	window.__lc.license = '<%= clickToChatChatProviderAccountId %>';
 

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/liveperson.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/liveperson.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script type="text/javascript">
+<aui:script position="inline" type="text/javascript">
 	(window.lpTag = window.lpTag || {}),
 		'undefined' == typeof window.lpTag._tagCount
 			? ((window.lpTag = {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/smartsupp.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/smartsupp.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script type="text/javascript">
+<aui:script position="inline" type="text/javascript">
 	var _smartsupp = _smartsupp || {};
 
 	_smartsupp.key = '<%= clickToChatChatProviderAccountId %>';

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tawkto.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tawkto.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script type="text/javascript">
+<aui:script position="inline" type="text/javascript">
 	var Tawk_API = Tawk_API || {},
 		Tawk_LoadStart = new Date();
 

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tidio.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tidio.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	(function () {
 		function loadTidioScript() {
 			function setTidioUserInfo() {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tolvnow.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/tolvnow.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script type="text/javascript">
+<aui:script position="inline" type="text/javascript">
 	var _tn = _tn || [];
 
 	_tn.push(['account', '<%= clickToChatChatProviderAccountId %>']);

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp
@@ -9,7 +9,7 @@
 
 <liferay-util:include page='<%= "/dynamic_include/" + clickToChatChatProviderId + ".jsp" %>' servletContext="<%= application %>" />
 
-<aui:script type="text/javascript">
+<aui:script position="inline" type="text/javascript">
 	(function () {
 		function handleVisibility(selectors, hide) {
 			let selectorsList = selectors.split(',');

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	(function () {
 		function loadZendeskScript() {
 			function setZendeskUserInfo() {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	(function () {
 		function loadZendeskScript() {
 			function setZendeskUserInfo() {

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget_classic.jsp
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/resources/META-INF/resources/dynamic_include/zendesk_web_widget_classic.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<aui:script>
+<aui:script position="inline">
 	(function () {
 		function loadZendeskScript() {
 			function setZendeskUserInfo() {


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPS-206315

In this PR, we are explicitly setting `position="inline"` for `<aui:script>` occurrences which have body, in the `click-to-chat-web` module. Reason is that some of these occurrences happen after AUI_SCRIPT_DATA is [flushed to the output stream,](https://github.com/liferay/liferay-portal/blob/9d3149cbd5f41d36a5ff2b36dea6f16ea1996dba/portal-web/docroot/html/common/themes/bottom.jsp#L35), so the tag markup is not emitted.

Goal of this PR is not to solve the above general problem but to fix it for the `click-to-chat-web` module, where a dynamic include adds the chat provider script via `<aui:script>` tags with body. 

Recently, due to the CSP implementation, we switched all <script> occurrences in JSP to use <aui:script>, handling there the `nonce` generation for CSP compliance.

A followup task will analyze how we can prevent <aui:script> tags with body to be rendered after the flush. Many java-based dynamic includes take care of flushing the data on their own. JSP-based ones which need to use <aui:script> need to ensure it. We'll like to avoid this situation because it's misleading for developers

cc/ @izaera @markocikos @bryceosterhaus 