### PR TITLE
LPD-5512 Create taglib for Resource Selector

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 13.3.2
+Bundle-Version: 13.4.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.constants,\

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -23,5 +23,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "13.3.2"
+	"version": "13.4.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ResourceSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ResourceSelectorTag.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.taglib.servlet.taglib;
+
+import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.taglib.util.IncludeTag;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
+
+/**
+ * @author Diego Hu
+ */
+public class ResourceSelectorTag extends IncludeTag {
+
+	public String getInputLabel() {
+		return _inputLabel;
+	}
+
+	public String getInputName() {
+		return _inputName;
+	}
+
+	public String getModalTitle() {
+		return _modalTitle;
+	}
+
+	public String getResourceName() {
+		return _resourceName;
+	}
+
+	public long getResourceValue() {
+		return _resourceValue;
+	}
+
+	public String getSelectEventName() {
+		return _selectEventName;
+	}
+
+	public String getSelectResourceURL() {
+		return _selectResourceURL;
+	}
+
+	public String getWarningMessage() {
+		return _warningMessage;
+	}
+
+	public boolean isShowRemoveButton() {
+		return _showRemoveButton;
+	}
+
+	public void setInputLabel(String inputLabel) {
+		_inputLabel = inputLabel;
+	}
+
+	public void setInputName(String inputName) {
+		_inputName = inputName;
+	}
+
+	public void setModalTitle(String modalTitle) {
+		_modalTitle = modalTitle;
+	}
+
+	@Override
+	public void setPageContext(PageContext pageContext) {
+		super.setPageContext(pageContext);
+
+		setServletContext(ServletContextUtil.getServletContext());
+	}
+
+	public void setResourceName(String resourceName) {
+		_resourceName = resourceName;
+	}
+
+	public void setResourceValue(long resourceValue) {
+		_resourceValue = resourceValue;
+	}
+
+	public void setSelectEventName(String selectEventName) {
+		_selectEventName = selectEventName;
+	}
+
+	public void setSelectResourceURL(String selectResourceURL) {
+		_selectResourceURL = selectResourceURL;
+	}
+
+	public void setShowRemoveButton(boolean showRemoveButton) {
+		_showRemoveButton = showRemoveButton;
+	}
+
+	public void setWarningMessage(String warningMessage) {
+		_warningMessage = warningMessage;
+	}
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_inputLabel = null;
+		_inputName = null;
+		_modalTitle = null;
+		_resourceName = null;
+		_resourceValue = 0;
+		_selectEventName = null;
+		_selectResourceURL = null;
+		_showRemoveButton = false;
+		_warningMessage = null;
+	}
+
+	@Override
+	protected String getPage() {
+		return _PAGE;
+	}
+
+	@Override
+	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:inputLabel", _inputLabel);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:inputName", _inputName);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:modalTitle", _modalTitle);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:resourceName", _resourceName);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:resourceValue", _resourceValue);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:selectEventName",
+			_selectEventName);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:selectResourceURL",
+			_selectResourceURL);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:showRemoveButton",
+			_showRemoveButton);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:warningMessage",
+			_warningMessage);
+	}
+
+	private static final String _PAGE = "/resource_selector/page.jsp";
+
+	private String _inputLabel;
+	private String _inputName;
+	private String _modalTitle;
+	private String _resourceName;
+	private long _resourceValue;
+	private String _selectEventName;
+	private String _selectResourceURL;
+	private boolean _showRemoveButton;
+	private String _warningMessage;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -623,6 +623,59 @@
 		</attribute>
 	</tag>
 	<tag>
+		<name>resource-selector</name>
+		<tag-class>com.liferay.frontend.taglib.servlet.taglib.ResourceSelectorTag</tag-class>
+		<body-content>JSP</body-content>
+		<attribute>
+			<name>inputLabel</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>inputName</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>modalTitle</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
+			<name>resourceName</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>resourceValue</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>long</type>
+		</attribute>
+		<attribute>
+			<name>selectEventName</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>selectResourceURL</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>showRemoveButton</name>
+			<required>true</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
+			<name>warningMessage</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+	</tag>
+	<tag>
 		<name>screen-navigation</name>
 		<tag-class>com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationTag</tag-class>
 		<body-content>JSP</body-content>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import {openSelectionModal} from 'frontend-js-web';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+
