### PR TITLE
LPD-17848 Functional automation for saving and editing of DSM list sections

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/ListVisualizationMode.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/css/ListVisualizationMode.scss
@@ -1,13 +1,13 @@
 @import 'cadmin-variables';
 
-html#{$cadmin-selector} .cadmin .table-autofit {
-	.list-visualization-mode-label-cell {
-		min-width: 20ch;
-		width: 30%;
-	}
-
-	.list-visualization-mode-value-cell {
+html#{$cadmin-selector} .cadmin .list-visualization-mode {
+	.field-name {
 		border-left: none;
 		width: auto;
+	}
+
+	.list-section-label {
+		min-width: 20ch;
+		width: 30%;
 	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/VisualizationModes.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/VisualizationModes.tsx
@@ -53,7 +53,7 @@ export default function VisualizationModes(props: IFDSViewSectionProps) {
 	] = useState(0);
 
 	return (
-		<ClayLayout.ContainerFluid className="mt-3">
+		<ClayLayout.ContainerFluid className="mt-3 visualization-modes">
 			<ClayLayout.Sheet>
 				<ClayLayout.SheetHeader className="mb-4">
 					<h2 className="mb-0">

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -49,7 +49,7 @@ export default function List(props: IFDSViewSectionProps) {
 
 	const getFDSListSections = async () => {
 		const response = await fetch(
-			`${API_URL.FDS_LIST_SECTIONS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_LIST_SECTION_ID} eq '${fdsView.id}')`
+			`${API_URL.FDS_LIST_SECTIONS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_LIST_SECTION_ERC} eq '${fdsView.externalReferenceCode}')`
 		);
 
 		if (!response.ok) {
@@ -111,7 +111,8 @@ export default function List(props: IFDSViewSectionProps) {
 
 		const response = await fetch(url, {
 			body: JSON.stringify({
-				[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_LIST_SECTION_ID]: fdsView.id,
+				[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_LIST_SECTION_ERC]:
+					fdsView.externalReferenceCode,
 				fieldName: field.name,
 				name: listSection.name,
 			}),

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -132,7 +132,7 @@ export default function List(props: IFDSViewSectionProps) {
 
 		const fdsListSection: IFDSListSection = await response.json();
 
-		openDefaultSuccessToast();
+		closeModal();
 
 		setListSections(
 			listSections.map((listSection) => {
@@ -150,7 +150,7 @@ export default function List(props: IFDSViewSectionProps) {
 			})
 		);
 
-		closeModal();
+		openDefaultSuccessToast();
 	};
 
 	useEffect(() => {
@@ -160,7 +160,7 @@ export default function List(props: IFDSViewSectionProps) {
 	}, []);
 
 	return (
-		<ClayLayout.ContentCol className="c-gap-4">
+		<ClayLayout.ContentCol className="c-gap-4 list-visualization-mode">
 			<ClayAlert
 				displayType="info"
 				title={`${Liferay.Language.get('info')}:`}
@@ -175,16 +175,13 @@ export default function List(props: IFDSViewSectionProps) {
 				<ClayTable.Head>
 					<ClayTable.Row>
 						<ClayTable.Cell
-							className="list-visualization-mode-label-cell"
+							className="list-section-label"
 							headingCell
 						>
 							{Liferay.Language.get('list-element')}
 						</ClayTable.Cell>
 
-						<ClayTable.Cell
-							className="list-visualization-mode-value-cell"
-							headingCell
-						>
+						<ClayTable.Cell className="field-name" headingCell>
 							{Liferay.Language.get('field')}
 						</ClayTable.Cell>
 					</ClayTable.Row>
@@ -235,6 +232,7 @@ function ListSection({
 
 	const onClick = () => {
 		openModal({
+			className: 'list-visualization-mode-field-select-modal',
 			contentComponent: ({closeModal}: {closeModal: Function}) => (
 				<FieldSelectModalContent
 					{...modalProps}
@@ -258,11 +256,11 @@ function ListSection({
 
 	return (
 		<ClayTable.Row>
-			<ClayTable.Cell className="list-visualization-mode-label-cell">
+			<ClayTable.Cell className="list-section-label">
 				<strong>{label}</strong>
 			</ClayTable.Cell>
 
-			<ClayTable.Cell className="list-visualization-mode-value-cell">
+			<ClayTable.Cell className="field-name">
 				<ClayInput.Group small>
 					<ClayInput.GroupItem>
 						<p

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/constants.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/constants.ts
@@ -46,8 +46,8 @@ const OBJECT_RELATIONSHIP = {
 	FDS_VIEW_FDS_ITEM_ACTION_ID:
 		'r_fdsViewFDSItemActionRelationship_c_fdsViewId',
 	FDS_VIEW_FDS_LIST_SECTION: 'fdsViewFDSListSectionRelationship',
-	FDS_VIEW_FDS_LIST_SECTION_ID:
-		'r_fdsViewFDSListSectionRelationship_c_fdsViewId',
+	FDS_VIEW_FDS_LIST_SECTION_ERC:
+		'r_fdsViewFDSListSectionRelationship_c_fdsViewERC',
 	FDS_VIEW_FDS_SORT: 'fdsViewFDSSortRelationship',
 	FDS_VIEW_FDS_SORT_ID: 'r_fdsViewFDSSortRelationship_c_fdsViewId',
 } as const;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/constants.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/constants.d.ts
@@ -37,7 +37,7 @@ declare const OBJECT_RELATIONSHIP: {
 	readonly FDS_VIEW_FDS_ITEM_ACTION: 'fdsViewFDSItemActionRelationship';
 	readonly FDS_VIEW_FDS_ITEM_ACTION_ID: 'r_fdsViewFDSItemActionRelationship_c_fdsViewId';
 	readonly FDS_VIEW_FDS_LIST_SECTION: 'fdsViewFDSListSectionRelationship';
-	readonly FDS_VIEW_FDS_LIST_SECTION_ID: 'r_fdsViewFDSListSectionRelationship_c_fdsViewId';
+	readonly FDS_VIEW_FDS_LIST_SECTION_ERC: 'r_fdsViewFDSListSectionRelationship_c_fdsViewERC';
 	readonly FDS_VIEW_FDS_SORT: 'fdsViewFDSSortRelationship';
 	readonly FDS_VIEW_FDS_SORT_ID: 'r_fdsViewFDSSortRelationship_c_fdsViewId';
 };

--- a/modules/test/playwright/tests/frontend-data-set-views-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/env/portal-ext.properties
@@ -1,0 +1,2 @@
+feature.flag.LPD-10735=true
+feature.flag.LPS-164563=true

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
@@ -12,6 +12,7 @@ import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
 import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 import {fieldsPageTest} from './fixtures/fieldsPageTest';
 import {viewsPageTest} from './fixtures/viewsPageTest';
+import {DEFAULT_LABEL} from './utils/constants';
 
 export const test = mergeTests(
 	applicationsMenuPageTest,
@@ -38,7 +39,7 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 		await test.step('Create sample DataSet', async () => {
 			await dataSetsPage.goto();
 			await dataSetsPage.createDataSet({
-				name: 'Data Set Sample',
+				name: DEFAULT_LABEL.DATA_SET,
 				restApplication: '/headless-delivery/v1.0',
 				restEndpoint: '/v1.0/sites/{siteId}/site-pages',
 				restSchema: 'SitePage',
@@ -141,7 +142,7 @@ test.describe('Add fields to a view and show them in a fragment', () => {
 			await page
 				.frameLocator('iframe[title="Select"]')
 				.locator('li')
-				.filter({hasText: 'Data Set View Sample'})
+				.filter({hasText: DEFAULT_LABEL.VIEW})
 				.first()
 				.click();
 			await page

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fields.spec.ts
@@ -19,6 +19,7 @@ export const test = mergeTests(
 	dataSetsPageTest,
 	fdsFragmentPageTest,
 	featureFlagsTest({
+		'LPD-10735': false,
 		'LPS-164563': true,
 		'LPS-178052': true,
 		'LPS-186871': true,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/dataSetManagerApiHelpersTest.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/dataSetManagerApiHelpersTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {DataSetManagerApiHelpers} from '../helpers/DataSetManagerApiHelpers';
+
+const dataSetManagerApiHelpersTest = test.extend<{
+	dataSetManagerApiHelpers: DataSetManagerApiHelpers;
+}>({
+	dataSetManagerApiHelpers: async ({page}, use) => {
+		await use(new DataSetManagerApiHelpers(page));
+	},
+});
+
+export {dataSetManagerApiHelpersTest};

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/listVisualizationModePageTest.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/listVisualizationModePageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ListVisualizationModePage} from '../pages/view/visualization_modes/list/ListVisualizationModePage';
+
+const listVisualizationModePageTest = test.extend<{
+	listVisualizationModePage: ListVisualizationModePage;
+}>({
+	listVisualizationModePage: async ({page}, use) => {
+		await use(new ListVisualizationModePage(page));
+	},
+});
+
+export {listVisualizationModePageTest};

--- a/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/viewPageTest.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/fixtures/viewPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {ViewPage} from '../pages/view/ViewPage';
+
+const viewPageTest = test.extend<{
+	viewPage: ViewPage;
+}>({
+	viewPage: async ({page}, use) => {
+		await use(new ViewPage(page));
+	},
+});
+
+export {viewPageTest};

--- a/modules/test/playwright/tests/frontend-data-set-views-web/helpers/DataSetManagerApiHelpers.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/helpers/DataSetManagerApiHelpers.ts
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
+import {DEFAULT_LABEL} from '../utils/constants';
+
+const DEFAULT_DATA_SET_ERC = 'sampleDataSetERC';
+export class DataSetManagerApiHelpers extends ApiHelpers {
+	async createDataSet({
+		erc = DEFAULT_DATA_SET_ERC,
+		label = DEFAULT_LABEL.DATA_SET,
+		restApplication = '/data-set-manager/fields',
+		restEndpoint = '/',
+		restSchema = 'FDSField',
+	}: {
+		erc?: string;
+		label?: string;
+		restApplication?: string;
+		restEndpoint?: string;
+		restSchema?: string;
+	}) {
+		const url = `${this.baseUrl}data-set-manager/entries`;
+
+		const data = {
+			externalReferenceCode: erc,
+			label,
+			restApplication,
+			restEndpoint,
+			restSchema,
+		};
+
+		return this.post(url, data);
+	}
+
+	async createDataSetView({
+		defaultItemsPerPage = 20,
+		description = 'Sample description',
+		erc = 'sampleDataSetERC',
+		label = DEFAULT_LABEL.VIEW,
+		listOfItemsPerPage = '4, 8, 20, 40, 60',
+		r_fdsEntryFDSViewRelationship_c_fdsEntryERC = DEFAULT_DATA_SET_ERC,
+		symbol = 'catalog',
+	}: {
+		defaultItemsPerPage?: number;
+		description?: string;
+		erc?: string;
+		label?: string;
+		listOfItemsPerPage?: string;
+		r_fdsEntryFDSViewRelationship_c_fdsEntryERC?: string;
+		symbol?: string;
+	}) {
+		const url = `${this.baseUrl}data-set-manager/views`;
+
+		const data = {
+			defaultItemsPerPage,
+			description,
+			externalReferenceCode: erc,
+			label,
+			listOfItemsPerPage,
+			r_fdsEntryFDSViewRelationship_c_fdsEntryERC,
+			symbol,
+		};
+
+		return this.post(url, data);
+	}
+
+	async deleteDataSet({erc = DEFAULT_DATA_SET_ERC}: {erc?: string}) {
+		const url = `${this.baseUrl}data-set-manager/entries/by-external-reference-code/${erc}`;
+
+		return this.delete(url);
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -19,6 +19,7 @@ export const test = mergeTests(
 	dataSetsPageTest,
 	fdsFragmentPageTest,
 	featureFlagsTest({
+		'LPD-10735': false,
 		'LPS-164563': true,
 		'LPS-178052': true,
 		'LPS-186871': true,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/listVisualizationMode.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/listVisualizationMode.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {dataSetManagerApiHelpersTest} from './fixtures/dataSetManagerApiHelpersTest';
+import {listVisualizationModePageTest} from './fixtures/listVisualizationModePageTest';
+import {DEFAULT_LABEL} from './utils/constants';
+
+export const test = mergeTests(
+	dataSetManagerApiHelpersTest,
+	featureFlagsTest({
+		'LPD-10735': true,
+		'LPS-164563': true,
+	}),
+	listVisualizationModePageTest,
+	loginTest()
+);
+
+test('Assign a field to a list section @LPD-10735', async ({
+	dataSetManagerApiHelpers,
+	listVisualizationModePage,
+}) => {
+	await test.step('Create sample data', async () => {
+		await dataSetManagerApiHelpers.createDataSet({});
+		await dataSetManagerApiHelpers.createDataSetView({});
+	});
+
+	await test.step('Navigate to list visualization mode', async () => {
+		await listVisualizationModePage.goto({
+			dataSetLabel: DEFAULT_LABEL.DATA_SET,
+			viewLabel: DEFAULT_LABEL.VIEW,
+		});
+	});
+
+	await test.step('Assign a field to title section', async () => {
+		const listSectionLabel = 'Title';
+		const fieldName = 'name';
+
+		await listVisualizationModePage.openAssignFieldModal({
+			listSectionLabel,
+		});
+
+		await listVisualizationModePage.fieldSelectModalContainer
+			.getByLabel(fieldName)
+			.check();
+
+		await listVisualizationModePage.saveFieldSelection();
+
+		await listVisualizationModePage.page.getByText('Success').waitFor();
+
+		const assignedFieldLocator =
+			await listVisualizationModePage.getAssignedFieldLocator({
+				listSectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(fieldName);
+	});
+
+	await test.step('Edit field to title section', async () => {
+		const listSectionLabel = 'Title';
+		const oldFieldName = 'name';
+		const newFieldName = 'rendererType';
+
+		await listVisualizationModePage.openAssignFieldModal({
+			listSectionLabel,
+		});
+
+		expect(
+			listVisualizationModePage.page.getByLabel(oldFieldName)
+		).toBeChecked();
+
+		await listVisualizationModePage.fieldSelectModalContainer
+			.getByLabel(newFieldName)
+			.check();
+
+		await listVisualizationModePage.saveFieldSelection();
+
+		await listVisualizationModePage.page.getByText('Success').waitFor();
+
+		const assignedFieldLocator =
+			await listVisualizationModePage.getAssignedFieldLocator({
+				listSectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(newFieldName);
+	});
+
+	await test.step('Delete all sample data', async () => {
+		await dataSetManagerApiHelpers.deleteDataSet({});
+	});
+});

--- a/modules/test/playwright/tests/frontend-data-set-views-web/listVisualizationMode.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/listVisualizationMode.spec.ts
@@ -51,8 +51,6 @@ test('Assign a field to a list section @LPD-10735', async ({
 
 		await listVisualizationModePage.saveFieldSelection();
 
-		await listVisualizationModePage.page.getByText('Success').waitFor();
-
 		const assignedFieldLocator =
 			await listVisualizationModePage.getAssignedFieldLocator({
 				listSectionLabel,
@@ -79,8 +77,6 @@ test('Assign a field to a list section @LPD-10735', async ({
 			.check();
 
 		await listVisualizationModePage.saveFieldSelection();
-
-		await listVisualizationModePage.page.getByText('Success').waitFor();
 
 		const assignedFieldLocator =
 			await listVisualizationModePage.getAssignedFieldLocator({

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ActionsPage.ts
@@ -72,7 +72,7 @@ export class ActionsPage {
 		dataSetViewName?: string;
 	} = {}) {
 		await this.viewsPage.goto(dataSetName);
-		await this.viewsPage.gotoDataSetView(dataSetViewName);
+		await this.viewsPage.openDataSetView(dataSetViewName);
 
 		await this.page.getByRole('button', {name: 'Actions'}).first().click();
 	}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
@@ -7,6 +7,7 @@ import {Locator, Page} from '@playwright/test';
 
 import {ApiHelpers} from '../../../helpers/ApiHelpers';
 import {ApplicationsMenuPage} from '../../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+import {DEFAULT_LABEL} from '../utils/constants';
 
 export class DataSetsPage {
 	readonly apiHelpers: ApiHelpers;
@@ -26,6 +27,7 @@ export class DataSetsPage {
 		readonly saveButton: Locator;
 	};
 	readonly page: Page;
+	private readonly pageContainer: Locator;
 
 	constructor(page: Page) {
 		this.apiHelpers = new ApiHelpers(page);
@@ -51,10 +53,11 @@ export class DataSetsPage {
 			saveButton: page.getByRole('button', {name: 'Save'}),
 		};
 		this.page = page;
+		this.pageContainer = page.locator('.fds-entries');
 	}
 
 	async createDataSet({
-		name = 'Data Set Sample',
+		name = DEFAULT_LABEL.DATA_SET,
 		restApplication = '/data-set-manager/fields',
 		restEndpoint = '/',
 		restSchema = 'FDSField',
@@ -102,28 +105,16 @@ export class DataSetsPage {
 	async goto() {
 		await this.applicationsMenuPage.goToDataSetManager();
 
-		await this.page
-			.getByRole('heading', {
-				name: 'Data Sets',
-			})
-			.waitFor();
+		await this.pageContainer.waitFor();
 	}
 
-	async gotoDataSet(name = 'Data Set Sample') {
-		await this.page
-			.locator('.data-set-content-wrapper')
-			.getByRole('link', {name})
-			.first()
-			.click();
+	async gotoDataSet(name = DEFAULT_LABEL.DATA_SET) {
+		await this.pageContainer.waitFor();
 
-		await this.page
-			.getByRole('heading', {
-				name,
-			})
-			.waitFor();
+		await this.pageContainer.getByRole('link', {name}).first().click();
 	}
 
-	async deleteDataSet(name = 'Data Set Sample') {
+	async deleteDataSet(name = DEFAULT_LABEL.DATA_SET) {
 		await this.goto();
 
 		const datasetTestRow = await this.page

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/FieldsPage.ts
@@ -40,7 +40,7 @@ export class FieldsPage {
 		dataSetViewName?: string;
 	} = {}) {
 		await this.viewsPage.goto(dataSetName);
-		await this.viewsPage.gotoDataSetView(dataSetViewName);
+		await this.viewsPage.openDataSetView(dataSetViewName);
 
 		await this.page
 			.getByRole('button', {exact: true, name: 'Fields'})

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ViewsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ViewsPage.ts
@@ -5,9 +5,8 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {DEFAULT_LABEL} from '../utils/constants';
 import {DataSetsPage} from './DataSetsPage';
-
-const DEFAULT_DATA_SET_VIEW_NAME = 'Data Set View Sample';
 
 export class ViewsPage {
 	readonly dataSetsPage: DataSetsPage;
@@ -34,14 +33,9 @@ export class ViewsPage {
 		this.page = page;
 	}
 
-	async goto(dataSetName?: string) {
-		await this.dataSetsPage.goto();
-		await this.dataSetsPage.gotoDataSet(dataSetName);
-	}
-
 	async createDataSetView({
 		description,
-		name = DEFAULT_DATA_SET_VIEW_NAME,
+		name = DEFAULT_LABEL.VIEW,
 	}: {
 		description?: string;
 		name?: string;
@@ -57,18 +51,23 @@ export class ViewsPage {
 		await this.newDataSetViewModal.saveButton.click();
 	}
 
-	async gotoDataSetView(name = DEFAULT_DATA_SET_VIEW_NAME) {
+	async goto(dataSetLabel: string = DEFAULT_LABEL.DATA_SET) {
+		await this.dataSetsPage.goto();
+		await this.dataSetsPage.gotoDataSet(dataSetLabel);
+	}
+
+	async openDataSetView(viewLabel: string = DEFAULT_LABEL.VIEW) {
 		await this.dataSetsViewTable
 			.getByRole('link', {
 				exact: true,
-				name,
+				name: viewLabel,
 			})
 			.first()
 			.click();
 
 		await this.page
-			.getByRole('heading', {
-				name,
+			.getByRole('button', {
+				name: 'Details',
 			})
 			.waitFor();
 	}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/ViewPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/ViewPage.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ViewsPage} from '../ViewsPage';
+
+export class ViewPage {
+	readonly page: Page;
+	private readonly tabsContainer: Locator;
+	private readonly viewsPage: ViewsPage;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.tabsContainer = page.locator('nav.navbar');
+		this.viewsPage = new ViewsPage(page);
+	}
+
+	async goto({
+		dataSetLabel,
+		viewLabel,
+	}: {
+		dataSetLabel: string;
+		viewLabel: string;
+	}) {
+		await this.viewsPage.goto(dataSetLabel);
+
+		await this.viewsPage.openDataSetView(viewLabel);
+	}
+
+	async selectTab(tabLabel: string) {
+		const tabLink = this.tabsContainer.getByRole('button', {
+			exact: true,
+			name: tabLabel,
+		});
+
+		await tabLink.click();
+
+		await tabLink.and(this.page.locator('.active')).waitFor();
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ViewPage} from '../ViewPage';
+
+export class VisualizationModesPage {
+	private readonly container: Locator;
+	readonly page: Page;
+	private readonly viewPage: ViewPage;
+
+	constructor(page: Page) {
+		this.container = page.locator('.visualization-modes');
+		this.page = page;
+		this.viewPage = new ViewPage(page);
+	}
+
+	async goto({
+		dataSetLabel,
+		viewLabel,
+	}: {
+		dataSetLabel: string;
+		viewLabel: string;
+	}) {
+		await this.viewPage.goto({
+			dataSetLabel,
+			viewLabel,
+		});
+
+		await this.viewPage.selectTab('Visualization Modes');
+	}
+
+	async selectTab(tabLabel: string) {
+		const tab = this.container.getByRole('tab', {
+			exact: true,
+			name: tabLabel,
+		});
+
+		await tab.click();
+
+		await tab.and(this.page.locator('.active')).waitFor();
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/list/ListVisualizationModePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/list/ListVisualizationModePage.ts
@@ -12,6 +12,7 @@ export class ListVisualizationModePage {
 	readonly fieldSelectModalContainer: Locator;
 	readonly page: Page;
 	private readonly pageContainer: Locator;
+	private readonly toastContainer: Locator;
 	private readonly viewPage: ViewPage;
 	private readonly visualizationModesPage: VisualizationModesPage;
 
@@ -21,6 +22,7 @@ export class ListVisualizationModePage {
 		);
 		this.page = page;
 		this.pageContainer = page.locator('.list-visualization-mode');
+		this.toastContainer = page.locator('.alert-container');
 		this.viewPage = new ViewPage(page);
 		this.visualizationModesPage = new VisualizationModesPage(page);
 	}
@@ -77,5 +79,19 @@ export class ListVisualizationModePage {
 				name: 'Save',
 			})
 			.click();
+
+		await this.fieldSelectModalContainer.isHidden();
+
+		await this.toastContainer.isVisible();
+
+		await this.page.getByText('Success').waitFor();
+
+		await this.toastContainer
+			.getByRole('button', {
+				name: 'Close',
+			})
+			.click();
+
+		await this.toastContainer.isHidden();
 	}
 }

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/list/ListVisualizationModePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/list/ListVisualizationModePage.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {ViewPage} from '../../ViewPage';
+import {VisualizationModesPage} from '../VisualizationModesPage';
+
+export class ListVisualizationModePage {
+	readonly fieldSelectModalContainer: Locator;
+	readonly page: Page;
+	private readonly pageContainer: Locator;
+	private readonly viewPage: ViewPage;
+	private readonly visualizationModesPage: VisualizationModesPage;
+
+	constructor(page: Page) {
+		this.fieldSelectModalContainer = page.locator(
+			'.list-visualization-mode-field-select-modal'
+		);
+		this.page = page;
+		this.pageContainer = page.locator('.list-visualization-mode');
+		this.viewPage = new ViewPage(page);
+		this.visualizationModesPage = new VisualizationModesPage(page);
+	}
+
+	async goto({
+		dataSetLabel,
+		viewLabel,
+	}: {
+		dataSetLabel: string;
+		viewLabel: string;
+	}) {
+		await this.viewPage.goto({
+			dataSetLabel,
+			viewLabel,
+		});
+
+		await this.viewPage.selectTab('Visualization Modes');
+
+		await this.visualizationModesPage.selectTab('List');
+
+		await this.pageContainer.waitFor();
+	}
+
+	async getAssignedFieldLocator({
+		listSectionLabel,
+	}: {
+		listSectionLabel: string;
+	}) {
+		return this.pageContainer
+			.locator('tr')
+			.filter({has: this.page.getByText(listSectionLabel)})
+			.locator('td.field-name');
+	}
+
+	async openAssignFieldModal({listSectionLabel}: {listSectionLabel: string}) {
+		await this.pageContainer
+			.locator('tr')
+			.filter({has: this.page.getByText(listSectionLabel)})
+			.getByTitle('Assign Field')
+			.click();
+
+		await this.fieldSelectModalContainer
+			.getByPlaceholder('Search')
+			.waitFor();
+	}
+
+	async saveFieldSelection() {
+
+		// Modal for field selection must be open.
+
+		await this.page
+			.getByRole('button', {
+				exact: true,
+				name: 'Save',
+			})
+			.click();
+	}
+}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/utils/constants.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/utils/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const DEFAULT_LABEL = {
+	DATA_SET: 'Sample Data Set',
+	VIEW: 'Sample View',
+};
+
+export {DEFAULT_LABEL};


### PR DESCRIPTION
### References

- Parent Story: [LPD-6624 Allow admins to save the definition for list as visualization mode](https://issues.liferay.com/browse/LPD-6624)

### What is the goal of this PR?

The main purpose of this PR is to add tests for assigning fields to of DSM list sections. In addition to it, we're
- adding a helper to create DSM data with API
- tweaking DSM code for easier tests, by adding container CSS classes and setting toast as last
- fixing a flakiness issue in existing tests
- adding default sample entity labels in constants

See technical notes inline.

### What does it look like?

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/b5562bc3-7908-43b2-b40c-9e8b6e08c0ac)
