### PR TITLE
LPD-15327 Refactor LinkOrButton component to simplify its API

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ActionControls.js
@@ -5,7 +5,6 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayDropDownWithItems} from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
 import {ManagementToolbar} from 'frontend-js-components-web';
 import React, {useMemo} from 'react';
 
@@ -83,19 +82,14 @@ const ActionControls = ({
 									disabled={disabled || item.disabled}
 									displayType="unstyled"
 									href={item.href}
+									label={item.label}
 									onClick={(event) => {
 										onActionButtonClick(event, {
 											item,
 										});
 									}}
-									title={item.label}
-								>
-									<span className="inline-item inline-item-before">
-										<ClayIcon symbol={item.icon} />
-									</span>
-
-									<span>{item.label}</span>
-								</LinkOrButton>
+									symbol={item.icon}
+								/>
 							</ManagementToolbar.Item>
 						))}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import {sub, unescapeHTML} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
@@ -172,21 +170,12 @@ const CreationMenu = ({
 					className="creation-menu"
 					onActiveChange={setActive}
 					trigger={
-						<ClayButton
-							aria-label={getPlusIconLabel()}
+						<LinkOrButton
 							className="nav-btn"
 							data-qa-id="creationMenuNewButton"
-							title={getPlusIconLabel()}
-						>
-							<ClayIcon
-								className="d-md-none dropdown-icon"
-								symbol="plus"
-							/>
-
-							<span className="d-md-block d-none pl-3 pr-3">
-								{getPlusIconLabel()}
-							</span>
-						</ClayButton>
+							label={getPlusIconLabel()}
+							symbol="plus"
+						/>
 					}
 				>
 					{visibleItemsCount < totalItemsCountRef.current ? (
@@ -212,9 +201,9 @@ const CreationMenu = ({
 
 							<div className="dropdown-section">
 								<LinkOrButton
-									button={{block: true}}
 									displayType="secondary"
 									href={viewMoreURL}
+									label={Liferay.Language.get('more')}
 									onClick={() => {
 										if (onShowMoreButtonClick) {
 											onShowMoreButtonClick();
@@ -226,9 +215,7 @@ const CreationMenu = ({
 											totalItemsCountRef.current
 										);
 									}}
-								>
-									{Liferay.Language.get('more')}
-								</LinkOrButton>
+								/>
 							</div>
 						</>
 					) : (
@@ -241,26 +228,19 @@ const CreationMenu = ({
 					)}
 				</ClayDropDown>
 			) : (
-				<>
-					<LinkOrButton
-						aria-label={getPlusIconLabel()}
-						button={true}
-						className="nav-btn"
-						data-qa-id="creationMenuNewButton"
-						displayType="primary"
-						href={firstItemRef.current.href}
-						onClick={(event) => {
-							onCreateButtonClick(event, {
-								item: firstItemRef.current,
-							});
-						}}
-						symbol="plus"
-						title={getPlusIconLabel()}
-						wide
-					>
-						{Liferay.Language.get('new')}
-					</LinkOrButton>
-				</>
+				<LinkOrButton
+					className="nav-btn"
+					data-qa-id="creationMenuNewButton"
+					displayType="primary"
+					href={firstItemRef.current.href}
+					label={getPlusIconLabel()}
+					onClick={(event) => {
+						onCreateButtonClick(event, {
+							item: firstItemRef.current,
+						});
+					}}
+					symbol="plus"
+				/>
 			)}
 		</>
 	);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -185,7 +185,11 @@ const FilterOrderControls = ({
 			{sortingURL && !showOrderToggle && (
 				<ManagementToolbar.Item>
 					<LinkOrButton
-						aria-label={sub(
+						className="nav-link nav-link-monospaced"
+						disabled={disabled}
+						displayType="unstyled"
+						href={sortingURL}
+						label={sub(
 							Liferay.Language.get(
 								'reverse-order-direction-currently-x'
 							),
@@ -193,10 +197,6 @@ const FilterOrderControls = ({
 								? Liferay.Language.get('descending')
 								: Liferay.Language.get('ascending')
 						)}
-						className="nav-link nav-link-monospaced"
-						disabled={disabled}
-						displayType="unstyled"
-						href={sortingURL}
 						role="button"
 						symbol={classNames({
 							'order-list-down': sortingOrder === 'desc',

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -41,21 +41,15 @@ function LinkOrButton(
 	},
 	ref
 ) {
-	const [element, setElement] = useState(null);
+	const showLabel = useMediaQuery(`(min-width: ${DEFAULT_BREAKPOINT_MD})`);
 	const TagName = href && !disabled ? ClayLink : ClayButton;
-
-	const breakpointMd = element
-		? window.getComputedStyle(element).getPropertyValue('--breakpoint-md')
-		: DEFAULT_BREAKPOINT_MD;
-
-	const showLabel = useMediaQuery(`(min-width: ${breakpointMd})`);
 
 	const buttonProps = {
 		...otherProps,
 		className: 'link-or-button',
 		disabled,
 		href,
-		ref: mergeRefs(setElement, ref),
+		ref,
 	};
 
 	if (showLabel || !symbol) {
@@ -88,19 +82,6 @@ function LinkOrButton(
 			<ClayIcon symbol={symbol} />
 		</TagName>
 	);
-}
-
-function mergeRefs(...refs) {
-	return (element) => {
-		refs.forEach((ref) => {
-			if (typeof ref === 'function') {
-				ref(element);
-			}
-			else if (ref) {
-				ref.current = element;
-			}
-		});
-	};
 }
 
 function useMediaQuery(query) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -7,54 +7,119 @@ import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
-import React from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
-const LinkOrButton = ({
-	ariaLabel,
-	children,
-	className,
-	disabled,
-	href,
-	symbol,
-	title,
-	wide,
-	...otherProps
-}) => {
-	const responsive = symbol && children;
-	const Wrapper = href && !disabled ? ClayLink : ClayButton;
+import './LinkOrButton.scss';
+
+const DEFAULT_BREAKPOINT_MD = '768px';
+
+/**
+ * A dynamic link/button that includes a symbol, a label, or both of them. All
+ * props are optional except for the label prop.
+ *
+ * It renders a ClayButton or a ClayLink depending on the provided:
+ * - disabled state (a ClayButton will be used).
+ * - href (a ClayLink will be used).
+ * - otherwise a ClayButton will be used.
+ *
+ * Then it shows a symbol on smaller screens, and label on larger screens.
+ * When only the symbol is being shown, an aria-label and title are added to the
+ * button for accessibility purposes. If there is no provided title, the label
+ * prop will be reused as title.
+ *
+ * It will always add a title to the button if it is specified as prop.
+ */
+function LinkOrButton(
+	{
+		className = '',
+		disabled = false,
+		href = '',
+		label,
+		symbol = '',
+		title = '',
+		...otherProps
+	},
+	ref
+) {
+	const [element, setElement] = useState(null);
+	const TagName = href && !disabled ? ClayLink : ClayButton;
+
+	const breakpointMd = element
+		? window.getComputedStyle(element).getPropertyValue('--breakpoint-md')
+		: DEFAULT_BREAKPOINT_MD;
+
+	const showLabel = useMediaQuery(`(min-width: ${breakpointMd})`);
+
+	const buttonProps = {
+		...otherProps,
+		className: 'link-or-button',
+		disabled,
+		href,
+		ref: mergeRefs(setElement, ref),
+	};
+
+	if (showLabel || !symbol) {
+		return (
+			<TagName
+				{...buttonProps}
+				className={classNames(
+					className,
+					buttonProps.className,
+					'link-or-button--with-label'
+				)}
+				title={title}
+			>
+				{label}
+			</TagName>
+		);
+	}
 
 	return (
-		<>
-			<Wrapper
-				aria-label={symbol && ariaLabel}
-				block={otherProps.button?.block}
-				className={classNames(className, {
-					'd-md-none': responsive,
-					'nav-btn-monospaced': responsive,
-					'pl-4 pr-4': wide && !symbol,
-				})}
-				disabled={disabled}
-				href={href}
-				{...otherProps}
-				title={symbol && title}
-			>
-				{symbol ? <ClayIcon symbol={symbol} /> : children}
-			</Wrapper>
-
-			{responsive && (
-				<Wrapper
-					block={otherProps.button?.block}
-					className={classNames(className, 'd-md-flex d-none', {
-						'pl-4 pr-4': wide,
-					})}
-					disabled={disabled}
-					href={href}
-					{...otherProps}
-				>
-					{children}
-				</Wrapper>
+		<TagName
+			{...buttonProps}
+			aria-label={label}
+			className={classNames(
+				className,
+				buttonProps.className,
+				'nav-btn-monospaced'
 			)}
-		</>
+			title={title || label}
+		>
+			<ClayIcon symbol={symbol} />
+		</TagName>
 	);
-};
-export default LinkOrButton;
+}
+
+function mergeRefs(...refs) {
+	return (element) => {
+		refs.forEach((ref) => {
+			if (typeof ref === 'function') {
+				ref(element);
+			}
+			else if (ref) {
+				ref.current = element;
+			}
+		});
+	};
+}
+
+function useMediaQuery(query) {
+	const mediaQueryList = useMemo(() => window.matchMedia(query), [query]);
+	const [matches, setMatches] = useState(mediaQueryList.matches);
+
+	useEffect(() => {
+		const handleQueryChange = (event) => {
+			setMatches(event.matches);
+		};
+
+		mediaQueryList.addEventListener('change', handleQueryChange);
+
+		return () => {
+			mediaQueryList.removeEventListener('change', handleQueryChange);
+		};
+	}, [mediaQueryList]);
+
+	return matches;
+}
+
+export default React.forwardRef(LinkOrButton);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.scss
@@ -1,9 +1,3 @@
-@import 'cadmin-variables';
-
-.link-or-button {
-	--breakpoint-md: #{map-get($cadmin-grid-breakpoints, md)};
-
-	&--with-label {
-		min-width: 9ch;
-	}
+.link-or-button--with-label {
+	min-width: 9ch;
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.scss
@@ -1,0 +1,9 @@
+@import 'cadmin-variables';
+
+.link-or-button {
+	--breakpoint-md: #{map-get($cadmin-grid-breakpoints, md)};
+
+	&--with-label {
+		min-width: 9ch;
+	}
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -229,12 +229,10 @@ function ManagementToolbar({
 										<LinkOrButton
 											className="nav-btn"
 											displayType="primary"
+											label={Liferay.Language.get('new')}
 											onClick={onCreateButtonClick}
 											symbol="plus"
-											wide
-										>
-											{Liferay.Language.get('new')}
-										</LinkOrButton>
+										/>
 									)}
 								</FrontendManagementToolbar.Item>
 							)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -250,10 +250,10 @@ const SelectionControls = ({
 					<>
 						<ManagementToolbar.Item className="nav-item-shrink">
 							<LinkOrButton
-								aria-label={Liferay.Language.get('clear')}
 								className="nav-link"
 								displayType="unstyled"
 								href={clearSelectionURL}
+								label={Liferay.Language.get('clear')}
 								onClick={(event) => {
 									searchContainerRef.current?.select?.toggleAllRows(
 										false,
@@ -267,14 +267,7 @@ const SelectionControls = ({
 									onClearButtonClick(event);
 								}}
 								symbol="times-circle"
-								title={Liferay.Language.get('clear')}
-							>
-								<span className="text-truncate-inline">
-									<span className="text-truncate">
-										{Liferay.Language.get('clear')}
-									</span>
-								</span>
-							</LinkOrButton>
+							/>
 						</ManagementToolbar.Item>
 
 						{selectAllButtonVisible && (
@@ -283,6 +276,7 @@ const SelectionControls = ({
 									className="nav-link"
 									displayType="unstyled"
 									href={selectAllURL}
+									label={Liferay.Language.get('select-all')}
 									onClick={(event) => {
 										searchContainerRef.current?.select?.toggleAllRows(
 											true,
@@ -295,13 +289,7 @@ const SelectionControls = ({
 
 										onSelectAllButtonClick(event);
 									}}
-								>
-									<span className="text-truncate-inline">
-										<span className="text-truncate">
-											{Liferay.Language.get('select-all')}
-										</span>
-									</span>
-								</LinkOrButton>
+								/>
 							</ManagementToolbar.Item>
 						)}
 					</>


### PR DESCRIPTION
A behavior description has also being added to the component. Changes:

- There is no "wide" prop, instead of that, we are setting a minimum width of 9ch (which has almost the same effect with the "new" button) when only the label is being shown.
- Instead of mixing children + symbol props, everything needs to be passed to the component as props (label, title, symbol). Then the component decides which markup should be rendered depending on props and the window width.
- As mentioned before, instead of rendering the whole markup and then updating the component with CSS classes, we are watching a media query to add/remove related props accordingly (specially useful for the element title).