### PR TITLE
LPD-1952 Remove disableFlag property from InputLocalized

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
@@ -13,7 +13,6 @@ import './InputLocalized.scss';
 
 interface InputLocalizedProps {
 	className?: string;
-	disableFlag?: boolean;
 	disabled?: boolean;
 	error?: string;
 	id?: string;
@@ -68,7 +67,6 @@ export function translationsNormalizer(
 }
 
 export default function InputLocalized({
-	disableFlag,
 	disabled,
 	error,
 	id,
@@ -89,19 +87,11 @@ export default function InputLocalized({
 	const translations = translationsNormalizer(initialTranslations);
 
 	useEffect(() => {
-		if (disableFlag) {
-			const localizationButton = document.querySelector(
-				'.dropdown-toggle'
-			);
-
-			localizationButton?.setAttribute('disabled', 'true');
-		}
-
 		const locale =
 			availableLocales.find(({label}) => label === selectedLocale)! ??
 			availableLocales[0];
 		setLocale(locale);
-	}, [disableFlag, selectedLocale]);
+	}, [selectedLocale]);
 
 	return (
 		<FieldBase

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
@@ -7,7 +7,6 @@ import React, {FocusEventHandler} from 'react';
 import './InputLocalized.scss';
 interface InputLocalizedProps {
 	className?: string;
-	disableFlag?: boolean;
 	disabled?: boolean;
 	error?: string;
 	id?: string;
@@ -38,7 +37,6 @@ export declare function translationsNormalizer(
 	translations: Liferay.Language.LocalizedValue<string>
 ): Liferay.Language.LocalizedValue<string>;
 export default function InputLocalized({
-	disableFlag,
 	disabled,
 	error,
 	id,

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ModelBuilder/RightSidebar/RightSidebarObjectRelationshipDetails.tsx
@@ -254,7 +254,6 @@ export function RightSidebarObjectRelationshipDetails({
 
 			<div className="lfr-objects__model-builder-right-sidebar-object-relationship-content">
 				<InputLocalized
-					disableFlag={readOnly}
 					disabled={readOnly}
 					error={errors.label}
 					label={Liferay.Language.get('label')}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfoContainer.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectField/Tabs/BasicInfo/BasicInfoContainer.tsx
@@ -76,7 +76,6 @@ export function BasicInfoContainer({
 			})}
 		>
 			<InputLocalized
-				disableFlag={readOnly}
 				disabled={readOnly}
 				error={errors.label}
 				label={Liferay.Language.get('label')}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectRelationship/EditObjectRelationship.tsx
@@ -105,7 +105,6 @@ export default function EditObjectRelationship({
 				)}
 
 				<InputLocalized
-					disableFlag={readOnly}
 					disabled={readOnly}
 					error={errors.label}
 					label={Liferay.Language.get('label')}


### PR DESCRIPTION
[Related issue](https://liferay.atlassian.net/browse/LPD-1952)

### Description:
In an attempt to select the button related to the flags of the `InputLocalized` component, the application is accidentally selecting the "Applications Menu" button and blocking it.

~~This solution aims to specify the parameters passed to the query selector.~~


https://github.com/liferay-frontend/liferay-portal/assets/61854510/8877a2b0-771a-4098-98be-2c2da8555092
