### PR TITLE
LPS-205549 Ensure escapedHREF is not evaluated in a JS context

### DIFF
--- a/portal-web/docroot/html/taglib/aui/button/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/button/end.jsp
@@ -47,7 +47,8 @@
 					onClick="<%= onClick %>"
 				</c:when>
 				<c:when test="<%= Validator.isNotNull(escapedHREF) %>">
-					onClick="Liferay.Util.navigate('<%= escapedHREF %>')"
+					data-href="<%= escapedHREF %>"
+					onClick="Liferay.Util.navigate(this.dataset.href)"
 				</c:when>
 			</c:choose>
 


### PR DESCRIPTION
This is a followup of https://github.com/liferay-frontend/liferay-portal/pull/3923 where:

- We fix the issue in a different way. More specifically,
  - Preserve the `escapedHREF` value as it comes
  - Avoid evaluating it directly in the JS context as part of the inline `onClick` event handler
- Fix is not applied to the [other requested cases](https://github.com/liferay-frontend/liferay-portal/pull/3923#discussion_r1453157957) because there, `escapedHREF` value comes already escaped, including the `'` character. 