+interface IResourceSelectorProps {
+	inputLabel: string;
+	inputName: string;
+	modalTitle: string;
+	portletNamespace: string;
+	resourceName: string;
+	resourceValue: string;
+	selectEventName: string;
+	selectResourceURL: string;
+	showRemoveButton: boolean;
+	warningMessage: boolean;
+}
+
+export default function ResourceSelector({
+	inputLabel,
+	inputName,
+	modalTitle,
+	portletNamespace,
+	resourceName: initialResourceName,
+	resourceValue: initialResourceValue,
+	selectEventName,
+	selectResourceURL,
+	showRemoveButton,
+	warningMessage,
+}: IResourceSelectorProps) {
+	const [resourceData, setResourceData] = useState({
+		resourceName: initialResourceName,
+		resourceValue: initialResourceValue,
+		showWarning: Boolean(warningMessage),
+	});
+
+	const onResourceRemove = () => {
+		setResourceData({
+			resourceName: '',
+			resourceValue: '0',
+			showWarning: false,
+		});
+	};
+
+	const onResourceSelect = () =>
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					setResourceData({
+						resourceName: selectedItem.resourcename,
+						resourceValue: selectedItem.resourceid,
+						showWarning: false,
+					});
+				}
+			},
+			selectEventName: `${portletNamespace}${selectEventName}`,
+			title: modalTitle,
+			url: selectResourceURL,
+		});
+
+	return (
+		<div className="form-group">
+			<ClayForm.Group>
+				<ClayInput
+					name={`${portletNamespace}${inputName}`}
+					type="hidden"
+					value={resourceData.resourceValue}
+				/>
+
+				<label htmlFor={`${portletNamespace}resourceName`}>
+					{inputLabel}
+				</label>
+
+				<ClayInput
+					disabled
+					id={`${portletNamespace}resourceName`}
+					type="text"
+					value={resourceData.resourceName}
+				/>
+			</ClayForm.Group>
+
+			{resourceData.showWarning ? (
+				<ClayAlert displayType="warning">{warningMessage}</ClayAlert>
+			) : null}
+
+			<ClayButton.Group spaced>
+				<ClayButton
+					displayType="secondary"
+					onClick={onResourceSelect}
+					type="button"
+				>
+					{Liferay.Language.get('select')}
+				</ClayButton>
+
+				{showRemoveButton ? (
+					<ClayButton
+						disabled={resourceData.resourceValue === '0'}
+						displayType="secondary"
+						onClick={onResourceRemove}
+						type="button"
+					>
+						{Liferay.Language.get('remove')}
+					</ClayButton>
+				) : null}
+			</ClayButton.Group>
+		</div>
+	);
+}
+
+ResourceSelector.propTypes = {
+	inputLabel: PropTypes.string.isRequired,
+	inputName: PropTypes.string.isRequired,
+	modalTitle: PropTypes.string.isRequired,
+	portletNamespace: PropTypes.string.isRequired,
+	resourceName: PropTypes.string.isRequired,
+	resourceValue: PropTypes.string.isRequired,
+	selectEventName: PropTypes.string.isRequired,
+	selectResourceURL: PropTypes.string.isRequired,
+	showRemoveButton: PropTypes.bool.isRequired,
+	warningMessage: PropTypes.bool,
+};

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/init.jsp
@@ -1,0 +1,10 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/page.jsp
@@ -1,0 +1,49 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/resource_selector/init.jsp" %>
+
+<%
+String inputLabel = (String)request.getAttribute("liferay-frontend:resource-selector:inputLabel");
+String inputName = (String)request.getAttribute("liferay-frontend:resource-selector:inputName");
+String modalTitle = (String)request.getAttribute("liferay-frontend:resource-selector:modalTitle");
+String resourceName = (String)request.getAttribute("liferay-frontend:resource-selector:resourceName");
+long resourceValue = (long)request.getAttribute("liferay-frontend:resource-selector:resourceValue");
+String selectEventName = (String)request.getAttribute("liferay-frontend:resource-selector:selectEventName");
+String selectResourceURL = (String)request.getAttribute("liferay-frontend:resource-selector:selectResourceURL");
+boolean showRemoveButton = (boolean)request.getAttribute("liferay-frontend:resource-selector:showRemoveButton");
+String warningMessage = (String)request.getAttribute("liferay-frontend:resource-selector:warningMessage");
+%>
+
+<div>
+	<span aria-hidden="true" class="loading-animation"></span>
+
+	<react:component
+		module="resource_selector/ResourceSelector"
+		props='<%=
+			HashMapBuilder.<String, Object>put(
+				"inputLabel", inputLabel
+			).put(
+				"inputName", inputName
+			).put(
+				"modalTitle", modalTitle
+			).put(
+				"resourceName", resourceName
+			).put(
+				"resourceValue", resourceValue
+			).put(
+				"selectEventName", selectEventName
+			).put(
+				"selectResourceURL", selectResourceURL
+			).put(
+				"showRemoveButton", showRemoveButton
+			).put(
+				"warningMessage", warningMessage
+			).build()
+		%>'
+	/>
+</div>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 9.2.0
+version 9.3.0


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-5512)

## Motivation 

In Echo team, we have realised that there are many usages of the Folder Selector and Categories Selector. These two selectors works in the same way but with different names.

![Screenshot 2024-01-23 at 18 31 44](https://github.com/liferay-frontend/liferay-portal/assets/91208451/7cc77656-f5f1-4a9b-933c-2c6543feb9d8)

![Screenshot 2024-01-31 at 12 06 29](https://github.com/liferay-frontend/liferay-portal/assets/91208451/0e4da744-0d7f-4c61-80af-2d1396261d23)

## Proposed solution 

We have decided to unify this component by creating a ResourceSelector component inside **frontend-taglib**, so that in the future we can replace the usages of each module for this new taglib, and this can apply to all selectors that select any source.