### PR TITLE
LPD-19671 Functional automation for clear assigned fields in DSM list and cards visualization modes

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
@@ -30,6 +30,27 @@ export class VisualizationModesPage {
 		this.viewPage = new ViewPage(page);
 	}
 
+	async clearAssignedField({
+		container,
+		sectionLabel,
+	}: {
+		container: Locator;
+		sectionLabel: string;
+	}) {
+		await container
+			.locator('tr')
+			.filter({has: this.page.getByText(sectionLabel)})
+			.getByTitle(`View ${sectionLabel} Options`)
+			.click();
+
+		const clearAssignmentButton = this.page.getByRole('menuitem', {
+			name: 'Clear Assignment',
+		});
+
+		await clearAssignmentButton.waitFor();
+		await clearAssignmentButton.click();
+	}
+
 	async getAssignedFieldLocator({
 		container,
 		sectionLabel,
@@ -70,6 +91,31 @@ export class VisualizationModesPage {
 			.filter({has: this.page.getByText(sectionLabel)})
 			.getByTitle('Assign Field')
 			.click();
+
+		await this.fieldSelectModalContainer
+			.getByPlaceholder('Search')
+			.waitFor();
+	}
+
+	async openChangeFieldModal({
+		container,
+		sectionLabel,
+	}: {
+		container: Locator;
+		sectionLabel: string;
+	}) {
+		await container
+			.locator('tr')
+			.filter({has: this.page.getByText(sectionLabel)})
+			.getByTitle(`View ${sectionLabel} Options`)
+			.click();
+
+		const changeAssignmentButton = this.page.getByRole('menuitem', {
+			name: 'Change Assignment',
+		});
+
+		await changeAssignmentButton.waitFor();
+		await changeAssignmentButton.click();
 
 		await this.fieldSelectModalContainer
 			.getByPlaceholder('Search')

--- a/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
@@ -72,7 +72,7 @@ test('Assign field to a cards section @LPD-10735', async ({
 		const container =
 			visualizationModesPage.cardsVisualizationModeContainer;
 
-		await visualizationModesPage.openAssignFieldModal({
+		await visualizationModesPage.openChangeFieldModal({
 			container,
 			sectionLabel,
 		});
@@ -94,6 +94,27 @@ test('Assign field to a cards section @LPD-10735', async ({
 			});
 
 		expect(assignedFieldLocator).toHaveText(newFieldName);
+	});
+
+	await test.step('Clear field to title section @LPD-15145', async () => {
+		const notAssignedLabel = 'Not Assigned';
+		const sectionLabel = 'Title';
+
+		const container =
+			visualizationModesPage.cardsVisualizationModeContainer;
+
+		await visualizationModesPage.clearAssignedField({
+			container,
+			sectionLabel,
+		});
+
+		const assignedFieldLocator =
+			await visualizationModesPage.getAssignedFieldLocator({
+				container,
+				sectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(notAssignedLabel);
 	});
 });
 
@@ -146,7 +167,7 @@ test('Assign field to a list section @LPD-10735', async ({
 
 		const container = visualizationModesPage.listVisualizationModeContainer;
 
-		await visualizationModesPage.openAssignFieldModal({
+		await visualizationModesPage.openChangeFieldModal({
 			container,
 			sectionLabel,
 		});
@@ -168,6 +189,26 @@ test('Assign field to a list section @LPD-10735', async ({
 			});
 
 		expect(assignedFieldLocator).toHaveText(newFieldName);
+	});
+
+	await test.step('Clear field to title section @LPD-6701', async () => {
+		const notAssignedLabel = 'Not Assigned';
+		const sectionLabel = 'Title';
+
+		const container = visualizationModesPage.listVisualizationModeContainer;
+
+		await visualizationModesPage.clearAssignedField({
+			container,
+			sectionLabel,
+		});
+
+		const assignedFieldLocator =
+			await visualizationModesPage.getAssignedFieldLocator({
+				container,
+				sectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(notAssignedLabel);
 	});
 });
 


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-19671

Covered cases: 

Given a Data Set with a View

In List visualization mode:

- Assign a field to an element
- Change assigned field
- Clear assigned element, returning to the "Not Assigned" state 
- 
In Cards visualization mode:

- Assign a field to an element
- Change assigned field
- Clear assigned element, returning to the "Not Assigned" state 
