### PR TITLE
LPD-15852 Create Data set Actions page object model

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-views-web/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/actions.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../fixtures/loginTest';
+import {liferayConfig} from '../../liferay.config';
+import {actionsPageTest} from './fixtures/actionsPageTest';
+import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
+import {viewsPageTest} from './fixtures/viewsPageTest';
+
+export const test = mergeTests(actionsPageTest, dataSetsPageTest, loginTest, viewsPageTest);
+
+test('Create a Creation Action', async ({actionsPage, dataSetsPage, page, viewsPage}) => {
+    await dataSetsPage.goto();
+    await dataSetsPage.createSampleDataSetUI();
+
+    await viewsPage.goto();
+    await viewsPage.createSampleDataSetViewUI();
+
+	await actionsPage.goto();
+	await actionsPage.createCreationAction({
+		icon: 'arrow-right-full',
+		name: 'Link action',
+		type: 'link',
+		url: liferayConfig.environment.baseUrl,
+	});
+
+	await expect(
+		page
+			.getByRole('cell', {exact: true, name: 'Link action'})
+			.locator('span')
+			.first()
+	).toBeVisible();
+});

--- a/modules/test/playwright/tests/frontend-data-set-views-web/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/actions.spec.ts
@@ -11,14 +11,24 @@ import {actionsPageTest} from './fixtures/actionsPageTest';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
 import {viewsPageTest} from './fixtures/viewsPageTest';
 
-export const test = mergeTests(actionsPageTest, dataSetsPageTest, loginTest, viewsPageTest);
+export const test = mergeTests(
+	actionsPageTest,
+	dataSetsPageTest,
+	loginTest,
+	viewsPageTest
+);
 
