### PR TITLE
LPD-19230 Fix placeholder prop in opensimpleinputmodal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/OpenSimpleInputModal.es.js
@@ -45,11 +45,11 @@ function openSimpleInputModalImplementation({
 	mainFieldComponent,
 	mainFieldLabel,
 	mainFieldName,
+	mainFieldPlaceholder,
 	mainFieldValue,
 	method,
 	namespace,
 	onFormSuccess,
-	placeholder,
 	required,
 	size,
 }) {
@@ -72,11 +72,11 @@ function openSimpleInputModalImplementation({
 			mainFieldComponent={mainFieldComponent}
 			mainFieldLabel={mainFieldLabel}
 			mainFieldName={mainFieldName}
+			mainFieldPlaceholder={mainFieldPlaceholder}
 			mainFieldValue={mainFieldValue}
 			method={method}
 			namespace={namespace}
 			onFormSuccess={onFormSuccess}
-			placeholder={placeholder}
 			required={required}
 			size={size}
 		/>,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -33,11 +33,11 @@ const SimpleInputModal = ({
 	mainFieldComponent,
 	mainFieldLabel,
 	mainFieldName,
+	mainFieldPlaceholder,
 	mainFieldValue = '',
 	method = 'POST',
 	namespace,
 	onFormSuccess,
-	placeholder,
 	required = true,
 	size = 'md',
 }) => {
@@ -188,7 +188,7 @@ const SimpleInputModal = ({
 
 									setInputValue(event.target.value);
 								}}
-								placeholder={placeholder}
+								placeholder={mainFieldPlaceholder}
 								ref={handleMainFieldRef}
 								required={required}
 								type="text"

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/js/index.js
@@ -23,9 +23,9 @@ export function WorkflowTaskAction({
 			mainFieldComponent: 'textarea',
 			mainFieldLabel: Liferay.Language.get('comment'),
 			mainFieldName: 'comment',
+			mainFieldPlaceholder: Liferay.Language.get('comment'),
 			namespace: portletNamespace,
 			onFormSuccess: () => window.location.reload(),
-			placeholder: Liferay.Language.get('comment'),
 			required: false,
 			size: 'lg',
 		});

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookManagementToolbarPropsTransformer.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/StyleBookManagementToolbarPropsTransformer.js
@@ -81,8 +81,8 @@ export default function propsTransformer({
 				formSubmitURL: data?.addStyleBookEntryURL,
 				mainFieldLabel: Liferay.Language.get('name'),
 				mainFieldName: 'name',
+				mainFieldPlaceholder: Liferay.Language.get('name'),
 				namespace: `${portletNamespace}`,
-				placeholder: Liferay.Language.get('name'),
 			});
 		},
 	};


### PR DESCRIPTION
## Motivation

Hi, @liferay-frontend! Recently I just saw that the placeholder is not working in the simple modals along the portal and I discovered that is because the naming has change recently and while we are using mainFieldPlaceholder in a lot of places to pass the property, the modal was expecting the property placeholder. 

[Link to ticket](https://liferay.atlassian.net/browse/LPD-19230)

## Changes

I changed the name to match that pattern. 

## Results

![image](https://github.com/liferay-frontend/liferay-portal/assets/93203423/eeea8e58-67ef-4f58-af18-59f16aff02d4)
![image](https://github.com/liferay-frontend/liferay-portal/assets/93203423/9ac7fc4a-da6b-4e29-a73c-203d7ec83994)


Let me know what you think. Thanks in advance! 😄 