### PR TITLE
LPD-15327 Tooltip / title no longer needed in "New" button

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -3,9 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
-import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import {sub, unescapeHTML} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
@@ -172,21 +170,18 @@ const CreationMenu = ({
 					className="creation-menu"
 					onActiveChange={setActive}
 					trigger={
-						<ClayButton
+						<LinkOrButton
 							aria-label={getPlusIconLabel()}
 							className="nav-btn"
 							data-qa-id="creationMenuNewButton"
+							symbol="plus"
 							title={getPlusIconLabel()}
+							wideViewportTitleVisible={false}
 						>
-							<ClayIcon
-								className="d-md-none dropdown-icon"
-								symbol="plus"
-							/>
-
 							<span className="d-md-block d-none pl-3 pr-3">
 								{getPlusIconLabel()}
 							</span>
-						</ClayButton>
+						</LinkOrButton>
 					}
 				>
 					{visibleItemsCount < totalItemsCountRef.current ? (
@@ -257,6 +252,7 @@ const CreationMenu = ({
 						symbol="plus"
 						title={getPlusIconLabel()}
 						wide
+						wideViewportTitleVisible={false}
 					>
 						{Liferay.Language.get('new')}
 					</LinkOrButton>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/LinkOrButton.js
@@ -18,9 +18,11 @@ const LinkOrButton = ({
 	symbol,
 	title,
 	wide,
+	wideViewportTitleVisible = true,
 	...otherProps
 }) => {
-	const responsive = symbol && children;
+	const responsive = Boolean(symbol && children);
+
 	const Wrapper = href && !disabled ? ClayLink : ClayButton;
 
 	return (
@@ -50,6 +52,7 @@ const LinkOrButton = ({
 					disabled={disabled}
 					href={href}
 					{...otherProps}
+					title={wideViewportTitleVisible && title}
 				>
 					{children}
 				</Wrapper>
@@ -57,4 +60,5 @@ const LinkOrButton = ({
 		</>
 	);
 };
-export default LinkOrButton;
+
+export default React.forwardRef(LinkOrButton);


### PR DESCRIPTION
### References

- [LPD-15327 Tooltip / title no longer needed in "New" button](https://issues.liferay.com/browse/LPD-15327)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/4006

### What is the goal of this PR?

Compared to the previous solution:
- We are keeping the old trick to manage viewport width versions, using `d-md-block d-none` CSS classes. With this, we are consistent with SSR.
- We are not adding the `label` prop, to retain flexibility in usages. This was a reasonable change, but it caused a lot of regression. To make it work, we would need a more wide-spread migration, which is out of the scope of this task, and IMO probably not worth doing overall.
- We are still keeping the `forwardRef`, as we want to have consistent solution for button in dropdown and standalone button.
- We are reducing the scope of changes just to the creation button, with API toggle that has unchanged default for other usages. We can tweak default or remove API later on, if we get the same product requirements for other usages.
