### PR TITLE
LPD-18834 Change search bar hint

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1089,7 +1089,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			}
 
 			jspWriter.write(" placeholder=\"");
-			jspWriter.write(LanguageUtil.get(resourceBundle, "search-for"));
+			jspWriter.write(LanguageUtil.get(resourceBundle, "search"));
 			jspWriter.write("\" type=\"text\"");
 
 			if (searchValue != null) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SearchControls.js
@@ -82,7 +82,7 @@ const SearchControls = ({
 								defaultValue={searchValue}
 								disabled={disabled}
 								name={searchInputName}
-								placeholder={Liferay.Language.get('search-for')}
+								placeholder={Liferay.Language.get('search')}
 								ref={searchInputRef}
 								type="search"
 							/>
@@ -94,7 +94,7 @@ const SearchControls = ({
 									displayType="unstyled"
 									onClick={onClick}
 									symbol="search"
-									title={Liferay.Language.get('search-for')}
+									title={Liferay.Language.get('search')}
 									type="submit"
 								/>
 							</ClayInput.GroupInsetItem>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-18834)

### Motivation

- The hint in the search input should say “Search” (instead of "Search for") to keep consistency with other parts of the portal
- This change should affect all admin search inputs currently using the text “Search for”

### Proposed solution
This pull changes the placeholder and the icon tooltip. 

![Screenshot 2024-02-27 at 13 48 36](https://github.com/liferay-frontend/liferay-portal/assets/8373764/10ca90f0-e9ba-487f-9c6b-126d10acd9f0)
