### PR TITLE
LPD-19669 Clear mapping of DSM fields in cards visualization mode

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
@@ -4,13 +4,11 @@
  */
 
 import ClayAlert from '@clayui/alert';
-import {ClayButtonWithIcon} from '@clayui/button';
-import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
-import {fetch, openModal, sub} from 'frontend-js-web';
+import {fetch, openModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import '../../../../css/CardsVisualizationMode.scss';
@@ -20,6 +18,7 @@ import {API_URL, OBJECT_RELATIONSHIP} from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 import {IField} from '../../../utils/types';
+import FieldAssignmentControls from '../components/FieldAssignmentControls';
 
 interface IFDSCardsSection {
 	externalReferenceCode: string;
@@ -314,7 +313,7 @@ function CardsSection({
 					</ClayInput.GroupItem>
 
 					<ClayInput.GroupItem shrink>
-						<UpdateButton
+						<FieldAssignmentControls
 							field={field}
 							label={label}
 							onClearSelection={onClearSelection}
@@ -324,56 +323,5 @@ function CardsSection({
 				</ClayInput.Group>
 			</ClayTable.Cell>
 		</ClayTable.Row>
-	);
-}
-
-interface IUpdateButtonProps {
-	field?: IField;
-	label: string;
-	onClearSelection: () => void;
-	openSelectFieldModal: () => void;
-}
-
-function UpdateButton({
-	field,
-	label,
-	onClearSelection,
-	openSelectFieldModal,
-}: IUpdateButtonProps) {
-	return field ? (
-		<ClayDropDownWithItems
-			items={[
-				{
-					label: Liferay.Language.get('change-assignment'),
-					onClick: openSelectFieldModal,
-					symbolLeft: 'change',
-				},
-				{
-					label: Liferay.Language.get('clear-assignment'),
-					onClick: onClearSelection,
-					symbolLeft: 'times-circle',
-				},
-			]}
-			trigger={
-				<ClayButtonWithIcon
-					aria-label={sub(
-						Liferay.Language.get('view-x-options'),
-						label
-					)}
-					displayType="secondary"
-					size="sm"
-					symbol="ellipsis-v"
-					title={sub(Liferay.Language.get('view-x-options'), label)}
-				/>
-			}
-		/>
-	) : (
-		<ClayButtonWithIcon
-			aria-label={Liferay.Language.get('assign-field')}
-			displayType="secondary"
-			onClick={openSelectFieldModal}
-			symbol="plus"
-			title={Liferay.Language.get('assign-field')}
-		/>
 	);
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
@@ -5,11 +5,12 @@
 
 import ClayAlert from '@clayui/alert';
 import {ClayButtonWithIcon} from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
 import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
-import {fetch, openModal} from 'frontend-js-web';
+import {fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import '../../../../css/CardsVisualizationMode.scss';
@@ -84,6 +85,38 @@ export default function Cards(props: IFDSViewSectionProps) {
 						name: fdsCardsSection.fieldName,
 					},
 				};
+			})
+		);
+	};
+
+	const clearFDSCardSection = async (cardSection: ICardsSection) => {
+		setSaveButtonDisabled(true);
+
+		const response = await fetch(
+			`${API_URL.FDS_CARDS_SECTIONS}/by-external-reference-code/${cardSection.externalReferenceCode}`,
+			{method: 'DELETE'}
+		);
+
+		setSaveButtonDisabled(false);
+
+		if (!response.ok) {
+			openDefaultFailureToast();
+
+			return;
+		}
+
+		setCardsSections(
+			cardsSections.map((section) => {
+				if (section.name !== cardSection.name) {
+					return section;
+				}
+
+				const nextCardSection = {...cardSection};
+
+				delete nextCardSection.externalReferenceCode;
+				delete nextCardSection.field;
+
+				return nextCardSection;
 			})
 		);
 	};
@@ -193,6 +226,9 @@ export default function Cards(props: IFDSViewSectionProps) {
 							cardsSection={cardsSection}
 							key={cardsSection.name}
 							modalProps={props}
+							onClearSelection={() => {
+								clearFDSCardSection(cardsSection);
+							}}
 							onSelect={({closeModal, selectedField}) => {
 								saveFDSCardsSection({
 									cardsSection,
@@ -212,6 +248,7 @@ export default function Cards(props: IFDSViewSectionProps) {
 interface ICardsSectionProps {
 	cardsSection: ICardsSection;
 	modalProps: IFDSViewSectionProps;
+	onClearSelection: () => void;
 	onSelect: ({
 		closeModal,
 		selectedField,
@@ -225,12 +262,13 @@ interface ICardsSectionProps {
 function CardsSection({
 	cardsSection,
 	modalProps,
+	onClearSelection,
 	onSelect,
 	saveButtonDisabled,
 }: ICardsSectionProps) {
 	const {field, label} = cardsSection;
 
-	const onClick = () => {
+	const openSelectFieldModal = () => {
 		openModal({
 			contentComponent: ({closeModal}: {closeModal: Function}) => (
 				<FieldSelectModalContent
@@ -269,22 +307,73 @@ function CardsSection({
 								{'text-secondary': !field}
 							)}
 						>
-							{field?.name ||
-								Liferay.Language.get('not-assigned')}
+							{field
+								? field.label || field.name
+								: Liferay.Language.get('not-assigned')}
 						</p>
 					</ClayInput.GroupItem>
 
 					<ClayInput.GroupItem shrink>
-						<ClayButtonWithIcon
-							aria-label={Liferay.Language.get('assign-field')}
-							displayType="secondary"
-							onClick={onClick}
-							symbol="plus"
-							title={Liferay.Language.get('assign-field')}
+						<UpdateButton
+							field={field}
+							label={label}
+							onClearSelection={onClearSelection}
+							openSelectFieldModal={openSelectFieldModal}
 						/>
 					</ClayInput.GroupItem>
 				</ClayInput.Group>
 			</ClayTable.Cell>
 		</ClayTable.Row>
+	);
+}
+
+interface IUpdateButtonProps {
+	field?: IField;
+	label: string;
+	onClearSelection: () => void;
+	openSelectFieldModal: () => void;
+}
+
+function UpdateButton({
+	field,
+	label,
+	onClearSelection,
+	openSelectFieldModal,
+}: IUpdateButtonProps) {
+	return field ? (
+		<ClayDropDownWithItems
+			items={[
+				{
+					label: Liferay.Language.get('change-assignment'),
+					onClick: openSelectFieldModal,
+					symbolLeft: 'change',
+				},
+				{
+					label: Liferay.Language.get('clear-assignment'),
+					onClick: onClearSelection,
+					symbolLeft: 'times-circle',
+				},
+			]}
+			trigger={
+				<ClayButtonWithIcon
+					aria-label={sub(
+						Liferay.Language.get('view-x-options'),
+						label
+					)}
+					displayType="secondary"
+					size="sm"
+					symbol="ellipsis-v"
+					title={sub(Liferay.Language.get('view-x-options'), label)}
+				/>
+			}
+		/>
+	) : (
+		<ClayButtonWithIcon
+			aria-label={Liferay.Language.get('assign-field')}
+			displayType="secondary"
+			onClick={openSelectFieldModal}
+			symbol="plus"
+			title={Liferay.Language.get('assign-field')}
+		/>
 	);
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/components/FieldAssignmentControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/components/FieldAssignmentControls.tsx
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayButtonWithIcon} from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import {sub} from 'frontend-js-web';
+import React from 'react';
+
+import {IField} from '../../../utils/types';
+
+interface IFieldAssignmentControlsProps {
+	field?: IField;
+	label: string;
+	onClearSelection: () => void;
+	openSelectFieldModal: () => void;
+}
+
+function FieldAssignmentControls({
+	field,
+	label,
+	onClearSelection,
+	openSelectFieldModal,
+}: IFieldAssignmentControlsProps) {
+	return field ? (
+		<ClayDropDownWithItems
+			items={[
+				{
+					label: Liferay.Language.get('change-assignment'),
+					onClick: openSelectFieldModal,
+					symbolLeft: 'change',
+				},
+				{
+					label: Liferay.Language.get('clear-assignment'),
+					onClick: onClearSelection,
+					symbolLeft: 'times-circle',
+				},
+			]}
+			trigger={
+				<ClayButtonWithIcon
+					aria-label={sub(
+						Liferay.Language.get('view-x-options'),
+						label
+					)}
+					displayType="secondary"
+					size="sm"
+					symbol="ellipsis-v"
+					title={sub(Liferay.Language.get('view-x-options'), label)}
+				/>
+			}
+		/>
+	) : (
+		<ClayButtonWithIcon
+			aria-label={Liferay.Language.get('assign-field')}
+			displayType="secondary"
+			onClick={openSelectFieldModal}
+			symbol="plus"
+			title={Liferay.Language.get('assign-field')}
+		/>
+	);
+}
+
+export default FieldAssignmentControls;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -4,24 +4,21 @@
  */
 
 import ClayAlert from '@clayui/alert';
-import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
 import ClayLayout from '@clayui/layout';
 import ClayTable from '@clayui/table';
 import classNames from 'classnames';
-import {fetch, openModal, sub} from 'frontend-js-web';
+import {fetch, openModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import '../../../../css/ListVisualizationMode.scss';
-
-import {ClayDropDownWithItems} from '@clayui/drop-down';
-
 import {IFDSViewSectionProps} from '../../../FDSView';
 import FieldSelectModalContent from '../../../components/FieldSelectModalContent';
 import {API_URL, OBJECT_RELATIONSHIP} from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 import {IField} from '../../../utils/types';
+import FieldAssignmentControls from '../components/FieldAssignmentControls';
 
 interface IFDSListSection {
 	externalReferenceCode: string;
@@ -314,7 +311,7 @@ function ListSection({
 					</ClayInput.GroupItem>
 
 					<ClayInput.GroupItem shrink>
-						<UpdateButton
+						<FieldAssignmentControls
 							field={field}
 							label={label}
 							onClearSelection={onClearSelection}
@@ -324,56 +321,5 @@ function ListSection({
 				</ClayInput.Group>
 			</ClayTable.Cell>
 		</ClayTable.Row>
-	);
-}
-
-interface IUpdateButtonProps {
-	field?: IField;
-	label: string;
-	onClearSelection: () => void;
-	openSelectFieldModal: () => void;
-}
-
-function UpdateButton({
-	field,
-	label,
-	onClearSelection,
-	openSelectFieldModal,
-}: IUpdateButtonProps) {
-	return field ? (
-		<ClayDropDownWithItems
-			items={[
-				{
-					label: Liferay.Language.get('change-assignment'),
-					onClick: openSelectFieldModal,
-					symbolLeft: 'change',
-				},
-				{
-					label: Liferay.Language.get('clear-assignment'),
-					onClick: onClearSelection,
-					symbolLeft: 'times-circle',
-				},
-			]}
-			trigger={
-				<ClayButtonWithIcon
-					aria-label={sub(
-						Liferay.Language.get('view-x-options'),
-						label
-					)}
-					displayType="secondary"
-					size="sm"
-					symbol="ellipsis-v"
-					title={sub(Liferay.Language.get('view-x-options'), label)}
-				/>
-			}
-		/>
-	) : (
-		<ClayButtonWithIcon
-			aria-label={Liferay.Language.get('assign-field')}
-			displayType="secondary"
-			onClick={openSelectFieldModal}
-			symbol="plus"
-			title={Liferay.Language.get('assign-field')}
-		/>
 	);
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/components/FieldAssignmentControls.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/components/FieldAssignmentControls.d.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+import {IField} from '../../../utils/types';
+interface IFieldAssignmentControlsProps {
+	field?: IField;
+	label: string;
+	onClearSelection: () => void;
+	openSelectFieldModal: () => void;
+}
+declare function FieldAssignmentControls({
+	field,
+	label,
+	onClearSelection,
+	openSelectFieldModal,
+}: IFieldAssignmentControlsProps): JSX.Element;
+export default FieldAssignmentControls;

--- a/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
@@ -111,7 +111,7 @@ test('Configure cards visualization mode @LPD-10735', async ({
 		const container =
 			visualizationModesPage.cardsVisualizationModeContainer;
 
-		await visualizationModesPage.openAssignFieldModal({
+		await visualizationModesPage.openChangeFieldModal({
 			container,
 			sectionLabel,
 		});


### PR DESCRIPTION
Comes from: https://github.com/liferay-frontend/liferay-portal/pull/4042

Task: https://liferay.atlassian.net/browse/LPD-19669

**Scope:**

**Allow users to clear and change assigned fields to DSM views in Cards visualization mode**

LPD-10735 FF should be added to access Visualization modes

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/35d82a10-396f-42bb-bf42-3a7ffe90b896)


When there is no a field mapped, the "Not Assigned" message should appear:

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/96bf860c-94ba-4f83-a955-f5ac2ff48bf6)

Once a field is mapped, a three-dot button should appears instead of the '+' button:

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/ee902f8a-5546-4476-a247-43e0eb3a30d1)

That button opens a dropdown menu that allows user to unmap the field (so the "Not Assigned" label should appear again, and the button should revert to the previous '+') or change the field. In that case, the selection fields modal is open, allowing the user to choose a new field.

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/dfc125d4-9b4f-4aca-9f51-9771417a194c)

**Acceptance Criteria:**

- Users can clear the assignment of fields in cards individually.
- When a user clicks on the action, the field is unmapped immediately and persisted.

