### PR TITLE
LPD-22017 - Use a link to navigate to Visualization Modes tab

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Settings.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Settings.tsx
@@ -8,6 +8,7 @@ import {Option, Picker, Text} from '@clayui/core';
 import DropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
 import {ClayTooltipProvider} from '@clayui/tooltip';
 import {fetch, navigate} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
@@ -38,6 +39,7 @@ const Settings = ({
 	const [defaultVisualizationMode, setDefaultVisualizationMode] = useState(
 		NOT_CONFIGURED_VISUALIZATION_MODE.type
 	);
+	const [loading, setLoading] = useState(true);
 	const [visualizationModes, setVisualizationModes] = useState<
 		Array<TVisualizationMode>
 	>([]);
@@ -57,6 +59,8 @@ const Settings = ({
 			openDefaultFailureToast();
 
 			setVisualizationModes([]);
+
+			setLoading(false);
 
 			return;
 		}
@@ -102,6 +106,8 @@ const Settings = ({
 					: NOT_CONFIGURED_VISUALIZATION_MODE.type;
 			}
 		});
+
+		setLoading(false);
 	};
 
 	const updateFDSViewSettings = async () => {
@@ -159,7 +165,7 @@ const Settings = ({
 				</h3>
 
 				<ClayLayout.Row className="align-items-center justify-content-between">
-					<ClayLayout.Col size={9}>
+					<ClayLayout.Col size={8}>
 						<div>
 							<label htmlFor="view-mode-picker" id="view-mode">
 								{Liferay.Language.get(
@@ -190,65 +196,89 @@ const Settings = ({
 						</div>
 					</ClayLayout.Col>
 
-					<ClayLayout.Col size={3}>
-						<Picker
-							aria-labelledby="view-mode"
-							id="view-mode-picker"
-							items={visualizationModes}
-							onSelectionChange={(option: React.Key) => {
-								if (
-									option ===
+					<ClayLayout.Col size={4}>
+						{!loading && (
+							<Picker
+								aria-labelledby="view-mode"
+								className="mb-2"
+								disabled={!visualizationModes.length}
+								id="view-mode-picker"
+								items={visualizationModes}
+								onSelectionChange={(option: React.Key) => {
+									if (
+										option !==
+										NOT_CONFIGURED_VISUALIZATION_MODE.type
+									) {
+										setDefaultVisualizationMode(
+											option as string
+										);
+									}
+								}}
+								placeholder={
 									NOT_CONFIGURED_VISUALIZATION_MODE.type
-								) {
-									onActiveSectionChange(1);
 								}
-								else {
-									setDefaultVisualizationMode(
-										option as string
-									);
-								}
-							}}
-							placeholder={NOT_CONFIGURED_VISUALIZATION_MODE.type}
-							selectedKey={defaultVisualizationMode}
-						>
-							{visualizationModes.length ? (
-								({label, thumbnail, type}) => (
-									<Option key={type} textValue={label}>
-										<ClayIcon
-											className="mr-3"
-											symbol={thumbnail}
-										/>
+								selectedKey={defaultVisualizationMode}
+							>
+								{visualizationModes.length ? (
+									({label, thumbnail, type}) => (
+										<Option key={type} textValue={label}>
+											<ClayIcon
+												className="mr-3"
+												symbol={thumbnail}
+											/>
 
-										{label}
-									</Option>
-								)
-							) : (
-								<DropDown.Group
-									header={Liferay.Language.get(
-										'not-configured'
-									)}
-								>
-									<Option
-										key={
-											NOT_CONFIGURED_VISUALIZATION_MODE.type
-										}
-										textValue={
-											NOT_CONFIGURED_VISUALIZATION_MODE.type
-										}
+											{label}
+										</Option>
+									)
+								) : (
+									<DropDown.Group
+										header={Liferay.Language.get(
+											'not-configured'
+										)}
 									>
-										<ClayLayout.Row>
-											<ClayLayout.Col>
-												<Text size={3}>
-													{
-														NOT_CONFIGURED_VISUALIZATION_MODE.label
-													}
-												</Text>
-											</ClayLayout.Col>
-										</ClayLayout.Row>
-									</Option>
-								</DropDown.Group>
-							)}
-						</Picker>
+										<Option
+											key={
+												NOT_CONFIGURED_VISUALIZATION_MODE.type
+											}
+											textValue={
+												NOT_CONFIGURED_VISUALIZATION_MODE.type
+											}
+										>
+											<ClayLayout.Row>
+												<ClayLayout.Col>
+													<Text size={3}>
+														{
+															NOT_CONFIGURED_VISUALIZATION_MODE.label
+														}
+													</Text>
+												</ClayLayout.Col>
+											</ClayLayout.Row>
+										</Option>
+									</DropDown.Group>
+								)}
+							</Picker>
+						)}
+
+						{!loading && !visualizationModes.length && (
+							<ClayLink
+								borderless
+								onClick={() => onActiveSectionChange(1)}
+								onKeyPress={() => onActiveSectionChange(1)}
+								tabIndex={0}
+								weight="semi-bold"
+							>
+								<span className="inline-item inline-item-before">
+									<ClayIcon
+										spritemap={spritemap}
+										symbol="shortcut"
+									/>
+								</span>
+
+								{Liferay.Language.get(
+									'go-to-visualization-modes'
+								)}
+							</ClayLink>
+						)}
 					</ClayLayout.Col>
 				</ClayLayout.Row>
 			</ClayLayout.SheetSection>

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/SettingsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/SettingsPage.ts
@@ -9,7 +9,7 @@ import {ViewPage} from './view/ViewPage';
 
 export class SettingsPage {
 	readonly cancelButton: Locator;
-	readonly configureNewLayoutButton: Locator;
+	readonly goToVisualizationModesLink: Locator;
 	readonly defaultVisualizationModeLabel: Locator;
 	readonly notConfiguredPlaceholder: Locator;
 	readonly page: Page;
@@ -19,9 +19,9 @@ export class SettingsPage {
 
 	constructor(page: Page) {
 		this.cancelButton = page.getByRole('button', {name: 'Cancel'});
-		this.configureNewLayoutButton = page.getByRole('option', {
-			name: 'Go to Visualization Modes',
-		});
+		this.goToVisualizationModesLink = page.getByText(
+			'Go to Visualization Modes'
+		);
 		this.defaultVisualizationModeLabel = page.getByLabel(
 			'Default Visualization Mode',
 			{exact: true}

--- a/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
@@ -78,13 +78,11 @@ test.describe('Data Set Settings', () => {
 			});
 
 			await test.step('Navigate to Visualization Mode section if  "Not Configured"', async () => {
-				await settingsPage.defaultVisualizationModeLabel.click();
-
 				await expect(
-					settingsPage.configureNewLayoutButton
+					settingsPage.goToVisualizationModesLink
 				).toBeInViewport();
 
-				await settingsPage.configureNewLayoutButton.click();
+				await settingsPage.goToVisualizationModesLink.click();
 
 				await expect(
 					visualizationModesPage.page.getByText(


### PR DESCRIPTION
## Story / Task
[LPD-21232](https://liferay.atlassian.net/browse/LPD-21232) / [LPD-22017](https://liferay.atlassian.net/browse/LPD-22017)

## Goal
We are replacing the dropdown as a way to navigate to the Visualization Modes tab when there are no Visualization Modes configured and using a link.

## UI
[Screencast from 2024-04-02 16-36-30.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/baab55e5-c927-4caf-a677-428aef813d98)

## Updated Test Cases doc
https://docs.google.com/spreadsheets/d/1GdTSw3KrMDtjEfpkDrih8JcWOTn22ZuIL8s8WPBDAyM/edit?pli=1#gid=0&range=13:13
