### PR TITLE
LPD-17674 Functional Automation - Show mapped hierarchical object fields in fragment

### DIFF
--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -109,10 +109,6 @@ export class ApplicationsMenuPage {
 		await this.apiBuilderMenuItem.click();
 	}
 
-	async goToHome() {
-		await this.homePage.goto();
-	}
-
 	async goToObjects() {
 		await this.goToControlPanel();
 		await this.objectsMenuItem.click();

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -109,6 +109,10 @@ export class ApplicationsMenuPage {
 		await this.apiBuilderMenuItem.click();
 	}
 
+	async goToHome() {
+		await this.homePage.goto();
+	}
+
 	async goToObjects() {
 		await this.goToControlPanel();
 		await this.objectsMenuItem.click();

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
@@ -6,14 +6,23 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
+import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 import {fieldsPageTest} from './fixtures/fieldsPageTest';
 import {viewsPageTest} from './fixtures/viewsPageTest';
 
 export const test = mergeTests(
 	applicationsMenuPageTest,
 	dataSetsPageTest,
+	fdsFragmentPageTest,
+	featureFlagsTest({
+		'LPS-164563': true,
+		'LPS-178052': true,
+		'LPS-186871': true,
+		'LPS-194395': true,
+	}),
 	fieldsPageTest,
 	loginTest,
 	viewsPageTest
@@ -28,12 +37,17 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 	}) => {
 		await test.step('Create sample DataSet', async () => {
 			await dataSetsPage.goto();
-			await dataSetsPage.createSampleDataSetUI();
+			await dataSetsPage.createDataSet({
+				name: 'Data Set Sample',
+				restApplication: '/headless-delivery/v1.0',
+				restEndpoint: '/v1.0/sites/{siteId}/site-pages',
+				restSchema: 'SitePage',
+			});
 		});
 
 		await test.step('Create sample DataSet View', async () => {
 			await viewsPage.goto();
-			await viewsPage.createSampleDataSetViewUI();
+			await viewsPage.createDataSetView();
 		});
 
 		await test.step('Open modal to add fields', async () => {
@@ -42,11 +56,11 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 		});
 
 		await test.step('Check fields in treeview', async () => {
-			await fieldsPage.addParentField('dateCreated');
-			await fieldsPage.addParentField('title');
-			await fieldsPage.addParentField('creator');
-			await fieldsPage.addChildField('creator', 'name');
-			await fieldsPage.addChildField('creator', 'id');
+			await fieldsPage.addRootField('dateCreated');
+			await fieldsPage.addRootField('title');
+			await fieldsPage.addRootField('creator');
+			await fieldsPage.addChildField(['creator'], 'name');
+			await fieldsPage.addChildField(['creator'], 'id');
 		});
 
 		await test.step('Save changes', async () => {
@@ -62,32 +76,37 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 		});
 	});
 
