### PR TITLE
LPD-17753 - Show and enforce item actions in fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -693,7 +693,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 					).put(
 						"successMessage", properties.get("successMessage")
 					).put(
-						"title", properties.get("label")
+						"title", properties.get("title")
 					)
 				).put(
 					"href", properties.get("url")

--- a/modules/test/playwright/tests/frontend-data-set-views-web/config.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/config.ts
@@ -6,7 +6,7 @@
 import {devices} from '@playwright/test';
 
 export const config = {
-	name: 'frontendDataSetViewsWeb',
+	name: 'frontend-data-set-views-web',
 	testDir: 'tests/frontend-data-set-views-web',
 	use: {
 		...devices['Desktop Chrome'],

--- a/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
@@ -21,7 +21,7 @@ test('Assert table column labels', async ({dataSetsPage, page}) => {
 	await dataSetsPage.goto();
 	await dataSetsPage.createDataSet();
 
-	await await page.locator('.dnd-table > .dnd-thead > .dnd-tr').waitFor();
+	await page.locator('.dnd-table > .dnd-thead > .dnd-tr').waitFor();
 
 	const tableColumnLabels = await page
 		.locator('.dnd-thead > .dnd-tr')

--- a/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
@@ -21,6 +21,8 @@ test('Assert table column labels', async ({dataSetsPage, page}) => {
 	await dataSetsPage.goto();
 	await dataSetsPage.createDataSet();
 
+	await await page.locator('.dnd-table > .dnd-thead > .dnd-tr').waitFor();
+
 	const tableColumnLabels = await page
 		.locator('.dnd-thead > .dnd-tr')
 		.first()

--- a/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
@@ -37,4 +37,6 @@ test('Assert table column labels', async ({dataSetsPage, page}) => {
 	];
 
 	await expect(tableColumnLabels).toEqual(expectedLabels);
+
+	await dataSetsPage.deleteDataSet();
 });

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
@@ -76,7 +76,8 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 		});
 	});
 
-	test('Show Creation Action in fragment', async ({
+	test('Show mapped hierarchical Fields in fragment', async ({
+		dataSetsPage,
 		fdsFragmentPage,
 		page,
 	}) => {
@@ -175,5 +176,6 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 		});
 
 		await fdsFragmentPage.deleteSite(site.id);
+		await dataSetsPage.deleteDataSet();
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -26,7 +26,7 @@ export const test = mergeTests(
 );
 
 test.describe('Data Set Item Actions', () => {
-	test.skip('Create a Link Item Action', async ({
+	test('Create a Link Item Action', async ({
 		actionsPage,
 		dataSetsPage,
 		page,
@@ -224,7 +224,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 	});
 
-	test.skip('Link, Modal and Side Panel Item Actions are shown in fragment', async ({
+	test('Link, Modal and Side Panel Item Actions are shown in fragment', async ({
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
@@ -481,7 +481,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 	});
 
-	test.skip('Async and Headless Item Actions are shown in fragment', async ({
+	test('Async and Headless Item Actions are shown in fragment', async ({
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -9,68 +9,202 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {actionsPageTest} from './fixtures/actionsPageTest';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
+import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 import {viewsPageTest} from './fixtures/viewsPageTest';
 
 export const test = mergeTests(
 	actionsPageTest,
 	dataSetsPageTest,
+	fdsFragmentPageTest,
 	featureFlagsTest({
 		'LPS-164563': true,
+		'LPS-178052': true,
 		'LPS-194395': true,
 	}),
 	loginTest,
 	viewsPageTest
 );
 
-test('Create a Link Item Action', async ({
-	actionsPage,
-	dataSetsPage,
-	page,
-	viewsPage,
-}) => {
-	const DATASET_NAME = 'Item Actions DS';
-	const DATASET_VIEW_NAME = 'Item Actions DS View';
-	const LINK_ITEM_ACTION_NAME = 'Link item action';
+test.describe('Data Set Item Actions', () => {
+	test('Create a Link Item Action', async ({
+		actionsPage,
+		dataSetsPage,
+		page,
+		viewsPage,
+	}) => {
+		const DATASET_NAME = 'Item Actions DS';
+		const DATASET_VIEW_NAME = 'Item Actions DS View';
+		const LINK_ITEM_ACTION_NAME = 'Link item action';
 
-	await test.step('Create Data Set', async () => {
-		await dataSetsPage.goto();
-		await dataSetsPage.createDataSet({name: DATASET_NAME});
-	});
+		await test.step('Create Data Set', async () => {
+			await dataSetsPage.goto();
+			await dataSetsPage.createDataSet({name: DATASET_NAME});
+		});
 
-	await test.step('Create Data Set View', async () => {
-		await viewsPage.goto(DATASET_NAME);
-		await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
-	});
+		await test.step('Create Data Set View', async () => {
+			await viewsPage.goto(DATASET_NAME);
+			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
+		});
 
-	await test.step('Go to Actions tab', async () => {
-		await actionsPage.goto({
-			dataSetName: DATASET_NAME,
-			dataSetViewName: DATASET_VIEW_NAME,
+		await test.step('Go to Actions tab', async () => {
+			await actionsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+		});
+
+		await test.step('Create an item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'link',
+				name: LINK_ITEM_ACTION_NAME,
+				type: 'link',
+				url: 'https://www.liferay.com/',
+			});
+		});
+
+		await test.step('Check that the item action is in the list', async () => {
+			await expect(
+				page
+					.getByRole('cell', {
+						exact: true,
+						name: LINK_ITEM_ACTION_NAME,
+					})
+					.locator('span')
+					.first()
+			).toBeVisible();
+		});
+
+		await test.step('Delete Data Set', async () => {
+			await dataSetsPage.deleteDataSet(DATASET_NAME);
 		});
 	});
 
-	await test.step('Create an item action', async () => {
-		await actionsPage.createItemAction({
-			icon: 'link',
-			name: LINK_ITEM_ACTION_NAME,
-			type: 'link',
-			url: 'https://www.liferay.com/',
-		});
-	});
+	test('Link Item Action is shown in fragment', async ({
+		actionsPage,
+		dataSetsPage,
+		fdsFragmentPage,
+		page,
+		viewsPage,
+	}) => {
+		const DATASET_NAME = 'Item Actions DS';
+		const DATASET_VIEW_NAME = 'Item Actions DS View';
+		const LINK_ITEM_ACTION_NAME = 'Link item action';
+		const PAGE_NAME = 'Test page';
+		const SITE_NAME = 'FDSFragmentSite';
 
-	await test.step('Check that the item action is in the list', async () => {
-		await expect(
-			page
-				.getByRole('cell', {
-					exact: true,
-					name: LINK_ITEM_ACTION_NAME,
-				})
-				.locator('span')
+		await test.step('Create Data Set', async () => {
+			await dataSetsPage.goto();
+			await dataSetsPage.createDataSet({name: DATASET_NAME});
+		});
+
+		await test.step('Create Data Set View', async () => {
+			await viewsPage.goto(DATASET_NAME);
+			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
+		});
+
+		// Missing (Add fields)
+
+		await test.step('Go to Actions tab', async () => {
+			await actionsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+		});
+
+		await test.step('Create a link item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'link',
+				name: LINK_ITEM_ACTION_NAME,
+				type: 'link',
+				url: 'https://www.liferay.com/',
+			});
+		});
+
+		const siteInfo =
+			await test.step('Go home and create a new site', async () => {
+				await page.goto('/');
+
+				const newSite = await fdsFragmentPage.createSite(SITE_NAME);
+
+				const pageLayout = await fdsFragmentPage.createPage({
+					siteId: newSite.id,
+					title: PAGE_NAME,
+				});
+
+				await page.reload();
+
+				return {layout: pageLayout, site: newSite};
+			});
+
+		await test.step('Edit page', async () => {
+			await fdsFragmentPage.editPage({...siteInfo});
+		});
+
+		await test.step('Search for "Data Set" fragment', async () => {
+			await fdsFragmentPage.searchFragmentOrWidget('Data Set');
+		});
+
+		await test.step('Drag "Data Set" fragment & Drop into the page editor w/ keyboard', async () => {
+			await fdsFragmentPage.dragAndDropFragment(
+				'Data Set Add Data Set Mark Data Set as Favorite'
+			);
+		});
+
+		await test.step('Select empty Data Set fragment', async () => {
+			await page
+				.getByText('Select a data set view. Beta')
 				.first()
-		).toBeVisible();
-	});
+				.click();
+		});
 
-	await test.step('Delete Data Set', async () => {
-		await dataSetsPage.deleteDataSet(DATASET_NAME);
+		await test.step('Open Data Set View Selector', async () => {
+			await page
+				.getByRole('button', {name: 'Select Data Set View'})
+				.click();
+		});
+
+		await test.step('Select Data Set View', async () => {
+			await expect(page.getByRole('dialog')).toBeVisible();
+
+			await expect(
+				page.getByRole('heading', {name: 'Select'})
+			).toBeVisible();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.locator('li')
+				.filter({hasText: DATASET_VIEW_NAME})
+				.first()
+				.click();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.getByRole('button', {name: 'Save'})
+				.click();
+		});
+
+		await test.step('Publish page with Data Set View', async () => {
+			await fdsFragmentPage.publishPage();
+
+			await fdsFragmentPage.gotoPage({...siteInfo});
+
+			await expect(page.locator('.data-set-wrapper')).toBeVisible();
+		});
+
+		await test.step('Item action are present in table row', async () => {
+			const tableRow = await page.locator('.dnd-td.item-actions').first();
+
+			await expect(tableRow.getByRole('link')).toBeVisible();
+
+			await tableRow.getByRole('link').click();
+
+			await page.waitForURL('https://www.liferay.com');
+			await expect(page.url()).toContain('https://www.liferay.com');
+		});
+
+		await test.step('Delete Data Set and site', async () => {
+			await fdsFragmentPage.deleteSite(siteInfo.site.id);
+			await dataSetsPage.deleteDataSet(DATASET_NAME);
+		});
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -7,6 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {liferayConfig} from '../../liferay.config';
 import {actionsPageTest} from './fixtures/actionsPageTest';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
 import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
@@ -264,7 +265,7 @@ test.describe('Data Set Item Actions', () => {
 		const PAGE_NAME = 'Test page';
 		const SITE_NAME = 'FDSFragmentSite';
 		const SIDE_PANEL_ITEM_ACTION_NAME = 'SidePanel item action';
-		const SIDE_PANEL_ITEM_ACTION_URL = '/home';
+		const SIDE_PANEL_ITEM_ACTION_URL = liferayConfig.environment.baseUrl;
 
 		const siteInfo =
 			await test.step('Go home and create a new site and page', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -742,13 +742,11 @@ test.describe('Data Set Item Actions', () => {
 
 			await page.getByRole('alert').waitFor();
 
-			const alert = await page.getByRole('alert');
+			const alert = await page.getByRole('alert').first();
 
 			await expect(alert).toHaveText(
 				'Success:Your request completed successfully.'
 			);
-
-			await alert.getByRole('button').click();
 		});
 
 		await test.step('Click in the async item action executes the action', async () => {
@@ -782,13 +780,11 @@ test.describe('Data Set Item Actions', () => {
 
 			await page.getByRole('alert').waitFor();
 
-			const alert = await page.getByRole('alert');
+			const alert = await page.getByRole('alert').first();
 
 			await expect(alert).toHaveText(
 				'Success:Your request completed successfully.'
 			);
-
-			await alert.getByRole('button').click();
 		});
 
 		await test.step('Delete Data Set and site', async () => {
@@ -939,7 +935,7 @@ test.describe('Data Set Item Actions', () => {
 
 			await page.getByRole('alert').waitFor();
 
-			const alert = await page.getByRole('alert');
+			const alert = await page.getByRole('alert').first();
 
 			await expect(alert).toHaveText(
 				'Error:An unexpected error occurred.'

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -102,8 +102,6 @@ test.describe('Data Set Item Actions', () => {
 			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
 		});
 
-		// Missing (Add fields)
-
 		await test.step('Go to Actions tab', async () => {
 			await actionsPage.goto({
 				dataSetName: DATASET_NAME,
@@ -199,7 +197,265 @@ test.describe('Data Set Item Actions', () => {
 			await tableRow.getByRole('link').click();
 
 			await page.waitForURL('https://www.liferay.com');
+
 			await expect(page.url()).toContain('https://www.liferay.com');
+		});
+
+		await test.step('Delete Data Set and site', async () => {
+			await fdsFragmentPage.deleteSite(siteInfo.site.id);
+			await dataSetsPage.deleteDataSet(DATASET_NAME);
+		});
+	});
+
+	test('Link, Modal and Side Panel Item Actions are shown in fragment', async ({
+		actionsPage,
+		dataSetsPage,
+		fdsFragmentPage,
+		page,
+		viewsPage,
+	}) => {
+		const DATASET_NAME = 'Item Actions DS';
+		const DATASET_VIEW_NAME = 'Item Actions DS View';
+		const LINK_ITEM_ACTION_NAME = 'Link item action';
+		const MODAL_ITEM_ACTION_NAME = 'Modal item action';
+		const MODAL_ITEM_ACTION_TITLE = 'Modal title';
+		const PAGE_NAME = 'Test page';
+		const SITE_NAME = 'FDSFragmentSite';
+		const SIDE_PANEL_ITEM_ACTION_NAME = 'SidePanel item action';
+		const SIDE_PANEL_ITEM_ACTION_URL = '/home';
+
+		const siteInfo =
+			await test.step('Go home and create a new site and page', async () => {
+				await page.goto('/');
+
+				const newSite = await fdsFragmentPage.createSite(SITE_NAME);
+
+				const pageLayout = await fdsFragmentPage.createPage({
+					siteId: newSite.id,
+					title: PAGE_NAME,
+				});
+
+				await page.reload();
+
+				return {layout: pageLayout, site: newSite};
+			});
+
+		await test.step('Create Data Set', async () => {
+			await dataSetsPage.goto();
+			await dataSetsPage.createDataSet({name: DATASET_NAME});
+		});
+
+		await test.step('Create Data Set View', async () => {
+			await viewsPage.goto(DATASET_NAME);
+			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
+		});
+
+		// Missing (Add fields)
+
+		await test.step('Go to Actions tab', async () => {
+			await actionsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+		});
+
+		await test.step('Create a link item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'link',
+				name: LINK_ITEM_ACTION_NAME,
+				type: 'link',
+				url: 'https://www.liferay.com/',
+			});
+		});
+
+		await test.step('Create a modal item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'cloud',
+				name: MODAL_ITEM_ACTION_NAME,
+				title: MODAL_ITEM_ACTION_TITLE,
+				type: 'modal',
+				url: '/home',
+			});
+		});
+
+		await test.step('Create a side panel item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'container',
+				name: SIDE_PANEL_ITEM_ACTION_NAME,
+				title: SIDE_PANEL_ITEM_ACTION_NAME,
+				type: 'sidePanel',
+				url: SIDE_PANEL_ITEM_ACTION_URL,
+			});
+		});
+
+		await test.step('Edit page', async () => {
+			await fdsFragmentPage.editPage({...siteInfo});
+		});
+
+		await test.step('Search for "Data Set" fragment', async () => {
+			await fdsFragmentPage.searchFragmentOrWidget('Data Set');
+		});
+
+		await test.step('Drag "Data Set" fragment & Drop into the page editor w/ keyboard', async () => {
+			await fdsFragmentPage.dragAndDropFragment(
+				'Data Set Add Data Set Mark Data Set as Favorite'
+			);
+		});
+
+		await test.step('Select empty Data Set fragment', async () => {
+			await page
+				.getByText('Select a data set view. Beta')
+				.first()
+				.click();
+		});
+
+		await test.step('Open Data Set View Selector', async () => {
+			await page
+				.getByRole('button', {name: 'Select Data Set View'})
+				.click();
+		});
+
+		await test.step('Select Data Set View', async () => {
+			await expect(page.getByRole('dialog')).toBeVisible();
+
+			await expect(
+				page.getByRole('heading', {name: 'Select'})
+			).toBeVisible();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.locator('li')
+				.filter({hasText: DATASET_VIEW_NAME})
+				.first()
+				.click();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.getByRole('button', {name: 'Save'})
+				.click();
+		});
+
+		await test.step('Publish page with Data Set View', async () => {
+			await fdsFragmentPage.publishPage();
+
+			await fdsFragmentPage.gotoPage({...siteInfo});
+
+			await expect(page.locator('.data-set-wrapper')).toBeVisible();
+		});
+
+		const datasetRow =
+			await test.step('Item actions dropdown is present in table row', async () => {
+				const tableRow = await page
+					.locator('.dnd-td.item-actions')
+					.first();
+
+				await expect(
+					tableRow.getByRole('button', {exact: true, name: 'Actions'})
+				).toBeVisible;
+
+				const button = await tableRow.getByRole('button', {
+					exact: true,
+					name: 'Actions',
+				});
+				const dropdownId = await button.evaluate((node) =>
+					node.getAttribute('aria-controls')
+				);
+
+				await button.click();
+
+				await page
+					.locator(`#${dropdownId}`)
+					.filter({has: page.getByRole('menu')})
+					.waitFor();
+
+				await expect(
+					page.locator(`#${dropdownId}`).getByRole('menuitem')
+				).toHaveCount(3);
+
+				await page.keyboard.press('Escape');
+
+				return tableRow;
+			});
+
+		await test.step('Click the modal item action opens a modal window', async () => {
+			const button = await datasetRow.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			});
+
+			const dropdownId = await button.evaluate((node) =>
+				node.getAttribute('aria-controls')
+			);
+
+			await button.click();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.getByRole('menuitem', {
+					exact: true,
+					name: MODAL_ITEM_ACTION_NAME,
+				})
+				.click();
+
+			await page.getByRole('dialog').waitFor();
+
+			const dialog = await page.getByRole('dialog');
+			await expect(dialog.getByRole('heading')).toHaveText(
+				MODAL_ITEM_ACTION_NAME
+			);
+
+			await dialog.getByRole('button', {name: 'close'}).click();
+
+			await expect(dialog).not.toBeInViewport();
+		});
+
+		await test.step('Click the side panel item action opens a side panel', async () => {
+			const button = await datasetRow.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			});
+
+			const dropdownId = await button.evaluate((node) =>
+				node.getAttribute('aria-controls')
+			);
+
+			await button.click();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.getByRole('menuitem', {
+					exact: true,
+					name: SIDE_PANEL_ITEM_ACTION_NAME,
+				})
+				.click();
+
+			await page.getByRole('tabpanel').waitFor();
+
+			const sidePanel = await page.getByRole('tabpanel');
+
+			const iframeElement = await sidePanel
+				.locator('iframe')
+				.elementHandle();
+
+			const frame = await iframeElement.contentFrame();
+
+			await frame.waitForURL(
+				new RegExp(`.*${SIDE_PANEL_ITEM_ACTION_URL}`, 'i')
+			);
+
+			await page.keyboard.press('Escape');
+
+			await expect(sidePanel).not.toBeInViewport();
 		});
 
 		await test.step('Delete Data Set and site', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -26,7 +26,7 @@ export const test = mergeTests(
 );
 
 test.describe('Data Set Item Actions', () => {
-	test('Create a Link Item Action', async ({
+	test.skip('Create a Link Item Action', async ({
 		actionsPage,
 		dataSetsPage,
 		page,
@@ -79,7 +79,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 	});
 
-	test('Link Item Action is shown in fragment', async ({
+	test.skip('Link Item Action is shown in fragment', async ({
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
@@ -207,7 +207,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 	});
 
-	test('Link, Modal and Side Panel Item Actions are shown in fragment', async ({
+	test.skip('Link, Modal and Side Panel Item Actions are shown in fragment', async ({
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
@@ -456,6 +456,305 @@ test.describe('Data Set Item Actions', () => {
 			await page.keyboard.press('Escape');
 
 			await expect(sidePanel).not.toBeInViewport();
+		});
+
+		await test.step('Delete Data Set and site', async () => {
+			await fdsFragmentPage.deleteSite(siteInfo.site.id);
+			await dataSetsPage.deleteDataSet(DATASET_NAME);
+		});
+	});
+
+	test('Async and Headless Item Actions are shown in fragment', async ({
+		actionsPage,
+		dataSetsPage,
+		fdsFragmentPage,
+		page,
+		viewsPage,
+	}) => {
+		const DATASET_NAME = 'Item Actions DS';
+		const DATASET_VIEW_NAME = 'Item Actions DS View';
+		const ASYNC_ITEM_ACTION_NAME = 'Async item action';
+		const ASYNC_ITEM_ACTION_METHOD = 'DELETE';
+		const ASYNC_ITEM_ACTION_URL = '/o/data-set-manager/fields/{id}';
+		const HEADLESS_ITEM_ACTION_NAME = 'Headless item action';
+		const HEADLESS_ITEM_ACTION_PERMISSION_KEY = 'delete';
+		const NON_AVAILABLE_HEADLESS_ITEM_ACTION_NAME =
+			'Useless Headless Item Action';
+		const PAGE_NAME = 'Test page';
+		const SITE_NAME = 'FDSFragmentSite';
+
+		const siteInfo =
+			await test.step('Go home and create a new site and page', async () => {
+				await page.goto('/');
+
+				const newSite = await fdsFragmentPage.createSite(SITE_NAME);
+
+				const pageLayout = await fdsFragmentPage.createPage({
+					siteId: newSite.id,
+					title: PAGE_NAME,
+				});
+
+				await page.reload();
+
+				return {layout: pageLayout, site: newSite};
+			});
+
+		await test.step('Create Data Set', async () => {
+			await dataSetsPage.goto();
+			await dataSetsPage.createDataSet({name: DATASET_NAME});
+		});
+
+		await test.step('Create Data Set View', async () => {
+			await viewsPage.goto(DATASET_NAME);
+			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
+		});
+
+		// Manually adding fields (with LPD-10735=false / visualization modes)
+
+		await test.step('Open Data Set Fields Tab', async () => {
+			await viewsPage.gotoDataSetView(DATASET_VIEW_NAME);
+
+			await page.getByRole('button', {name: 'Fields'}).first().waitFor();
+
+			await page.getByRole('button', {name: 'Fields'}).first().click();
+		});
+
+		const fieldModal =
+			await test.step('Open Data Set Fields Modal', async () => {
+				page.getByRole('button', {
+					name: 'Add Fields',
+				})
+					.first()
+					.waitFor();
+
+				page.getByRole('button', {
+					name: 'Add Fields',
+				})
+					.first()
+					.click();
+
+				page.getByRole('heading', {
+					name: 'Add Fields',
+				}).waitFor;
+
+				return page.getByRole('dialog');
+			});
+
+		await test.step('Select id and name fields', async () => {
+			await fieldModal.getByLabel(/id/).check();
+			await fieldModal.getByLabel(/name/).check();
+			await fieldModal.getByRole('button', {name: 'Save'}).click();
+
+			await expect(
+				page.locator('.orderable-table-row').nth(0)
+			).toContainText('id');
+			await expect(
+				page.locator('.orderable-table-row').nth(1)
+			).toContainText('name');
+		});
+
+		// Finish manually adding fields
+
+		await test.step('Go to Actions tab', async () => {
+			await actionsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+		});
+
+		await test.step('Create a headless item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'link',
+				name: HEADLESS_ITEM_ACTION_NAME,
+				permissionKey: HEADLESS_ITEM_ACTION_PERMISSION_KEY,
+				type: 'headless',
+			});
+		});
+
+		await test.step('Create a non available headless item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'link',
+				name: NON_AVAILABLE_HEADLESS_ITEM_ACTION_NAME,
+				permissionKey: 'remove',
+				type: 'headless',
+			});
+		});
+
+		await test.step('Create an async item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'cloud',
+				method: ASYNC_ITEM_ACTION_METHOD,
+				name: ASYNC_ITEM_ACTION_NAME,
+				type: 'async',
+				url: ASYNC_ITEM_ACTION_URL,
+			});
+		});
+
+		await test.step('Edit page', async () => {
+			await fdsFragmentPage.editPage({...siteInfo});
+		});
+
+		await test.step('Search for "Data Set" fragment', async () => {
+			await fdsFragmentPage.searchFragmentOrWidget('Data Set');
+		});
+
+		await test.step('Drag "Data Set" fragment & Drop into the page editor w/ keyboard', async () => {
+			await fdsFragmentPage.dragAndDropFragment(
+				'Data Set Add Data Set Mark Data Set as Favorite'
+			);
+		});
+
+		await test.step('Select empty Data Set fragment', async () => {
+			await page
+				.getByText('Select a data set view. Beta')
+				.first()
+				.click();
+		});
+
+		await test.step('Open Data Set View Selector', async () => {
+			await page
+				.getByRole('button', {name: 'Select Data Set View'})
+				.click();
+		});
+
+		await test.step('Select Data Set View', async () => {
+			await expect(page.getByRole('dialog')).toBeVisible();
+
+			await expect(
+				page.getByRole('heading', {name: 'Select'})
+			).toBeVisible();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.locator('li')
+				.filter({hasText: DATASET_VIEW_NAME})
+				.first()
+				.click();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.getByRole('button', {name: 'Save'})
+				.click();
+		});
+
+		await test.step('Publish page with Data Set View', async () => {
+			await fdsFragmentPage.publishPage();
+
+			await fdsFragmentPage.gotoPage({...siteInfo});
+
+			await expect(page.locator('.data-set-wrapper')).toBeVisible();
+		});
+
+		const datasetRow =
+			await test.step('Item actions dropdown is present in table row', async () => {
+				const tableRow = await page
+					.locator('.dnd-td.item-actions')
+					.first();
+
+				await expect(
+					tableRow.getByRole('button', {exact: true, name: 'Actions'})
+				).toBeVisible;
+
+				const button = await tableRow.getByRole('button', {
+					exact: true,
+					name: 'Actions',
+				});
+				const dropdownId = await button.evaluate((node) =>
+					node.getAttribute('aria-controls')
+				);
+
+				await button.click();
+
+				await page
+					.locator(`#${dropdownId}`)
+					.filter({has: page.getByRole('menu')})
+					.waitFor();
+
+				await expect(
+					page.locator(`#${dropdownId}`).getByRole('menuitem')
+				).toHaveCount(2);
+
+				await expect(
+					page.locator(`#${dropdownId}`).getByRole('menuitem', {
+						name: NON_AVAILABLE_HEADLESS_ITEM_ACTION_NAME,
+					})
+				).not.toBeVisible();
+
+				await page.keyboard.press('Escape');
+
+				return tableRow;
+			});
+
+		await test.step('Click in the headless item action executes the action', async () => {
+			const button = await datasetRow.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			});
+
+			const dropdownId = await button.evaluate((node) =>
+				node.getAttribute('aria-controls')
+			);
+
+			await button.click();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.getByRole('menuitem', {
+					exact: true,
+					name: HEADLESS_ITEM_ACTION_NAME,
+				})
+				.click();
+
+			await page.getByRole('alert').waitFor();
+
+			const alert = await page.getByRole('alert');
+
+			await expect(alert).toHaveText(
+				'Success:Your request completed successfully.'
+			);
+		});
+
+		await test.step('Click in the async item action executes the action', async () => {
+			const nextTableRow = await page
+				.locator('.dnd-td.item-actions')
+				.first();
+
+			const button = await nextTableRow.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			});
+
+			const dropdownId = await button.evaluate((node) =>
+				node.getAttribute('aria-controls')
+			);
+
+			await button.click();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			await page
+				.locator(`#${dropdownId}`)
+				.getByRole('menuitem', {
+					exact: true,
+					name: ASYNC_ITEM_ACTION_NAME,
+				})
+				.click();
+
+			await page.getByRole('alert').waitFor();
+
+			const alert = await page.getByRole('alert');
+
+			await expect(alert).toHaveText(
+				'Success:Your request completed successfully.'
+			);
 		});
 
 		await test.step('Delete Data Set and site', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -79,7 +79,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 	});
 
-	test.skip('Link Item Action is shown in fragment', async ({
+	test('Link Item Action is shown in fragment', async ({
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
@@ -88,6 +88,8 @@ test.describe('Data Set Item Actions', () => {
 	}) => {
 		const DATASET_NAME = 'Item Actions DS';
 		const DATASET_VIEW_NAME = 'Item Actions DS View';
+		const LINK_ITEM_ACTION_CONFIRMATION_MESSAGE =
+			'Do you want to navigate to http://www.liferay.com?';
 		const LINK_ITEM_ACTION_NAME = 'Link item action';
 		const PAGE_NAME = 'Test page';
 		const SITE_NAME = 'FDSFragmentSite';
@@ -111,6 +113,7 @@ test.describe('Data Set Item Actions', () => {
 
 		await test.step('Create a link item action', async () => {
 			await actionsPage.createItemAction({
+				confirmationMessage: LINK_ITEM_ACTION_CONFIRMATION_MESSAGE,
 				icon: 'link',
 				name: LINK_ITEM_ACTION_NAME,
 				type: 'link',
@@ -190,11 +193,25 @@ test.describe('Data Set Item Actions', () => {
 		});
 
 		await test.step('Item action are present in table row', async () => {
+			const dialogPromise = page
+				.waitForEvent('dialog')
+				.then(async (dialog) => {
+					await dialog.accept();
+
+					return dialog.message();
+				});
+
 			const tableRow = await page.locator('.dnd-td.item-actions').first();
 
 			await expect(tableRow.getByRole('link')).toBeVisible();
 
 			await tableRow.getByRole('link').click();
+
+			const confirmationMessage = await dialogPromise;
+
+			expect(confirmationMessage).toBe(
+				LINK_ITEM_ACTION_CONFIRMATION_MESSAGE
+			);
 
 			await page.waitForURL('https://www.liferay.com');
 
@@ -464,7 +481,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 	});
 
-	test('Async and Headless Item Actions are shown in fragment', async ({
+	test.skip('Async and Headless Item Actions are shown in fragment', async ({
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -10,6 +10,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {actionsPageTest} from './fixtures/actionsPageTest';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
 import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
+import {fieldsPageTest} from './fixtures/fieldsPageTest';
 import {viewsPageTest} from './fixtures/viewsPageTest';
 
 export const test = mergeTests(
@@ -19,8 +20,10 @@ export const test = mergeTests(
 	featureFlagsTest({
 		'LPS-164563': true,
 		'LPS-178052': true,
+		'LPS-186871': true,
 		'LPS-194395': true,
 	}),
+	fieldsPageTest,
 	loginTest,
 	viewsPageTest
 );
@@ -83,6 +86,7 @@ test.describe('Data Set Item Actions', () => {
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
+		fieldsPage,
 		page,
 		viewsPage,
 	}) => {
@@ -102,6 +106,23 @@ test.describe('Data Set Item Actions', () => {
 		await test.step('Create Data Set View', async () => {
 			await viewsPage.goto(DATASET_NAME);
 			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
+		});
+
+		await test.step('Open modal to add fields', async () => {
+			await fieldsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+			await fieldsPage.openAddFieldsModal();
+		});
+
+		await test.step('Select fields in treeview', async () => {
+			await fieldsPage.addRootField('id');
+			await fieldsPage.addRootField('name');
+		});
+
+		await test.step('Save changes', async () => {
+			await fieldsPage.saveAddFieldsModal();
 		});
 
 		await test.step('Go to Actions tab', async () => {
@@ -187,12 +208,12 @@ test.describe('Data Set Item Actions', () => {
 		await test.step('Publish page with Data Set View', async () => {
 			await fdsFragmentPage.publishPage();
 
-			await fdsFragmentPage.gotoPage({...siteInfo});
+			await fdsFragmentPage.goToPage({...siteInfo});
 
 			await expect(page.locator('.data-set-wrapper')).toBeVisible();
 		});
 
-		await test.step('Item action are present in table row', async () => {
+		await test.step('Item actions are present in table row', async () => {
 			const dialogPromise = page
 				.waitForEvent('dialog')
 				.then(async (dialog) => {
@@ -200,6 +221,8 @@ test.describe('Data Set Item Actions', () => {
 
 					return dialog.message();
 				});
+
+			await page.locator('.dnd-td.item-actions').first().waitFor();
 
 			const tableRow = await page.locator('.dnd-td.item-actions').first();
 
@@ -219,6 +242,7 @@ test.describe('Data Set Item Actions', () => {
 		});
 
 		await test.step('Delete Data Set and site', async () => {
+			await fdsFragmentPage.goto();
 			await fdsFragmentPage.deleteSite(siteInfo.site.id);
 			await dataSetsPage.deleteDataSet(DATASET_NAME);
 		});
@@ -228,6 +252,7 @@ test.describe('Data Set Item Actions', () => {
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
+		fieldsPage,
 		page,
 		viewsPage,
 	}) => {
@@ -267,7 +292,22 @@ test.describe('Data Set Item Actions', () => {
 			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
 		});
 
-		// Missing (Add fields)
+		await test.step('Open modal to add fields', async () => {
+			await fieldsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+			await fieldsPage.openAddFieldsModal();
+		});
+
+		await test.step('Select fields in treeview', async () => {
+			await fieldsPage.addRootField('id');
+			await fieldsPage.addRootField('name');
+		});
+
+		await test.step('Save changes', async () => {
+			await fieldsPage.saveAddFieldsModal();
+		});
 
 		await test.step('Go to Actions tab', async () => {
 			await actionsPage.goto({
@@ -355,7 +395,7 @@ test.describe('Data Set Item Actions', () => {
 		await test.step('Publish page with Data Set View', async () => {
 			await fdsFragmentPage.publishPage();
 
-			await fdsFragmentPage.gotoPage({...siteInfo});
+			await fdsFragmentPage.goToPage({...siteInfo});
 
 			await expect(page.locator('.data-set-wrapper')).toBeVisible();
 		});
@@ -485,6 +525,7 @@ test.describe('Data Set Item Actions', () => {
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
+		fieldsPage,
 		page,
 		viewsPage,
 	}) => {
@@ -526,51 +567,22 @@ test.describe('Data Set Item Actions', () => {
 			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
 		});
 
-		// Manually adding fields (with LPD-10735=false / visualization modes)
-
-		await test.step('Open Data Set Fields Tab', async () => {
-			await viewsPage.gotoDataSetView(DATASET_VIEW_NAME);
-
-			await page.getByRole('button', {name: 'Fields'}).first().waitFor();
-
-			await page.getByRole('button', {name: 'Fields'}).first().click();
-		});
-
-		const fieldModal =
-			await test.step('Open Data Set Fields Modal', async () => {
-				page.getByRole('button', {
-					name: 'Add Fields',
-				})
-					.first()
-					.waitFor();
-
-				page.getByRole('button', {
-					name: 'Add Fields',
-				})
-					.first()
-					.click();
-
-				page.getByRole('heading', {
-					name: 'Add Fields',
-				}).waitFor;
-
-				return page.getByRole('dialog');
+		await test.step('Open modal to add fields', async () => {
+			await fieldsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
 			});
-
-		await test.step('Select id and name fields', async () => {
-			await fieldModal.getByLabel(/id/).check();
-			await fieldModal.getByLabel(/name/).check();
-			await fieldModal.getByRole('button', {name: 'Save'}).click();
-
-			await expect(
-				page.locator('.orderable-table-row').nth(0)
-			).toContainText('id');
-			await expect(
-				page.locator('.orderable-table-row').nth(1)
-			).toContainText('name');
+			await fieldsPage.openAddFieldsModal();
 		});
 
-		// Finish manually adding fields
+		await test.step('Select fields in treeview', async () => {
+			await fieldsPage.addRootField('id');
+			await fieldsPage.addRootField('name');
+		});
+
+		await test.step('Save changes', async () => {
+			await fieldsPage.saveAddFieldsModal();
+		});
 
 		await test.step('Go to Actions tab', async () => {
 			await actionsPage.goto({
@@ -657,7 +669,7 @@ test.describe('Data Set Item Actions', () => {
 		await test.step('Publish page with Data Set View', async () => {
 			await fdsFragmentPage.publishPage();
 
-			await fdsFragmentPage.gotoPage({...siteInfo});
+			await fdsFragmentPage.goToPage({...siteInfo});
 
 			await expect(page.locator('.data-set-wrapper')).toBeVisible();
 		});
@@ -784,6 +796,7 @@ test.describe('Data Set Item Actions', () => {
 		actionsPage,
 		dataSetsPage,
 		fdsFragmentPage,
+		fieldsPage,
 		page,
 		viewsPage,
 	}) => {
@@ -821,51 +834,22 @@ test.describe('Data Set Item Actions', () => {
 			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
 		});
 
-		// Manually adding fields (with LPD-10735=false / visualization modes)
-
-		await test.step('Open Data Set Fields Tab', async () => {
-			await viewsPage.gotoDataSetView(DATASET_VIEW_NAME);
-
-			await page.getByRole('button', {name: 'Fields'}).first().waitFor();
-
-			await page.getByRole('button', {name: 'Fields'}).first().click();
-		});
-
-		const fieldModal =
-			await test.step('Open Data Set Fields Modal', async () => {
-				page.getByRole('button', {
-					name: 'Add Fields',
-				})
-					.first()
-					.waitFor();
-
-				page.getByRole('button', {
-					name: 'Add Fields',
-				})
-					.first()
-					.click();
-
-				page.getByRole('heading', {
-					name: 'Add Fields',
-				}).waitFor;
-
-				return page.getByRole('dialog');
+		await test.step('Open modal to add fields', async () => {
+			await fieldsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
 			});
-
-		await test.step('Select id and name fields', async () => {
-			await fieldModal.getByLabel(/id/).check();
-			await fieldModal.getByLabel(/name/).check();
-			await fieldModal.getByRole('button', {name: 'Save'}).click();
-
-			await expect(
-				page.locator('.orderable-table-row').nth(0)
-			).toContainText('id');
-			await expect(
-				page.locator('.orderable-table-row').nth(1)
-			).toContainText('name');
+			await fieldsPage.openAddFieldsModal();
 		});
 
-		// Finish manually adding fields
+		await test.step('Select fields in treeview', async () => {
+			await fieldsPage.addRootField('id');
+			await fieldsPage.addRootField('name');
+		});
+
+		await test.step('Save changes', async () => {
+			await fieldsPage.saveAddFieldsModal();
+		});
 
 		await test.step('Go to Actions tab', async () => {
 			await actionsPage.goto({
@@ -934,7 +918,7 @@ test.describe('Data Set Item Actions', () => {
 		await test.step('Publish page with Data Set View', async () => {
 			await fdsFragmentPage.publishPage();
 
-			await fdsFragmentPage.gotoPage({...siteInfo});
+			await fdsFragmentPage.goToPage({...siteInfo});
 
 			await expect(page.locator('.data-set-wrapper')).toBeVisible();
 		});

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -406,7 +406,7 @@ test.describe('Data Set Item Actions', () => {
 
 			const dialog = await page.getByRole('dialog');
 			await expect(dialog.getByRole('heading')).toHaveText(
-				MODAL_ITEM_ACTION_NAME
+				MODAL_ITEM_ACTION_TITLE
 			);
 
 			await dialog.getByRole('button', {name: 'close'}).click();

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -779,4 +779,187 @@ test.describe('Data Set Item Actions', () => {
 			await dataSetsPage.deleteDataSet(DATASET_NAME);
 		});
 	});
+
+	test('Async Item Action shows an error toast in the fragment when a failure occurs', async ({
+		actionsPage,
+		dataSetsPage,
+		fdsFragmentPage,
+		page,
+		viewsPage,
+	}) => {
+		const DATASET_NAME = 'Item Actions DS';
+		const DATASET_VIEW_NAME = 'Item Actions DS View';
+		const ASYNC_ITEM_ACTION_NAME = 'Async item action';
+		const ASYNC_ITEM_ACTION_METHOD = 'DELETE';
+		const ASYNC_ITEM_ACTION_WRONG_URL = '/o/data-set-manager/fields/{foo}';
+		const PAGE_NAME = 'Test page';
+		const SITE_NAME = 'FDSFragmentSite';
+
+		const siteInfo =
+			await test.step('Go home and create a new site and page', async () => {
+				await page.goto('/');
+
+				const newSite = await fdsFragmentPage.createSite(SITE_NAME);
+
+				const pageLayout = await fdsFragmentPage.createPage({
+					siteId: newSite.id,
+					title: PAGE_NAME,
+				});
+
+				await page.reload();
+
+				return {layout: pageLayout, site: newSite};
+			});
+
+		await test.step('Create Data Set', async () => {
+			await dataSetsPage.goto();
+			await dataSetsPage.createDataSet({name: DATASET_NAME});
+		});
+
+		await test.step('Create Data Set View', async () => {
+			await viewsPage.goto(DATASET_NAME);
+			await viewsPage.createDataSetView({name: DATASET_VIEW_NAME});
+		});
+
+		// Manually adding fields (with LPD-10735=false / visualization modes)
+
+		await test.step('Open Data Set Fields Tab', async () => {
+			await viewsPage.gotoDataSetView(DATASET_VIEW_NAME);
+
+			await page.getByRole('button', {name: 'Fields'}).first().waitFor();
+
+			await page.getByRole('button', {name: 'Fields'}).first().click();
+		});
+
+		const fieldModal =
+			await test.step('Open Data Set Fields Modal', async () => {
+				page.getByRole('button', {
+					name: 'Add Fields',
+				})
+					.first()
+					.waitFor();
+
+				page.getByRole('button', {
+					name: 'Add Fields',
+				})
+					.first()
+					.click();
+
+				page.getByRole('heading', {
+					name: 'Add Fields',
+				}).waitFor;
+
+				return page.getByRole('dialog');
+			});
+
+		await test.step('Select id and name fields', async () => {
+			await fieldModal.getByLabel(/id/).check();
+			await fieldModal.getByLabel(/name/).check();
+			await fieldModal.getByRole('button', {name: 'Save'}).click();
+
+			await expect(
+				page.locator('.orderable-table-row').nth(0)
+			).toContainText('id');
+			await expect(
+				page.locator('.orderable-table-row').nth(1)
+			).toContainText('name');
+		});
+
+		// Finish manually adding fields
+
+		await test.step('Go to Actions tab', async () => {
+			await actionsPage.goto({
+				dataSetName: DATASET_NAME,
+				dataSetViewName: DATASET_VIEW_NAME,
+			});
+		});
+
+		await test.step('Create an async item action', async () => {
+			await actionsPage.createItemAction({
+				icon: 'cloud',
+				method: ASYNC_ITEM_ACTION_METHOD,
+				name: ASYNC_ITEM_ACTION_NAME,
+				type: 'async',
+				url: ASYNC_ITEM_ACTION_WRONG_URL,
+			});
+		});
+
+		await test.step('Edit page', async () => {
+			await fdsFragmentPage.editPage({...siteInfo});
+		});
+
+		await test.step('Search for "Data Set" fragment', async () => {
+			await fdsFragmentPage.searchFragmentOrWidget('Data Set');
+		});
+
+		await test.step('Drag "Data Set" fragment & Drop into the page editor w/ keyboard', async () => {
+			await fdsFragmentPage.dragAndDropFragment(
+				'Data Set Add Data Set Mark Data Set as Favorite'
+			);
+		});
+
+		await test.step('Select empty Data Set fragment', async () => {
+			await page
+				.getByText('Select a data set view. Beta')
+				.first()
+				.click();
+		});
+
+		await test.step('Open Data Set View Selector', async () => {
+			await page
+				.getByRole('button', {name: 'Select Data Set View'})
+				.click();
+		});
+
+		await test.step('Select Data Set View', async () => {
+			await expect(page.getByRole('dialog')).toBeVisible();
+
+			await expect(
+				page.getByRole('heading', {name: 'Select'})
+			).toBeVisible();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.locator('li')
+				.filter({hasText: DATASET_VIEW_NAME})
+				.first()
+				.click();
+
+			await page
+				.frameLocator('iframe[title="Select"]')
+				.getByRole('button', {name: 'Save'})
+				.click();
+		});
+
+		await test.step('Publish page with Data Set View', async () => {
+			await fdsFragmentPage.publishPage();
+
+			await fdsFragmentPage.gotoPage({...siteInfo});
+
+			await expect(page.locator('.data-set-wrapper')).toBeVisible();
+		});
+
+		await test.step('Item action is present in table row', async () => {
+			const tableRow = await page.locator('.dnd-td.item-actions').first();
+
+			await expect(tableRow.getByRole('button')).toBeVisible();
+
+			await tableRow
+				.getByRole('button', {name: ASYNC_ITEM_ACTION_NAME})
+				.click();
+
+			await page.getByRole('alert').waitFor();
+
+			const alert = await page.getByRole('alert');
+
+			await expect(alert).toHaveText(
+				'Error:An unexpected error occurred.'
+			);
+		});
+
+		await test.step('Delete Data Set and site', async () => {
+			await fdsFragmentPage.deleteSite(siteInfo.site.id);
+			await dataSetsPage.deleteDataSet(DATASET_NAME);
+		});
+	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -747,6 +747,8 @@ test.describe('Data Set Item Actions', () => {
 			await expect(alert).toHaveText(
 				'Success:Your request completed successfully.'
 			);
+
+			await alert.getByRole('button').click();
 		});
 
 		await test.step('Click in the async item action executes the action', async () => {
@@ -785,6 +787,8 @@ test.describe('Data Set Item Actions', () => {
 			await expect(alert).toHaveText(
 				'Success:Your request completed successfully.'
 			);
+
+			await alert.getByRole('button').click();
 		});
 
 		await test.step('Delete Data Set and site', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -14,17 +14,17 @@ export class ActionsPage {
 	readonly newActionButton: Locator;
 	readonly newActionForm: {
 		addIconButton: Locator;
-		confirmationMessageText: Locator;
-		headlessPermissionKeyText: Locator;
+		confirmationMessageInput: Locator;
+		headlessPermissionKeyInput: Locator;
 		methodSelect: Locator;
 		nameInput: Locator;
-		permissionKeyText: Locator;
+		permissionKeyInput: Locator;
 		saveButton: Locator;
 		selectIconModal: {
 			iconsList: Locator;
 			searchInput: Locator;
 		};
-		titleText: Locator;
+		titleInput: Locator;
 		typeSelect: Locator;
 		urlText: Locator;
 	};
@@ -39,16 +39,16 @@ export class ActionsPage {
 		this.newActionButton = page.getByRole('button', {name: 'Add Action'});
 		this.newActionForm = {
 			addIconButton: page.getByLabel('add-icon'),
-			confirmationMessageText: page.getByLabel('Confirmation Message', {
+			confirmationMessageInput: page.getByLabel('Confirmation Message', {
 				exact: true,
 			}),
-			headlessPermissionKeyText: page.getByLabel(
+			headlessPermissionKeyInput: page.getByLabel(
 				'Headless Action KeyRequired',
 				{exact: true}
 			),
 			methodSelect: page.getByLabel('MethodRequired', {exact: true}),
 			nameInput: page.getByPlaceholder('Action Name'),
-			permissionKeyText: page.getByLabel('Headless Action Key', {
+			permissionKeyInput: page.getByLabel('Headless Action Key', {
 				exact: true,
 			}),
 			saveButton: page.getByRole('button', {name: 'Save'}),
@@ -56,7 +56,7 @@ export class ActionsPage {
 				iconsList: page.getByRole('listitem'),
 				searchInput: page.getByPlaceholder('Search'),
 			},
-			titleText: page.getByLabel('TitleRequired', {exact: true}),
+			titleInput: page.getByLabel('TitleRequired', {exact: true}),
 			typeSelect: page.getByLabel('TypeRequired', {exact: true}),
 			urlText: page.getByPlaceholder('Add a URL here.'),
 		};
@@ -129,19 +129,19 @@ export class ActionsPage {
 
 		if ('permissionKey' in actionProps) {
 			if (actionProps.type === 'headless') {
-				await this.newActionForm.headlessPermissionKeyText.fill(
+				await this.newActionForm.headlessPermissionKeyInput.fill(
 					actionProps.permissionKey
 				);
 			}
 			else {
-				await this.newActionForm.permissionKeyText.fill(
+				await this.newActionForm.permissionKeyInput.fill(
 					actionProps.permissionKey
 				);
 			}
 		}
 
 		if ('confirmationMessage' in actionProps) {
-			this.newActionForm.confirmationMessageText.fill(
+			this.newActionForm.confirmationMessageInput.fill(
 				actionProps.confirmationMessage
 			);
 		}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {CreationActionTypes, ItemActionTypes} from '../utils/types';
+import {ICreationAction, IItemAction} from '../utils/types';
 import {ViewsPage} from './ViewsPage';
 
 export class ActionsPage {
@@ -20,6 +20,7 @@ export class ActionsPage {
 			iconsList: Locator;
 			searchInput: Locator;
 		};
+		titleText: Locator;
 		typeSelect: Locator;
 		urlText: Locator;
 	};
@@ -40,6 +41,7 @@ export class ActionsPage {
 				iconsList: page.getByRole('listitem'),
 				searchInput: page.getByPlaceholder('Search'),
 			},
+			titleText: page.getByLabel('TitleRequired', {exact: true}),
 			typeSelect: page.getByLabel('TypeRequired', {exact: true}),
 			urlText: page.getByPlaceholder('Add a URL here.'),
 		};
@@ -60,17 +62,7 @@ export class ActionsPage {
 		await this.page.getByRole('button', {name: 'Actions'}).first().click();
 	}
 
-	async createCreationAction({
-		icon,
-		name,
-		type,
-		url,
-	}: {
-		icon: string;
-		name: string;
-		type: CreationActionTypes;
-		url: string;
-	}) {
+	async createCreationAction({icon, name, type, url}: ICreationAction) {
 		await this.creationActionsTab.click();
 
 		await this.newActionButton.click();
@@ -78,35 +70,21 @@ export class ActionsPage {
 		await this.createAction({icon, name, type, url});
 	}
 
-	async createItemAction({
-		icon,
-		name,
-		type,
-		url,
-	}: {
-		icon: string;
-		name: string;
-		type: ItemActionTypes;
-		url?: string;
-	}) {
+	async createItemAction({icon, name, title, type, url}: IItemAction) {
 		await this.itemActionsTab.click();
 
 		await this.newActionButton.click();
 
-		await this.createAction({icon, name, type, url});
+		await this.createAction({icon, name, title, type, url});
 	}
 
 	private async createAction({
 		icon,
 		name,
+		title,
 		type,
 		url,
-	}: {
-		icon: string;
-		name: string;
-		type: ItemActionTypes;
-		url?: string;
-	}) {
+	}: ICreationAction | IItemAction) {
 		await this.newActionForm.nameInput.fill(name);
 		await this.newActionForm.addIconButton.click();
 
@@ -118,10 +96,12 @@ export class ActionsPage {
 		await this.newActionForm.typeSelect.selectOption(type);
 
 		if (type === 'modal' || type === 'sidePanel') {
+			const actionTitle = !title ? `${name} title` : `${title}`;
+
 			await this.page.getByPlaceholder('add-here-the-title').click();
 			await this.page
 				.getByPlaceholder('add-here-the-title')
-				.fill(`${name} Title`);
+				.fill(`${actionTitle}`);
 		}
 
 		await this.newActionForm.urlText.fill(url);

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -14,6 +14,7 @@ export class ActionsPage {
 	readonly newActionButton: Locator;
 	readonly newActionForm: {
 		addIconButton: Locator;
+		confirmationMessageText: Locator;
 		headlessPermissionKeyText: Locator;
 		methodSelect: Locator;
 		nameInput: Locator;
@@ -38,6 +39,9 @@ export class ActionsPage {
 		this.newActionButton = page.getByRole('button', {name: 'Add Action'});
 		this.newActionForm = {
 			addIconButton: page.getByLabel('add-icon'),
+			confirmationMessageText: page.getByLabel('Confirmation Message', {
+				exact: true,
+			}),
 			headlessPermissionKeyText: page.getByLabel(
 				'Headless Action KeyRequired',
 				{exact: true}
@@ -134,6 +138,12 @@ export class ActionsPage {
 					actionProps.permissionKey
 				);
 			}
+		}
+
+		if ('confirmationMessage' in actionProps) {
+			this.newActionForm.confirmationMessageText.fill(
+				actionProps.confirmationMessage
+			);
 		}
 
 		await this.newActionForm.saveButton.click();

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -14,7 +14,10 @@ export class ActionsPage {
 	readonly newActionButton: Locator;
 	readonly newActionForm: {
 		addIconButton: Locator;
+		headlessPermissionKeyText: Locator;
+		methodSelect: Locator;
 		nameInput: Locator;
+		permissionKeyText: Locator;
 		saveButton: Locator;
 		selectIconModal: {
 			iconsList: Locator;
@@ -35,7 +38,15 @@ export class ActionsPage {
 		this.newActionButton = page.getByRole('button', {name: 'Add Action'});
 		this.newActionForm = {
 			addIconButton: page.getByLabel('add-icon'),
+			headlessPermissionKeyText: page.getByLabel(
+				'Headless Action KeyRequired',
+				{exact: true}
+			),
+			methodSelect: page.getByLabel('MethodRequired', {exact: true}),
 			nameInput: page.getByPlaceholder('Action Name'),
+			permissionKeyText: page.getByLabel('Headless Action Key', {
+				exact: true,
+			}),
 			saveButton: page.getByRole('button', {name: 'Save'}),
 			selectIconModal: {
 				iconsList: page.getByRole('listitem'),
@@ -70,33 +81,31 @@ export class ActionsPage {
 		await this.createAction({icon, name, type, url});
 	}
 
-	async createItemAction({icon, name, title, type, url}: IItemAction) {
+	async createItemAction(itemActionProps: IItemAction) {
 		await this.itemActionsTab.click();
 
 		await this.newActionButton.click();
 
-		await this.createAction({icon, name, title, type, url});
+		await this.createAction({...itemActionProps});
 	}
 
-	private async createAction({
-		icon,
-		name,
-		title,
-		type,
-		url,
-	}: ICreationAction | IItemAction) {
-		await this.newActionForm.nameInput.fill(name);
+	private async createAction(actionProps: ICreationAction | IItemAction) {
+		await this.newActionForm.nameInput.fill(actionProps.name);
 		await this.newActionForm.addIconButton.click();
 
-		await this.newActionForm.selectIconModal.searchInput.fill(icon);
+		await this.newActionForm.selectIconModal.searchInput.fill(
+			actionProps.icon
+		);
 		await this.newActionForm.selectIconModal.iconsList
-			.getByText(icon, {exact: true})
+			.getByText(actionProps.icon, {exact: true})
 			.click();
 
-		await this.newActionForm.typeSelect.selectOption(type);
+		await this.newActionForm.typeSelect.selectOption(actionProps.type);
 
-		if (type === 'modal' || type === 'sidePanel') {
-			const actionTitle = !title ? `${name} title` : `${title}`;
+		if (actionProps.type === 'modal' || actionProps.type === 'sidePanel') {
+			const actionTitle = !actionProps.title
+				? `${actionProps.name} title`
+				: `${actionProps.title}`;
 
 			await this.page.getByPlaceholder('add-here-the-title').click();
 			await this.page
@@ -104,7 +113,29 @@ export class ActionsPage {
 				.fill(`${actionTitle}`);
 		}
 
-		await this.newActionForm.urlText.fill(url);
+		if (actionProps.type === 'async') {
+			await this.newActionForm.methodSelect.selectOption(
+				actionProps.method
+			);
+		}
+
+		if (actionProps.type !== 'headless') {
+			await this.newActionForm.urlText.fill(actionProps.url);
+		}
+
+		if ('permissionKey' in actionProps) {
+			if (actionProps.type === 'headless') {
+				await this.newActionForm.headlessPermissionKeyText.fill(
+					actionProps.permissionKey
+				);
+			}
+			else {
+				await this.newActionForm.permissionKeyText.fill(
+					actionProps.permissionKey
+				);
+			}
+		}
+
 		await this.newActionForm.saveButton.click();
 	}
 }

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/FDSFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/FDSFragmentPage.ts
@@ -64,6 +64,11 @@ export class FDSFragmentPage {
 		await source.focus();
 		await source.press('Enter');
 		await source.press('Enter');
+
+		await this.page
+			.getByText('Select a data set view. Beta')
+			.first()
+			.waitFor();
 	}
 
 	async editPage({layout, site}) {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
@@ -32,9 +32,15 @@ export class FieldsPage {
 		this.viewsPage = new ViewsPage(page);
 	}
 
-	async goto() {
-		await this.viewsPage.goto();
-		await this.viewsPage.gotoDataSetView();
+	async goto({
+		dataSetName,
+		dataSetViewName,
+	}: {
+		dataSetName?: string;
+		dataSetViewName?: string;
+	} = {}) {
+		await this.viewsPage.goto(dataSetName);
+		await this.viewsPage.gotoDataSetView(dataSetViewName);
 
 		await this.page
 			.getByRole('button', {exact: true, name: 'Fields'})

--- a/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
@@ -9,6 +9,7 @@ export type ItemActionTypes =
 	| 'link'
 	| 'modal'
 	| 'sidePanel';
+export type AsyncActionMethod = 'DELETE' | 'GET' | 'PATCH' | 'POST';
 
 interface IBaseAction {
 	icon: string;
@@ -22,5 +23,7 @@ export interface ICreationAction extends IBaseAction {
 }
 
 export interface IItemAction extends IBaseAction {
+	method?: AsyncActionMethod;
+	permissionKey?: string;
 	type: ItemActionTypes;
 }

--- a/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
@@ -23,6 +23,7 @@ export interface ICreationAction extends IBaseAction {
 }
 
 export interface IItemAction extends IBaseAction {
+	confirmationMessage?: string;
 	method?: AsyncActionMethod;
 	permissionKey?: string;
 	type: ItemActionTypes;

--- a/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/utils/types.ts
@@ -9,3 +9,18 @@ export type ItemActionTypes =
 	| 'link'
 	| 'modal'
 	| 'sidePanel';
+
+interface IBaseAction {
+	icon: string;
+	name: string;
+	title?: string;
+	url?: string;
+}
+
+export interface ICreationAction extends IBaseAction {
+	type: CreationActionTypes;
+}
+
+export interface IItemAction extends IBaseAction {
+	type: ItemActionTypes;
+}

--- a/test.properties
+++ b/test.properties
@@ -925,6 +925,7 @@
         client-extension,\
         commerce,\
         export-import-web,\
+        frontend-data-set-views-web,\
         headless-builder-web,\
         journal-web,\
         layout-content-page-editor-web,\


### PR DESCRIPTION
Related story / task
[LPD-11758](https://liferay.atlassian.net/browse/LPD-11758) / [LPD-11753](https://liferay.atlassian.net/browse/LPD-17753)

Coverage

- simple Link item action creation
- simple Link item action in the fragment (button/link for each row)
- Link, modal and side panel item actions in the fragment (three dots menu action for each row)
- Async and Headless actions shown & enforced in the fragment 
- Toast showing error executing an action

Also, bug fixed for modal item actions that should display the correct title defined in the Data Set Manager (wrong property in the [FDSViewFragmentRenderer](https://github.com/liferay-frontend/liferay-portal/compare/master...juanjofgliferay:LPD-17753?expand=1#diff-14ac39b8c7158c0601a7ccd2a2cacb7d24afe76cdd503e7f3c4921a11e3d22c9R696))