### PR TITLE
LPD-17128 Adapt ThemeCSS CX build process to account for caching

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
@@ -1,8 +1,8 @@
 assemble:
-    - from: build/buildTheme/img
-      into: static/img
+    - from: build/buildTheme/css/assets
+      into: static/assets
 liferay-sample-theme-css-1:
-    clayURL: css/clay.css
-    mainURL: css/main.css
+    clayURL: css/clay.*.css
+    mainURL: css/main.*.css
     name: Liferay Sample Theme CSS 1
     type: themeCSS

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
@@ -1,5 +1,5 @@
 assemble:
-    - from: build/buildTheme/css/assets
+    - from: build/buildTheme/assets
       into: static/assets
 liferay-sample-theme-css-1:
     clayURL: css/clay.*.css

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/package.json
@@ -5,7 +5,8 @@
 	"devDependencies": {
 		"webpack": "^5.4.0",
 		"webpack-cli": "^4.2.0",
-		"webpack-remove-empty-scripts": "^1.0.4"
+		"webpack-remove-empty-scripts": "^1.0.4",
+		"filemanager-webpack-plugin": "^8.0.0"
 	},
 	"liferayDesignPack": {
 		"baseTheme": "styled"

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/package.json
@@ -2,10 +2,18 @@
 	"dependencies": {
 		"sassy-inputs": "1.0.6"
 	},
+	"devDependencies": {
+		"webpack": "^5.4.0",
+		"webpack-cli": "^4.2.0",
+		"webpack-remove-empty-scripts": "^1.0.4"
+	},
 	"liferayDesignPack": {
 		"baseTheme": "styled"
 	},
 	"main": "package.json",
 	"name": "@liferay/liferay-sample-theme-css-1",
+	"scripts": {
+		"build": "webpack"
+	},
 	"version": "0.0.0"
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+module.exports = {
+	context: path.join(__dirname, '/build/buildTheme/css/'),
+	entry: {
+		main: './main.css',
+		clay: './clay.css',
+	},
+	mode: 'production',
+	module: {
+		rules: [
+			{
+				test: /\.css$/i,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader,
+					},
+					{
+						loader: "css-loader",
+						options: {
+							url: {
+								filter: (url, resourcePath) => {
+									if (url.startsWith("data:image") || url.includes("@theme_image_path@")) {
+										return false;
+									}
+
+									console.log("  url " + url + " → " + path.join(__dirname, "src", "css", url))
+									if (!fs.existsSync(path.join(__dirname, "src", "css", url))) {
+										return false;
+									}
+
+									return true;
+								}
+							}
+						}
+					}
+				]
+			},
+			{
+				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
+				type: "asset/resource",
+			},
+		],
+	},
+	output: {
+		clean: {
+			keep(asset) {
+				return !['main.css', 'main_rtl.css', 'clay.css', 'clay_rtl.css'].some((file) => asset.includes(file));
+			},
+			//dry: true, // Log the assets that should be removed instead of deleting them.
+		},
+		assetModuleFilename: 'assets/[name].[contenthash][ext]',
+		path: path.resolve(__dirname, 'build/buildTheme/css/')
+		//path: path.resolve(__dirname, 'build/liferay-client-extension-build/static2')
+	},
+	plugins: [
+		new RemoveEmptyScriptsPlugin(),
+		new MiniCssExtractPlugin({
+			filename: "[name].[contenthash].css"
+		})
+	]
+};
+

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
@@ -33,7 +33,10 @@ module.exports = {
 						options: {
 							url: {
 								filter: (url, resourcePath) => {
-									if (url.startsWith("data:image") || url.includes("@theme_image_path@")) {
+									"@base_url@", "@portal_ctx@", "@theme_image_path@", ""
+
+
+									if (url.startsWith("data:image") || url.includes("@theme_image_path@")) { 
 										return false;
 									}
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
@@ -1,13 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const FileManagerPlugin = require('filemanager-webpack-plugin');
 const fs = require('fs');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+const buildThemeDir = path.join(__dirname, '/build/buildTheme/');
+const sourceCSSDir = path.join(__dirname, "src", "css");
+
 
 module.exports = {
 	context: path.join(__dirname, '/build/buildTheme/css/'),
 	entry: {
-		main: './main.css',
 		clay: './clay.css',
+		main: './main.css'
 	},
 	mode: 'production',
 	module: {
@@ -27,8 +37,7 @@ module.exports = {
 										return false;
 									}
 
-									console.log("  url " + url + " → " + path.join(__dirname, "src", "css", url))
-									if (!fs.existsSync(path.join(__dirname, "src", "css", url))) {
+									if (!fs.existsSync(path.join(sourceCSSDir, url))) {
 										return false;
 									}
 
@@ -40,23 +49,32 @@ module.exports = {
 				]
 			},
 			{
+				generator: {
+					filename: 'assets/[name].[contenthash][ext]'
+				},
 				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
 				type: "asset/resource",
 			},
 		],
 	},
 	output: {
+		//assetModuleFilename: '../assets/[name].[contenthash][ext]',
 		clean: {
 			keep(asset) {
 				return !['main.css', 'main_rtl.css', 'clay.css', 'clay_rtl.css'].some((file) => asset.includes(file));
-			},
-			//dry: true, // Log the assets that should be removed instead of deleting them.
+			}
 		},
-		assetModuleFilename: 'assets/[name].[contenthash][ext]',
-		path: path.resolve(__dirname, 'build/buildTheme/css/')
-		//path: path.resolve(__dirname, 'build/liferay-client-extension-build/static2')
+		path: buildThemeDir
+		//path: path.resolve(__dirname, 'build/buildTheme/css/')
 	},
 	plugins: [
+		new FileManagerPlugin({
+			events: {
+				onStart: {
+					delete: [path.resolve(__dirname, 'build/buildTheme/assets'), path.resolve(__dirname, 'build/buildTheme/css/') + '/main.?*.css', path.resolve(__dirname, 'build/buildTheme/css/') + '/clay.?*.css',  ],
+				}
+			},
+		}),
 		new RemoveEmptyScriptsPlugin(),
 		new MiniCssExtractPlugin({
 			filename: "[name].[contenthash].css"

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
@@ -4,22 +4,28 @@
  */
 
 const FileManagerPlugin = require('filemanager-webpack-plugin');
-const fs = require('fs');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const path = require('path');
 const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
 
-const buildThemeDir = path.join(__dirname, '/build/buildTheme/');
-const sourceCSSDir = path.join(__dirname, "src", "css");
+const fs = require('fs');
+const path = require('path');
 
+const buildDir = path.join(__dirname, 'build', 'buildTheme');
+const buildAssetsDir = path.join(buildDir, 'assets');
+const buildCSSDir = path.join(buildDir, 'css');
+
+const sourceCSSDir = path.join(__dirname, 'src', 'css');
+const urlTokens = ['@base_url@', '@portal_ctx@', '@theme_image_path@']
+
+const DEVELOPMENT = process.env.NODE_ENV === 'development';
 
 module.exports = {
-	context: path.join(__dirname, '/build/buildTheme/css/'),
+	context: buildCSSDir,
 	entry: {
 		clay: './clay.css',
 		main: './main.css'
 	},
-	mode: 'production',
+	mode: DEVELOPMENT ? 'development' : 'production',
 	module: {
 		rules: [
 			{
@@ -33,10 +39,8 @@ module.exports = {
 						options: {
 							url: {
 								filter: (url, resourcePath) => {
-									"@base_url@", "@portal_ctx@", "@theme_image_path@", ""
 
-
-									if (url.startsWith("data:image") || url.includes("@theme_image_path@")) { 
+									if (url.startsWith("data:image") || urlTokens.some((str) => url.includes(str))) {
 										return false;
 									}
 
@@ -61,24 +65,33 @@ module.exports = {
 		],
 	},
 	output: {
-		//assetModuleFilename: '../assets/[name].[contenthash][ext]',
-		clean: {
-			keep(asset) {
-				return !['main.css', 'main_rtl.css', 'clay.css', 'clay_rtl.css'].some((file) => asset.includes(file));
-			}
-		},
-		path: buildThemeDir
-		//path: path.resolve(__dirname, 'build/buildTheme/css/')
+		//clean: {
+			//keep: '*.scss'
+
+			//	keep(asset) {
+//		return !['main.css', 'main_rtl.css', 'clay.css', 'clay_rtl.css'].some((file) => asset.includes(file));
+//	}
+		//},
+		path: buildCSSDir
 	},
 	plugins: [
-		new FileManagerPlugin({
-			events: {
-				onStart: {
-					delete: [path.resolve(__dirname, 'build/buildTheme/assets'), path.resolve(__dirname, 'build/buildTheme/css/') + '/main.?*.css', path.resolve(__dirname, 'build/buildTheme/css/') + '/clay.?*.css',  ],
-				}
-			},
-		}),
-		new RemoveEmptyScriptsPlugin(),
+		// new FileManagerPlugin({
+		// 	events: {
+		// 		onStart: {
+		// 			delete: [
+		// 				buildAssetsDir,
+		// 				path.join(buildCSSDir, 'main.?*.css'),
+		// 				path.join(buildCSSDir, 'clay.?*.css'),
+		// 			],
+		// 		},
+		// 		onEnd: {
+		// 			delete: [
+		// 				path.join(buildCSSDir, 'main.js'),
+		// 				path.join(buildCSSDir, 'clay.js')
+		// 			],
+		// 		}
+		// 	},
+		// }),
 		new MiniCssExtractPlugin({
 			filename: "[name].[contenthash].css"
 		})


### PR DESCRIPTION
This WIP shows how `buildCSS` task outputs resulting from building a ThemeCSS client extension can be further processed  to facilitate a caching-forever strategy. Proposal uses webpack 5 for this purpose.

Essentially:
* After `buildCSS` task finishes, webpack takes the css assets `main.css`, `clay.css` (I left RTL variants out for now)
* For each, processes the `url()`, skipping those not referring to assets in this same project, that is, skips inherited resources from theme as well as template URLs
* There should be no `@imports` there unless added by custom css not handled by scss. As this is unlikely, I've skipped import processing
* Outputs processed assets and css
* Tells CX assembler to add them to the final package

pls @izaera take a deep look at this, it's just a wip