### PR TITLE
LPD-18034 Setting cache-control header to private only when there's no info about languageId

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
@@ -78,12 +78,14 @@ public class LanguageFilter extends BasePortalFilter {
 
 		String queryString = httpServletRequest.getQueryString();
 
-		if (Validator.isNotNull(queryString) && StringUtil.contains(queryString, "languageId")) {
+		if (Validator.isNotNull(queryString) &&
+			StringUtil.contains(queryString, "languageId")) {
+
 			httpServletResponse.setHeader(
 				HttpHeaders.CACHE_CONTROL, "no-cache");
-		} else {
-			httpServletResponse.setHeader(
-				HttpHeaders.CACHE_CONTROL, "private");
+		}
+		else {
+			httpServletResponse.setHeader(HttpHeaders.CACHE_CONTROL, "private");
 		}
 
 		BufferCacheServletResponse bufferCacheServletResponse =

--- a/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/language/LanguageFilter.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 
@@ -75,8 +76,15 @@ public class LanguageFilter extends BasePortalFilter {
 			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
 
-		httpServletResponse.setHeader(
-			HttpHeaders.CACHE_CONTROL, "private, no-cache");
+		String queryString = httpServletRequest.getQueryString();
+
+		if (Validator.isNotNull(queryString) && StringUtil.contains(queryString, "languageId")) {
+			httpServletResponse.setHeader(
+				HttpHeaders.CACHE_CONTROL, "no-cache");
+		} else {
+			httpServletResponse.setHeader(
+				HttpHeaders.CACHE_CONTROL, "private");
+		}
 
 		BufferCacheServletResponse bufferCacheServletResponse =
 			new BufferCacheServletResponse(httpServletResponse);


### PR DESCRIPTION
Hey,

This pull request is the result from the conversation [here](https://liferay.atlassian.net/browse/LPP-52157) between @izaera , @holatuwol and @bryceosterhaus .

As you can see by [this comment](https://liferay.atlassian.net/browse/LPP-52157?focusedCommentId=2550255) the idea is to only set `cache-control` header to `private` when there's no information about `languageId` in URL.

Thanks.

Regards.