### PR TITLE
LPD-20683 - Fix flaky Data Set creation test

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/dataSets.spec.ts
@@ -7,9 +7,9 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
+import getRandomString from '../../utils/getRandomString';
 import {dataSetManagerApiHelpersTest} from './fixtures/dataSetManagerApiHelpersTest';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
-import {DEFAULT_LABEL} from './utils/constants';
 
 export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
@@ -20,14 +20,16 @@ export const test = mergeTests(
 	loginTest()
 );
 
+const DATASET_LABEL = getRandomString();
+
 const dataSetConfig = {
-	name: DEFAULT_LABEL.DATA_SET,
+	name: DATASET_LABEL,
 	restApplication: '/data-set-manager/fields',
 	restEndpoint: '/',
 	restSchema: 'FDSField',
 };
 
-const DEFAULT_DATA_SET_ERC = 'sampleDataSetERC';
+const DEFAULT_DATA_SET_ERC = getRandomString();
 
 test.describe('Data Set Table', () => {
 	test('Data Set created via UI', async ({dataSetsPage, page}) => {
@@ -113,6 +115,7 @@ test.describe('Data Set Table', () => {
 			await dataSetManagerApiHelpers.createDataSet({
 				...dataSetConfig,
 				erc: DEFAULT_DATA_SET_ERC,
+				label: dataSetConfig.name,
 			});
 		});
 

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/DataSetsPage.ts
@@ -100,6 +100,10 @@ export class DataSetsPage {
 		await this.newDataSetModal.restEndpointField.click();
 
 		await this.newDataSetModal.saveButton.click();
+
+		await this.newDataSetModal.saveButton.isEnabled();
+
+		await this.newDataSetModal.heading.isHidden();
 	}
 
 	async goto() {


### PR DESCRIPTION
## Bug
https://liferay.atlassian.net/browse/LPD-20683

## Issue
Data Set tests fail randomly among different runs.

## Solution
Ensure that we wait for the response to update the UI and we are able to continue with Data Set checks.

Ensure that tests run consistent (success) several times using `--repeat-each=N` independently 
- `npx playwright test tests/frontend-data-set-views-web/dataSets.spec.ts --repeat-each=12` 
- `npx playwright test tests/frontend-data-set-views-web/ --repeat-each=3` 