### PR TITLE
LPD-18341 Fix Creation Actions form title

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/actions/ActionForm.tsx
@@ -407,9 +407,15 @@ const ActionForm = ({
 	return (
 		<>
 			<h2 className="mb-0 p-4">
-				{editing
-					? initialValues?.label
-					: Liferay.Language.get('new-item-action')}
+				{editing && initialValues?.label}
+
+				{!editing &&
+					activeTab === 0 &&
+					Liferay.Language.get('new-item-action')}
+
+				{!editing &&
+					activeTab === 1 &&
+					Liferay.Language.get('new-creation-action')}
 			</h2>
 
 			<ClayPanel


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-18341

This PR fixes the title of Creation Action creation form:

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/fdbec62f-8273-430e-9892-c36c29c54673)

"New Item Action" should be "New Creation Action" now