### PR TITLE
LPD-20723 Clay link is translating asset titles/names by default in vertical card

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib Clay
 Bundle-SymbolicName: com.liferay.frontend.taglib.clay
-Bundle-Version: 14.2.2
+Bundle-Version: 14.3.0
 Export-Package:\
 	com.liferay.frontend.taglib.clay.servlet.taglib,\
 	com.liferay.frontend.taglib.clay.servlet.taglib.contributor,\

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -57,5 +57,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "14.2.2"
+	"version": "14.3.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCard.java
@@ -93,4 +93,8 @@ public interface VerticalCard extends BaseClayCard {
 		return null;
 	}
 
+	public default boolean isTranslated() {
+		return true;
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -200,14 +200,20 @@ public class VerticalCardTag extends BaseCardTag {
 	}
 
 	public String getTitle() {
+		String title = _title;
+
 		VerticalCard verticalCard = getVerticalCard();
 
 		if ((_title == null) && (verticalCard != null)) {
-			return verticalCard.getTitle();
+			title = verticalCard.getTitle();
 		}
 
-		return LanguageUtil.get(
-			TagResourceBundleUtil.getResourceBundle(pageContext), _title);
+		if (_isTranslated()) {
+			title = LanguageUtil.get(
+				TagResourceBundleUtil.getResourceBundle(pageContext), title);
+		}
+
+		return title;
 	}
 
 	public VerticalCard getVerticalCard() {
@@ -339,6 +345,10 @@ public class VerticalCardTag extends BaseCardTag {
 		_title = title;
 	}
 
+	public void setTranslated(Boolean translated) {
+		_translated = translated;
+	}
+
 	public void setVerticalCard(VerticalCard verticalCard) {
 		setCardModel(verticalCard);
 	}
@@ -365,6 +375,7 @@ public class VerticalCardTag extends BaseCardTag {
 		_stickerTitle = null;
 		_subtitle = null;
 		_title = null;
+		_translated = null;
 	}
 
 	@Override
@@ -592,6 +603,7 @@ public class VerticalCardTag extends BaseCardTag {
 			linkTag.setCssClass("text-truncate");
 			linkTag.setHref(href);
 			linkTag.setLabel(title);
+			linkTag.setTranslated(_isTranslated());
 
 			linkTag.doTag(pageContext);
 		}
@@ -684,6 +696,20 @@ public class VerticalCardTag extends BaseCardTag {
 		return "file";
 	}
 
+	private boolean _isTranslated() {
+		if (_translated != null) {
+			return _translated;
+		}
+
+		VerticalCard verticalCard = getVerticalCard();
+
+		if (verticalCard == null) {
+			return true;
+		}
+
+		return verticalCard.isTranslated();
+	}
+
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:verticalcard:";
 
 	private String _ariaLabel;
@@ -704,5 +730,6 @@ public class VerticalCardTag extends BaseCardTag {
 	private String _stickerTitle;
 	private String _subtitle;
 	private String _title;
+	private Boolean _translated;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/com/liferay/frontend/taglib/clay/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 7.12.0
+version 7.13.0


### PR DESCRIPTION
bug: https://liferay.atlassian.net/browse/LPD-20723

Description
----------
Add isTranslating method in order to decide if we want translate clay card content or not. For the moment, it is only implemented for the title as we have for the vertical card.

