### PR TITLE
LPD-17452 Allow admins to save the definition for list as visualization mode

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -22,6 +22,7 @@ import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -470,6 +471,47 @@ public class FDSViewsPortlet extends MVCPortlet {
 			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
 	}
 
+	private void _createFDSListSectionObjectDefinition(
+			ObjectDefinition fdsViewObjectDefinition, Locale locale,
+			long userId)
+		throws Exception {
+
+		ObjectDefinition fdsListSectionObjectDefinition =
+			_objectDefinitionLocalService.addSystemObjectDefinition(
+				"FDSListSection", userId, 0, "FDSListSection", "FDSListSection",
+				false, LocalizedMapUtil.getLocalizedMap("FDS List Section"),
+				true, "FDSListSection", null, null, null, null,
+				LocalizedMapUtil.getLocalizedMap("FDS List Sections"),
+				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
+				WorkflowConstants.STATUS_DRAFT,
+				Arrays.asList(
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "field-name"), "fieldName", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "name"), "name", true),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "renderer-name"), "rendererName",
+						false)));
+
+		_objectDefinitionLocalService.publishSystemObjectDefinition(
+			userId, fdsListSectionObjectDefinition.getObjectDefinitionId());
+
+		_objectRelationshipLocalService.addObjectRelationship(
+			null, userId, fdsViewObjectDefinition.getObjectDefinitionId(),
+			fdsListSectionObjectDefinition.getObjectDefinitionId(), 0,
+			ObjectRelationshipConstants.DELETION_TYPE_CASCADE,
+			LocalizedMapUtil.getLocalizedMap(
+				"FDSView FDSListSection Relationship"),
+			"fdsViewFDSListSectionRelationship", false,
+			ObjectRelationshipConstants.TYPE_ONE_TO_MANY, null);
+	}
+
 	private void _createFDSSortObjectDefinition(
 			ObjectDefinition fdsViewObjectDefinition, Locale locale,
 			long userId)
@@ -626,6 +668,11 @@ public class FDSViewsPortlet extends MVCPortlet {
 		_createFDSFieldObjectDefinition(
 			fdsViewObjectDefinition, locale, userId);
 		_createFDSSortObjectDefinition(fdsViewObjectDefinition, locale, userId);
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-10735")) {
+			_createFDSListSectionObjectDefinition(
+				fdsViewObjectDefinition, locale, userId);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/item/selector/FDSViewItemSelector.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/item/selector/FDSViewItemSelector.tsx
@@ -8,7 +8,7 @@ import ClayModal from '@clayui/modal';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import React, {useState} from 'react';
 
-import {API_URL, FDS_DEFAULT_PROPS} from '../../js/Constants';
+import {API_URL, FDS_DEFAULT_PROPS} from '../../js/utils/constants';
 
 import './FDSViewItemSelector.scss';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -16,16 +16,16 @@ import fuzzy from 'fuzzy';
 import React, {useState} from 'react';
 
 import '../css/FDSEntries.scss';
+import {FDSViewType} from './FDSViews';
+import RequiredMark from './components/RequiredMark';
+import ValidationFeedback from './components/ValidationFeedback';
 import {
 	ALLOWED_ENDPOINTS_PARAMETERS,
 	API_URL,
 	FDS_DEFAULT_PROPS,
 	FUZZY_OPTIONS,
 	OBJECT_RELATIONSHIP,
-} from './Constants';
-import {FDSViewType} from './FDSViews';
-import RequiredMark from './components/RequiredMark';
-import ValidationFeedback from './components/ValidationFeedback';
+} from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 import openDefaultSuccessToast from './utils/openDefaultSuccessToast';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -10,7 +10,6 @@ import {IClientExtensionRenderer} from '@liferay/frontend-data-set-web';
 import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';
 import Actions from './fds_view/Actions';
 import Details from './fds_view/Details';
@@ -19,6 +18,7 @@ import Pagination from './fds_view/Pagination';
 import Sorting from './fds_view/Sorting';
 import VisualizationModes from './fds_view/visualization_modes/VisualizationModes';
 import {Fields} from './fds_view/visualization_modes/table/Table';
