### PR TITLE
LPD-12451 Apply editor config contributor client extensions to CKEditor

### DIFF
--- a/modules/test/playwright/pages/portal-web/HomePage.ts
+++ b/modules/test/playwright/pages/portal-web/HomePage.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+export class HomePage {
+	readonly page: Page;
+
+	private readonly applicationsMenuButton: Locator;
+
+	constructor(page: Page) {
+		this.page = page;
+
+		this.applicationsMenuButton = page.getByLabel(
+			'Open Applications MenuCtrl+'
+		);
+	}
+
+	async goto() {
+		await this.page.goto('/');
+	}
+
+	async openApplicationMenu() {
+		await this.applicationsMenuButton.click();
+	}
+}

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -8,6 +8,7 @@ import {Locator, Page} from '@playwright/test';
 export class ApplicationsMenuPage {
 	readonly applicationMenuButton: Locator;
 	readonly applicationsMenuTabButton: Locator;
+	readonly clientExtensionsLink: Locator;
 	readonly controlPanelButton: Locator;
 	readonly dataMigrationCenterMenuItem: Locator;
 	readonly instanceSettingsLink: Locator;
@@ -23,6 +24,9 @@ export class ApplicationsMenuPage {
 		);
 		this.applicationsMenuTabButton = page.getByRole('tab', {
 			name: 'Applications',
+		});
+		this.clientExtensionsLink = page.getByRole('menuitem', {
+			name: 'Client Extensions',
 		});
 		this.controlPanelButton = page.getByRole('tab', {
 			name: 'Control Panel',
@@ -54,6 +58,12 @@ export class ApplicationsMenuPage {
 		await this.goto();
 		await this.applicationMenuButton.click();
 		await this.applicationsMenuTabButton.click();
+	}
+
+	async goToClientExtensions() {
+		await this.goto();
+		await this.applicationMenuButton.click();
+		await this.clientExtensionsLink.click();
 	}
 
 	async goToDataMigrationCenter() {

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -3,25 +3,22 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
+
+import {HomePage} from '../portal-web/HomePage';
 
 export class ApplicationsMenuPage {
-	readonly applicationMenuButton: Locator;
-	readonly applicationsMenuTabButton: Locator;
-	readonly clientExtensionsLink: Locator;
-	readonly controlPanelButton: Locator;
-	readonly dataMigrationCenterMenuItem: Locator;
-	readonly instanceSettingsLink: Locator;
-	readonly objectsLink: Locator;
-	readonly objectsMenuItem: Locator;
+	private readonly applicationsMenuTabButton: Locator;
+	private readonly clientExtensionsLink: Locator;
+	private readonly controlPanelButton: Locator;
+	private readonly dataMigrationCenterMenuItem: Locator;
+	private readonly homePage: HomePage;
+	private readonly instanceSettingsLink: Locator;
+	private readonly objectsMenuItem: Locator;
 	readonly page: Page;
-	readonly signInButton: Locator;
-	readonly usersAndOrganizationsItem: Locator;
+	private readonly usersAndOrganizationsItem: Locator;
 
 	constructor(page: Page) {
-		this.applicationMenuButton = page.getByLabel(
-			'Open Applications MenuCtrl+'
-		);
 		this.applicationsMenuTabButton = page.getByRole('tab', {
 			name: 'Applications',
 		});
@@ -31,6 +28,7 @@ export class ApplicationsMenuPage {
 		this.controlPanelButton = page.getByRole('tab', {
 			name: 'Control Panel',
 		});
+		this.homePage = new HomePage(page);
 		this.instanceSettingsLink = page.getByRole('link', {
 			name: 'Instance Settings',
 		});
@@ -43,7 +41,6 @@ export class ApplicationsMenuPage {
 			name: 'Objects',
 		});
 		this.page = page;
-		this.signInButton = page.getByRole('button', {name: 'Sign In'});
 		this.usersAndOrganizationsItem = page.getByRole('menuitem', {
 			exact: true,
 			name: 'Users and Organizations',
@@ -51,18 +48,19 @@ export class ApplicationsMenuPage {
 	}
 
 	async goto() {
-		await this.page.goto('/');
+		await this.homePage.goto();
+		await this.homePage.openApplicationMenu();
+
+		await expect(this.applicationsMenuTabButton).toBeVisible();
 	}
 
 	async goToApplicationsMenu() {
 		await this.goto();
-		await this.applicationMenuButton.click();
 		await this.applicationsMenuTabButton.click();
 	}
 
 	async goToClientExtensions() {
 		await this.goto();
-		await this.applicationMenuButton.click();
 		await this.clientExtensionsLink.click();
 	}
 
@@ -83,13 +81,11 @@ export class ApplicationsMenuPage {
 
 	async goToControlPanel() {
 		await this.goto();
-		await this.applicationMenuButton.click();
 		await this.controlPanelButton.click();
 	}
 
 	async goToUsersAndOrganizations() {
 		await this.goto();
-		await this.applicationMenuButton.click();
 		await this.controlPanelButton.click();
 		await this.usersAndOrganizationsItem.click();
 	}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -5,12 +5,13 @@
 
 import {defineConfig} from '@playwright/test';
 
-import {config as batchPlanner} from './tests/batch-planner/config';
-import {config as exportImportWeb} from './tests/export-import-web/config';
-import {config as layoutContentPageEditorWeb} from './tests/layout-content-page-editor-web/config';
-import {config as object} from './tests/object-web/config';
-import {config as portalWeb} from './tests/portal-web/config';
-import {config as usersAdminWeb} from './tests/users-admin-web/config';
+import {config as batchPlannerConfig} from './tests/batch-planner/config';
+import {config as clientExtensionWebConfig} from './tests/client-extension-web/config';
+import {config as exportImportWebConfig} from './tests/export-import-web/config';
+import {config as layoutContentPageEditorWebConfig} from './tests/layout-content-page-editor-web/config';
+import {config as objectWebConfig} from './tests/object-web/config';
+import {config as portalWebConfig} from './tests/portal-web/config';
+import {config as usersAdminWebConfig} from './tests/users-admin-web/config';
 
 export default defineConfig({
 	expect: {
@@ -18,12 +19,13 @@ export default defineConfig({
 	},
 	forbidOnly: !!process.env.CI,
 	projects: [
-		batchPlanner,
-		exportImportWeb,
-		layoutContentPageEditorWeb,
-		object,
-		portalWeb,
-		usersAdminWeb,
+		batchPlannerConfig,
+		clientExtensionWebConfig,
+		exportImportWebConfig,
+		layoutContentPageEditorWebConfig,
+		objectWebConfig,
+		portalWebConfig,
+		usersAdminWebConfig,
 	],
 	reporter: [
 		[

--- a/modules/test/playwright/tests/client-extension-web/config.ts
+++ b/modules/test/playwright/tests/client-extension-web/config.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	dependencies: ['setup'],
+	name: 'clientExtension',
+	testDir: 'tests/client-extension-web',
+	use: {
+		...devices['Desktop Chrome'],
+		storageState: 'tmp/.auth/user.json',
+	},
+};

--- a/modules/test/playwright/tests/client-extension-web/config.ts
+++ b/modules/test/playwright/tests/client-extension-web/config.ts
@@ -7,7 +7,7 @@ import {devices} from '@playwright/test';
 
 export const config = {
 	dependencies: ['setup'],
-	name: 'clientExtension',
+	name: 'client-extension',
 	testDir: 'tests/client-extension-web',
 	use: {
 		...devices['Desktop Chrome'],

--- a/modules/test/playwright/tests/client-extension-web/config.ts
+++ b/modules/test/playwright/tests/client-extension-web/config.ts
@@ -6,11 +6,9 @@
 import {devices} from '@playwright/test';
 
 export const config = {
-	dependencies: ['setup'],
 	name: 'client-extension',
 	testDir: 'tests/client-extension-web',
 	use: {
 		...devices['Desktop Chrome'],
-		storageState: 'tmp/.auth/user.json',
 	},
 };

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {clientExtensionsPageTest} from './fixtures/clientExtensionsPageTest';
+import {newEditorConfigContributorPageTest} from './fixtures/newEditorConfigContributorPageTest';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	clientExtensionsPageTest,
+	newEditorConfigContributorPageTest
+);
+
+test('Editor config contributor client extension is disabled if FF is set to false', async ({
+	apiHelpers,
+	clientExtensionsPage,
+}) => {
+	await apiHelpers.featureFlag.updateFeatureFlag('LPS-186870', false);
+
+	await clientExtensionsPage.goto();
+
+	await clientExtensionsPage.newClientExtensionButton.click();
+
+	await expect(
+		clientExtensionsPage.editorConfigContributorMenuItem
+	).not.toBeAttached();
+});
+
+test('Create, edit and delete editor config contributor client extension', async ({
+	apiHelpers,
+	clientExtensionsPage,
+	newEditorConfigContributorPage,
+}) => {
+	await apiHelpers.featureFlag.updateFeatureFlag('LPS-186870', true);
+
+	await clientExtensionsPage.goto();
+
+	await clientExtensionsPage.newClientExtensionButton.click();
+
+	await clientExtensionsPage.editorConfigContributorMenuItem.click();
+
+	const sampleName1 = 'Sample Name 1';
+
+	await newEditorConfigContributorPage.nameInput.fill(sampleName1);
+
+	await newEditorConfigContributorPage.descriptionEditable.isEditable();
+
+	await newEditorConfigContributorPage.descriptionEditable.fill(
+		'Sample Description'
+	);
+
+	await newEditorConfigContributorPage.urlInput.fill(
+		'https://www.liferay.com'
+	);
+
+	await newEditorConfigContributorPage.portletNamesInput.fill(
+		'Sample Portlet Name'
+	);
+
+	await newEditorConfigContributorPage.editorNamesInput.fill(
+		'Sample Editor Names'
+	);
+
+	await newEditorConfigContributorPage.editorConfigKeysInput.fill(
+		'Sample Editor Config Keys'
+	);
+
+	await newEditorConfigContributorPage.publishButton.click();
+
+	await clientExtensionsPage.openItemActionsDropdown({text: sampleName1});
+
+	await clientExtensionsPage.itemEditButton.click();
+
+	const sampleName2 = 'Sample Name 2';
+
+	await newEditorConfigContributorPage.nameInput.click();
+
+	await newEditorConfigContributorPage.nameInput.fill(sampleName2);
+
+	await newEditorConfigContributorPage.publishButton.click();
+
+	await clientExtensionsPage.openItemActionsDropdown({text: sampleName2});
+
+	clientExtensionsPage.page.on('dialog', (dialog) => dialog.accept());
+
+	await clientExtensionsPage.itemDeleteButton.click();
+});
+
+/**
+ * This test requires manual setup:
+ *
+ *     1. Run `gradle build` in /workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor
+ *     2. Copy `liferay-sample-editor-config-contributor.zip` from /dist to @LIFERAY_HOME/osgi/client-extensions
+ *
+ * We are skipping the test until we automate these steps.
+ */
+test('Add a toolbar button to a CKEditor, by applying editor config contributor client extension', async ({
+	apiHelpers,
+	newEditorConfigContributorPage,
+}) => {
+	await apiHelpers.featureFlag.updateFeatureFlag('LPS-186870', true);
+
+	await newEditorConfigContributorPage.goto();
+
+	await expect(
+		newEditorConfigContributorPage.descriptionEditable
+	).toBeEditable();
+
+	await expect(
+		newEditorConfigContributorPage.aiCreatorEditorToolbarButton
+	).toBeVisible();
+});

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -6,12 +6,14 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {clientExtensionsPageTest} from './fixtures/clientExtensionsPageTest';
 import {newEditorConfigContributorPageTest} from './fixtures/newEditorConfigContributorPageTest';
 
 export const test = mergeTests(
 	apiHelpersTest,
 	clientExtensionsPageTest,
+	loginTest,
 	newEditorConfigContributorPageTest
 );
 

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -98,7 +98,7 @@ test('Create, edit and delete editor config contributor client extension', async
  *
  * We are skipping the test until we automate these steps.
  */
-test('Add a toolbar button to a CKEditor, by applying editor config contributor client extension', async ({
+test.skip('Add a toolbar button to a CKEditor, by applying editor config contributor client extension', async ({
 	apiHelpers,
 	newEditorConfigContributorPage,
 }) => {

--- a/modules/test/playwright/tests/client-extension-web/fixtures/clientExtensionsPageTest.ts
+++ b/modules/test/playwright/tests/client-extension-web/fixtures/clientExtensionsPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ClientExtensionsPage} from '../pages/ClientExtensionsPage';
+
+const clientExtensionsPageTest = test.extend<{
+	clientExtensionsPage: ClientExtensionsPage;
+}>({
+	clientExtensionsPage: async ({page}, use) => {
+		await use(new ClientExtensionsPage(page));
+	},
+});
+
+export {clientExtensionsPageTest};

--- a/modules/test/playwright/tests/client-extension-web/fixtures/newEditorConfigContributorPageTest.ts
+++ b/modules/test/playwright/tests/client-extension-web/fixtures/newEditorConfigContributorPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {NewEditorConfigContributorPage} from '../pages/NewEditorConfigContributorPage';
+
+const newEditorConfigContributorPageTest = test.extend<{
+	newEditorConfigContributorPage: NewEditorConfigContributorPage;
+}>({
+	newEditorConfigContributorPage: async ({page}, use) => {
+		await use(new NewEditorConfigContributorPage(page));
+	},
+});
+
+export {newEditorConfigContributorPageTest};

--- a/modules/test/playwright/tests/client-extension-web/pages/ClientExtensionsPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/ClientExtensionsPage.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ApplicationsMenuPage} from '../../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+
+export class ClientExtensionsPage {
+	readonly applicationsMenuPage: ApplicationsMenuPage;
+	readonly editorConfigContributorMenuItem: Locator;
+	readonly itemDeleteButton: Locator;
+	readonly itemEditButton: Locator;
+	readonly newClientExtensionButton: Locator;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+
+		this.editorConfigContributorMenuItem = page.getByRole('menuitem', {
+			name: 'Add Editor Config Contributor',
+		});
+
+		this.itemDeleteButton = page.getByRole('menuitem', {
+			name: 'Delete',
+		});
+		this.itemEditButton = page.getByRole('menuitem', {
+			name: 'Edit',
+		});
+
+		this.newClientExtensionButton = page
+			.getByRole('button')
+			.and(page.getByTitle('New'));
+
+		this.page = page;
+	}
+
+	async goto() {
+		await this.applicationsMenuPage.goToClientExtensions();
+	}
+
+	async gotoNewEditorConfigContributorPage() {
+		await this.goto();
+
+		await this.newClientExtensionButton.click();
+		await this.editorConfigContributorMenuItem.click();
+	}
+
+	async openItemActionsDropdown({text}: {text: string}) {
+		await this.page
+			.locator('.dnd-tr')
+			.filter({has: this.page.getByText(text)})
+			.getByRole('button', {
+				name: 'Actions',
+			})
+			.click();
+	}
+}

--- a/modules/test/playwright/tests/client-extension-web/pages/NewEditorConfigContributorPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/NewEditorConfigContributorPage.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ClientExtensionsPage} from './ClientExtensionsPage';
+
+export class NewEditorConfigContributorPage {
+	readonly aiCreatorEditorToolbarButton: Locator;
+	readonly clientExtensionsPage: ClientExtensionsPage;
+	readonly descriptionEditable: Locator;
+	readonly editorConfigKeysInput: Locator;
+	readonly editorNamesInput: Locator;
+	readonly nameInput: Locator;
+	readonly portletNamesInput: Locator;
+	readonly publishButton: Locator;
+	readonly page: Page;
+	readonly urlInput: Locator;
+
+	constructor(page: Page) {
+		this.clientExtensionsPage = new ClientExtensionsPage(page);
+		this.page = page;
+
+		const portletId =
+			'_com_liferay_client_extension_web_internal_portlet_ClientExtensionAdminPortlet';
+
+		this.nameInput = page.locator(`#${portletId}_name`);
+
+		const descriptionIframe = page.frameLocator(
+			`#cke_${portletId}_description iframe`
+		);
+
+		this.descriptionEditable = descriptionIframe.locator('.cke_editable');
+
+		this.aiCreatorEditorToolbarButton =
+			page.getByTitle('Create AI Content');
+		this.urlInput = page.locator(`#${portletId}_url`);
+		this.portletNamesInput = page.locator(
+			`[name=${portletId}_portletNames]`
+		);
+		this.editorNamesInput = page.locator(`[name=${portletId}_editorNames]`);
+		this.editorConfigKeysInput = page.locator(
+			`[name=${portletId}_editorConfigKeys]`
+		);
+
+		this.publishButton = page.getByRole('button', {name: 'Publish'});
+	}
+
+	async goto() {
+		await this.clientExtensionsPage.gotoNewEditorConfigContributorPage();
+	}
+}


### PR DESCRIPTION
### References

- Parent story: [LPS-187309 Apply editor config contributor client extensions to CKEditor](https://issues.liferay.com/browse/LPS-187309)
- related: https://github.com/brianchandotcom/liferay-portal/pull/146451
- related: https://github.com/brianchandotcom/liferay-portal/pull/146447

### What is the goal of this PR?

This PR completes functional tests for editor CET. The only part that is missing is automation of workspace sample deployment. When that is done, we can enable the last test.

### What does it look like?

This is after the third test is enabled in code, after manual workspace sample deployment:

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/447306a8-bb45-4ca6-9696-80b88ca358a0)