### PR TITLE
LPD-19618 - DataSetViewActions#CanSeeEmptyActionTable

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -2975,7 +2975,7 @@ definition {
 
 		task ("Then the text “No actions were created. Start creating one action to interact with your data.” is displayed above the Create Item Action button") {
 			AssertElementPresent(
-				key_textName = "No actions were created.",
+				key_textName = "No actions were created.Start creating one action to interact with your data.",
 				locator1 = "DataSet#ACTIONS_EMPTY_TABLE");
 		}
 	}


### PR DESCRIPTION
## Story / Task
 [LPD-19513](https://liferay.atlassian.net/browse/LPD-19513) / [LPD-19618](https://liferay.atlassian.net/browse/LPD-19618)

## Issue 
Cannot find empty state text.
![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/9bb3b461-17b9-4502-b459-89f2f3c0bbc2)

## Solution
Update text to match the string retrieved from the DOM node

Other approach could be using a more [restrictive selector](https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/paths/portlet/frontenddataset/DataSet.path#L451) to get only the title (previous expecte text)
