### PR TITLE
LPD-19840 Enable permission bypass when accessing DSM object entries from the fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -17,6 +17,7 @@ import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
@@ -136,6 +137,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		throws IOException {
 
 		try {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
+
 			PrintWriter printWriter = httpServletResponse.getWriter();
 
 			FragmentEntryLink fragmentEntryLink =
@@ -220,6 +223,9 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			_log.error("Unable to render frontend data set view", exception);
 
 			throw new IOException(exception);
+		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(false);
 		}
 	}
 


### PR DESCRIPTION
Reference:
 * https://liferay.atlassian.net/browse/LPD-19840

In this PR, we let FDS fragment bypass any permission check when accessing any necessary, DSM managed object entries (such as `FDSEntry` and friends) to do its duties.

Reasoning is that any permission for such entities must be interpreted in the DSM context, and not in the fragment usage context. So, the fact that a user can't `VIEW` a given `FDSEntry` object means it won't be shown in the DSM, but still, that same user could consume the dataset when rendered through the fragment. See https://liferay.atlassian.net/browse/LPD-6836 for more context.

Notes:
 * This is a story we did not estimate yet. However, as solution is so straightforward, I'm sending it in a subtask
 * Some other solutions are possible, but the convenient to object entries via `defaultObjectEntryManager` makes us go through [objectEntryService](https://github.com/liferay/liferay-portal/blob/dc929f3b8eeffe163a17564938188e33a8b3a41f/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryServiceImpl.java#L286-L299) (instead of the local service). So, easiest way to bypass this is the trheadLocal pattern already used in portal.
 * This PR enables any user to consume any data-set view. Other permission limitations still apply, namely:
   * Permissions to view the page where fragment is
   * Permissions on individual data items being fetched by the FDS when rendering
   * Permissions on the actions that can be performed on such data items
 * There is another subtask to add a test. We need to estimate that one because we need to either sign in with a less privileged user in order to test this
 * Depending on the API REST endpoint targeted by the dataset, `guest` users may get a `403` forbidden http response when browsing the fragment, shown in a toast. This is expected and has to do with the FDS not being able to fetch data at all. I'm not dealing with this in this PR because it's not clear whether we want to keep or hide the toast