### PR TITLE
LPD-20694 Fix aria-label attribute for MT filter and order buttons

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/FilterOrderControls.js
@@ -80,9 +80,7 @@ const FilterOrderControls = ({
 						)}
 						trigger={
 							<ClayButton
-								aria-label={Liferay.Language.get(
-									'filter-and-order'
-								)}
+								aria-label={Liferay.Language.get('filter')}
 								className="ml-2 mr-2 nav-link"
 								disabled={disabled}
 								displayType="unstyled"
@@ -137,6 +135,7 @@ const FilterOrderControls = ({
 						])}
 						trigger={
 							<ClayButton
+								aria-label={Liferay.Language.get('order[sort]')}
 								className="ml-2 mr-2 nav-link"
 								disabled={disabled}
 								displayType="unstyled"


### PR DESCRIPTION
This PR fixes `aria-label` properties in clay MT component to match a11y tree with reality.

Reference: https://liferay.atlassian.net/browse/LPD-20693  (see there for snapshots)

Note: PR does not include MT in FDS as this is part of a much larger initiative to harmonize FDS MT