### PR TITLE
LPD-17026 Apply editor config contributor client extensions to alloy editor configurations

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -294,41 +294,16 @@ name = HtmlUtil.escapeJS(name);
 
 			editorContainer.appendChild(loadingIndicator);
 
-			Liferay.Util.loadClientExtensions([
-				{
-					clientExtensionDefinitions: editorTransformerURLs.map(
-						(url) => ({
-							importDeclaration: 'default from ' + url,
-						})
-					),
-					onLoad: (bindingContexts) => {
-						var transformedConfig = editorConfig;
+			Liferay.Util.loadEditorClientExtensions({
+				config: editorConfig,
+				onLoad: ({transformedConfig}) => {
+					if (loadingIndicator) {
+						loadingIndicator.remove();
+					}
 
-						bindingContexts.forEach(
-							({binding: editorTransformer, error}) => {
-								if (error) {
-									console.error(error);
-								}
-
-								if (
-									editorTransformer &&
-									editorTransformer.editorConfigTransformer
-								) {
-									transformedConfig = editorTransformer.editorConfigTransformer(
-										transformedConfig
-									);
-								}
-							}
-						);
-
-						if (loadingIndicator) {
-							loadingIndicator.remove();
-						}
-
-						initInstance(transformedConfig);
-					},
+					initInstance(transformedConfig);
 				},
-			]);
+			});
 		}
 		else {
 			initInstance(editorConfig);

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -179,11 +179,10 @@ name = HtmlUtil.escapeJS(name);
 	};
 
 	var createInstance = function () {
+		var editorContainer = A.one('#<%= name %>Container');
 		var editorNode = A.one('#<%= name %>');
 
 		if (!editorNode) {
-			var editorContainer = A.one('#<%= name %>Container');
-
 			editorContainer.setHTML('');
 
 			editorNode = A.Node.create('<%= HtmlUtil.escapeJS(editor) %>');
@@ -193,6 +192,63 @@ name = HtmlUtil.escapeJS(name);
 
 		if (editorNode) {
 			editorNode.attr('contenteditable', true);
+		}
+
+		function initInstance(editorConfig) {
+			var plugins = [];
+
+			<c:if test="<%= showSource %>">
+				plugins.push(A.Plugin.LiferayAlloyEditorSource);
+			</c:if>
+
+			alloyEditor = new A.LiferayAlloyEditor({
+				contents: '<%= HtmlUtil.escapeJS(contents) %>',
+				editorConfig: editorConfig,
+				editorPaths: [
+					'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_ALLOYEDITOR) %>',
+					'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR) %>',
+				],
+				namespace: '<%= name %>',
+
+				<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
+					onBlurMethod: '<%= HtmlUtil.escapeJS(namespace + onBlurMethod) %>',
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
+					onChangeMethod:
+						'<%= HtmlUtil.escapeJS(namespace + onChangeMethod) %>',
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
+					onFocusMethod:
+						'<%= HtmlUtil.escapeJS(namespace + onFocusMethod) %>',
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onInitMethod) %>">
+					onInitMethod: '<%= HtmlUtil.escapeJS(namespace + onInitMethod) %>',
+				</c:if>
+
+				plugins: plugins,
+				portletId: '<%= portletId %>',
+				textMode: <%= (editorOptions != null) ? editorOptions.isTextMode() : Boolean.FALSE.toString() %>,
+
+				useCustomDataProcessor: <%= (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor")) %>,
+			}).render();
+
+			CKEDITOR.dom.selection.prototype.selectElement = function (element) {
+				this.isLocked = 0;
+
+				var range = new CKEDITOR.dom.range(this.root);
+
+				range.setEndAfter(element);
+				range.setStartBefore(element);
+
+				this.selectRanges([range]);
+			};
+
+			<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.alloyeditor.web#" + editorName + "#onEditorCreate" %>' />
+
+			Liferay.namespace('EDITORS').alloyEditor.addInstance();
 		}
 
 		var editorConfig = <%= Validator.isNotNull(editorConfigJSONObject) %>
@@ -228,58 +284,55 @@ name = HtmlUtil.escapeJS(name);
 			editorConfig
 		);
 
-		var plugins = [];
+		var editorTransformerURLs = editorConfig.editorTransformerURLs;
 
-		<c:if test="<%= showSource %>">
-			plugins.push(A.Plugin.LiferayAlloyEditorSource);
-		</c:if>
+		if (Liferay.FeatureFlags['LPS-186870'] && editorTransformerURLs) {
+			var loadingIndicator = document.createElement('span');
 
-		alloyEditor = new A.LiferayAlloyEditor({
-			contents: '<%= HtmlUtil.escapeJS(contents) %>',
-			editorConfig: editorConfig,
-			editorPaths: [
-				'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_ALLOYEDITOR) %>',
-				'<%= PortalWebResourcesUtil.getContextPath(PortalWebResourceConstants.RESOURCE_TYPE_EDITOR_CKEDITOR) %>',
-			],
-			namespace: '<%= name %>',
+			loadingIndicator.classList.add('loading-animation');
+			loadingIndicator.setAttribute('aria-hidden', true);
 
-			<c:if test="<%= Validator.isNotNull(onBlurMethod) %>">
-				onBlurMethod: '<%= HtmlUtil.escapeJS(namespace + onBlurMethod) %>',
-			</c:if>
+			editorContainer.appendChild(loadingIndicator);
 
-			<c:if test="<%= Validator.isNotNull(onChangeMethod) %>">
-				onChangeMethod: '<%= HtmlUtil.escapeJS(namespace + onChangeMethod) %>',
-			</c:if>
+			Liferay.Util.loadClientExtensions([
+				{
+					clientExtensionDefinitions: editorTransformerURLs.map(
+						(url) => ({
+							importDeclaration: 'default from ' + url,
+						})
+					),
+					onLoad: (bindingContexts) => {
+						var transformedConfig = editorConfig;
 
-			<c:if test="<%= Validator.isNotNull(onFocusMethod) %>">
-				onFocusMethod: '<%= HtmlUtil.escapeJS(namespace + onFocusMethod) %>',
-			</c:if>
+						bindingContexts.forEach(
+							({binding: editorTransformer, error}) => {
+								if (error) {
+									console.error(error);
+								}
 
-			<c:if test="<%= Validator.isNotNull(onInitMethod) %>">
-				onInitMethod: '<%= HtmlUtil.escapeJS(namespace + onInitMethod) %>',
-			</c:if>
+								if (
+									editorTransformer &&
+									editorTransformer.editorConfigTransformer
+								) {
+									transformedConfig = editorTransformer.editorConfigTransformer(
+										transformedConfig
+									);
+								}
+							}
+						);
 
-			plugins: plugins,
-			portletId: '<%= portletId %>',
-			textMode: <%= (editorOptions != null) ? editorOptions.isTextMode() : Boolean.FALSE.toString() %>,
+						if (loadingIndicator) {
+							loadingIndicator.remove();
+						}
 
-			useCustomDataProcessor: <%= (editorOptionsDynamicAttributes != null) && GetterUtil.getBoolean(editorOptionsDynamicAttributes.get("useCustomDataProcessor")) %>,
-		}).render();
-
-		CKEDITOR.dom.selection.prototype.selectElement = function (element) {
-			this.isLocked = 0;
-
-			var range = new CKEDITOR.dom.range(this.root);
-
-			range.setEndAfter(element);
-			range.setStartBefore(element);
-
-			this.selectRanges([range]);
-		};
-
-		<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.alloyeditor.web#" + editorName + "#onEditorCreate" %>' />
-
-		Liferay.namespace('EDITORS').alloyEditor.addInstance();
+						initInstance(transformedConfig);
+					},
+				},
+			]);
+		}
+		else {
+			initInstance(editorConfig);
+		}
 	};
 
 	var ignoreClass = ['ddm-options-target'];

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -738,41 +738,16 @@ name = HtmlUtil.escapeJS(name);
 
 			editorContainer.appendChild(loadingIndicator);
 