-	test('Add DataSet fragment', async ({applicationsMenuPage, page}) => {
-		await test.step('Go to Home', async () => {
-			await applicationsMenuPage.goToHome();
-		});
+	test('Show Creation Action in fragment', async ({
+		fdsFragmentPage,
+		page,
+	}) => {
+		await fdsFragmentPage.goto();
 
-		await test.step('Click on "Edit" button', async () => {
-			const editPageButton = await page.getByRole('link', {
-				name: 'Edit',
-			});
-			await editPageButton.click();
+		const site = await fdsFragmentPage
+			.createSite('FDSFragment')
+			.then((response) => response);
+
+		const layout = await fdsFragmentPage
+			.createPage({
+				siteId: site.id,
+				title: 'fdsfragmentpagetest',
+			})
+			.then((response) => response);
+
+		await page.reload();
+
+		await test.step('Edit page', async () => {
+			await fdsFragmentPage.editPage({layout, site});
 		});
 
 		await test.step('Search for "Data Set" fragment', async () => {
-			const fragmentSearchInput = await page.getByLabel(
-				'Search Fragments and Widgets'
-			);
-			fragmentSearchInput.fill('Data Set');
+			await fdsFragmentPage.searchFragmentOrWidget('Data Set');
 		});
 
 		await test.step('Drag "Data Set" fragment & Drop into the page editor w/ keyboard', async () => {
-			const source = await page.getByRole('menuitem', {
-				name: 'Data Set Add Data Set Mark Data Set as Favorite',
-			});
-			await source.focus();
-			await source.press('Enter');
-			await source.press('Enter');
+			await fdsFragmentPage.dragAndDropFragment(
+				'Data Set Add Data Set Mark Data Set as Favorite'
+			);
 		});
 
 		await test.step('Select empty Data Set fragment', async () => {
@@ -101,12 +120,19 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 			await page
 				.getByRole('button', {name: 'Select Data Set View'})
 				.click();
-			await page
-				.getByRole('menuitem', {name: 'Select Data Set View...'})
-				.click();
 		});
 
 		await test.step('Select Data Set View', async () => {
+			if (
+				await page
+					.getByRole('menuitem', {name: 'Select Data Set View...'})
+					.isVisible()
+			) {
+				await page
+					.getByRole('menuitem', {name: 'Select Data Set View...'})
+					.click();
+			}
+
 			await expect(page.getByRole('dialog')).toBeVisible();
 			await expect(
 				page.getByRole('heading', {name: 'Select'})
@@ -124,31 +150,30 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 		});
 
 		await test.step('Publish page with Data Set View', async () => {
-			await page.getByRole('button', {name: 'Publish'}).click();
+			await fdsFragmentPage.publishPage();
+			await fdsFragmentPage.goToPage({layout, site});
 
-			await applicationsMenuPage.goToHome();
-
-			await expect(
-				page.locator('.data-set-wrapper').first()
-			).toBeVisible();
+			await page.locator('.data-set-wrapper').waitFor();
 		});
 
 		await test.step('Fields are present in fragment table heading', async () => {
 			await expect(
-				page.getByRole('button', {name: 'creator.*'})
+				page.getByRole('button', {name: 'creator.*'}).first()
 			).toBeVisible();
 			await expect(
-				page.getByRole('button', {name: 'creator.id'})
+				page.getByRole('button', {name: 'creator.id'}).first()
 			).toBeVisible();
 			await expect(
-				page.getByRole('button', {name: 'creator.name'})
+				page.getByRole('button', {name: 'creator.name'}).first()
 			).toBeVisible();
 			await expect(
-				page.getByRole('button', {name: 'dateCreated'})
+				page.getByRole('button', {name: 'dateCreated'}).first()
 			).toBeVisible();
 			await expect(
-				page.getByRole('button', {name: 'title'})
+				page.getByRole('button', {name: 'title'}).first()
 			).toBeVisible();
 		});
+
+		await fdsFragmentPage.deleteSite(site.id);
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
+import {fieldsPageTest} from './fixtures/fieldsPageTest';
+import {viewsPageTest} from './fixtures/viewsPageTest';
+
+export const test = mergeTests(
+	applicationsMenuPageTest,
+	dataSetsPageTest,
+	fieldsPageTest,
+	loginTest,
+	viewsPageTest
+);
+
+test.describe('Add fields to a view and show them in a fragment', () => {
+	test('Add fields to a view', async ({
+		dataSetsPage,
+		fieldsPage,
+		page,
+		viewsPage,
+	}) => {
+		await test.step('Create sample DataSet', async () => {
+			await dataSetsPage.goto();
+			await dataSetsPage.createSampleDataSetUI();
+		});
+
+		await test.step('Create sample DataSet View', async () => {
+			await viewsPage.goto();
+			await viewsPage.createSampleDataSetViewUI();
+		});
+
+		await test.step('Open modal to add fields', async () => {
+			await fieldsPage.goto();
+			await fieldsPage.openAddFieldsModal();
+		});
+
+		await test.step('Check fields in treeview', async () => {
+			await fieldsPage.addParentField('dateCreated');
+			await fieldsPage.addParentField('title');
+			await fieldsPage.addParentField('creator');
+			await fieldsPage.addChildField('creator', 'name');
+			await fieldsPage.addChildField('creator', 'id');
+		});
+
+		await test.step('Save changes', async () => {
+			await fieldsPage.saveAddFieldsModal();
+		});
+
+		await test.step('Fields are present in table', async () => {
+			await expect(page.getByText('dateCreated').first()).toBeVisible();
+			await expect(page.getByText('title').first()).toBeVisible();
+			await expect(page.getByText('creator.*').first()).toBeVisible();
+			await expect(page.getByText('creator.id').first()).toBeVisible();
+			await expect(page.getByText('creator.name').first()).toBeVisible();
+		});
+	});
+
+	test('Add DataSet fragment', async ({applicationsMenuPage, page}) => {
+		await test.step('Go to Home', async () => {
+			await applicationsMenuPage.goToHome();
+		});
+
+		await test.step('Click on "Edit" button', async () => {
+			const editPageButton = await page.getByRole('link', {
+				name: 'Edit',
+			});
+			await editPageButton.click();
+		});
+
+		await test.step('Search for "Data Set" fragment', async () => {
+			const fragmentSearchInput = await page.getByLabel(
+				'Search Fragments and Widgets'
+			);
+			fragmentSearchInput.fill('Data Set');
+		});
+
+		await test.step('Drag "Data Set" fragment & Drop into the page editor w/ keyboard', async () => {
+			const source = await page.getByRole('menuitem', {
+				name: 'Data Set Add Data Set Mark Data Set as Favorite',
+			});
+			await source.focus();
+			await source.press('Enter');
+			await source.press('Enter');
+		});
+
+		await test.step('Select empty Data Set fragment', async () => {
+			await page
+				.getByText('Select a data set view. Beta')
+				.first()
+				.click();
+		});
+
+		await test.step('Open Data Set View Selector', async () => {
+			await page
+				.getByRole('button', {name: 'Select Data Set View'})
+				.click();
+			await page
+				.getByRole('menuitem', {name: 'Select Data Set View...'})
+				.click();
+		});
+
+		await test.step('Select Data Set View', async () => {
+			await expect(page.getByRole('dialog')).toBeVisible();
+			await expect(
+				page.getByRole('heading', {name: 'Select'})
+			).toBeVisible();
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.locator('li')
+				.filter({hasText: 'Data Set View Sample'})
+				.first()
+				.click();
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.getByRole('button', {name: 'Save'})
+				.click();
+		});
+
+		await test.step('Publish page with Data Set View', async () => {
+			await page.getByRole('button', {name: 'Publish'}).click();
+
+			await applicationsMenuPage.goToHome();
+
+			await expect(
+				page.locator('.data-set-wrapper').first()
+			).toBeVisible();
+		});
+
+		await test.step('Fields are present in fragment table heading', async () => {
+			await expect(
+				page.getByRole('button', {name: 'creator.*'})
+			).toBeVisible();
+			await expect(
+				page.getByRole('button', {name: 'creator.id'})
+			).toBeVisible();
+			await expect(
+				page.getByRole('button', {name: 'creator.name'})
+			).toBeVisible();
+			await expect(
+				page.getByRole('button', {name: 'dateCreated'})
+			).toBeVisible();
+			await expect(
+				page.getByRole('button', {name: 'title'})
+			).toBeVisible();
+		});
+	});
+});

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/fdsFragmentPageTest.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/fdsFragmentPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {FDSFragmentPage} from '../pages/FDSFragmentPage';
+
+const fdsFragmentPageTest = test.extend<{
+	fdsFragmentPage: FDSFragmentPage;
+}>({
+	fdsFragmentPage: async ({page}, use) => {
+		await use(new FDSFragmentPage(page));
+	},
+});
+
+export {fdsFragmentPageTest};

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/fieldsPageTest.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/fieldsPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {FieldsPage} from '../pages/FieldsPage';
+
+const fieldsPageTest = test.extend<{
+	fieldsPage: FieldsPage;
+}>({
+	fieldsPage: async ({page}, use) => {
+		await use(new FieldsPage(page));
+	},
+});
+
+export {fieldsPageTest};

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
@@ -72,17 +72,25 @@ export class DataSetsPage {
 		await this.newDataSetModal.restApplicationOptions
 			.getByRole('option', {name: restApplication})
 			.click();
-
 		await this.newDataSetModal.restSchemaField.waitFor();
 		await this.newDataSetModal.restSchemaField.click();
-		await this.page.getByRole('textbox', {name: 'Search'}).fill('page');
+		await this.page.getByRole('textbox', {name: 'Search'}).fill(restSchema);
 		await this.newDataSetModal.restSchemaOptions.waitFor();
 		await this.newDataSetModal.restSchemaOptions
 			.getByRole('option', {name: restSchema})
 			.click();
 
-		await this.newDataSetModal.restEndpointField.waitFor();
+		await this.page
+			.locator('div')
+			.filter({hasText: /^SaveCancel$/})
+			.first()
+			.click();
+
 		await this.newDataSetModal.restEndpointField.click();
+		await this.page
+			.getByRole('textbox', {name: 'Search'})
+			.fill(restEndpoint);
+		await this.newDataSetModal.restEndpointOptions.waitFor();
 		await this.newDataSetModal.restEndpointOptions
 			.getByRole('option', {name: restEndpoint})
 			.click();

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
@@ -75,10 +75,11 @@ export class DataSetsPage {
 
 		await this.newDataSetModal.restSchemaField.waitFor();
 		await this.newDataSetModal.restSchemaField.click();
+		await this.page.getByRole('textbox', {name: 'Search'}).fill('page');
+		await this.newDataSetModal.restSchemaOptions.waitFor();
 		await this.newDataSetModal.restSchemaOptions
 			.getByRole('option', {name: restSchema})
 			.click();
-		await this.newDataSetModal.restSchemaField.click();
 
 		await this.newDataSetModal.restEndpointField.waitFor();
 		await this.newDataSetModal.restEndpointField.click();

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/FDSFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/FDSFragmentPage.ts
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
+
+export class FDSFragmentPage {
+	readonly apiHelpers: ApiHelpers;
+	readonly editPageButton: Locator;
+	readonly fragmentWidgetSearchInput: Locator;
+	readonly page: Page;
+	readonly publishPageButton: Locator;
+
+	constructor(page: Page) {
+		this.apiHelpers = new ApiHelpers(page);
+		this.page = page;
+		this.fragmentWidgetSearchInput = this.page.getByLabel(
+			'Search Fragments and Widgets'
+		);
+		this.publishPageButton = this.page.getByRole('button', {
+			name: 'Publish',
+		});
+	}
+
+	async goto() {
+		await this.page.goto('/');
+	}
+
+	async createPage({
+		siteId,
+		title,
+	}: {
+		siteId: string;
+		title: string;
+	}): Promise<Layout> {
+		const pageLayout =
+			await this.apiHelpers.headlessDelivery.createSitePage(
+				siteId,
+				title
+			);
+
+		return pageLayout;
+	}
+
+	async createSite(name: string): Promise<Site> {
+		const site = await this.apiHelpers.headlessSite.createSite(name);
+
+		return site;
+	}
+
+	async deleteSite(siteId: string) {
+		await this.apiHelpers.headlessSite.deleteSite(siteId);
+	}
+
+	async dragAndDropFragment(itemName) {
+		const source = await this.page.getByRole('menuitem', {
+			exact: true,
+			name: itemName,
+		});
+
+		await source.focus();
+		await source.press('Enter');
+		await source.press('Enter');
+	}
+
+	async editPage({layout, site}) {
+		await this.page.goto(
+			`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}?p_l_mode=edit`
+		);
+	}
+
+	async goToPage({layout, site}) {
+		await this.page.goto(
+			`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+	}
+
+	async publishPage() {
+		await this.publishPageButton.click();
+	}
+
+	async searchFragmentOrWidget(itemName: string) {
+		await this.fragmentWidgetSearchInput.fill(itemName);
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ViewsPage} from './ViewsPage';
+
+export class FieldsPage {
+	readonly addFieldsButton: Locator;
+	readonly fieldsTable: Locator;
+	readonly addFieldsDialog: {
+		cancelButton: Locator;
+		fields: Locator;
+		fieldsTreeview: Locator;
+		saveButton: Locator;
+	};
+	readonly page: Page;
+	readonly viewsPage: ViewsPage;
+
+	constructor(page: Page) {
+		this.addFieldsButton = page.getByLabel('Add Fields');
+		this.fieldsTable = page.locator('.table-responsive');
+		this.addFieldsDialog = {
+			cancelButton: page.getByRole('button', {name: 'Cancel'}),
+			fields: page.locator('.treeview-item'),
+			fieldsTreeview: page.locator('.treeview'),
+			saveButton: page.getByRole('button', {name: 'Save'}),
+		};
+		this.page = page;
+		this.viewsPage = new ViewsPage(page);
+	}
+
+	async goto() {
+		await this.viewsPage.goto();
+		await this.viewsPage.gotoSampleDataSetView();
+
+		await this.page
+			.getByRole('button', {exact: true, name: 'Fields'})
+			.click();
+	}
+
+	async openAddFieldsModal() {
+		await this.addFieldsButton.click();
+
+		await this.addFieldsDialog.fields.first().waitFor();
+	}
+
+	async saveAddFieldsModal() {
+		await this.addFieldsDialog.saveButton.click();
+	}
+
+	async addParentField(field: string) {
+		await this.addFieldsDialog.fields
+			.getByText(field, {exact: true})
+			.click();
+	}
+
+	async addChildField(parent: string, field: string) {
+		await this.page
+			.locator(`[id*="${parent}"]`)
+			.getByText(field, {exact: true})
+			.check();
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
@@ -34,7 +34,7 @@ export class FieldsPage {
 
 	async goto() {
 		await this.viewsPage.goto();
-		await this.viewsPage.gotoSampleDataSetView();
+		await this.viewsPage.gotoDataSetView();
 
 		await this.page
 			.getByRole('button', {exact: true, name: 'Fields'})
@@ -51,15 +51,33 @@ export class FieldsPage {
 		await this.addFieldsDialog.saveButton.click();
 	}
 
-	async addParentField(field: string) {
+	async addRootField(field: string) {
 		await this.addFieldsDialog.fields
 			.getByText(field, {exact: true})
 			.click();
 	}
 
-	async addChildField(parent: string, field: string) {
+	async openParentField(path: string[]) {
+		let fullPath = '';
+
+		path.forEach(async (item) => {
+			fullPath += item;
+			const expandButton = this.page.locator(
+				`button[aria-controls='${fullPath}.*']`
+			);
+			fullPath += '.';
+
+			if (!(await expandButton.getAttribute('aria-expanded'))) {
+				await expandButton.click();
+			}
+		});
+	}
+
+	async addChildField(path: string[], field: string) {
+		this.openParentField(path);
+
 		await this.page
-			.locator(`[id*="${parent}"]`)
+			.locator(`[data-id$="${path.join('.')}.${field}"]`)
 			.getByText(field, {exact: true})
 			.check();
 	}


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-17674

This PR covers:

- Add fields to a given Data Set View, including a parent field and children fields from the Fields tree view.
- Make sure the fields appears in a fragment added to a page that shows the Data Set View previously created.