### PR TITLE
LPD-19957 Prevents any action on submit over the search bar

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
@@ -298,7 +298,9 @@ const AddFieldsModalContent = ({
 				) : (
 					<>
 						<ClayManagementToolbar>
-							<ClayManagementToolbar.Search>
+							<ClayManagementToolbar.Search
+								onSubmit={(event) => event.preventDefault()}
+							>
 								<AutoSearch onSearch={onSearch} query={query} />
 							</ClayManagementToolbar.Search>
 						</ClayManagementToolbar>


### PR DESCRIPTION
Hey,

You can find further information in [LPD-19957](https://liferay.atlassian.net/browse/LPD-19957).

In a nutshell, `ClayManagementToolbar.search` is adding a form element around our search bar and we don't need since we are not using it as a form, just as a filter, so we need to prevent `onSubmit` event.