### PR TITLE
LPD-18558 - Adapt AutoSearch to UX requirements

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/SearchResultsMessage.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/SearchResultsMessage.tsx
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {sub} from 'frontend-js-web';
+import React, {useEffect, useState} from 'react';
+
+import isNullOrUndefined from './isNullOrUndefined';
+
+export default function SearchResultsMessage({
+	numberOfResults = null,
+	resultType = Liferay.Language.get('results'),
+}: {
+	numberOfResults: number | null;
+	resultType?: string;
+}) {
+	const [text, setText] = useState('');
+
+	useEffect(() => {
+		if (!isNullOrUndefined(numberOfResults)) {
+			const timeout = setTimeout(() => {
+				const message = numberOfResults
+					? sub(Liferay.Language.get('showing-x-x'), [
+							numberOfResults.toString(),
+							resultType,
+					  ])
+					: Liferay.Language.get('no-results-found');
+
+				setText(message);
+			}, 500);
+
+			return () => {
+				clearTimeout(timeout);
+			};
+		}
+	}, [resultType, numberOfResults]);
+
+	return (
+		<span className="sr-only" role="status">
+			{text}
+		</span>
+	);
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/isNullOrUndefined.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/isNullOrUndefined.tsx
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function isNullOrUndefined(
+	value: unknown
+): value is null | undefined {
+	return value === null || value === undefined;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -6,9 +6,11 @@
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {ClayResultsBar} from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
 import {
 	FDS_INTERNAL_CELL_RENDERERS,
@@ -130,6 +132,7 @@ const SaveFDSFieldsModalContent = ({
 	saveFDSFieldsURL,
 }: ISaveFDSFieldsModalContentProps) => {
 	const [fields, setFields] = useState<Array<IField> | null>(null);
+	const [focused, setFocused] = useState(false);
 	const [query, setQuery] = useState('');
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState<boolean>(
 		false
@@ -236,16 +239,22 @@ const SaveFDSFieldsModalContent = ({
 		});
 	}, [fdsFields, fdsView]);
 
+	const getSelectedFieldsCount = () => {
+		if (!fields) {
+			return 0;
+		}
+
+		const selectedFields = fields.filter((field) => field.selected);
+
+		return selectedFields?.length || 0;
+	};
+
 	const isSelectAllChecked = () => {
 		if (!fields) {
 			return false;
 		}
 
-		const selectedFields = fields.filter((field) => field.selected);
-
-		const selectedFieldsCount = selectedFields?.length || 0;
-
-		return selectedFieldsCount === fields.length;
+		return getSelectedFieldsCount() === fields.length;
 	};
 
 	const isSelectAllIndeterminate = () => {
@@ -292,11 +301,27 @@ const SaveFDSFieldsModalContent = ({
 								<ManagementToolbar.Item className="nav-item-expand">
 									<ClayInput.Group>
 										<ClayInput.GroupItem>
+											{!focused && (
+												<ClayInput.GroupInsetItem
+													before
+													tag="span"
+												>
+													<ClayIcon
+														className="inline-item inline-item-before"
+														focusable="false"
+														role="presentation"
+														symbol="search"
+													/>
+												</ClayInput.GroupInsetItem>
+											)}
+
 											<ClayInput
-												insetAfter
+												insetAfter={Boolean(focused)}
+												insetBefore={!focused}
 												onChange={(event) =>
 													onSearch(event.target.value)
 												}
+												onFocus={() => setFocused(true)}
 												placeholder={Liferay.Language.get(
 													'search'
 												)}
@@ -304,25 +329,73 @@ const SaveFDSFieldsModalContent = ({
 												value={query}
 											/>
 
-											<ClayInput.GroupInsetItem
-												after
-												tag="span"
-											>
-												<ClayButtonWithIcon
-													aria-label={Liferay.Language.get(
-														'search'
-													)}
-													displayType="unstyled"
-													symbol="search"
-												/>
-											</ClayInput.GroupInsetItem>
+											{focused && (
+												<ClayInput.GroupInsetItem
+													after
+													tag="span"
+												>
+													<ClayButtonWithIcon
+														aria-label={Liferay.Language.get(
+															'clear-search'
+														)}
+														borderless
+														displayType="secondary"
+														monospaced={false}
+														onClick={() => {
+															setQuery('');
+															onSearch('');
+															setFocused(false);
+														}}
+														size="sm"
+														symbol="times"
+														title={Liferay.Language.get(
+															'clear-search'
+														)}
+													/>
+												</ClayInput.GroupInsetItem>
+											)}
 										</ClayInput.GroupItem>
 									</ClayInput.Group>
 								</ManagementToolbar.Item>
 							</ManagementToolbar.ItemList>
 						</ManagementToolbar.Container>
 
-						<div className="bg-light fields pb-2 pt-2">
+						{getSelectedFieldsCount() > 0 && (
+							<ClayResultsBar>
+								<ClayResultsBar.Item expand>
+									<span className="component-text text-truncate-inline">
+										<span className="text-truncate">
+											{getSelectedFieldsCount() > 1
+												? `${getSelectedFieldsCount()} ${Liferay.Language.get(
+														'items-selected'
+												  )}`
+												: `${getSelectedFieldsCount()} ${Liferay.Language.get(
+														'item-selected'
+												  )}`}
+										</span>
+									</span>
+								</ClayResultsBar.Item>
+
+								<ClayResultsBar.Item>
+									<ClayButton
+										className="component-link tbar-link"
+										displayType="unstyled"
+										onClick={() =>
+											setFields(
+												fields.map((field) => ({
+													...field,
+													selected: false,
+												}))
+											)
+										}
+									>
+										{Liferay.Language.get('deselect-all')}
+									</ClayButton>
+								</ClayResultsBar.Item>
+							</ClayResultsBar>
+						)}
+
+						<div className="bg-light fields mt-3 pb-2 pt-2 py-2">
 							{visibleFields.length ? (
 								visibleFields.map(({name, selected}) => (
 									<div

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -26,6 +26,7 @@ import {IFDSViewSectionProps} from '../../../FDSView';
 import {FDSViewType} from '../../../FDSViews';
 import {getFields} from '../../../api';
 import OrderableTable from '../../../components/OrderableTable';
+import SearchResultsMessage from '../../../components/SearchResultsMessage';
 import {
 	API_URL,
 	FUZZY_OPTIONS,
@@ -299,6 +300,10 @@ const SaveFDSFieldsModalContent = ({
 								</ManagementToolbar.Item>
 
 								<ManagementToolbar.Item className="nav-item-expand">
+									<SearchResultsMessage
+										numberOfResults={visibleFields.length}
+									/>
+
 									<ClayInput.Group>
 										<ClayInput.GroupItem>
 											{!focused && (

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/SearchResultsMessage.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/SearchResultsMessage.d.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+export default function SearchResultsMessage({
+	numberOfResults,
+	resultType,
+}: {
+	numberOfResults: number | null;
+	resultType?: string;
+}): JSX.Element;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/isNullOrUndefined.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/isNullOrUndefined.d.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function isNullOrUndefined(
+	value: unknown
+): value is null | undefined;


### PR DESCRIPTION
Basic rules for AutoSearch design can be found in [this document](https://liferay.atlassian.net/wiki/spaces/PEDS/pages/2334556869/Auto-Search+and+Manual-Search+visually+different).

In comparison to our current AutoSearch bar the changes we need to introduce are:
* Add a decorative magnifying glass icon on the left when input is empty.
* Remove that decorative icon and adding a button on the right to delete the query
* Add a results bar showing the number of items selected and including a button to deselect all of them.
* Make it accessible so screen reader are able to know how many results are present on the page after every query.

Although this supposed to be an standard along Liferay, as of today, there's no AutoSearch meeting all those requirements. The closest case is AutoSearch for fragment/widget selection while editing a content page. However, in that case, it's not including a decorative magnifying glass icon, probably due to space reasons.

If we are going to make this a pattern along Liferay, we should move new components to frontend-js-components-web module so they can be reused.