### PR TITLE
LPD-18450 Remove no longer needed test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetView.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetView.testcase
@@ -620,48 +620,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-176189. Confirm that the view was really deleted"
-	@priority = 4
-	test CanUpdateNumberOfViews {
-		task ("When Add a new view") {
-			DataSetAdmin.createDataSetView(
-				description = "Description Test",
-				key_name = "View Test");
-		}
-
-		task ("And back to the Data Sets admin page") {
-			Navigator.gotoBack();
-		}
-
-		task ("Then confirm that the views column shows 1 views") {
-			AssertElementPresent(
-				locator1 = "DataSet#NUMBER_OF_VIEWS",
-				numberOfViews = 1);
-		}
-
-		task ("When go to View admin page") {
-			Click(
-				key_entry = "Data Set Test",
-				locator1 = "ObjectPortlet#ENTRY_KEBAB_MENU");
-
-			Click(locator1 = "DataSet#VIEW_ENTRY_BUTTON");
-		}
-
-		task ("And the user deletes a View created") {
-			DataSetAdmin.deleteDataSetViewViaAPI(dataSetViewsNameList = "View Test");
-		}
-
-		task ("And back to the Data Sets admin page") {
-			Navigator.gotoBack();
-		}
-
-		task ("Then confirm that the views column shows 0 views") {
-			AssertElementPresent(
-				locator1 = "DataSet#NUMBER_OF_VIEWS",
-				numberOfViews = 0);
-		}
-	}
-
 	@description = "Needs refactor after LPS-183512 is fixed | LPS-172396. Confirm that special characters are confirmed in the display name on the page "
 	@priority = 4
 	test CanUseSpecialCharactersInNameField {


### PR DESCRIPTION
References:

- https://liferay.atlassian.net/browse/LPD-18449 (this PR)
- https://liferay.atlassian.net/browse/LPD-17091 (story that caused this PR)
- [Test history](https://testray.liferay.com/home/-/testray/case_results/2541760492/history?tab=result&hideFilterPin=true)
[- Last test report,](https://testray.liferay.com/reports/production/logs/2024-02/test-1-32/test-portal-acceptance-pullrequest(master)/3711/functional-tomcat90-mysql57-jdk8/0/8/LocalFile.DataSetView_CanUpdateNumberOfViews/index.html.gz?authuser=0) where we see the lack of the "views" column in the screenshots

Once we removed the "views" column, there is no need to test this. So we are removing the corresponding poshi test