+import {API_URL, OBJECT_RELATIONSHIP} from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 
 const NAVIGATION_BAR_ITEMS = [

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -15,9 +15,13 @@ import classNames from 'classnames';
 import {fetch, navigate, openModal} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
-import {API_URL, FDS_DEFAULT_PROPS, OBJECT_RELATIONSHIP} from './Constants';
 import {FDSEntryType} from './FDSEntries';
 import RequiredMark from './components/RequiredMark';
+import {
+	API_URL,
+	FDS_DEFAULT_PROPS,
+	OBJECT_RELATIONSHIP,
+} from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 import openDefaultSuccessToast from './utils/openDefaultSuccessToast';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -9,10 +9,10 @@ import {
 } from '@liferay/frontend-data-set-web';
 import {fetch} from 'frontend-js-web';
 
-import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';
-import {EFieldFormat, EFieldType, IField, IPickList} from './types';
+import {OBJECT_RELATIONSHIP} from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
+import {EFieldFormat, EFieldType, IField, IPickList} from './utils/types';
 
 const INVALID_FIELDS = ['actions', 'scopeKey', 'x-class-name', 'x-schema-name'];
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -1,0 +1,364 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {TreeView} from '@clayui/core';
+import {ClayCheckbox} from '@clayui/form';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import ClayManagementToolbar, {
+	ClayResultsBar,
+} from '@clayui/management-toolbar';
+import ClayModal from '@clayui/modal';
+import {sub} from 'frontend-js-web';
+import React, {ComponentProps, useEffect, useState} from 'react';
+
+import {FDSViewType} from '../FDSViews';
+import {getFields} from '../api';
+import {IField} from '../utils/types';
+import Search from './Search';
+
+interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	query?: string;
+	selected?: boolean;
+}
+
+function visit(fields: Array<IFieldTreeItem>, callback: Function) {
+	fields.forEach((field) => {
+		callback(field);
+
+		if (field.children) {
+			visit(field.children, callback);
+		}
+	});
+}
+
+const initializeFields = ({
+	fields: initialFields,
+	selectedFields,
+}: {
+	fields: IField[];
+	selectedFields: Array<IField>;
+}): [Set<React.Key>, Array<IFieldTreeItem>] => {
+	const selectedKeys = new Set<React.Key>();
+	const fields: IFieldTreeItem[] = Array.from(initialFields);
+
+	visit(fields, (field: IFieldTreeItem) => {
+		const selectedField = selectedFields.find(
+			(selectedField) => selectedField.name === field.name
+		);
+
+		if (selectedField) {
+			selectedKeys.add(selectedField.name);
+		}
+
+		field.id = field.name;
+	});
+
+	return [selectedKeys, fields];
+};
+
+function filterFields({
+	fields,
+	onFilter,
+	onMatch,
+	query,
+}: {
+	fields: Array<IFieldTreeItem>;
+	onFilter?: (field: IFieldTreeItem) => void;
+	onMatch?: (field: IFieldTreeItem) => void;
+	query: string;
+}) {
+	const filteredItems: Array<IFieldTreeItem> = [];
+	const regexp = new RegExp(query, 'i');
+
+	fields.forEach((field) => {
+		const match = field.label ? regexp.test(field.label) : false;
+
+		const filteredChildren = field.children?.length
+			? filterFields({fields: field.children, onFilter, onMatch, query})
+			: [];
+
+		if (match || (field.children?.length && filteredChildren.length)) {
+			filteredItems.push({
+				...field,
+				children: filteredChildren,
+				query,
+			});
+
+			if (onFilter) {
+				onFilter(field);
+			}
+		}
+
+		if (match && onMatch) {
+			onMatch(field);
+		}
+	});
+
+	return filteredItems;
+}
+
+function applyFilter({
+	fields,
+	query,
+}: {fields?: Array<IFieldTreeItem>; query?: string} = {}) {
+	if (!query || !fields) {
+		return {
+			counter: 0,
+			filteredItems: fields ?? [],
+			filteredKeys: [],
+		};
+	}
+
+	let counter = 0;
+	const filteredKeys: Array<React.Key> = [];
+	const filteredItems = filterFields({
+		fields,
+		onFilter: ({id}: IFieldTreeItem) => {
+			if (id) {
+				filteredKeys.push(id);
+			}
+		},
+		onMatch: () => counter++,
+		query,
+	});
+
+	return {
+		counter,
+		filteredItems,
+		filteredKeys,
+	};
+}
+
+const Highlight = ({query, text}: {query?: string; text?: string}) => {
+	if (!query || !text) {
+		return <>{text ?? ''}</>;
+	}
+
+	const indexMatch = text.search(RegExp(query, 'i'));
+
+	return indexMatch > -1 ? (
+		<>
+			{text.substring(0, indexMatch)}
+			<mark className="bg-transparent border-0 font-weight-bold p-0 shadow-none">
+				{text.substring(indexMatch, indexMatch + query.length)}
+			</mark>
+			{text.substring(indexMatch + query.length)}
+		</>
+	) : (
+		<>{text}</>
+	);
+};
+
+const FieldSelectModalContent = ({
+	closeModal,
+	fdsView,
+	onSaveButtonClick,
+	saveButtonDisabled,
+	selectedFields,
+	selectionMode = 'single',
+}: {
+	closeModal: Function;
+	fdsView: FDSViewType;
+	onSaveButtonClick: ({
+		selectedFields,
+	}: {
+		selectedFields: Array<IFieldTreeItem>;
+	}) => void;
+	saveButtonDisabled: boolean;
+	selectedFields: Array<IField>;
+	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
+}) => {
+	const [initialFields, setInitialFields] = useState<Array<
+		IFieldTreeItem
+	> | null>(null);
+	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
+		new Set<React.Key>()
+	);
+	const [fields, setFields] = useState<Array<IFieldTreeItem> | null>(
+		initialFields
+	);
+	const [query, setQuery] = useState<string>('');
+	const [expandedKeys, setExpandedKeys] = useState<Array<React.Key>>([]);
+	const [searchCounter, setSearchCounter] = useState<number>(0);
+
+	useEffect(() => {
+		getFields(fdsView).then((fields) => {
+			if (fields) {
+				const [initialSelectedKeys, updatedFields] = initializeFields({
+					fields,
+					selectedFields,
+				});
+
+				setSelectedKeys(initialSelectedKeys);
+
+				setInitialFields(updatedFields);
+				setFields(updatedFields);
+			}
+		});
+	}, [selectedFields, fdsView]);
+
+	const onSearch = (query: string) => {
+		setQuery(query);
+
+		const {counter, filteredItems, filteredKeys} = applyFilter({
+			fields: initialFields ?? [],
+			query,
+		});
+
+		setFields(filteredItems);
+		setExpandedKeys(filteredKeys);
+		setSearchCounter(counter);
+	};
+
+	return (
+		<>
+			<ClayModal.Header>
+				{sub(
+					Liferay.Language.get('select-x'),
+					Liferay.Language.get('field')
+				)}
+			</ClayModal.Header>
+
+			<ClayModal.Body className="pt-0 px-0">
+				{fields === null ? (
+					<ClayLoadingIndicator />
+				) : (
+					<>
+						<ClayManagementToolbar>
+							<ClayManagementToolbar.Search>
+								<Search onSearch={onSearch} query={query} />
+							</ClayManagementToolbar.Search>
+						</ClayManagementToolbar>
+
+						{query && (
+							<ClayResultsBar>
+								<ClayResultsBar.Item expand>
+									<span className="component-text text-truncate-inline">
+										<span className="text-truncate">
+											{sub(
+												searchCounter === 1
+													? Liferay.Language.get(
+															'x-result-for-x'
+													  )
+													: Liferay.Language.get(
+															'x-results-for-x'
+													  ),
+												searchCounter,
+												query
+											)}
+										</span>
+									</span>
+								</ClayResultsBar.Item>
+
+								<ClayResultsBar.Item>
+									<ClayButton
+										className="component-link tbar-link"
+										displayType="unstyled"
+										onClick={() => {
+											setQuery('');
+											setFields(initialFields);
+										}}
+									>
+										{Liferay.Language.get('clear')}
+									</ClayButton>
+								</ClayResultsBar.Item>
+							</ClayResultsBar>
+						)}
+
+						<div className="container-fluid container-fluid-max-xl px-4 py-2">
+							<TreeView
+								className="bg-light"
+								expandedKeys={new Set(expandedKeys)}
+								items={fields}
+								nestedKey="children"
+								onExpandedChange={(keys) => {
+									setExpandedKeys(Array.from(keys));
+								}}
+								onItemsChange={(items) =>
+									setInitialFields(
+										items as Array<IFieldTreeItem>
+									)
+								}
+								onSelectionChange={setSelectedKeys}
+								selectedKeys={selectedKeys}
+								selectionMode={selectionMode}
+								showExpanderOnHover={false}
+							>
+								{({children, label, query}: IFieldTreeItem) => (
+									<TreeView.Item>
+										<TreeView.ItemStack>
+											<ClayCheckbox checked>
+												<span className="font-weight-normal pl-1 text-3">
+													<Highlight
+														query={query}
+														text={label}
+													/>
+												</span>
+											</ClayCheckbox>
+										</TreeView.ItemStack>
+
+										<TreeView.Group items={children}>
+											{({label}: IFieldTreeItem) => (
+												<TreeView.Item>
+													<ClayCheckbox checked>
+														<span className="font-weight-normal pl-1 text-3">
+															<Highlight
+																query={query}
+																text={label}
+															/>
+														</span>
+													</ClayCheckbox>
+												</TreeView.Item>
+											)}
+										</TreeView.Group>
+									</TreeView.Item>
+								)}
+							</TreeView>
+						</div>
+					</>
+				)}
+			</ClayModal.Body>
+
+			<ClayModal.Footer
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton
+							disabled={saveButtonDisabled}
+							onClick={() => {
+								const selectedFields: Array<IFieldTreeItem> = [];
+
+								visit(
+									initialFields || [],
+									(field: IFieldTreeItem) => {
+										if (selectedKeys.has(field.name)) {
+											selectedFields.push(field);
+										}
+									}
+								);
+
+								onSaveButtonClick({
+									selectedFields,
+								});
+							}}
+						>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => closeModal()}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</>
+	);
+};
+
+export default FieldSelectModalContent;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/OrderableTable.tsx
@@ -16,7 +16,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import {DndProvider, useDrag, useDrop} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
 
