### PR TITLE
LPD-20164 Destroy searchContainerId so new searchContainerId can be built and used

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -166,6 +166,10 @@ const SelectionControls = ({
 		});
 
 		return () => {
+			Liferay.destroyComponent(searchContainerId);
+
+			searchContainerRef.current = null;
+
 			eventHandler?.detach();
 		};
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20164

The issue is when the Export/Import Module is closed, a refresh occurs on the portlet. With this refresh, SelectionControls reused the old searchContainerId and the toolbar and content are no longer synced to each other so the check box no longer work.

By destroying the searchContainerId, we wait for the new one to be built and they will then be synced, fixing the check box issue.

Please let me know if there are any questions or comments about this.
Thank you!