### PR TITLE
LPD-1899 Remove combo: from client-extension url in widget page

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -134,6 +134,10 @@
 					.filter((path) => path.startsWith('module:'))
 					.map((path) => path.substring(7));
 
+				javascriptPaths = javascriptPaths
+					.filter((path) => path.startsWith('nocombo:'))
+					.map((path) => path.substring(8));
+
 				javascriptPaths = javascriptPaths.filter(
 					(path) => !path.startsWith('module:')
 				);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-1899

Issue: Deploying liferay-sample-custom-element-1 and adding it in a widget page, results in an error and the #shadow-root not rendering correctly. 

In portlet.js, the `response.headerJavaScriptPaths` contains combo: in the front of the url which is what is causing the error.

After removing the combo:, I found that the portlet renders correct without any issues.

Please let me know if there are any questions or comments about this.
Thank you!