-import {FUZZY_OPTIONS} from '../Constants';
+import {FUZZY_OPTIONS} from '../utils/constants';
 import Search from './Search';
 
 import '../../css/OrderableTable.scss';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.tsx
@@ -14,7 +14,7 @@ import classNames from 'classnames';
 import fuzzy from 'fuzzy';
 import React, {useState} from 'react';
 
-import {IPickList} from '../../types';
+import {IPickList} from '../../utils/types';
 import CheckboxMultiSelect from '../CheckboxMultiSelect';
 
 function Header() {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -10,8 +10,8 @@ import ClayTabs from '@clayui/tabs';
 import {fetch, openModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, OBJECT_RELATIONSHIP} from '../Constants';
 import {IFDSViewSectionProps} from '../FDSView';
+import {API_URL, OBJECT_RELATIONSHIP} from '../utils/constants';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 import ActionForm from './actions/ActionForm';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Details.tsx
@@ -12,9 +12,9 @@ import classNames from 'classnames';
 import {fetch, navigate} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
-import {API_URL} from '../Constants';
 import {IFDSViewSectionProps} from '../FDSView';
 import RequiredMark from '../components/RequiredMark';
+import {API_URL} from '../utils/constants';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Filters.tsx
@@ -15,7 +15,6 @@ import {InputLocalized} from 'frontend-js-components-web';
 import {fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, OBJECT_RELATIONSHIP} from '../Constants';
 import {FDSViewType} from '../FDSViews';
 import {getAllPicklists, getFields} from '../api';
 import OrderableTable from '../components/OrderableTable';
@@ -23,6 +22,9 @@ import ValidationFeedback from '../components/ValidationFeedback';
 import ClientExtensionFilterModalContent from '../components/modal_content/ClientExtensionFilter';
 import DateRangeFilterModalContent from '../components/modal_content/DateRangeFilter';
 import SelectionFilterModalContent from '../components/modal_content/SelectionFilter';
+import {API_URL, OBJECT_RELATIONSHIP} from '../utils/constants';
+import openDefaultFailureToast from '../utils/openDefaultFailureToast';
+import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 import {
 	EFieldFormat,
 	EFieldType,
@@ -33,9 +35,7 @@ import {
 	IFilter,
 	IPickList,
 	ISelectionFilter,
-} from '../types';
-import openDefaultFailureToast from '../utils/openDefaultFailureToast';
-import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
+} from '../utils/types';
 
 import '../../css/Filters.scss';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Pagination.tsx
@@ -10,9 +10,9 @@ import classnames from 'classnames';
 import {fetch, navigate} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
-import {API_URL} from '../Constants';
 import {IFDSViewSectionProps} from '../FDSView';
 import RequiredMark from '../components/RequiredMark';
+import {API_URL} from '../utils/constants';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -13,15 +13,15 @@ import {fetch, openModal} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../Constants';
 import {IFDSViewSectionProps} from '../FDSView';
 import {FDSViewType} from '../FDSViews';
 import {getFields} from '../api';
 import OrderableTable from '../components/OrderableTable';
 import RequiredMark from '../components/RequiredMark';
-import {IField} from '../types';
+import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../utils/constants';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
+import {IField} from '../utils/types';
 
 interface IAddFDSSortModalContentInterface {
 	closeModal: Function;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
@@ -14,11 +14,11 @@ import {InputLocalized} from 'frontend-js-components-web';
 import {fetch, openModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, OBJECT_RELATIONSHIP} from '../../Constants';
 import {FDSViewType} from '../../FDSViews';
 import RequiredMark from '../../components/RequiredMark';
 import Search from '../../components/Search';
 import ValidationFeedback from '../../components/ValidationFeedback';
+import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {IFDSAction} from '../Actions';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -9,34 +9,155 @@ import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
-import {openModal} from 'frontend-js-web';
-import React from 'react';
+import {fetch, openModal} from 'frontend-js-web';
+import React, {useEffect, useState} from 'react';
 
 import '../../../../css/ListVisualizationMode.scss';
 import {IFDSViewSectionProps} from '../../../FDSView';
+import FieldSelectModalContent from '../../../components/FieldSelectModalContent';
+import {API_URL, OBJECT_RELATIONSHIP} from '../../../utils/constants';
+import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
+import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
+import {IField} from '../../../utils/types';
 import {IBaseVisualizationMode} from '../VisualizationModes';
-import {IFDSField} from '../table/Table';
-import AddFieldsModalContent from '../table/modal_content/AddFieldsModalContent';
 
 export interface IList extends IBaseVisualizationMode<'list'> {}
-
-interface IListField {
-	fieldId: string;
+interface IFDSListSection {
+	externalReferenceCode: string;
+	fieldName: string;
+	name: string;
+	rendererName?: string;
+}
+interface IListSection {
+	externalReferenceCode?: IFDSListSection['externalReferenceCode'];
+	field?: IField;
 	label: string;
+	name: IFDSListSection['name'];
 }
 
-const LIST_VISUALIZATION_MODE_FIELDS: IListField[] = [
-	{fieldId: 'title', label: Liferay.Language.get('title')},
-	{fieldId: 'description', label: Liferay.Language.get('description')},
-	{fieldId: 'symbol', label: Liferay.Language.get('symbol')},
-	{fieldId: 'link', label: Liferay.Language.get('link')},
-	{fieldId: 'label', label: Liferay.Language.get('label')},
-];
-
 export default function List(props: IFDSViewSectionProps) {
-	const [fieldValues, setFieldValues] = React.useState<
-		Record<IListField['fieldId'], IFDSField>
-	>({});
+	const {fdsView} = props;
+
+	const [listSections, setListSections] = useState<Array<IListSection>>([
+		{label: Liferay.Language.get('title'), name: 'title'},
+		{label: Liferay.Language.get('description'), name: 'description'},
+		{label: Liferay.Language.get('symbol'), name: 'symbol'},
+		{label: Liferay.Language.get('link'), name: 'link'},
+		{label: Liferay.Language.get('label'), name: 'label'},
+	]);
+	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
+
+	const getFDSListSections = async () => {
+		const response = await fetch(
+			`${API_URL.FDS_LIST_SECTIONS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_LIST_SECTION_ID} eq '${fdsView.id}')`
+		);
+
+		if (!response.ok) {
+			openDefaultFailureToast();
+
+			return null;
+		}
+
+		const responseJSON = await response.json();
+
+		const fdsListSections = responseJSON?.items;
+
+		if (!fdsListSections) {
+			openDefaultFailureToast();
+
+			return null;
+		}
+
+		setListSections(
+			listSections.map((listSection) => {
+				const fdsListSection = fdsListSections.find(
+					(fdsListSection: IFDSListSection) =>
+						fdsListSection.name === listSection.name
+				);
+
+				if (!fdsListSection) {
+					return listSection;
+				}
+
+				return {
+					...listSection,
+					externalReferenceCode: fdsListSection.externalReferenceCode,
+					field: {
+						name: fdsListSection.fieldName,
+					},
+				};
+			})
+		);
+	};
+
+	const saveFDSListSection = async ({
+		closeModal,
+		field,
+		listSection,
+	}: {
+		closeModal: Function;
+		field: IField;
+		listSection: IListSection;
+	}) => {
+		setSaveButtonDisabled(true);
+
+		let method = 'POST';
+		let url = API_URL.FDS_LIST_SECTIONS;
+
+		if (listSection.externalReferenceCode) {
+			method = 'PATCH';
+			url = `${API_URL.FDS_LIST_SECTIONS}/by-external-reference-code/${listSection.externalReferenceCode}`;
+		}
+
+		const response = await fetch(url, {
+			body: JSON.stringify({
+				[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_LIST_SECTION_ID]: fdsView.id,
+				fieldName: field.name,
+				name: listSection.name,
+			}),
+			headers: {
+				'Accept': 'application/json',
+				'Content-Type': 'application/json',
+			},
+			method,
+		});
+
+		setSaveButtonDisabled(false);
+
+		if (!response.ok) {
+			openDefaultFailureToast();
+
+			return;
+		}
+
+		const fdsListSection: IFDSListSection = await response.json();
+
+		openDefaultSuccessToast();
+
+		setListSections(
+			listSections.map((listSection) => {
+				if (listSection.name !== fdsListSection.name) {
+					return listSection;
+				}
+
+				return {
+					...listSection,
+					externalReferenceCode: fdsListSection.externalReferenceCode,
+					field: {
+						name: fdsListSection.fieldName,
+					},
+				};
+			})
+		);
+
+		closeModal();
+	};
+
+	useEffect(() => {
+		getFDSListSections();
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	return (
 		<ClayLayout.ContentCol className="c-gap-4">
@@ -70,18 +191,19 @@ export default function List(props: IFDSViewSectionProps) {
 				</ClayTable.Head>
 
 				<ClayTable.Body>
-					{LIST_VISUALIZATION_MODE_FIELDS.map((field) => (
-						<ListField
-							field={field}
-							key={field.fieldId}
+					{listSections.map((listSection) => (
+						<ListSection
+							key={listSection.name}
+							listSection={listSection}
 							modalProps={props}
-							onSave={(fdsField) =>
-								setFieldValues({
-									...fieldValues,
-									[field.fieldId]: fdsField,
-								})
-							}
-							value={fieldValues[field.fieldId]}
+							onSelect={({closeModal, selectedField}) => {
+								saveFDSListSection({
+									closeModal,
+									field: selectedField,
+									listSection,
+								});
+							}}
+							saveButtonDisabled={saveButtonDisabled}
 						/>
 					))}
 				</ClayTable.Body>
@@ -90,25 +212,45 @@ export default function List(props: IFDSViewSectionProps) {
 	);
 }
 
-interface IListFieldProps {
-	field: IListField;
+interface IListSectionProps {
+	listSection: IListSection;
 	modalProps: IFDSViewSectionProps;
-	onSave: (fdsField: IFDSField) => void;
-	value?: IFDSField;
+	onSelect: ({
+		closeModal,
+		selectedField,
+	}: {
+		closeModal: Function;
+		selectedField: IField;
+	}) => void;
+	saveButtonDisabled: boolean;
 }
 
-function ListField({field, modalProps, onSave, value}: IListFieldProps) {
+function ListSection({
+	listSection,
+	modalProps,
+	onSelect,
+	saveButtonDisabled,
+}: IListSectionProps) {
+	const {field, label} = listSection;
+
 	const onClick = () => {
 		openModal({
 			contentComponent: ({closeModal}: {closeModal: Function}) => (
-				<AddFieldsModalContent
+				<FieldSelectModalContent
 					{...modalProps}
 					closeModal={closeModal}
-					onSave={({createdFDSFields: [createdFDSField]}) =>
-						onSave(createdFDSField)
-					}
-					savedFDSFields={value ? [value] : []}
-					selectionMode="single"
+					onSaveButtonClick={({
+						selectedFields,
+					}: {
+						selectedFields: Array<IField>;
+					}) => {
+						onSelect({
+							closeModal,
+							selectedField: selectedFields[0],
+						});
+					}}
+					saveButtonDisabled={saveButtonDisabled}
+					selectedFields={field ? [field] : []}
 				/>
 			),
 		});
@@ -117,7 +259,7 @@ function ListField({field, modalProps, onSave, value}: IListFieldProps) {
 	return (
 		<ClayTable.Row>
 			<ClayTable.Cell className="list-visualization-mode-label-cell">
-				<strong>{field.label}</strong>
+				<strong>{label}</strong>
 			</ClayTable.Cell>
 
 			<ClayTable.Cell className="list-visualization-mode-value-cell">
@@ -126,10 +268,10 @@ function ListField({field, modalProps, onSave, value}: IListFieldProps) {
 						<p
 							className={classNames(
 								'align-items-center d-flex mb-0',
-								{'text-secondary': !value}
+								{'text-secondary': !field}
 							)}
 						>
-							{value?.label ||
+							{field?.name ||
 								Liferay.Language.get('not-assigned')}
 						</p>
 					</ClayInput.GroupItem>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -20,37 +20,26 @@ import {fetch, openModal} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../../../Constants';
 import {IFDSViewSectionProps} from '../../../FDSView';
 import {FDSViewType} from '../../../FDSViews';
 import {getFields} from '../../../api';
 import OrderableTable from '../../../components/OrderableTable';
+import {
+	API_URL,
+	FUZZY_OPTIONS,
+	OBJECT_RELATIONSHIP,
+} from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 
 import '../../../../css/TableVisualizationMode.scss';
-import {IField} from '../../../types';
+import {IFDSField, IField} from '../../../utils/types';
 import {IBaseVisualizationMode} from '../VisualizationModes';
 import AddFieldsModalContent from './modal_content/AddFieldsModalContent';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
-type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 
 export interface ITable extends IBaseVisualizationMode<'table'> {}
-
-export interface IFDSField {
-	contextPath: string;
-	externalReferenceCode: string;
-	id: number;
-	label: string;
-	label_i18n: LocalizedValue<string>;
-	name: string;
-	renderer: string;
-	rendererLabel?: string;
-	sortable: boolean;
-	type: string;
-}
-
 interface ISaveFDSFieldsModalContentProps {
 	closeModal: Function;
 	fdsFields: Array<IFDSField>;
@@ -171,7 +160,10 @@ const SaveFDSFieldsModalContent = ({
 
 		fields?.forEach((field) => {
 			if (field.selected && !field.id) {
-				creationData.push({name: field.name, type: field.type});
+				creationData.push({
+					name: field.name,
+					type: field.type || 'string',
+				});
 			}
 
 			if (!field.selected && field.id) {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
@@ -17,10 +17,9 @@ import React, {ComponentProps, useEffect, useState} from 'react';
 import {FDSViewType} from '../../../../FDSViews';
 import {getFields} from '../../../../api';
 import Search from '../../../../components/Search';
-import {IField} from '../../../../types';
 import openDefaultFailureToast from '../../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../../utils/openDefaultSuccessToast';
-import {IFDSField} from '../Table';
+import {IFDSField, IField} from '../../../../utils/types';
 
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
@@ -206,7 +205,7 @@ const AddFieldsModalContent = ({
 			if (selectedKeys.has(field.name) && !field.savedId) {
 				creationData.push({
 					name: field.name,
-					type: field.type,
+					type: field.type || 'string',
 				});
 			}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/constants.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/constants.ts
@@ -11,6 +11,7 @@ const API_URL = {
 	FDS_DYNAMIC_FILTERS: '/o/data-set-manager/dynamic-filters',
 	FDS_ENTRIES: '/o/data-set-manager/entries',
 	FDS_FIELDS: '/o/data-set-manager/fields',
+	FDS_LIST_SECTIONS: '/o/data-set-manager/list-sections',
 	FDS_SORTS: '/o/data-set-manager/sorts',
 	FDS_VIEWS: '/o/data-set-manager/views',
 };
@@ -40,6 +41,9 @@ const OBJECT_RELATIONSHIP = {
 	FDS_VIEW_FDS_ITEM_ACTION: 'fdsViewFDSItemActionRelationship',
 	FDS_VIEW_FDS_ITEM_ACTION_ID:
 		'r_fdsViewFDSItemActionRelationship_c_fdsViewId',
+	FDS_VIEW_FDS_LIST_SECTION: 'fdsViewFDSListSectionRelationship',
+	FDS_VIEW_FDS_LIST_SECTION_ID:
+		'r_fdsViewFDSListSectionRelationship_c_fdsViewId',
 	FDS_VIEW_FDS_SORT: 'fdsViewFDSSortRelationship',
 	FDS_VIEW_FDS_SORT_ID: 'r_fdsViewFDSSortRelationship_c_fdsViewId',
 } as const;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -3,23 +3,27 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-declare type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
-export declare enum EFilterType {
+type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
+
+export enum EFilterType {
 	CLIENT_EXTENSION = 'CLIENT_EXTENSION',
 	DATE_RANGE = 'DATE_RANGE',
 	SELECTION = 'SELECTION',
 }
-export declare enum EFieldFormat {
+
+export enum EFieldFormat {
 	DATE = 'date',
 	DATE_TIME = 'date-time',
 	INT64 = 'int64',
 }
-export declare enum EFieldType {
+
+export enum EFieldType {
 	ARRAY = 'array',
 	INTEGER = 'integer',
 	OBJECT = 'object',
 	STRING = 'string',
 }
+
 export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
@@ -27,9 +31,23 @@ export interface IField {
 	label?: string;
 	name: string;
 	selected?: boolean;
-	type: string;
+	type?: string;
 	visible?: boolean;
 }
+
+export interface IFDSField {
+	contextPath: string;
+	externalReferenceCode: string;
+	id: number;
+	label: string;
+	label_i18n: LocalizedValue<string>;
+	name: string;
+	renderer: string;
+	rendererLabel?: string;
+	sortable: boolean;
+	type: string;
+}
+
 export interface IFilter {
 	fieldName: string;
 	filterType?: EFilterType;
@@ -38,19 +56,23 @@ export interface IFilter {
 	label_i18n: LocalizedValue<string>;
 	type: string;
 }
+
 export interface IClientExtensionFilter extends IFilter {
 	fdsFilterClientExtensionERC: string;
 }
+
 export interface IDateFilter extends IFilter {
 	from: string;
 	to: string;
 }
+
 export interface ISelectionFilter extends IFilter {
 	include: boolean;
 	listTypeDefinitionERC: string;
 	multiple: boolean;
 	preselectedValues: string;
 }
+
 export interface IPickList {
 	externalReferenceCode: string;
 	id: string;
@@ -60,6 +82,7 @@ export interface IPickList {
 		[key: string]: string;
 	};
 }
+
 export interface IListTypeEntry {
 	externalReferenceCode: string;
 	id: number;
@@ -69,4 +92,3 @@ export interface IListTypeEntry {
 		[key: string]: string;
 	};
 }
-export {};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSEntries.d.ts
@@ -6,8 +6,8 @@
 /// <reference types="react" />
 
 import '../css/FDSEntries.scss';
-import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSViewType} from './FDSViews';
+import {OBJECT_RELATIONSHIP} from './utils/constants';
 declare type FDSEntryType = {
 	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: Array<FDSViewType>;
 	actions: {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSViews.d.ts
@@ -5,8 +5,8 @@
 
 /// <reference types="react" />
 
-import {OBJECT_RELATIONSHIP} from './Constants';
 import {FDSEntryType} from './FDSEntries';
+import {OBJECT_RELATIONSHIP} from './utils/constants';
 declare type FDSViewType = {
 	[OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW]: FDSEntryType;
 	defaultItemsPerPage: number;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/api.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/api.d.ts
@@ -4,7 +4,7 @@
  */
 
 import {FDSViewType} from './FDSViews';
-import {IField, IPickList} from './types';
+import {IField, IPickList} from './utils/types';
 export declare function getFields(fdsView: FDSViewType): Promise<IField[]>;
 export declare function getAllPicklists(
 	page?: number,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {TreeView} from '@clayui/core';
+import {ComponentProps} from 'react';
+import {FDSViewType} from '../FDSViews';
+import {IField} from '../utils/types';
+interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	query?: string;
+	selected?: boolean;
+}
+declare const FieldSelectModalContent: ({
+	closeModal,
+	fdsView,
+	onSaveButtonClick,
+	saveButtonDisabled,
+	selectedFields,
+	selectionMode,
+}: {
+	closeModal: Function;
+	fdsView: FDSViewType;
+	onSaveButtonClick: ({
+		selectedFields,
+	}: {
+		selectedFields: Array<IFieldTreeItem>;
+	}) => void;
+	saveButtonDisabled: boolean;
+	selectedFields: Array<IField>;
+	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
+}) => JSX.Element;
+export default FieldSelectModalContent;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/modal_content/SelectionFilter.d.ts
@@ -5,7 +5,7 @@
 
 /// <reference types="react" />
 
-import {IPickList} from '../../types';
+import {IPickList} from '../../utils/types';
 declare function Header(): JSX.Element;
 interface IBodyProps {
 	includeMode: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
@@ -5,8 +5,8 @@
 
 /// <reference types="react" />
 
-import {OBJECT_RELATIONSHIP} from '../Constants';
 import {IFDSViewSectionProps} from '../FDSView';
+import {OBJECT_RELATIONSHIP} from '../utils/constants';
 import '../../css/Actions.scss';
 declare const SECTIONS: {
 	CREATION_ACTIONS: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.d.ts
@@ -8,20 +8,7 @@
 import {IFDSViewSectionProps} from '../../../FDSView';
 import '../../../../css/TableVisualizationMode.scss';
 import {IBaseVisualizationMode} from '../VisualizationModes';
-declare type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 export interface ITable extends IBaseVisualizationMode<'table'> {}
-export interface IFDSField {
-	contextPath: string;
-	externalReferenceCode: string;
-	id: number;
-	label: string;
-	label_i18n: LocalizedValue<string>;
-	name: string;
-	renderer: string;
-	rendererLabel?: string;
-	sortable: boolean;
-	type: string;
-}
 declare function Table({
 	fdsClientExtensionCellRenderers,
 	fdsView,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.d.ts
@@ -6,7 +6,7 @@
 import {TreeView} from '@clayui/core';
 import {ComponentProps} from 'react';
 import {FDSViewType} from '../../../../FDSViews';
-import {IFDSField} from '../Table';
+import {IFDSField} from '../../../../utils/types';
 declare const AddFieldsModalContent: ({
 	closeModal,
 	fdsView,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/constants.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/constants.d.ts
@@ -10,6 +10,7 @@ declare const API_URL: {
 	FDS_DYNAMIC_FILTERS: string;
 	FDS_ENTRIES: string;
 	FDS_FIELDS: string;
+	FDS_LIST_SECTIONS: string;
 	FDS_SORTS: string;
 	FDS_VIEWS: string;
 };
@@ -32,6 +33,8 @@ declare const OBJECT_RELATIONSHIP: {
 	readonly FDS_VIEW_FDS_FIELD_ID: 'r_fdsViewFDSFieldRelationship_c_fdsViewId';
 	readonly FDS_VIEW_FDS_ITEM_ACTION: 'fdsViewFDSItemActionRelationship';
 	readonly FDS_VIEW_FDS_ITEM_ACTION_ID: 'r_fdsViewFDSItemActionRelationship_c_fdsViewId';
+	readonly FDS_VIEW_FDS_LIST_SECTION: 'fdsViewFDSListSectionRelationship';
+	readonly FDS_VIEW_FDS_LIST_SECTION_ID: 'r_fdsViewFDSListSectionRelationship_c_fdsViewId';
 	readonly FDS_VIEW_FDS_SORT: 'fdsViewFDSSortRelationship';
 	readonly FDS_VIEW_FDS_SORT_ID: 'r_fdsViewFDSSortRelationship_c_fdsViewId';
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -3,27 +3,23 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
-
-export enum EFilterType {
+declare type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
+export declare enum EFilterType {
 	CLIENT_EXTENSION = 'CLIENT_EXTENSION',
 	DATE_RANGE = 'DATE_RANGE',
 	SELECTION = 'SELECTION',
 }
-
-export enum EFieldFormat {
+export declare enum EFieldFormat {
 	DATE = 'date',
 	DATE_TIME = 'date-time',
 	INT64 = 'int64',
 }
-
-export enum EFieldType {
+export declare enum EFieldType {
 	ARRAY = 'array',
 	INTEGER = 'integer',
 	OBJECT = 'object',
 	STRING = 'string',
 }
-
 export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
@@ -31,10 +27,21 @@ export interface IField {
 	label?: string;
 	name: string;
 	selected?: boolean;
-	type: string;
+	type?: string;
 	visible?: boolean;
 }
-
+export interface IFDSField {
+	contextPath: string;
+	externalReferenceCode: string;
+	id: number;
+	label: string;
+	label_i18n: LocalizedValue<string>;
+	name: string;
+	renderer: string;
+	rendererLabel?: string;
+	sortable: boolean;
+	type: string;
+}
 export interface IFilter {
 	fieldName: string;
 	filterType?: EFilterType;
@@ -43,23 +50,19 @@ export interface IFilter {
 	label_i18n: LocalizedValue<string>;
 	type: string;
 }
-
 export interface IClientExtensionFilter extends IFilter {
 	fdsFilterClientExtensionERC: string;
 }
-
 export interface IDateFilter extends IFilter {
 	from: string;
 	to: string;
 }
-
 export interface ISelectionFilter extends IFilter {
 	include: boolean;
 	listTypeDefinitionERC: string;
 	multiple: boolean;
 	preselectedValues: string;
 }
-
 export interface IPickList {
 	externalReferenceCode: string;
 	id: string;
@@ -69,7 +72,6 @@ export interface IPickList {
 		[key: string]: string;
 	};
 }
-
 export interface IListTypeEntry {
 	externalReferenceCode: string;
 	id: number;
@@ -79,3 +81,4 @@ export interface IListTypeEntry {
 		[key: string]: string;
 	};
 }
+export {};

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -119,6 +119,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"FDSField", "/data-set-manager/fields"
 		).put(
+			"FDSListSection", "/data-set-manager/list-sections"
+		).put(
 			"FDSSort", "/data-set-manager/sorts"
 		).put(
 			"FDSView", "/data-set-manager/views"


### PR DESCRIPTION
### References

- Parent story: [LPD-6624 Allow admins to save the definition for list as visualization mode](https://issues.liferay.com/browse/LPD-6624)

### What is the goal of this PR?

In this PR we are:
- creating persistence for list visualization mode.
- implementing saving and editing of list sections (list elements). This included some refactoring of UI implementation of list implementation, in naming and internal structures @p2kmgcl  
- doing some minor refactoring with utils locations.

See technical notes in inline comments.

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/5435511/dd299ce9-7e35-4e20-a328-a88b085f9934


