### PR TITLE
LPD-20532 Match DSM List and Cards mapped fields with visual component elements

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -116,7 +116,7 @@ const FDSView = ({
 	const Content = NAVIGATION_BAR_ITEMS[activeIndex].Component;
 
 	return (
-		<div className="cadmin">
+		<div className="cadmin fds-view">
 			<ClayNavigationBar
 				triggerLabel={NAVIGATION_BAR_ITEMS[activeIndex].label}
 			>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -316,40 +316,42 @@ const FDSViews = ({
 	];
 
 	return (
-		<FrontendDataSet
-			{...FDS_DEFAULT_PROPS}
-			apiURL={`${API_URL.FDS_VIEWS}/?filter=(${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW_ID} eq '${fdsEntryId}')`}
-			creationMenu={creationMenu}
-			emptyState={{
-				description: Liferay.Language.get(
-					'start-creating-one-to-show-your-data'
-				),
-				image: '/states/empty_state.gif',
-				title: Liferay.Language.get('no-views-created'),
-			}}
-			header={{
-				title: Liferay.Language.get('views'),
-			}}
-			id={`${namespace}FDSViews`}
-			itemsActions={[
-				{
-					icon: 'pencil',
-					label: Liferay.Language.get('edit'),
-					onClick: onEditClick,
-				},
-				{
-					separator: true,
-					type: 'group',
-				},
-				{
-					icon: 'trash',
-					label: Liferay.Language.get('delete'),
-					onClick: onDeleteClick,
-				},
-			]}
-			sorts={[{direction: 'desc', key: 'dateModified'}]}
-			views={views}
-		/>
+		<div className="fds-views">
+			<FrontendDataSet
+				{...FDS_DEFAULT_PROPS}
+				apiURL={`${API_URL.FDS_VIEWS}/?filter=(${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW_ID} eq '${fdsEntryId}')`}
+				creationMenu={creationMenu}
+				emptyState={{
+					description: Liferay.Language.get(
+						'start-creating-one-to-show-your-data'
+					),
+					image: '/states/empty_state.gif',
+					title: Liferay.Language.get('no-views-created'),
+				}}
+				header={{
+					title: Liferay.Language.get('views'),
+				}}
+				id={`${namespace}FDSViews`}
+				itemsActions={[
+					{
+						icon: 'pencil',
+						label: Liferay.Language.get('edit'),
+						onClick: onEditClick,
+					},
+					{
+						separator: true,
+						type: 'group',
+					},
+					{
+						icon: 'trash',
+						label: Liferay.Language.get('delete'),
+						onClick: onDeleteClick,
+					},
+				]}
+				sorts={[{direction: 'desc', key: 'dateModified'}]}
+				views={views}
+			/>
+		</div>
 	);
 };
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
@@ -43,8 +43,6 @@ export default function Cards(props: IFDSViewSectionProps) {
 		{label: Liferay.Language.get('description'), name: 'description'},
 		{label: Liferay.Language.get('image'), name: 'image'},
 		{label: Liferay.Language.get('symbol'), name: 'symbol'},
-		{label: Liferay.Language.get('link'), name: 'link'},
-		{label: Liferay.Language.get('sticker'), name: 'sticker'},
 	]);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -44,9 +44,8 @@ export default function List(props: IFDSViewSectionProps) {
 	const [listSections, setListSections] = useState<Array<IListSection>>([
 		{label: Liferay.Language.get('title'), name: 'title'},
 		{label: Liferay.Language.get('description'), name: 'description'},
+		{label: Liferay.Language.get('image'), name: 'image'},
 		{label: Liferay.Language.get('symbol'), name: 'symbol'},
-		{label: Liferay.Language.get('link'), name: 'link'},
-		{label: Liferay.Language.get('label'), name: 'label'},
 	]);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
@@ -108,7 +108,7 @@ export class DataSetsPage {
 		await this.pageContainer.waitFor();
 	}
 
-	async gotoDataSet(name = DEFAULT_LABEL.DATA_SET) {
+	async openDataSet(name = DEFAULT_LABEL.DATA_SET) {
 		await this.pageContainer.waitFor();
 
 		await this.pageContainer.getByRole('link', {name}).first().click();

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/ViewsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/ViewsPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {DEFAULT_LABEL} from '../utils/constants';
 import {DataSetsPage} from './DataSetsPage';
@@ -19,6 +19,7 @@ export class ViewsPage {
 		saveButton: Locator;
 	};
 	readonly page: Page;
+	private readonly pageContainer: Locator;
 
 	constructor(page: Page) {
 		this.dataSetsPage = new DataSetsPage(page);
@@ -31,6 +32,7 @@ export class ViewsPage {
 			saveButton: page.getByRole('button', {name: 'Save'}),
 		};
 		this.page = page;
+		this.pageContainer = page.locator('.fds-views');
 	}
 
 	async createDataSetView({
@@ -53,7 +55,10 @@ export class ViewsPage {
 
 	async goto(dataSetLabel: string = DEFAULT_LABEL.DATA_SET) {
 		await this.dataSetsPage.goto();
-		await this.dataSetsPage.gotoDataSet(dataSetLabel);
+
+		await this.dataSetsPage.openDataSet(dataSetLabel);
+
+		await expect(this.pageContainer).toBeInViewport();
 	}
 
 	async openDataSetView(viewLabel: string = DEFAULT_LABEL.VIEW) {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/ViewPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/ViewPage.ts
@@ -3,17 +3,19 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {ViewsPage} from '../ViewsPage';
 
 export class ViewPage {
 	readonly page: Page;
+	private readonly pageContainer: Locator;
 	private readonly tabsContainer: Locator;
 	private readonly viewsPage: ViewsPage;
 
 	constructor(page: Page) {
 		this.page = page;
+		this.pageContainer = page.locator('.fds-view');
 		this.tabsContainer = page.locator('nav.navbar');
 		this.viewsPage = new ViewsPage(page);
 	}
@@ -28,6 +30,8 @@ export class ViewPage {
 		await this.viewsPage.goto(dataSetLabel);
 
 		await this.viewsPage.openDataSetView(viewLabel);
+
+		await expect(this.pageContainer).toBeInViewport();
 	}
 
 	async selectTab(tabLabel: string) {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {ViewPage} from '../ViewPage';
 
@@ -76,6 +76,31 @@ export class VisualizationModesPage {
 			.waitFor();
 	}
 
+	async openChangeFieldModal({
+		container,
+		sectionLabel,
+	}: {
+		container: Locator;
+		sectionLabel: string;
+	}) {
+		await container
+			.locator('tr')
+			.filter({has: this.page.getByText(sectionLabel)})
+			.getByTitle(`View ${sectionLabel} Options`)
+			.click();
+
+		const changeAssignmentButton = this.page.getByRole('menuitem', {
+			name: 'Change Assignment',
+		});
+
+		await changeAssignmentButton.waitFor();
+		await changeAssignmentButton.click();
+
+		await this.fieldSelectModalContainer
+			.getByPlaceholder('Search')
+			.waitFor();
+	}
+
 	async selectTab(tabLabel: string) {
 		const tab = this.container.getByRole('tab', {
 			exact: true,
@@ -96,9 +121,9 @@ export class VisualizationModesPage {
 			})
 			.click();
 
-		await this.fieldSelectModalContainer.isHidden();
+		await expect(this.fieldSelectModalContainer).not.toBeInViewport();
 
-		await this.toastContainer.isVisible();
+		await expect(this.toastContainer).toBeInViewport();
 
 		await this.page.getByText('Success').waitFor();
 
@@ -108,6 +133,6 @@ export class VisualizationModesPage {
 			})
 			.click();
 
-		await this.toastContainer.isHidden();
+		await expect(this.toastContainer).toBeHidden();
 	}
 }

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
@@ -71,9 +71,17 @@ export class VisualizationModesPage {
 			.getByTitle('Assign Field')
 			.click();
 
-		await this.fieldSelectModalContainer
-			.getByPlaceholder('Search')
-			.waitFor();
+		await expect(
+			this.fieldSelectModalContainer
+				.locator('.custom-control-input')
+				.first()
+		).toBeEditable();
+
+		await expect(
+			this.fieldSelectModalContainer
+				.locator('.custom-control-label')
+				.first()
+		).toBeInViewport();
 	}
 
 	async openChangeFieldModal({

--- a/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
@@ -6,9 +6,9 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {loginTest} from '../../fixtures/loginTest';
+import getRandomString from '../../utils/getRandomString';
 import {dataSetManagerApiHelpersTest} from './fixtures/dataSetManagerApiHelpersTest';
 import {visualizationModesPageTest} from './fixtures/visualizationModesPageTest';
-import {DEFAULT_LABEL} from './utils/constants';
 
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
@@ -16,161 +16,222 @@ export const test = mergeTests(
 	loginTest()
 );
 
+let dataSetERC: string;
+let viewERC: string;
+
+const dataSetLabel: string = getRandomString();
+const viewLabel: string = getRandomString();
+
 test.beforeEach(async ({dataSetManagerApiHelpers}) => {
-	await dataSetManagerApiHelpers.createDataSet({});
-	await dataSetManagerApiHelpers.createDataSetView({});
-});
+	dataSetERC = getRandomString();
 
-test('Assign field to a cards section @LPD-10735', async ({
-	visualizationModesPage,
-}) => {
-	await test.step('Navigate to cards visualization mode', async () => {
-		await visualizationModesPage.goto({
-			dataSetLabel: DEFAULT_LABEL.DATA_SET,
-			viewLabel: DEFAULT_LABEL.VIEW,
-		});
-
-		await visualizationModesPage.selectTab('Cards');
-
-		await visualizationModesPage.page
-			.getByText('Cards Element', {exact: true})
-			.isVisible();
+	await dataSetManagerApiHelpers.createDataSet({
+		erc: dataSetERC,
+		label: dataSetLabel,
 	});
-
-	await test.step('Assign a field to title section', async () => {
-		const fieldName = 'name';
-		const sectionLabel = 'Title';
-
-		const container =
-			visualizationModesPage.cardsVisualizationModeContainer;
-
-		await visualizationModesPage.openAssignFieldModal({
-			container,
-			sectionLabel,
-		});
-
-		await visualizationModesPage.fieldSelectModalContainer
-			.getByLabel(fieldName)
-			.click();
-
-		await visualizationModesPage.saveFieldSelection();
-
-		const assignedFieldLocator =
-			await visualizationModesPage.getAssignedFieldLocator({
-				container,
-				sectionLabel,
-			});
-
-		expect(assignedFieldLocator).toHaveText(fieldName);
-	});
-
-	await test.step('Edit field to title section', async () => {
-		const newFieldName = 'rendererType';
-		const oldFieldName = 'name';
-		const sectionLabel = 'Title';
-
-		const container =
-			visualizationModesPage.cardsVisualizationModeContainer;
-
-		await visualizationModesPage.openAssignFieldModal({
-			container,
-			sectionLabel,
-		});
-
-		expect(
-			visualizationModesPage.page.getByLabel(oldFieldName)
-		).toBeChecked();
-
-		await visualizationModesPage.fieldSelectModalContainer
-			.getByLabel(newFieldName)
-			.click();
-
-		await visualizationModesPage.saveFieldSelection();
-
-		const assignedFieldLocator =
-			await visualizationModesPage.getAssignedFieldLocator({
-				container,
-				sectionLabel,
-			});
-
-		expect(assignedFieldLocator).toHaveText(newFieldName);
-	});
-});
-
-test('Assign field to a list section @LPD-10735', async ({
-	visualizationModesPage,
-}) => {
-	await test.step('Navigate to list visualization mode', async () => {
-		await visualizationModesPage.goto({
-			dataSetLabel: DEFAULT_LABEL.DATA_SET,
-			viewLabel: DEFAULT_LABEL.VIEW,
-		});
-
-		await visualizationModesPage.selectTab('List');
-
-		await visualizationModesPage.page
-			.getByText('List Element', {exact: true})
-			.isVisible();
-	});
-
-	await test.step('Assign a field to title section', async () => {
-		const fieldName = 'name';
-		const sectionLabel = 'Title';
-
-		const container = visualizationModesPage.listVisualizationModeContainer;
-
-		await visualizationModesPage.openAssignFieldModal({
-			container,
-			sectionLabel,
-		});
-
-		await visualizationModesPage.fieldSelectModalContainer
-			.getByLabel(fieldName)
-			.click();
-
-		await visualizationModesPage.saveFieldSelection();
-
-		const assignedFieldLocator =
-			await visualizationModesPage.getAssignedFieldLocator({
-				container,
-				sectionLabel,
-			});
-
-		expect(assignedFieldLocator).toHaveText(fieldName);
-	});
-
-	await test.step('Edit field to title section', async () => {
-		const newFieldName = 'rendererType';
-		const oldFieldName = 'name';
-		const sectionLabel = 'Title';
-
-		const container = visualizationModesPage.listVisualizationModeContainer;
-
-		await visualizationModesPage.openAssignFieldModal({
-			container,
-			sectionLabel,
-		});
-
-		expect(
-			visualizationModesPage.page.getByLabel(oldFieldName)
-		).toBeChecked();
-
-		await visualizationModesPage.fieldSelectModalContainer
-			.getByLabel(newFieldName)
-			.click();
-
-		await visualizationModesPage.saveFieldSelection();
-
-		const assignedFieldLocator =
-			await visualizationModesPage.getAssignedFieldLocator({
-				container,
-				sectionLabel,
-			});
-
-		expect(assignedFieldLocator).toHaveText(newFieldName);
+	await dataSetManagerApiHelpers.createDataSetView({
+		erc: viewERC,
+		label: viewLabel,
+		r_fdsEntryFDSViewRelationship_c_fdsEntryERC: dataSetERC,
 	});
 });
 
 test.afterEach(async ({dataSetManagerApiHelpers}) => {
-	await dataSetManagerApiHelpers.deleteDataSet({});
+	await dataSetManagerApiHelpers.deleteDataSet({
+		erc: dataSetERC,
+	});
+});
+
+test('Configure cards visualization mode @LPD-10735', async ({
+	visualizationModesPage,
+}) => {
+	await test.step('Navigate to cards visualization mode page', async () => {
+		await visualizationModesPage.goto({
+			dataSetLabel,
+			viewLabel,
+		});
+
+		await visualizationModesPage.selectTab('Cards');
+
+		await expect(
+			visualizationModesPage.cardsVisualizationModeContainer
+		).toBeVisible();
+	});
+
+	await test.step('Check if cards sections are correct', async () => {
+		await expect(
+			visualizationModesPage.cardsVisualizationModeContainer.locator(
+				'.cards-section-label'
+			)
+		).toHaveText([
+			'Card Element',
+			'Title',
+			'Description',
+			'Image',
+			'Symbol',
+		]);
+	});
+
+	await test.step('Assign a field to title section', async () => {
+		const fieldName = 'name';
+		const sectionLabel = 'Title';
+
+		const container =
+			visualizationModesPage.cardsVisualizationModeContainer;
+
+		await visualizationModesPage.openAssignFieldModal({
+			container,
+			sectionLabel,
+		});
+
+		await visualizationModesPage.fieldSelectModalContainer
+			.getByLabel(fieldName)
+			.click();
+
+		await expect(
+			visualizationModesPage.page.getByLabel(fieldName)
+		).toBeChecked();
+
+		await visualizationModesPage.saveFieldSelection();
+
+		const assignedFieldLocator =
+			await visualizationModesPage.getAssignedFieldLocator({
+				container,
+				sectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(fieldName);
+	});
+
+	await test.step('Edit field to title section', async () => {
+		const newFieldName = 'rendererType';
+		const oldFieldName = 'name';
+		const sectionLabel = 'Title';
+
+		const container =
+			visualizationModesPage.cardsVisualizationModeContainer;
+
+		await visualizationModesPage.openAssignFieldModal({
+			container,
+			sectionLabel,
+		});
+
+		await expect(
+			visualizationModesPage.page.getByLabel(oldFieldName)
+		).toBeChecked();
+
+		await visualizationModesPage.fieldSelectModalContainer
+			.getByLabel(newFieldName)
+			.click();
+
+		await expect(
+			visualizationModesPage.page.getByLabel(newFieldName)
+		).toBeChecked();
+
+		await visualizationModesPage.saveFieldSelection();
+
+		const assignedFieldLocator =
+			await visualizationModesPage.getAssignedFieldLocator({
+				container,
+				sectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(newFieldName);
+	});
+});
+
+test('Configure list visualization mode @LPD-10735', async ({
+	visualizationModesPage,
+}) => {
+	await test.step('Navigate to list visualization mode page', async () => {
+		await visualizationModesPage.goto({
+			dataSetLabel,
+			viewLabel,
+		});
+
+		await visualizationModesPage.selectTab('List');
+
+		await expect(
+			visualizationModesPage.listVisualizationModeContainer
+		).toBeVisible();
+	});
+
+	await test.step('Check if list sections are correct', async () => {
+		await expect(
+			visualizationModesPage.listVisualizationModeContainer.locator(
+				'.list-section-label'
+			)
+		).toHaveText([
+			'List Element',
+			'Title',
+			'Description',
+			'Image',
+			'Symbol',
+		]);
+	});
+
+	await test.step('Assign a field to title section', async () => {
+		const fieldName = 'name';
+		const sectionLabel = 'Title';
+
+		const container = visualizationModesPage.listVisualizationModeContainer;
+
+		await visualizationModesPage.openAssignFieldModal({
+			container,
+			sectionLabel,
+		});
+
+		await visualizationModesPage.fieldSelectModalContainer
+			.getByLabel(fieldName)
+			.click();
+
+		await expect(
+			visualizationModesPage.page.getByLabel(fieldName)
+		).toBeChecked();
+
+		await visualizationModesPage.saveFieldSelection();
+
+		const assignedFieldLocator =
+			await visualizationModesPage.getAssignedFieldLocator({
+				container,
+				sectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(fieldName);
+	});
+
+	await test.step('Edit field to title section', async () => {
+		const newFieldName = 'rendererType';
+		const oldFieldName = 'name';
+		const sectionLabel = 'Title';
+
+		const container = visualizationModesPage.listVisualizationModeContainer;
+
+		await visualizationModesPage.openChangeFieldModal({
+			container,
+			sectionLabel,
+		});
+
+		await expect(
+			visualizationModesPage.page.getByLabel(oldFieldName)
+		).toBeChecked();
+
+		await visualizationModesPage.fieldSelectModalContainer
+			.getByLabel(newFieldName)
+			.click();
+
+		await expect(
+			visualizationModesPage.page.getByLabel(newFieldName)
+		).toBeChecked();
+
+		await visualizationModesPage.saveFieldSelection();
+
+		const assignedFieldLocator =
+			await visualizationModesPage.getAssignedFieldLocator({
+				container,
+				sectionLabel,
+			});
+
+		expect(assignedFieldLocator).toHaveText(newFieldName);
+	});
 });


### PR DESCRIPTION
### References

- [LPD-19954 Match DSM List and Cards mapped fields with visual component elements](https://issues.liferay.com/browse/LPD-19954)

### What is the goal of this PR?

We're changing list and cards sections. This is a simple change. The large part of this PR is about extending and fixing tests for visualization modes. 

There are still a lot of flakiness failures in existing tests (see screenshot), but they all look to me like failures are in tests themselves. We can fix them in followups, this PR is large enough as it.

### What does it look like?

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/cb23b692-b0df-4296-8d33-748bbf123822)

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/a4b58a59-2cbb-43f9-b350-1e84537a9d65)

![image](https://github.com/liferay-frontend/liferay-portal/assets/5435511/50fb306c-028f-44b5-a0c6-41e25f157043)


