### PR TITLE
LPD-15505 Add tests to check if a triggerRef can be passed by props

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -703,7 +703,7 @@ AUI.add(
 				},
 
 				INPUT_HIDDEN_TEMPLATE:
-					'<input data-field-name={name} data-language-id={languageId} id="{namespace}{id}_{languageId}" name="{namespace}{fieldNamePrefix}{name}_{languageId}{fieldNameSuffix}" type="hidden" value="" />',
+					'<input data-field-name={name} data-languageid={languageId} id="{namespace}{id}_{languageId}" name="{namespace}{fieldNamePrefix}{name}_{languageId}{fieldNameSuffix}" type="hidden" value="" />',
 
 				TRANSLATION_STATUS_TEMPLATE:
 					'<span aria-label="{translationAriaLabel}" role="button" tabindex="0"> {languageId} <span class="dropdown-item-indicator-end w-auto"><span class="label label-{translationStatusCssClass}">{translationStatus}</span></span></span>',

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -30,6 +30,7 @@ interface IProps extends Translations {
 		languageIds: Liferay.Language.Locale[]
 	) => void;
 	onSelectedLanguageIdChange?: (languageId: Liferay.Language.Locale) => void;
+	onSelectorActiveChange?: () => void;
 	selectedLanguageId: Liferay.Language.Locale;
 	showOnlyFlags?: boolean;
 	small?: boolean;
@@ -111,11 +112,12 @@ export default function TranslationAdminSelector({
 	displayType = DISPLAY_TYPE.DEFAULT,
 	onActiveLanguageIdsChange = noop,
 	onSelectedLanguageIdChange = noop,
+	onSelectorActiveChange = noop,
 	selectedLanguageId: initialSelectedLanguageId,
 	showOnlyFlags,
 	small = false,
-	translations = null,
 	translationProgress = null,
+	translations = null,
 }: IProps) {
 	const [activeLanguageIds, setActiveLanguageIds] = useState<
 		Liferay.Language.Locale[]
@@ -177,10 +179,18 @@ export default function TranslationAdminSelector({
 	if (Liferay.FeatureFlags['LPS-114700'] && !adminMode) {
 		return (
 			<Picker
+				active={selectorDropdownActive}
 				as={TriggerButton}
 				displayType={displayType}
 				id={selectorId}
 				items={activeLocales}
+				onActiveChange={(active: any) => {
+					if (active) {
+						onSelectorActiveChange();
+					}
+
+					setSelectorDropdownActive(active);
+				}}
 				onSelectionChange={(id: React.Key) => {
 					setSelectedLanguageId(id as Liferay.Language.Locale);
 				}}
@@ -222,7 +232,13 @@ export default function TranslationAdminSelector({
 			<ClayDropDown
 				active={selectorDropdownActive}
 				hasLeftSymbols
-				onActiveChange={setSelectorDropdownActive}
+				onActiveChange={(active: any) => {
+					if (active) {
+						onSelectorActiveChange();
+					}
+
+					setSelectorDropdownActive(active);
+				}}
 				trigger={
 					<TriggerButton
 						displayType={displayType}

--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
@@ -375,4 +375,22 @@ describe('TranslationAdminSelector', () => {
 
 		Liferay.FeatureFlags['LPS-114700'] = false;
 	});
+
+	it('calls onSelectorActiveChange when the trigger is clicked', () => {
+		const onSelectorActiveChange = jest.fn();
+
+		const {getByTitle} = render(
+			<TranslationAdminSelector
+				{...props}
+				onSelectorActiveChange={onSelectorActiveChange}
+				selectedLanguageId="en_US"
+			/>
+		);
+
+		const trigger = getByTitle('select-translation-language');
+
+		fireEvent.click(trigger);
+
+		expect(onSelectorActiveChange).toBeCalled();
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
@@ -18,6 +18,7 @@ interface IProps extends Translations {
 		languageIds: Liferay.Language.Locale[]
 	) => void;
 	onSelectedLanguageIdChange?: (languageId: Liferay.Language.Locale) => void;
+	onSelectorActiveChange?: () => void;
 	selectedLanguageId: Liferay.Language.Locale;
 	showOnlyFlags?: boolean;
 	small?: boolean;
@@ -36,10 +37,11 @@ export default function TranslationAdminSelector({
 	displayType,
 	onActiveLanguageIdsChange,
 	onSelectedLanguageIdChange,
+	onSelectorActiveChange,
 	selectedLanguageId: initialSelectedLanguageId,
 	showOnlyFlags,
 	small,
-	translations,
 	translationProgress,
+	translations,
 }: IProps): JSX.Element;
 export {};

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -116,7 +116,7 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 			}
 		%>
 
-			<aui:input data-languageid="<%= curLanguageId %>" dir="<%= curLanguageDir %>" disabled="<%= disabled %>" id="<%= HtmlUtil.escapeAttribute(id + StringPool.UNDERLINE + curLanguageId) %>" name="<%= HtmlUtil.escapeAttribute(fieldNamePrefix + name + StringPool.UNDERLINE + curLanguageId + fieldNameSuffix) %>" type="hidden" value="<%= languageValue %>" />
+			<aui:input data-field-name="<%= HtmlUtil.escapeAttribute(id + fieldSuffix) %>" data-languageid="<%= curLanguageId %>" dir="<%= curLanguageDir %>" disabled="<%= disabled %>" id="<%= HtmlUtil.escapeAttribute(id + StringPool.UNDERLINE + curLanguageId) %>" name="<%= HtmlUtil.escapeAttribute(fieldNamePrefix + name + StringPool.UNDERLINE + curLanguageId + fieldNameSuffix) %>" type="hidden" value="<%= languageValue %>" />
 
 		<%
 		}


### PR DESCRIPTION
Hi guys!

From the Echo team we are working on several changes that we need to continue with this story https://liferay.atlassian.net/browse/LPD-6819. The changes are as follows:
- We have added a new `prop` to the `TranslationAdminSelector` component, `triggerRef`, so that we can pass a reference from outside the component to the language selector button. Also a test for this has been added.
- There was a bug in the attributes of the localized input. On the one hand there were different attributes `data-language-id` and `data-languageid` that are the same, so we have been unified into `data-languageid`. On the other hand, a `data-field-name` attribute was missing in the input_localized taglib.

Let me know if you have any doubts. Thanks in advance! :smile: 

Note: this commits are part of this PR https://github.com/liferay-forms/liferay-portal/pull/2465 so we have to wait to merge it