### PR TITLE
LPD-21684 Add helpMessage prop to input localized

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/input/InputLocalized.tsx
@@ -16,6 +16,7 @@ interface InputLocalizedProps {
 	disableFlag?: boolean;
 	disabled?: boolean;
 	error?: string;
+	helpMessage?: string;
 	id?: string;
 	label: string;
 	name?: string;
@@ -71,6 +72,7 @@ export default function InputLocalized({
 	disableFlag,
 	disabled,
 	error,
+	helpMessage,
 	id,
 	label,
 	name,
@@ -108,6 +110,7 @@ export default function InputLocalized({
 			className="input-localized"
 			disabled={disabled}
 			errorMessage={error}
+			helpMessage={helpMessage}
 			id={id}
 			label={label}
 			required={required}

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/input/InputLocalized.d.ts
@@ -10,6 +10,7 @@ interface InputLocalizedProps {
 	disableFlag?: boolean;
 	disabled?: boolean;
 	error?: string;
+	helpMessage?: string;
 	id?: string;
 	label: string;
 	name?: string;
@@ -41,6 +42,7 @@ export default function InputLocalized({
 	disableFlag,
 	disabled,
 	error,
+	helpMessage,
 	id,
 	label,
 	name,


### PR DESCRIPTION
Related Issue: [LPD-21684](https://liferay.atlassian.net/browse/LPD-21684)

Hello Team! I'm currently working on an story and for it, I would need to have the helpMessage prop from FieldBase brought to the InputLocalized, to pass a helpText. Thanks in advance!