### PR TITLE
LPD-17828 Data Set Manager object definitions can't be created on non-default portal instances

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -8,6 +8,7 @@ package com.liferay.frontend.data.set.views.web.internal.display.context;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.data.set.views.web.internal.constants.FDSViewsPortletKeys;
+import com.liferay.frontend.data.set.views.web.internal.portlet.FDSViewsPortlet;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
@@ -20,11 +21,13 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import javax.portlet.ActionRequest;
@@ -41,7 +44,8 @@ public class FDSViewsDisplayContext {
 		CETManager cetManager,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		RenderRequest renderRequest, RenderResponse renderResponse,
-		ServiceTrackerList<String> serviceTrackerList) {
+		ServiceTrackerList<FDSViewsPortlet.CompanyScopedOpenapiResource>
+			serviceTrackerList) {
 
 		_cetManager = cetManager;
 		_renderRequest = renderRequest;
@@ -159,12 +163,31 @@ public class FDSViewsDisplayContext {
 	public JSONArray getRESTApplicationsJSONArray() {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		List<String> restApplications = _serviceTrackerList.toList();
+		List<FDSViewsPortlet.CompanyScopedOpenapiResource>
+			companyScopedOpenapiResources = _serviceTrackerList.toList();
 
-		Collections.sort(restApplications);
+		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
-		for (String restApplication : restApplications) {
-			jsonArray.put(restApplication);
+		long companyId = themeDisplay.getCompanyId();
+
+		companyScopedOpenapiResources = ListUtil.filter(
+			companyScopedOpenapiResources,
+			companyScopedOpenapiResource ->
+				companyScopedOpenapiResource.matches(companyId));
+
+		Collections.sort(
+			companyScopedOpenapiResources,
+			Comparator.comparing(
+				FDSViewsPortlet.CompanyScopedOpenapiResource::
+					getOpenapiResourcePath,
+				String::compareTo));
+
+		for (FDSViewsPortlet.CompanyScopedOpenapiResource
+				companyScopedOpenapiResource : companyScopedOpenapiResources) {
+
+			jsonArray.put(
+				companyScopedOpenapiResource.getOpenapiResourcePath());
 		}
 
 		return jsonArray;
@@ -186,7 +209,8 @@ public class FDSViewsDisplayContext {
 	private final ObjectDefinition _fdsEntryObjectDefinition;
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
-	private final ServiceTrackerList<String> _serviceTrackerList;
+	private final ServiceTrackerList
+		<FDSViewsPortlet.CompanyScopedOpenapiResource> _serviceTrackerList;
 	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -71,13 +72,44 @@ import org.osgi.util.tracker.ServiceTrackerCustomizer;
 )
 public class FDSViewsPortlet extends MVCPortlet {
 
+	public static class CompanyScopedOpenapiResource {
+
+		public CompanyScopedOpenapiResource(
+			long companyId, String openapiResourcePath) {
+
+			_companyId = companyId;
+			_openapiResourcePath = openapiResourcePath;
+		}
+
+		public long getCompanyId() {
+			return _companyId;
+		}
+
+		public String getOpenapiResourcePath() {
+			return _openapiResourcePath;
+		}
+
+		public boolean matches(long companyId) {
+			if ((_companyId == 0) || (_companyId == companyId)) {
+				return true;
+			}
+
+			return false;
+		}
+
+		private final long _companyId;
+		private final String _openapiResourcePath;
+
+	}
+
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_bundle = BundleUtil.getBundle(
 			bundleContext, "com.liferay.frontend.data.set.views.web");
 		_serviceTrackerList = ServiceTrackerListFactory.open(
 			bundleContext, null, "(openapi.resource=true)",
-			new RESTApplicationServiceTrackerCustomizer(bundleContext));
+			new CompanyScopedRESTApplicationServiceTrackerCustomizer(
+				bundleContext));
 	}
 
 	@Deactivate
@@ -740,13 +772,17 @@ public class FDSViewsPortlet extends MVCPortlet {
 	@Reference
 	private Portal _portal;
 
-	private ServiceTrackerList<String> _serviceTrackerList;
+	private ServiceTrackerList<CompanyScopedOpenapiResource>
+		_serviceTrackerList;
 
-	private class RESTApplicationServiceTrackerCustomizer
-		implements ServiceTrackerCustomizer<Object, String> {
+	private class CompanyScopedRESTApplicationServiceTrackerCustomizer
+		implements ServiceTrackerCustomizer
+			<Object, CompanyScopedOpenapiResource> {
 
 		@Override
-		public String addingService(ServiceReference<Object> serviceReference) {
+		public CompanyScopedOpenapiResource addingService(
+			ServiceReference<Object> serviceReference) {
+
 			String openapiResourcePath = (String)serviceReference.getProperty(
 				"openapi.resource.path");
 
@@ -758,25 +794,31 @@ public class FDSViewsPortlet extends MVCPortlet {
 				"api.version");
 
 			if (apiVersion != null) {
-				return openapiResourcePath + "/" + apiVersion;
+				openapiResourcePath = openapiResourcePath + "/" + apiVersion;
 			}
 
-			return openapiResourcePath;
+			long companyId = GetterUtil.getLong(
+				(String)serviceReference.getProperty("companyId"));
+
+			return new CompanyScopedOpenapiResource(
+				companyId, openapiResourcePath);
 		}
 
 		@Override
 		public void modifiedService(
-			ServiceReference<Object> serviceReference, String restApplication) {
+			ServiceReference<Object> serviceReference,
+			CompanyScopedOpenapiResource companyScopedOpenapiResource) {
 		}
 
 		@Override
 		public void removedService(
-			ServiceReference<Object> serviceReference, String restApplication) {
+			ServiceReference<Object> serviceReference,
+			CompanyScopedOpenapiResource companyScopedOpenapiResource) {
 
 			_bundleContext.ungetService(serviceReference);
 		}
 
-		private RESTApplicationServiceTrackerCustomizer(
+		private CompanyScopedRESTApplicationServiceTrackerCustomizer(
 			BundleContext bundleContext) {
 
 			_bundleContext = bundleContext;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -231,8 +231,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsCardsSectionObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSCardsSection", userId, 0, "FDSCardsSection",
-				"FDSCardsSection", false,
+				"FDSCardsSection", userId, 0, "FDSCardsSection", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Cards Section"), true,
 				"FDSCardsSection", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Cards Sections"),
@@ -519,9 +518,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsListSectionObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSListSection", userId, 0, "FDSListSection", "FDSListSection",
-				false, LocalizedMapUtil.getLocalizedMap("FDS List Section"),
-				true, "FDSListSection", null, null, null, null,
+				"FDSListSection", userId, 0, "FDSListSection", null, false,
+				LocalizedMapUtil.getLocalizedMap("FDS List Section"), true,
+				"FDSListSection", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS List Sections"),
 				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
 				WorkflowConstants.STATUS_DRAFT,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -146,7 +146,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsActionObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSAction", userId, 0, "FDSAction", "FDSAction", false,
+				"FDSAction", userId, 0, "FDSAction", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Action"), true,
 				"FDSAction", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Actions"),
@@ -274,7 +274,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 		ObjectDefinition fdsClientExtensionFilterObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
 				"FDSClientExtensionFilter", userId, 0,
-				"FDSClientExtensionFilter", "FDSClientExtensionFilter", false,
+				"FDSClientExtensionFilter", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Client Extension Filter"),
 				true, "FDSClientExtensionFilter", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap(
@@ -320,9 +320,9 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsDateFilterObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSDateFilter", userId, 0, "FDSDateFilter", "FDSDateFilter",
-				false, LocalizedMapUtil.getLocalizedMap("FDS Date Filter"),
-				true, "FDSDateFilter", null, null, null, null,
+				"FDSDateFilter", userId, 0, "FDSDateFilter", null, false,
+				LocalizedMapUtil.getLocalizedMap("FDS Date Filter"), true,
+				"FDSDateFilter", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Date Filters"),
 				ObjectDefinitionConstants.SCOPE_COMPANY, null, 1,
 				WorkflowConstants.STATUS_DRAFT,
@@ -370,8 +370,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsDynamicFilterObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSDynamicFilter", userId, 0, "FDSDynamicFilter",
-				"FDSDynamicFilter", false,
+				"FDSDynamicFilter", userId, 0, "FDSDynamicFilter", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filter"), true,
 				"FDSDynamicFilter", null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Dynamic Filters"),
@@ -426,7 +425,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsEntryObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSEntry", userId, 0, "FDSEntry", "FDSEntry", false,
+				"FDSEntry", userId, 0, "FDSEntry", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Entry"), true, "FDSEntry",
 				null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Entries"),
@@ -466,7 +465,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsFieldObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSField", userId, 0, "FDSField", "FDSField", false,
+				"FDSField", userId, 0, "FDSField", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Field"), true, "FDSField",
 				null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Fields"),
@@ -561,7 +560,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsSortObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSSort", userId, 0, "FDSSort", "FDSSort", false,
+				"FDSSort", userId, 0, "FDSSort", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS Sort"), true, "FDSSort",
 				"300", null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Sorts"),
@@ -597,7 +596,7 @@ public class FDSViewsPortlet extends MVCPortlet {
 
 		ObjectDefinition fdsViewObjectDefinition =
 			_objectDefinitionLocalService.addSystemObjectDefinition(
-				"FDSView", userId, 0, "FDSView", "FDSView", false,
+				"FDSView", userId, 0, "FDSView", null, false,
 				LocalizedMapUtil.getLocalizedMap("FDS View"), true, "FDSView",
 				null, null, null, null,
 				LocalizedMapUtil.getLocalizedMap("FDS Views"),


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-17828

In this PR:

- We let object service to decide the `DBTableName` to avoid "Table already exists" error when re-creating the data-set object definitions in a new portal instance
- We filter out the relevant rest applications on a per-company basis, so that we don't allow cross-company leaking (duplications) of the REST applications available to the data set manager when running in different portal instances.

Additional notes:

- This PR is meant to check the CI. I'll add a followup commit to extract `CompanyScopedRESTApplication` class to its own file
- We need to add this to the list/card object definitions too @markocikos 
- This makes it even more necessary to migrate the data model to batch import of object definitions (cc @herrardo)