### PR TITLE
LPD-15187 Remove unnecesary tab and tablist roles

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PanelTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/PanelTag.java
@@ -25,7 +25,6 @@ public class PanelTag extends BaseContainerTag {
 	@Override
 	public int doStartTag() throws JspException {
 		setAttributeNamespace(_ATTRIBUTE_NAMESPACE);
-		setDynamicAttribute(StringPool.BLANK, "role", "tablist");
 
 		return super.doStartTag();
 	}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -34,7 +34,7 @@ else if (collapsible) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
-					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" id="<%= id %>Toggle" role="tab">
+					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" id="<%= id %>Toggle">
 						<span>
 							<%= header %>
 						</span>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -24,7 +24,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 
 		<div class="form-group input-group mb-2">
 			<div class="input-group-item">
-				<input class="field form-control lfr-input-text lfr-portal-tooltip" id="<portlet:namespace />ddmTemplateName" readonly="readonly" title="<%= LanguageUtil.get(request, "template-name") %>" type="text" value="<%= (ddmTemplate != null) ? HtmlUtil.escape(ddmTemplate.getName(locale)) : LanguageUtil.get(request, "no-template") %>" />
+				<input aria-label="<%= LanguageUtil.get(request, "template-name") %>" class="field form-control lfr-input-text lfr-portal-tooltip" id="<portlet:namespace />ddmTemplateName" readonly="readonly" type="text" value="<%= (ddmTemplate != null) ? HtmlUtil.escape(ddmTemplate.getName(locale)) : LanguageUtil.get(request, "no-template") %>" />
 			</div>
 
 			<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SmallImage.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SmallImage.js
@@ -107,7 +107,7 @@ export default function SmallImage({
 					<ClayInput.Group small>
 						<ClayInput.GroupItem>
 							<input
-								className="sr-only"
+								hidden
 								id={`${portletNamespace}smallFile`}
 								name={`${portletNamespace}smallFile`}
 								onChange={(event) =>
@@ -120,9 +120,9 @@ export default function SmallImage({
 							/>
 
 							<ClayInput
-								onClick={() => fileInputRef.current?.click()}
-								placeholder={Liferay.Language.get(
-									'select-image'
+								placeholder={sub(
+									Liferay.Language.get('no-x-selected'),
+									Liferay.Language.get('image')
 								)}
 								readOnly
 								sizing="sm"
@@ -195,9 +195,9 @@ export default function SmallImage({
 
 							<ClayInput
 								id={`${portletNamespace}smallImageId`}
-								onClick={() => openItemSelector()}
-								placeholder={Liferay.Language.get(
-									'select-image'
+								placeholder={sub(
+									Liferay.Language.get('no-x-selected'),
+									Liferay.Language.get('image')
 								)}
 								readOnly
 								sizing="sm"

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/article/SelectAssetDisplayPage.js
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
-import {ClayDropDownWithItems} from '@clayui/drop-down';
-import ClayForm, {ClayInput} from '@clayui/form';
+import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
 import React, {useState} from 'react';
 
 import AssetDisplayPageSelector from './AssetDisplayPageSelector';
@@ -62,19 +60,14 @@ export default function SelectAssetDisplayPage({
 	const ITEMS = [
 		{
 			label: getLabel(DISPLAY_PAGE_TYPE.default),
-			onClick: () =>
-				setSelectedDisplayPageType(DISPLAY_PAGE_TYPE.default),
 			value: DISPLAY_PAGE_TYPE.default,
 		},
 		{
 			label: getLabel(DISPLAY_PAGE_TYPE.specific),
-			onClick: () =>
-				setSelectedDisplayPageType(DISPLAY_PAGE_TYPE.specific),
 			value: DISPLAY_PAGE_TYPE.specific,
 		},
 		{
 			label: getLabel(DISPLAY_PAGE_TYPE.none),
-			onClick: () => setSelectedDisplayPageType(DISPLAY_PAGE_TYPE.none),
 			value: DISPLAY_PAGE_TYPE.none,
 		},
 	];
@@ -82,20 +75,18 @@ export default function SelectAssetDisplayPage({
 	return (
 		<>
 			<ClayForm.Group>
-				<ClayDropDownWithItems
-					items={ITEMS}
-					trigger={
-						<ClayButton
-							aria-label={Liferay.Language.get(
-								'select-display-page-type'
-							)}
-							className="bg-light form-control-select text-left w-100"
-							displayType="secondary"
-							type="button"
-						>
-							<span>{getLabel(selectedDisplayPageType)}</span>
-						</ClayButton>
+				<ClaySelectWithOption
+					aria-label={Liferay.Language.get(
+						'select-display-page-type'
+					)}
+					id={`${namespace}selectDisplayPageType`}
+					onChange={(event) =>
+						setSelectedDisplayPageType(
+							parseInt(event.target.value, 10)
+						)
 					}
+					options={ITEMS}
+					value={selectedDisplayPageType}
 				/>
 			</ClayForm.Group>
 

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -110,7 +110,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 					<option <%= inputPermissionsViewRole.equals(RoleConstants.OWNER) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.OWNER %>"><liferay-ui:message key="owner" /></option>
 				</select>
 
-				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm <%= inputPermissionsShowOptions ? "mb-1 mt-3" : "mb-5 mt-3" %>" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" onclick="<%= uniqueNamespace %>inputPermissionsToggle();" type="button">
+				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm mt-3" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" onclick="<%= uniqueNamespace %>inputPermissionsToggle();" type="button">
 					<%= inputPermissionsShowOptions ? LanguageUtil.get(request, "hide-options") : LanguageUtil.get(request, "more-options") %>
 				</button>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1231,13 +1231,10 @@ definition {
 				value1 = ${displayPageTemplateType});
 		}
 		else {
-			Click(
+			Select(
 				ariaLabel = "Select Display Page Type",
-				locator1 = "Button#ANY_WITH_ARIA_LABEL");
-
-			Click(
-				key_menuItem = ${displayPageTemplateType},
-				locator1 = "MenuItem#ANY_MENU_ITEM");
+				locator1 = "Select#ANY_ARIA_LABEL",
+				value1 = ${displayPageTemplateType});
 		}
 
 		if (${displayPageTemplateType} == "Specific") {
@@ -2549,9 +2546,9 @@ definition {
 				value1 = ${displayPageTemplateType});
 		}
 		else {
-			AssertTextEquals(
+			AssertSelectedLabel(
 				ariaLabel = "Select Display Page Type",
-				locator1 = "Button#ANY_WITH_ARIA_LABEL",
+				locator1 = "Select#ANY_ARIA_LABEL",
 				value1 = ${displayPageTemplateType});
 		}
 


### PR DESCRIPTION
Hi guys!

I was fixing several accessibility issues related to our Web Content Configuration panel  https://liferay.atlassian.net/browse/LPD-15187 and saw one issue related to the Clay Panel component taglib. A while ago, the `tablist` and `tab` roles were removed from that component (https://liferay.atlassian.net/browse/LPS-201300) but the taglib was not updated. I send you the fix in this commit https://github.com/liferay-frontend/liferay-portal/commit/5acf9fbe3b9c8df0708711ab27529cad5b05531b.

Thanks in advance! :smile: 