### PR TITLE
LPD-17829 Make ClientExtensionUsingConfigFile#CanUseOsgiClientExtensionIframeAsPortlet work with jdk21

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionUsingConfigFile.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionUsingConfigFile.testcase
@@ -86,7 +86,7 @@ definition {
 		}
 
 		task ("Then My Pretty IFrame is displayed correctly") {
-			AssertElementPresent(locator1 = "//iframe[contains(@src,'https://liferay.github.io/liferay-frontend-projects/index.html?b=2&a=1')]");
+			AssertElementPresent(locator1 = "//iframe[contains(@src,'https://liferay.github.io/liferay-frontend-projects/index.html?') and contains(@src,'a=1') and contains(@src, 'b=2')]");
 		}
 	}
 


### PR DESCRIPTION
Hi Team,

### References

Please see this issue for details: https://liferay.atlassian.net/browse/LPD-17829

### What is the goal of this PR?

Change ClientExtensionUsingConfigFile#CanUseOsgiClientExtensionIframeAsPortlet so that it works in both jdk8 and jdk21 server runtime.
In jdk21, properties has been changed from internally using Hashtable to ConcurrentHashMap. Hashtable literally uses key.hashCode() as the hash code for saving, but ConcurrentHashMap does a hash spreading on top of key.hashCode(), therefore same key ends up having different hashcode used for saving. This is jdk internal, by using Properties we already agreed the order is not really predictable. The test should not assert the parameter list in certain order, but should parse the parameter list to assert what are expected.

### What does it look like?

ClientExtensionusingConfigFile#CanUseOsgiClientExtensionIframeAsPortlet currently checks if iframe element is present like this:
```
AssertElementPresent(locator1 = "//iframe[contains(@src,'https://liferay.github.io/liferay-frontend-projects/index.html?b=2&a=1')]");
```


#### Before PR
JDK21 fails because instead of `?b=2&a=1` for the request params, it showed up as `?a=1&b=2`

#### After PR
Test assertion using 3 contains:
1. the url part `https://liferay.github.io/liferay-frontend-projects/index.html?`
2. param `b=2`
3. param `a=1`

This way checks the url regardless of param order

### Steps to reproduce
1. Set feature.flag.LPS-164563=true in portal-ext 

2. Start fresh portal 

3. Deploy com.liferay.client.extension.type.configuration.CETConfiguration~iframe.config to osgi/configs 

4. Create a widget page 

5. Add the "My Pretty iFrame" portlet in Client Extension category to the page and inspect the order of the src url parameters.
