### PR TITLE
LPD-17876 Set the fdsFields after reorder

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -660,6 +660,38 @@ function Table({
 }: IFDSViewSectionProps & {title?: string}) {
 	const [fdsFields, setFDSFields] = useState<Array<IFDSField> | null>(null);
 
+	const reorderFDSFields = ({
+		fdsFieldsOrder,
+		storedFDSFields,
+	}: {
+		fdsFieldsOrder: string;
+		storedFDSFields: Array<IFDSField>;
+	}): Array<IFDSField> => {
+		const storedOrderedFDSFieldIds = fdsFieldsOrder.split(',');
+
+		const orderedFDSFields: Array<IFDSField> = [];
+
+		const orderedFDSFieldIds: Array<number> = [];
+
+		storedOrderedFDSFieldIds.forEach((fdsFieldId: string) => {
+			storedFDSFields.forEach((storedFDSField: IFDSField) => {
+				if (fdsFieldId === String(storedFDSField.id)) {
+					orderedFDSFields.push(storedFDSField);
+
+					orderedFDSFieldIds.push(storedFDSField.id);
+				}
+			});
+		});
+
+		storedFDSFields.forEach((storedFDSField: IFDSField) => {
+			if (!orderedFDSFieldIds.includes(storedFDSField.id)) {
+				orderedFDSFields.push(storedFDSField);
+			}
+		});
+
+		return orderedFDSFields;
+	};
+
 	const getFDSFields = async () => {
 		const response = await fetch(
 			`${API_URL.FDS_FIELDS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD}`
@@ -686,26 +718,9 @@ function Table({
 				?.fdsFieldsOrder;
 
 		if (fdsFieldsOrder) {
-			const storedOrderedFDSFieldIds = fdsFieldsOrder.split(',');
-
-			const orderedFDSFields: Array<IFDSField> = [];
-
-			const orderedFDSFieldIds: Array<number> = [];
-
-			storedOrderedFDSFieldIds.forEach((fdsFieldId: string) => {
-				storedFDSFields.forEach((storedFDSField: IFDSField) => {
-					if (fdsFieldId === String(storedFDSField.id)) {
-						orderedFDSFields.push(storedFDSField);
-
-						orderedFDSFieldIds.push(storedFDSField.id);
-					}
-				});
-			});
-
-			storedFDSFields.forEach((storedFDSField: IFDSField) => {
-				if (!orderedFDSFieldIds.includes(storedFDSField.id)) {
-					orderedFDSFields.push(storedFDSField);
-				}
+			const orderedFDSFields = reorderFDSFields({
+				fdsFieldsOrder,
+				storedFDSFields,
 			});
 
 			setFDSFields(orderedFDSFields);
@@ -793,7 +808,20 @@ function Table({
 
 		const storedFDSFieldsOrder = responseJSON?.fdsFieldsOrder;
 
-		if (storedFDSFieldsOrder && storedFDSFieldsOrder === fdsFieldsOrder) {
+		const storedFDSFields = fdsFields;
+
+		if (
+			storedFDSFields &&
+			storedFDSFieldsOrder &&
+			storedFDSFieldsOrder === fdsFieldsOrder
+		) {
+			const orderedFDSFields = reorderFDSFields({
+				fdsFieldsOrder,
+				storedFDSFields,
+			});
+
+			setFDSFields(orderedFDSFields);
+
 			openDefaultSuccessToast();
 		}
 		else {


### PR DESCRIPTION
When the user updates the order of the fields and then edits and saves a field, the fields reverts back to its original order.

To resolve this, we need to set the `fdsFields` once the fields order has been updated.
Please let me know if there are any questions or comments about this.

Thank you!