-test('Create a Creation Action', async ({actionsPage, dataSetsPage, page, viewsPage}) => {
-    await dataSetsPage.goto();
-    await dataSetsPage.createSampleDataSetUI();
+test('Create a Creation Action', async ({
+	actionsPage,
+	dataSetsPage,
+	page,
+	viewsPage,
+}) => {
+	await dataSetsPage.goto();
+	await dataSetsPage.createSampleDataSetUI();
 
-    await viewsPage.goto();
-    await viewsPage.createSampleDataSetViewUI();
+	await viewsPage.goto();
+	await viewsPage.createSampleDataSetViewUI();
 
 	await actionsPage.goto();
 	await actionsPage.createCreationAction({

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/actionsPageTest.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/actionsPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ActionsPage} from '../pages/ActionsPage';
+
+const actionsPageTest = test.extend<{
+	actionsPage: ActionsPage;
+}>({
+	actionsPage: async ({page}, use) => {
+		await use(new ActionsPage(page));
+	},
+});
+
+export {actionsPageTest};

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -12,7 +12,7 @@ export class ActionsPage {
 	readonly creationActionsTab: Locator;
 	readonly itemActionsTab: Locator;
 	readonly newActionButton: Locator;
-	readonly newCreationActionForm: {
+	readonly newActionForm: {
 		addIconButton: Locator;
 		nameInput: Locator;
 		saveButton: Locator;
@@ -32,7 +32,7 @@ export class ActionsPage {
 		});
 		this.itemActionsTab = page.getByRole('tab', {name: 'Item Actions'});
 		this.newActionButton = page.getByRole('button', {name: 'Add Action'});
-		this.newCreationActionForm = {
+		this.newActionForm = {
 			addIconButton: page.getByLabel('add-icon'),
 			nameInput: page.getByPlaceholder('Action Name'),
 			saveButton: page.getByRole('button', {name: 'Save'}),
@@ -69,15 +69,15 @@ export class ActionsPage {
 
 		await this.newActionButton.click();
 
-		await this.newCreationActionForm.nameInput.fill(name);
-		await this.newCreationActionForm.addIconButton.click();
+		await this.newActionForm.nameInput.fill(name);
+		await this.newActionForm.addIconButton.click();
 
-		await this.newCreationActionForm.selectIconModal.searchInput.fill(icon);
-		await this.newCreationActionForm.selectIconModal.iconsList
+		await this.newActionForm.selectIconModal.searchInput.fill(icon);
+		await this.newActionForm.selectIconModal.iconsList
 			.filter({hasText: icon})
 			.click();
 
-		await this.newCreationActionForm.typeSelect.selectOption(type);
+		await this.newActionForm.typeSelect.selectOption(type);
 
 		if (type === 'modal' || type === 'sidePanel') {
 			await this.page.getByPlaceholder('add-here-the-title').click();
@@ -86,8 +86,8 @@ export class ActionsPage {
 				.fill(`${name} Title`);
 		}
 
-		await this.newCreationActionForm.urlText.fill(url);
-		await this.newCreationActionForm.saveButton.click();
+		await this.newActionForm.urlText.fill(url);
+		await this.newActionForm.saveButton.click();
 	}
 
 	async createItemAction({
@@ -105,15 +105,15 @@ export class ActionsPage {
 
 		await this.newActionButton.click();
 
-		await this.newCreationActionForm.nameInput.fill(name);
-		await this.newCreationActionForm.addIconButton.click();
+		await this.newActionForm.nameInput.fill(name);
+		await this.newActionForm.addIconButton.click();
 
-		await this.newCreationActionForm.selectIconModal.searchInput.fill(icon);
-		await this.newCreationActionForm.selectIconModal.iconsList
+		await this.newActionForm.selectIconModal.searchInput.fill(icon);
+		await this.newActionForm.selectIconModal.iconsList
 			.filter({hasText: icon})
 			.click();
 
-		await this.newCreationActionForm.typeSelect.selectOption(type);
+		await this.newActionForm.typeSelect.selectOption(type);
 
 		if (type === 'modal' || type === 'sidePanel') {
 			await this.page.getByPlaceholder('add-here-the-title').click();
@@ -122,7 +122,7 @@ export class ActionsPage {
 				.fill(`${name} Title`);
 		}
 
-		await this.newCreationActionForm.urlText.fill(url);
-		await this.newCreationActionForm.saveButton.click();
+		await this.newActionForm.urlText.fill(url);
+		await this.newActionForm.saveButton.click();
 	}
 }

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {CreationActionTypes, ItemActionTypes} from '../utils/types';
+import {ViewsPage} from './ViewsPage';
+
+export class ActionsPage {
+	readonly creationActionsTab: Locator;
+	readonly itemActionsTab: Locator;
+	readonly newActionButton: Locator;
+	readonly newCreationActionForm: {
+		addIconButton: Locator;
+		nameInput: Locator;
+		saveButton: Locator;
+		selectIconModal: {
+			iconsList: Locator;
+			searchInput: Locator;
+		};
+		typeSelect: Locator;
+		urlText: Locator;
+	};
+	readonly page: Page;
+	readonly viewsPage: ViewsPage;
+
+	constructor(page: Page) {
+		this.creationActionsTab = page.getByRole('tab', {
+			name: 'Creation Actions',
+		});
+		this.itemActionsTab = page.getByRole('tab', {name: 'Item Actions'});
+		this.newActionButton = page.getByRole('button', {name: 'Add Action'});
+		this.newCreationActionForm = {
+			addIconButton: page.getByLabel('add-icon'),
+			nameInput: page.getByPlaceholder('Action Name'),
+			saveButton: page.getByRole('button', {name: 'Save'}),
+			selectIconModal: {
+				iconsList: page.locator('li'),
+				searchInput: page.getByPlaceholder('Search'),
+			},
+			typeSelect: page.getByLabel('TypeRequired', {exact: true}),
+			urlText: page.getByPlaceholder('Add a URL here.'),
+		};
+		this.page = page;
+		this.viewsPage = new ViewsPage(page);
+	}
+
+	async goto() {
+		await this.viewsPage.goto();
+		await this.viewsPage.gotoSampleDataSetView();
+
+		this.page.getByRole('button', {name: 'Actions'}).first().click();
+	}
+
+	async createCreationAction({
+		icon,
+		name,
+		type,
+		url,
+	}: {
+		icon: string;
+		name: string;
+		type: CreationActionTypes;
+		url: string;
+	}) {
+		await this.creationActionsTab.click();
+
+		await this.newActionButton.click();
+
+		await this.newCreationActionForm.nameInput.fill(name);
+		await this.newCreationActionForm.addIconButton.click();
+
+		await this.newCreationActionForm.selectIconModal.searchInput.fill(icon);
+		await this.newCreationActionForm.selectIconModal.iconsList
+			.filter({hasText: icon})
+			.click();
+
+		await this.newCreationActionForm.typeSelect.selectOption(type);
+
+		if (type === 'modal' || type === 'sidePanel') {
+			await this.page.getByPlaceholder('add-here-the-title').click();
+			await this.page
+				.getByPlaceholder('add-here-the-title')
+				.fill(`${name} Title`);
+		}
+
+		await this.newCreationActionForm.urlText.fill(url);
+		await this.newCreationActionForm.saveButton.click();
+	}
+
+	async createItemAction({
+		icon,
+		name,
+		type,
+		url,
+	}: {
+		icon: string;
+		name: string;
+		type: ItemActionTypes;
+		url: string;
+	}) {
+		await this.itemActionsTab.click();
+
+		await this.newActionButton.click();
+
+		await this.newCreationActionForm.nameInput.fill(name);
+		await this.newCreationActionForm.addIconButton.click();
+
+		await this.newCreationActionForm.selectIconModal.searchInput.fill(icon);
+		await this.newCreationActionForm.selectIconModal.iconsList
+			.filter({hasText: icon})
+			.click();
+
+		await this.newCreationActionForm.typeSelect.selectOption(type);
+
+		if (type === 'modal' || type === 'sidePanel') {
+			await this.page.getByPlaceholder('add-here-the-title').click();
+			await this.page
+				.getByPlaceholder('add-here-the-title')
+				.fill(`${name} Title`);
+		}
+
+		await this.newCreationActionForm.urlText.fill(url);
+		await this.newCreationActionForm.saveButton.click();
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+export type CreationActionTypes = 'link' | 'modal' | 'sidePanel';
+export type ItemActionTypes =
+	| 'async'
+	| 'headless'
+	| 'link'
+	| 'modal'
+	| 'sidePanel';


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-15852

The goal of the PR is to provide a page object model representing the Actions tab for the DSM. That allows to navigate to this tab, having both a Data Set and a View previously created.

There is also a test for Creation Actions creation.

For the moment, the responsibility of creating previous required data (a Data Set with a View) belongs to the test itself, done by UI, since there's no consensus yet within the team about how and where that thing should be placed.