### PR TITLE
LPD-19789 - Add default view field to Data Set model

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -649,6 +649,11 @@ public class FDSViewsPortlet extends MVCPortlet {
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+						_language.get(locale, "default-view"), "defaultView",
+						false),
+					ObjectFieldUtil.createObjectField(
+						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(locale, "list-of-items-per-page"),
 						"listOfItemsPerPage", true),
 					ObjectFieldUtil.createObjectField(

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/FDSViewsPortlet.java
@@ -649,11 +649,6 @@ public class FDSViewsPortlet extends MVCPortlet {
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
 						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
-						_language.get(locale, "default-view"), "defaultView",
-						false),
-					ObjectFieldUtil.createObjectField(
-						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
-						ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
 						_language.get(locale, "list-of-items-per-page"),
 						"listOfItemsPerPage", true),
 					ObjectFieldUtil.createObjectField(
@@ -693,6 +688,32 @@ public class FDSViewsPortlet extends MVCPortlet {
 		_objectDefinitionLocalService.updateTitleObjectFieldId(
 			fdsViewObjectDefinition.getObjectDefinitionId(),
 			labelObjectField.getObjectFieldId());
+
+		if (FeatureFlagManagerUtil.isEnabled("LPD-10735")) {
+			ObjectField defaultViewObjectField =
+				ObjectFieldUtil.createObjectField(
+					ObjectFieldConstants.BUSINESS_TYPE_TEXT,
+					ObjectFieldConstants.DB_TYPE_STRING, true, false, null,
+					_language.get(locale, "default-view"), "defaultView",
+					false);
+
+			_objectFieldLocalService.addCustomObjectField(
+				defaultViewObjectField.getExternalReferenceCode(), userId,
+				defaultViewObjectField.getListTypeDefinitionId(),
+				fdsViewObjectDefinition.getObjectDefinitionId(),
+				defaultViewObjectField.getBusinessType(),
+				defaultViewObjectField.getDBType(),
+				defaultViewObjectField.isIndexed(),
+				defaultViewObjectField.isIndexedAsKeyword(),
+				defaultViewObjectField.getIndexedLanguageId(),
+				defaultViewObjectField.getLabelMap(), false,
+				defaultViewObjectField.getName(),
+				defaultViewObjectField.getReadOnly(),
+				defaultViewObjectField.getReadOnlyConditionExpression(),
+				defaultViewObjectField.isRequired(),
+				defaultViewObjectField.isState(),
+				defaultViewObjectField.getObjectFieldSettings());
+		}
 
 		_objectDefinitionLocalService.publishSystemObjectDefinition(
 			userId, fdsViewObjectDefinition.getObjectDefinitionId());


### PR DESCRIPTION
## Story / Task
[LPD-6630](https://liferay.atlassian.net/browse/LPD-6630) / [LPD-19789](https://liferay.atlassian.net/browse/LPD-19789)

## Goal
Define a DB field to store the default view of a Data Set in order to be used when rendering the fragment