### PR TITLE
LPD-17381 Allow use the resource selector taglib with item selectors

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_entry.jsp
@@ -92,7 +92,7 @@ renderResponse.setTitle(headerTitle);
 								inputName="newFolderId"
 								modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 								resourceName="<%= folderName %>"
-								resourceValue="<%= folderId %>"
+								resourceValue="<%= String.valueOf(folderId) %>"
 								selectEventName="selectFolder"
 								selectResourceURL='<%=
 									PortletURLBuilder.createRenderURL(

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/edit_folder.jsp
@@ -100,7 +100,7 @@ renderResponse.setTitle(headerTitle);
 							inputName="newFolderId"
 							modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 							resourceName="<%= parentFolderName %>"
-							resourceValue="<%= parentFolderId %>"
+							resourceValue="<%= String.valueOf(parentFolderId) %>"
 							selectEventName="selectFolder"
 							selectResourceURL='<%=
 								PortletURLBuilder.createRenderURL(

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/move_entries.jsp
@@ -250,7 +250,7 @@ if (portletTitleBasedNavigation) {
 						inputName="newFolderId"
 						modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 						resourceName="<%= folderName %>"
-						resourceValue="<%= newFolderId %>"
+						resourceValue="<%= String.valueOf(newFolderId) %>"
 						selectEventName="selectFolder"
 						selectResourceURL='<%=
 							PortletURLBuilder.createRenderURL(

--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks_admin/configuration_browse.jsp
@@ -90,7 +90,7 @@ portletDisplay.setURLBackTitle("bookmarks");
 									inputName="preferences--rootFolderId--"
 									modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 									resourceName="<%= rootFolderName %>"
-									resourceValue="<%= rootFolderId %>"
+									resourceValue="<%= String.valueOf(rootFolderId) %>"
 									selectEventName="selectFolder"
 									selectResourceURL='<%=
 										PortletURLBuilder.create(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/configuration.jsp
@@ -96,7 +96,7 @@ DLPortletInstanceSettingsHelper dlPortletInstanceSettingsHelper = new DLPortletI
 				inputName="preferences--rootFolderId--"
 				modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 				resourceName="<%= dlAdminDisplayContext.getRootFolderName() %>"
-				resourceValue="<%= dlAdminDisplayContext.getRootFolderId() %>"
+				resourceValue="<%= String.valueOf(dlAdminDisplayContext.getRootFolderId()) %>"
 				selectEventName="folderSelected"
 				selectResourceURL="<%= dlAdminDisplayContext.getSelectRootFolderURL() %>"
 				showRemoveButton="<%= true %>"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -301,7 +301,7 @@ renderResponse.setTitle(headerTitle);
 							inputName="newFolderId"
 							modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 							resourceName="<%= folderName %>"
-							resourceValue="<%= folderId %>"
+							resourceValue="<%= String.valueOf(folderId) %>"
 							selectEventName="folderSelected"
 							selectResourceURL="<%= folderItemSelectorURLProvider.getSelectAddFileEntryFolderURL(folderId) %>"
 							showRemoveButton="<%= true %>"

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/configuration.jsp
@@ -82,7 +82,7 @@ IGConfigurationDisplayContext igConfigurationDisplayContext = (IGConfigurationDi
 					inputName="preferences--rootFolderId--"
 					modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 					resourceName="<%= igConfigurationDisplayContext.getRootFolderName() %>"
-					resourceValue="<%= igConfigurationDisplayContext.getRootFolderId() %>"
+					resourceValue="<%= String.valueOf(igConfigurationDisplayContext.getRootFolderId()) %>"
 					selectEventName="folderSelected"
 					selectResourceURL="<%= igConfigurationDisplayContext.getSelectRootFolderURL() %>"
 					showRemoveButton="<%= true %>"

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ResourceSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ResourceSelectorTag.java
@@ -36,7 +36,7 @@ public class ResourceSelectorTag extends IncludeTag {
 		return _resourceNameKey;
 	}
 
-	public long getResourceValue() {
+	public String getResourceValue() {
 		return _resourceValue;
 	}
 
@@ -87,7 +87,7 @@ public class ResourceSelectorTag extends IncludeTag {
 		_resourceNameKey = resourceNameKey;
 	}
 
-	public void setResourceValue(long resourceValue) {
+	public void setResourceValue(String resourceValue) {
 		_resourceValue = resourceValue;
 	}
 
@@ -120,7 +120,7 @@ public class ResourceSelectorTag extends IncludeTag {
 		_modalTitle = null;
 		_resourceName = null;
 		_resourceNameKey = null;
-		_resourceValue = 0;
+		_resourceValue = null;
 		_resourceValueKey = null;
 		_selectEventName = null;
 		_selectResourceURL = null;
@@ -172,7 +172,7 @@ public class ResourceSelectorTag extends IncludeTag {
 	private String _modalTitle;
 	private String _resourceName;
 	private String _resourceNameKey;
-	private long _resourceValue;
+	private String _resourceValue;
 	private String _resourceValueKey;
 	private String _selectEventName;
 	private String _selectResourceURL;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ResourceSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ResourceSelectorTag.java
@@ -32,8 +32,16 @@ public class ResourceSelectorTag extends IncludeTag {
 		return _resourceName;
 	}
 
+	public String getResourceNameKey() {
+		return _resourceNameKey;
+	}
+
 	public long getResourceValue() {
 		return _resourceValue;
+	}
+
+	public String getResourceValueKey() {
+		return _resourceValueKey;
 	}
 
 	public String getSelectEventName() {
@@ -75,8 +83,16 @@ public class ResourceSelectorTag extends IncludeTag {
 		_resourceName = resourceName;
 	}
 
+	public void setResourceNameKey(String resourceNameKey) {
+		_resourceNameKey = resourceNameKey;
+	}
+
 	public void setResourceValue(long resourceValue) {
 		_resourceValue = resourceValue;
+	}
+
+	public void setResourceValueKey(String resourceValueKey) {
+		_resourceValueKey = resourceValueKey;
 	}
 
 	public void setSelectEventName(String selectEventName) {
@@ -103,7 +119,9 @@ public class ResourceSelectorTag extends IncludeTag {
 		_inputName = null;
 		_modalTitle = null;
 		_resourceName = null;
+		_resourceNameKey = null;
 		_resourceValue = 0;
+		_resourceValueKey = null;
 		_selectEventName = null;
 		_selectResourceURL = null;
 		_showRemoveButton = false;
@@ -126,7 +144,13 @@ public class ResourceSelectorTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-frontend:resource-selector:resourceName", _resourceName);
 		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:resourceNameKey",
+			_resourceNameKey);
+		httpServletRequest.setAttribute(
 			"liferay-frontend:resource-selector:resourceValue", _resourceValue);
+		httpServletRequest.setAttribute(
+			"liferay-frontend:resource-selector:resourceValueKey",
+			_resourceValueKey);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:resource-selector:selectEventName",
 			_selectEventName);
@@ -147,7 +171,9 @@ public class ResourceSelectorTag extends IncludeTag {
 	private String _inputName;
 	private String _modalTitle;
 	private String _resourceName;
+	private String _resourceNameKey;
 	private long _resourceValue;
+	private String _resourceValueKey;
 	private String _selectEventName;
 	private String _selectResourceURL;
 	private boolean _showRemoveButton;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -648,10 +648,20 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>resourceNameKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>resourceValue</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>long</type>
+		</attribute>
+		<attribute>
+			<name>resourceValueKey</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<name>selectEventName</name>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -656,7 +656,6 @@
 			<name>resourceValue</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
-			<type>long</type>
 		</attribute>
 		<attribute>
 			<name>resourceValueKey</name>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/ResourceSelector.tsx
@@ -16,7 +16,9 @@ interface IResourceSelectorProps {
 	modalTitle: string;
 	portletNamespace: string;
 	resourceName: string;
+	resourceNameKey: string;
 	resourceValue: string;
+	resourceValueKey: string;
 	selectEventName: string;
 	selectResourceURL: string;
 	showRemoveButton: boolean;
@@ -29,7 +31,9 @@ export default function ResourceSelector({
 	modalTitle,
 	portletNamespace,
 	resourceName: initialResourceName,
+	resourceNameKey = 'resourcename',
 	resourceValue: initialResourceValue,
+	resourceValueKey = 'resourceid',
 	selectEventName,
 	selectResourceURL,
 	showRemoveButton,
@@ -54,8 +58,8 @@ export default function ResourceSelector({
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					setResourceData({
-						resourceName: selectedItem.resourcename,
-						resourceValue: selectedItem.resourceid,
+						resourceName: selectedItem[resourceNameKey],
+						resourceValue: selectedItem[resourceValueKey],
 						showWarning: false,
 					});
 				}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/resource_selector/page.jsp
@@ -12,7 +12,9 @@ String inputLabel = (String)request.getAttribute("liferay-frontend:resource-sele
 String inputName = (String)request.getAttribute("liferay-frontend:resource-selector:inputName");
 String modalTitle = (String)request.getAttribute("liferay-frontend:resource-selector:modalTitle");
 String resourceName = (String)request.getAttribute("liferay-frontend:resource-selector:resourceName");
-long resourceValue = (long)request.getAttribute("liferay-frontend:resource-selector:resourceValue");
+String resourceNameKey = (String)request.getAttribute("liferay-frontend:resource-selector:resourceNameKey");
+String resourceValue = (String)request.getAttribute("liferay-frontend:resource-selector:resourceValue");
+String resourceValueKey = (String)request.getAttribute("liferay-frontend:resource-selector:resourceValueKey");
 String selectEventName = (String)request.getAttribute("liferay-frontend:resource-selector:selectEventName");
 String selectResourceURL = (String)request.getAttribute("liferay-frontend:resource-selector:selectResourceURL");
 boolean showRemoveButton = (boolean)request.getAttribute("liferay-frontend:resource-selector:showRemoveButton");
@@ -34,7 +36,11 @@ String warningMessage = (String)request.getAttribute("liferay-frontend:resource-
 			).put(
 				"resourceName", resourceName
 			).put(
+				"resourceNameKey", resourceNameKey
+			).put(
 				"resourceValue", resourceValue
+			).put(
+				"resourceValueKey", resourceValueKey
 			).put(
 				"selectEventName", selectEventName
 			).put(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -33,7 +33,7 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 		inputName="newFolderId"
 		modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 		resourceName="<%= journalEditArticleDisplayContext.getFolderName() %>"
-		resourceValue="<%= journalEditArticleDisplayContext.getFolderId() %>"
+		resourceValue="<%= String.valueOf(journalEditArticleDisplayContext.getFolderId()) %>"
 		selectEventName="selectFolder"
 		selectResourceURL='<%=
 			PortletURLBuilder.createRenderURL(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -167,7 +167,7 @@ renderResponse.setTitle(title);
 					inputName="newFolderId"
 					modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 					resourceName="<%= parentFolderName %>"
-					resourceValue="<%= parentFolderId %>"
+					resourceValue="<%= String.valueOf(parentFolderId) %>"
 					selectEventName="selectFolder"
 					selectResourceURL='<%=
 						PortletURLBuilder.createRenderURL(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp
@@ -157,7 +157,7 @@ JournalMoveEntriesDisplayContext journalMoveEntriesDisplayContext = new JournalM
 				inputName="newFolderId"
 				modalTitle='<%= LanguageUtil.get(request, "select-folder") %>'
 				resourceName="<%= journalMoveEntriesDisplayContext.getNewFolderName() %>"
-				resourceValue="<%= journalMoveEntriesDisplayContext.getNewFolderId() %>"
+				resourceValue="<%= String.valueOf(journalMoveEntriesDisplayContext.getNewFolderId()) %>"
 				selectEventName="selectFolder"
 				selectResourceURL='<%=
 					PortletURLBuilder.createRenderURL(

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/move_category.jsp
@@ -62,7 +62,7 @@ if (portletTitleBasedNavigation) {
 						inputName="parentCategoryId"
 						modalTitle='<%= LanguageUtil.format(request, "select-x", "category") %>'
 						resourceName="<%= parentCategoryName %>"
-						resourceValue="<%= parentCategoryId %>"
+						resourceValue="<%= String.valueOf(parentCategoryId) %>"
 						selectEventName="selectCategory"
 						selectResourceURL='<%=
 							PortletURLBuilder.createRenderURL(


### PR DESCRIPTION
## Motivation

Hi guys! @p2kmgcl @liferay-frontend 
In this issue [Link to ticket](https://liferay.atlassian.net/browse/LPD-15679) we have realized that the resource selector doesn't work properly with the item selectors because the returned elements of every item selector are different. That's why in this pr I have modified the taglib and its uses. 

### Changes

Due to this [LPP-52603](https://liferay.atlassian.net/browse/LPP-52603) the echo team has decided to replace the selector by using the item selector for layouts and the Resource Selector taglib created recently by @DiegoHu97. This means that I had to add the `resourceNameKey` and the `resourceValueKey` to specify in the necessary cases the key that the item selector returns to use them instead of `resourcename` and `resourceid`. This allow us to use it without change every item selector. Also I changed the resource value to receive a String instead of a long because not every id is a long and we are currently working in the frontend with a String.

