### PR TITLE
LPD-18069 Allow the user to enter a description for the Display Page Template folders

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
@@ -45,12 +45,18 @@ function openSimpleInputModalImplementation({
 	mainFieldComponent,
 	mainFieldLabel,
 	mainFieldName,
+	mainFieldPlaceholder,
 	mainFieldValue,
+	maxlength,
 	method,
 	namespace,
 	onFormSuccess,
-	placeholder,
 	required,
+	secondaryFieldComponent,
+	secondaryFieldLabel,
+	secondaryFieldName,
+	secondaryFieldPlaceholder,
+	secondaryFieldValue,
 	size,
 }) {
 	dispose();
@@ -72,12 +78,18 @@ function openSimpleInputModalImplementation({
 			mainFieldComponent={mainFieldComponent}
 			mainFieldLabel={mainFieldLabel}
 			mainFieldName={mainFieldName}
+			mainFieldPlaceholder={mainFieldPlaceholder}
 			mainFieldValue={mainFieldValue}
+			maxlength={maxlength}
 			method={method}
 			namespace={namespace}
 			onFormSuccess={onFormSuccess}
-			placeholder={placeholder}
 			required={required}
+			secondaryFieldComponent={secondaryFieldComponent}
+			secondaryFieldLabel={secondaryFieldLabel}
+			secondaryFieldName={secondaryFieldName}
+			secondaryFieldPlaceholder={secondaryFieldPlaceholder}
+			secondaryFieldValue={secondaryFieldValue}
 			size={size}
 		/>,
 		DEFAULT_RENDER_DATA,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -33,12 +33,18 @@ const SimpleInputModal = ({
 	mainFieldComponent,
 	mainFieldLabel,
 	mainFieldName,
+	mainFieldPlaceholder,
 	mainFieldValue = '',
+	maxlength,
 	method = 'POST',
 	namespace,
 	onFormSuccess,
-	placeholder,
 	required = true,
+	secondaryFieldComponent,
+	secondaryFieldLabel,
+	secondaryFieldName,
+	secondaryFieldValue = '',
+	secondaryFieldPlaceholder,
 	size = 'md',
 }) => {
 	const isMounted = useIsMounted();
@@ -48,6 +54,9 @@ const SimpleInputModal = ({
 	const [visible, setVisible] = useState(initialVisible);
 	const [inputValue, setInputValue] = useState(mainFieldValue);
 	const [isChecked, setChecked] = useState(checkboxFieldValue);
+	const [secondaryInputValue, setSecondaryInputValue] = useState(
+		secondaryFieldValue
+	);
 
 	const handleFormError = (responseContent) => {
 		setErrorMessage(responseContent.error || '');
@@ -188,7 +197,7 @@ const SimpleInputModal = ({
 
 									setInputValue(event.target.value);
 								}}
-								placeholder={placeholder}
+								placeholder={mainFieldPlaceholder}
 								ref={handleMainFieldRef}
 								required={required}
 								type="text"
@@ -223,6 +232,32 @@ const SimpleInputModal = ({
 								/>
 							</div>
 						)}
+
+						{
+							<>
+								<label
+									className="control-label"
+									htmlFor={`${namespace}${secondaryFieldName}`}
+								>
+									{secondaryFieldLabel}
+								</label>
+
+								<ClayInput
+									component={secondaryFieldComponent}
+									id={`${namespace}${secondaryFieldName}`}
+									maxLength={maxlength}
+									name={`${namespace}${secondaryFieldName}`}
+									onChange={(event) => {
+										setSecondaryInputValue(
+											event.target.value
+										);
+									}}
+									placeholder={secondaryFieldPlaceholder}
+									type="text"
+									value={secondaryInputValue}
+								/>
+							</>
+						}
 					</ClayModal.Body>
 
 					<ClayModal.Footer

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
@@ -90,6 +90,9 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 									_httpServletRequest,
 									layoutPageTemplateCollection));
 							dropdownItem.putData(
+								"layoutPageTemplateCollectionDescription",
+								layoutPageTemplateCollection.getDescription());
+							dropdownItem.putData(
 								"layoutPageTemplateCollectionName",
 								layoutPageTemplateCollection.getName());
 							dropdownItem.putData(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/DisplayPageManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/DisplayPageManagementToolbarPropsTransformer.js
@@ -54,6 +54,12 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					mainFieldName: 'name',
 					mainFieldPlaceholder: Liferay.Language.get('name'),
 					namespace: portletNamespace,
+					secondaryFieldComponent: 'textarea',
+					secondaryFieldLabel: Liferay.Language.get('description'),
+					secondaryFieldName: 'description',
+					secondaryFieldPlaceholder: Liferay.Language.get(
+						'description'
+					),
 				});
 			}
 		},

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
@@ -35,6 +35,7 @@ const ACTIONS = {
 	updateLayoutPageTemplateCollection(
 		{
 			dialogTitle,
+			layoutPageTemplateCollectionDescription,
 			layoutPageTemplateCollectionName,
 			updateLayoutPageTemplateCollectionURL,
 		},
@@ -47,7 +48,13 @@ const ACTIONS = {
 			mainFieldName: 'name',
 			mainFieldPlaceholder: Liferay.Language.get('name'),
 			mainFieldValue: layoutPageTemplateCollectionName,
+			maxlength: 400,
 			namespace: portletNamespace,
+			secondaryFieldComponent: 'textarea',
+			secondaryFieldLabel: Liferay.Language.get('description'),
+			secondaryFieldName: 'description',
+			secondaryFieldPlaceholder: Liferay.Language.get('description'),
+			secondaryFieldValue: layoutPageTemplateCollectionDescription,
 		});
 	},
 };


### PR DESCRIPTION
>[!IMPORTANT]
>You need the FF LPS-189856 for the test scenario

## Motivation

Hi, @liferay-frontend ! Due to the story of [Ability to Organise Display Pages Templates in Folders Enhancement](https://liferay.atlassian.net/browse/LPD-15320) I am sending this pr to change the openSimpleInputModal to allow adding a second input as the description. Let me know what you think. Thanks in advance! 

[Link to ticket](https://liferay.atlassian.net/browse/LPD-18069)

## Changes

Change the openSimpleInputModal and the SimpleInput Modal to allow adding a second input as the description.

## Test Scenario 1

1. Go to Page Templates > Display Page Templates.
2. Create a folder with a description.
3. Rename the folder using the kebab menu of the folder.


https://github.com/liferay-frontend/liferay-portal/assets/93203423/c158c035-d8d0-438e-9f76-eb6eb5d24254

