### PR TITLE
LPD-15145 Clear mapping of DSM fields in cards visualization mode

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
@@ -5,7 +5,9 @@
 
 import ClayAlert from '@clayui/alert';
 import {ClayButtonWithIcon} from '@clayui/button';
+import ClayDropDown from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
@@ -77,7 +79,7 @@ export default function Cards(props: IFDSViewSectionProps) {
 				);
 
 				if (!fdsCardsSection) {
-					return cardsSection;
+					return {label: cardsSection.label, name: cardsSection.name};
 				}
 
 				return {
@@ -90,6 +92,31 @@ export default function Cards(props: IFDSViewSectionProps) {
 				};
 			})
 		);
+	};
+
+	const clearFDSCardsSectionAssignment = async (
+		cardsSection: ICardsSection
+	) => {
+		const method = 'DELETE';
+		const url = `${API_URL.FDS_CARDS_SECTIONS}/by-external-reference-code/${cardsSection.externalReferenceCode}`;
+
+		const response = await fetch(url, {
+			headers: {
+				'Accept': 'application/json',
+				'Content-Type': 'application/json',
+			},
+			method,
+		});
+
+		if (!response.ok) {
+			openDefaultFailureToast();
+
+			return;
+		}
+
+		getFDSCardsSections();
+
+		openDefaultSuccessToast();
 	};
 
 	const saveFDSCardsSection = async ({
@@ -133,26 +160,9 @@ export default function Cards(props: IFDSViewSectionProps) {
 			return;
 		}
 
-		const fdsCardsSection: IFDSCardsSection = await response.json();
-
 		closeModal();
 
-		setCardsSections(
-			cardsSections.map((cardsSection) => {
-				if (cardsSection.name !== fdsCardsSection.name) {
-					return cardsSection;
-				}
-
-				return {
-					...cardsSection,
-					externalReferenceCode:
-						fdsCardsSection.externalReferenceCode,
-					field: {
-						name: fdsCardsSection.fieldName,
-					},
-				};
-			})
-		);
+		getFDSCardsSections();
 
 		openDefaultSuccessToast();
 	};
@@ -197,6 +207,9 @@ export default function Cards(props: IFDSViewSectionProps) {
 							cardsSection={cardsSection}
 							key={cardsSection.name}
 							modalProps={props}
+							onClear={() =>
+								clearFDSCardsSectionAssignment(cardsSection)
+							}
 							onSelect={({closeModal, selectedField}) => {
 								saveFDSCardsSection({
 									cardsSection,
@@ -216,6 +229,7 @@ export default function Cards(props: IFDSViewSectionProps) {
 interface ICardsSectionProps {
 	cardsSection: ICardsSection;
 	modalProps: IFDSViewSectionProps;
+	onClear: (cardsSection: ICardsSection) => void;
 	onSelect: ({
 		closeModal,
 		selectedField,
@@ -229,12 +243,13 @@ interface ICardsSectionProps {
 function CardsSection({
 	cardsSection,
 	modalProps,
+	onClear,
 	onSelect,
 	saveButtonDisabled,
 }: ICardsSectionProps) {
 	const {field, label} = cardsSection;
 
-	const onClick = () => {
+	const onClickAssign = () => {
 		openModal({
 			contentComponent: ({closeModal}: {closeModal: Function}) => (
 				<FieldSelectModalContent
@@ -255,6 +270,10 @@ function CardsSection({
 				/>
 			),
 		});
+	};
+
+	const onClickClear = () => {
+		onClear(cardsSection);
 	};
 
 	return (
@@ -278,13 +297,55 @@ function CardsSection({
 					</ClayInput.GroupItem>
 
 					<ClayInput.GroupItem shrink>
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get('assign-field')}
-							displayType="secondary"
-							onClick={onClick}
-							symbol="plus"
-							title={Liferay.Language.get('assign-field')}
-						/>
+						{field?.name ? (
+							<ClayDropDown
+								trigger={
+									<ClayButtonWithIcon
+										aria-label={Liferay.Language.get(
+											'change-assignment'
+										)}
+										displayType="secondary"
+										size="sm"
+										symbol="ellipsis-v"
+										title={Liferay.Language.get(
+											'change-assignment'
+										)}
+									/>
+								}
+							>
+								<ClayDropDown.ItemList>
+									<ClayDropDown.Item onClick={onClickAssign}>
+										<span className="pr-2">
+											<ClayIcon symbol="change" />
+										</span>
+
+										{Liferay.Language.get(
+											'change-assignment'
+										)}
+									</ClayDropDown.Item>
+
+									<ClayDropDown.Item onClick={onClickClear}>
+										<span className="pr-2">
+											<ClayIcon symbol="times-circle" />
+										</span>
+
+										{Liferay.Language.get(
+											'clear-assignment'
+										)}
+									</ClayDropDown.Item>
+								</ClayDropDown.ItemList>
+							</ClayDropDown>
+						) : (
+							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'assign-field'
+								)}
+								displayType="secondary"
+								onClick={onClickAssign}
+								symbol="plus"
+								title={Liferay.Language.get('assign-field')}
+							/>
+						)}
 					</ClayInput.GroupItem>
 				</ClayInput.Group>
 			</ClayTable.Cell>


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-15145

**Scope:**

**Allow users to clear and change assigned fields to DSM views in Cards visualization mode**

LPD-10735 FF should be added to access Visualization modes

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/35d82a10-396f-42bb-bf42-3a7ffe90b896)


When there is no a field mapped, the "Not Assigned" message should appear:

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/96bf860c-94ba-4f83-a955-f5ac2ff48bf6)

Once a field is mapped, a three-dot button should appears instead of the '+' button:

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/ee902f8a-5546-4476-a247-43e0eb3a30d1)

That button opens a dropdown menu that allows user to unmap the field (so the "Not Assigned" label should appear again, and the button should revert to the previous '+') or change the field. In that case, the selection fields modal is open, allowing the user to choose a new field.

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/dfc125d4-9b4f-4aca-9f51-9771417a194c)

**Acceptance Criteria:**

- Users can clear the assignment of fields in cards individually.
- When a user clicks on the action, the field is unmapped immediately and persisted.