-			Liferay.Util.loadClientExtensions([
-				{
-					clientExtensionDefinitions: editorTransformerURLs.map(
-						(url) => ({
-							importDeclaration: 'default from ' + url,
-						})
-					),
-					onLoad: (bindingContexts) => {
-						var transformedConfig = config;
+			Liferay.Util.loadEditorClientExtensions({
+				config: config,
+				onLoad: ({transformedConfig}) => {
+					if (loadingIndicator) {
+						loadingIndicator.remove();
+					}
 
-						bindingContexts.forEach(
-							({binding: editorTransformer, error}) => {
-								if (error) {
-									console.error(error);
-								}
-
-								if (
-									editorTransformer &&
-									editorTransformer.editorConfigTransformer
-								) {
-									transformedConfig = editorTransformer.editorConfigTransformer(
-										transformedConfig
-									);
-								}
-							}
-						);
-
-						if (loadingIndicator) {
-							loadingIndicator.remove();
-						}
-
-						initEditor(transformedConfig);
-					},
+					initEditor(transformedConfig);
 				},
-			]);
+			});
 		}
 		else {
 			initEditor(config);

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/BaseEditor.js
@@ -6,7 +6,7 @@
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {flipThirdPartyCookiesOff} from '@liferay/cookies-banner-web';
 import CKEditor from 'ckeditor4-react';
-import {loadClientExtensions} from 'frontend-js-web';
+import {loadEditorClientExtensions} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {
 	forwardRef,
@@ -71,42 +71,14 @@ const BaseEditor = forwardRef(
 
 			setLoading(true);
 
-			loadClientExtensions([
-				{
-					clientExtensionDefinitions: initialConfig.editorTransformerURLs.map(
-						(url) => ({
-							importDeclaration: `default from ${url}`,
-						})
-					),
-					onLoad: (bindingContexts) => {
-						let transformedConfig = initialConfig;
+			loadEditorClientExtensions({
+				config: initialConfig,
+				onLoad: ({transformedConfig}) => {
+					setConfig(transformedConfig);
 
-						bindingContexts.forEach(
-							({binding: editorTransformer, error}) => {
-								if (
-									process.env.NODE_ENV === 'development' &&
-									error
-								) {
-									console.error(error);
-								}
-
-								const editorConfigTransformer =
-									editorTransformer?.editorConfigTransformer;
-
-								if (editorConfigTransformer) {
-									transformedConfig = editorConfigTransformer(
-										transformedConfig
-									);
-								}
-							}
-						);
-
-						setConfig(transformedConfig);
-
-						setLoading(false);
-					},
+					setLoading(false);
 				},
-			]);
+			});
 		}, [initialConfig]);
 
 		const getHTML = useCallback(() => {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts
@@ -898,4 +898,5 @@ export function isReducedMotion(): boolean;
  * Client Extensions API
  */
 export {default as loadClientExtensions} from './utils/client_extensions/loadClientExtensions';
+export {default as loadEditorClientExtensions} from './utils/client_extensions/loadEditorClientExtensions';
 export {loadModule} from './utils/client_extensions/loadModule';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -85,6 +85,7 @@ export {default as createResourceURL} from './liferay/util/portlet_url/create_re
 // Client Extensions API
 
 export {default as loadClientExtensions} from './utils/client_extensions/loadClientExtensions';
+export {default as loadEditorClientExtensions} from './utils/client_extensions/loadEditorClientExtensions';
 export {loadModule} from './utils/client_extensions/loadModule';
 
 // Session API

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -7,6 +7,7 @@ import groupBy from 'lodash.groupby';
 import isEqual from 'lodash.isequal';
 
 import loadClientExtensions from '../utils/client_extensions/loadClientExtensions';
+import loadEditorClientExtensions from '../utils/client_extensions/loadEditorClientExtensions';
 import DynamicSelect from './DynamicSelect';
 import BREAKPOINTS from './breakpoints';
 import {
@@ -268,6 +269,7 @@ Liferay.Util.isPhone = isPhone;
 Liferay.Util.isTablet = isTablet;
 
 Liferay.Util.loadClientExtensions = loadClientExtensions;
+Liferay.Util.loadEditorClientExtensions = loadEditorClientExtensions;
 Liferay.Util.navigate = navigate;
 Liferay.Util.ns = ns;
 Liferay.Util.objectToFormData = objectToFormData;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/client_extensions/loadClientExtensions.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/client_extensions/loadClientExtensions.ts
@@ -6,7 +6,7 @@
 import {loadModule} from './loadModule';
 
 interface ClientExtensionDefinition<T> {
-	context: T;
+	context?: T;
 	importDeclaration: string;
 }
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/client_extensions/loadEditorClientExtensions.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/client_extensions/loadEditorClientExtensions.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import loadClientExtensions from './loadClientExtensions';
+
+interface IConfig {
+	editorTransformerURLs: Array<string>;
+}
+
+export default function loadEditorClientExtensions({
+	config,
+	onLoad,
+}: {
+	config: IConfig;
+	onLoad: ({transformedConfig}: {transformedConfig: IConfig}) => void;
+}) {
+	loadClientExtensions([
+		{
+			clientExtensionDefinitions: config.editorTransformerURLs.map(
+				(url) => ({
+					importDeclaration: `default from ${url}`,
+				})
+			),
+			onLoad: (bindingContexts) => {
+				let transformedConfig = config;
+
+				bindingContexts.forEach(
+					({binding: editorTransformer, error}) => {
+						if (process.env.NODE_ENV === 'development' && error) {
+							console.error(error);
+						}
+
+						const editorConfigTransformer =
+							editorTransformer?.editorConfigTransformer;
+
+						if (editorConfigTransformer) {
+							transformedConfig = editorConfigTransformer(
+								transformedConfig
+							);
+						}
+					}
+				);
+
+				onLoad({transformedConfig});
+			},
+		},
+	]);
+}

--- a/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/utils/client_extensions/loadClientExtensions.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/utils/client_extensions/loadClientExtensions.d.ts
@@ -4,7 +4,7 @@
  */
 
 interface ClientExtensionDefinition<T> {
-	context: T;
+	context?: T;
 	importDeclaration: string;
 }
 interface ClientExtensionDefinitionsHandlerItem<T> {

--- a/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/utils/client_extensions/loadEditorClientExtensions.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/types/src/main/resources/META-INF/resources/utils/client_extensions/loadEditorClientExtensions.d.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+interface IConfig {
+	editorTransformerURLs: Array<string>;
+}
+export default function loadEditorClientExtensions({
+	config,
+	onLoad,
+}: {
+	config: IConfig;
+	onLoad: ({transformedConfig}: {transformedConfig: IConfig}) => void;
+}): void;
+export {};

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/client-extension.yaml
@@ -3,6 +3,7 @@ assemble:
       into: static
 liferay-sample-editor-config-contributor:
     editorConfigKeys:
+        - contentEditor
         - description
         - sampleClassicEditor
         - sampleLegacyEditor

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/src/index.ts
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/src/index.ts
@@ -9,6 +9,33 @@ import {
 } from '@liferay/js-api/editor';
 
 const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
+
+	// Alloy Editor
+
+	const toolbars: any = config.toolbars;
+
+	if (typeof toolbars === 'object') {
+		interface ISelection {
+			buttons: Array<string>;
+			name: string;
+		}
+
+		const textSelection: ISelection = toolbars.styles?.selections?.find(
+			(selection: ISelection) => selection.name === 'text'
+		);
+
+		if (textSelection.buttons) {
+			textSelection.buttons.push('video');
+
+			return {
+				...config,
+				toolbars,
+			};
+		}
+	}
+
+	// CKEditor
+
 	const toolbar: string | [string[]] = config.toolbar;
 
 	const buttonName = 'AICreator';
@@ -24,7 +51,7 @@ const editorConfigTransformer: EditorConfigTransformer<any> = (config) => {
 			[`toolbar_${toolbar}`]: activeToolbar,
 		};
 	}
-	else {
+	else if (Array.isArray(toolbar)) {
 		toolbar.push([buttonName]);
 
 		transformedConfig = {


### PR DESCRIPTION
### References

- Parent story: [LPD-6597 Apply editor config contributor client extensions to alloy editor configurations](https://issues.liferay.com/browse/LPD-6597)

### What is the goal of this PR?

We are implementing support for editor config contributor client extension in Alloy Editor. We are extending CX workspace sample to cover AE config format and applying it to Blogs content.

What is notably **not** in this PR are functional tests. This is blocked until automated CX deployment is available. [Related PR](https://github.com/liferay-frontend/liferay-portal/pull/3959).

### What does it look like?

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/55286254-8d6d-4624-99a6-9544587ec222)
