### PR TITLE
LPD-6702 Allow admins to select complex fields in list and cards visualization modes

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -22,7 +22,7 @@ import AutoSearch from './AutoSearch';
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
 	query?: string;
-    savedId?: string;
+	savedId?: string;
 	selected?: boolean;
 }
 
@@ -54,7 +54,7 @@ const initializeFields = ({
 		if (selectedField) {
 			selectedKeys.add(selectedField.name);
 
-            field.savedId = selectedField.id;
+			field.savedId = selectedField.id;
 		}
 
 		field.id = field.name;
@@ -162,7 +162,7 @@ const FieldSelectModalContent = ({
 	onSaveButtonClick,
 	saveButtonDisabled,
 	selectedFields,
-	selectionMode = 'single'
+	selectionMode = 'single',
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
@@ -204,7 +204,7 @@ const FieldSelectModalContent = ({
 	}, [selectedFields, fdsView]);
 
 	const onSearch = (query: string) => {
-        setQuery(query);
+		setQuery(query);
 
 		const {filteredItems, filteredKeys} = applyFilter({
 			fields: initialFields ?? [],
@@ -216,7 +216,7 @@ const FieldSelectModalContent = ({
 	};
 
 	return (
-        <>
+		<>
 			<ClayModal.Header>
 				{sub(
 					Liferay.Language.get('select-x'),
@@ -237,21 +237,20 @@ const FieldSelectModalContent = ({
 							</ClayManagementToolbar.Search>
 						</ClayManagementToolbar>
 
-
-                        {selectedKeys.size > 0 && (
+						{selectedKeys.size > 0 && (
 							<ClayResultsBar>
 								<ClayResultsBar.Item expand>
 									<span className="component-text text-truncate-inline">
 										<span className="text-truncate">
-                                            {selectedKeys.size}
-                                            &nbsp;
-                                            {selectedKeys.size === 1
-													? Liferay.Language.get(
-															'item-selected'
-													  )
-													: Liferay.Language.get(
-															'items-selected'
-													  )}
+											{selectedKeys.size}
+											&nbsp;
+											{selectedKeys.size === 1
+												? Liferay.Language.get(
+														'item-selected'
+												  )
+												: Liferay.Language.get(
+														'items-selected'
+												  )}
 										</span>
 									</span>
 								</ClayResultsBar.Item>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -226,7 +226,7 @@ const FieldSelectModalContent = ({
 				)}
 			</ClayModal.Header>
 
-			<ClayModal.Body className="pt-0 px-0">
+			<ClayModal.Body className="field-select-modal pt-0 px-0">
 				{fields === null ? (
 					<ClayLoadingIndicator />
 				) : (

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -21,6 +21,7 @@ import AutoSearch from './AutoSearch';
 
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
+	initialChildren?: IFieldTreeItem[];
 	query?: string;
 	savedId?: string;
 	selected?: boolean;
@@ -57,6 +58,7 @@ const initializeFields = ({
 			field.savedId = selectedField.id;
 		}
 
+		field.initialChildren = field.children;
 		field.id = field.name;
 	});
 
@@ -289,9 +291,22 @@ const FieldSelectModalContent = ({
 								selectionMode={selectionMode}
 								showExpanderOnHover={false}
 							>
-								{({children, label, query}: IFieldTreeItem) => (
+								{({
+									children,
+									initialChildren,
+									label,
+									query,
+								}: IFieldTreeItem) => (
 									<TreeView.Item>
-										<TreeView.ItemStack>
+										<TreeView.ItemStack
+											disabled={
+												initialChildren &&
+												!!initialChildren.length
+													? true
+													: false
+											}
+											expanderDisabled={false}
+										>
 											<ClayCheckbox checked>
 												<span className="font-weight-normal pl-1 text-3">
 													<Highlight

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -17,11 +17,12 @@ import React, {ComponentProps, useEffect, useState} from 'react';
 import {FDSViewType} from '../FDSViews';
 import {getFields} from '../api';
 import {IField} from '../utils/types';
-import Search from './Search';
+import AutoSearch from './AutoSearch';
 
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
 	query?: string;
+    savedId?: string;
 	selected?: boolean;
 }
 
@@ -52,6 +53,8 @@ const initializeFields = ({
 
 		if (selectedField) {
 			selectedKeys.add(selectedField.name);
+
+            field.savedId = selectedField.id;
 		}
 
 		field.id = field.name;
@@ -159,7 +162,7 @@ const FieldSelectModalContent = ({
 	onSaveButtonClick,
 	saveButtonDisabled,
 	selectedFields,
-	selectionMode = 'single',
+	selectionMode = 'single'
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
@@ -183,7 +186,6 @@ const FieldSelectModalContent = ({
 	);
 	const [query, setQuery] = useState<string>('');
 	const [expandedKeys, setExpandedKeys] = useState<Array<React.Key>>([]);
-	const [searchCounter, setSearchCounter] = useState<number>(0);
 
 	useEffect(() => {
 		getFields(fdsView).then((fields) => {
@@ -202,20 +204,19 @@ const FieldSelectModalContent = ({
 	}, [selectedFields, fdsView]);
 
 	const onSearch = (query: string) => {
-		setQuery(query);
+        setQuery(query);
 
-		const {counter, filteredItems, filteredKeys} = applyFilter({
+		const {filteredItems, filteredKeys} = applyFilter({
 			fields: initialFields ?? [],
 			query,
 		});
 
 		setFields(filteredItems);
 		setExpandedKeys(filteredKeys);
-		setSearchCounter(counter);
 	};
 
 	return (
-		<div className="field-select-modal">
+        <>
 			<ClayModal.Header>
 				{sub(
 					Liferay.Language.get('select-x'),
@@ -229,27 +230,28 @@ const FieldSelectModalContent = ({
 				) : (
 					<>
 						<ClayManagementToolbar>
-							<ClayManagementToolbar.Search>
-								<Search onSearch={onSearch} query={query} />
+							<ClayManagementToolbar.Search
+								onSubmit={(event) => event.preventDefault()}
+							>
+								<AutoSearch onSearch={onSearch} query={query} />
 							</ClayManagementToolbar.Search>
 						</ClayManagementToolbar>
 
-						{query && (
+
+                        {selectedKeys.size > 0 && (
 							<ClayResultsBar>
 								<ClayResultsBar.Item expand>
 									<span className="component-text text-truncate-inline">
 										<span className="text-truncate">
-											{sub(
-												searchCounter === 1
+                                            {selectedKeys.size}
+                                            &nbsp;
+                                            {selectedKeys.size === 1
 													? Liferay.Language.get(
-															'x-result-for-x'
+															'item-selected'
 													  )
 													: Liferay.Language.get(
-															'x-results-for-x'
-													  ),
-												searchCounter,
-												query
-											)}
+															'items-selected'
+													  )}
 										</span>
 									</span>
 								</ClayResultsBar.Item>
@@ -259,11 +261,11 @@ const FieldSelectModalContent = ({
 										className="component-link tbar-link"
 										displayType="unstyled"
 										onClick={() => {
-											setQuery('');
-											setFields(initialFields);
+											selectedKeys.clear();
+											onSearch('');
 										}}
 									>
-										{Liferay.Language.get('clear')}
+										{Liferay.Language.get('deselect-all')}
 									</ClayButton>
 								</ClayResultsBar.Item>
 							</ClayResultsBar>
@@ -357,7 +359,7 @@ const FieldSelectModalContent = ({
 					</ClayButton.Group>
 				}
 			/>
-		</div>
+		</>
 	);
 };
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
@@ -250,7 +250,7 @@ function CardsSection({
 					selectedFields={field ? [field] : []}
 				/>
 			),
-			size: 'full-screen'
+			size: 'full-screen',
 		});
 	};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/cards/Cards.tsx
@@ -250,6 +250,7 @@ function CardsSection({
 					selectedFields={field ? [field] : []}
 				/>
 			),
+			size: 'full-screen'
 		});
 	};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -288,7 +288,7 @@ function ListSection({
 					selectedFields={field ? [field] : []}
 				/>
 			),
-			size: 'full-screen'
+			size: 'full-screen',
 		});
 	};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/list/List.tsx
@@ -288,6 +288,7 @@ function ListSection({
 					selectedFields={field ? [field] : []}
 				/>
 			),
+			size: 'full-screen'
 		});
 	};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -843,7 +843,7 @@ function Table({
 					/>
 				),
 				size: 'full-screen',
-			}); 
+			});
 		}
 		else {
 			openModal({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -843,7 +843,7 @@ function Table({
 					/>
 				),
 				size: 'full-screen',
-			});
+			}); 
 		}
 		else {
 			openModal({

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
@@ -11,7 +11,7 @@ import ClayManagementToolbar, {
 	ClayResultsBar,
 } from '@clayui/management-toolbar';
 import ClayModal from '@clayui/modal';
-import {fetch, sub} from 'frontend-js-web';
+import {fetch} from 'frontend-js-web';
 import React, {ComponentProps, useEffect, useState} from 'react';
 
 import {FDSViewType} from '../../../../FDSViews';
@@ -312,17 +312,15 @@ const AddFieldsModalContent = ({
 								<ClayResultsBar.Item expand>
 									<span className="component-text text-truncate-inline">
 										<span className="text-truncate">
-											{sub(
-												selectedKeys.size === 1
-													? Liferay.Language.get(
-															'x-result-for-x'
-													  )
-													: Liferay.Language.get(
-															'x-results-for-x'
-													  ),
-												selectedKeys.size,
-												query
-											)}
+											{selectedKeys.size}
+											&nbsp;
+											{selectedKeys.size === 1
+												? Liferay.Language.get(
+														'item-selected'
+												  )
+												: Liferay.Language.get(
+														'items-selected'
+												  )}
 										</span>
 									</span>
 								</ClayResultsBar.Item>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
@@ -9,6 +9,7 @@ import {FDSViewType} from '../FDSViews';
 import {IField} from '../utils/types';
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
+	initialChildren?: IFieldTreeItem[];
 	query?: string;
 	savedId?: string;
 	selected?: boolean;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
@@ -10,6 +10,7 @@ import {IField} from '../utils/types';
 interface IFieldTreeItem extends IField {
 	children?: IFieldTreeItem[];
 	query?: string;
+	savedId?: string;
 	selected?: boolean;
 }
 declare const FieldSelectModalContent: ({

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/visualization_modes/VisualizationModesPage.ts
@@ -75,7 +75,7 @@ export class VisualizationModesPage {
 			this.fieldSelectModalContainer
 				.locator('.custom-control-input')
 				.first()
-		).toBeEditable();
+		).toBeVisible();
 
 		await expect(
 			this.fieldSelectModalContainer

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -159,12 +159,12 @@ prefixUrlTest(
 
 translationTest(
 	'LPD-13732: This is a test for reset translations button in web content',
-	async ({journalEditArticlePage, page, site}) => {
-		const title = getRandomString();
+	async ({journalEditArticlePage, journalPage, page, site}) => {
+		await journalPage.goto();
 
 		await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
 
-		await journalEditArticlePage.fillTitle(title);
+		await journalEditArticlePage.fillTitle(getRandomString());
 
 		const translationButton = page.getByRole('combobox', {
 			name: 'Select a language',


### PR DESCRIPTION
Story: https://liferay.atlassian.net/browse/LPD-6702

**Scope**:

- Only leaf nodes should be selected on Lists and Cards modes
- “Save” and “Cancel” buttons on Table, Lists and Cards modal should be reachable via scroll for large tree views
- Fix Search bar message. It should show only number of items selected, not search matches

**Expected UI**:

![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/c64fc5a3-aa86-498e-9d1a-4d00a8703fbe)
![image](https://github.com/liferay-frontend/liferay-portal/assets/20504176/abd3f708-e9d8-48e5-9bd3-898faeccf36a)

