### PR TITLE
LPD-21465 When filtering in management toolbar we should always set r…

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -91,6 +91,10 @@ function ManagementToolbar({
 	const searchButtonRef = useRef();
 
 	const updateFilterDropdownItems = () => {
+		if (!filterDropdownItems) {
+			return null;
+		}
+
 		filterDropdownItems.forEach((filterDropdownItem) => {
 			filterDropdownItem.items.forEach((item) => {
 				if (item.href) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -96,6 +96,10 @@ function ManagementToolbar({
 		}
 
 		filterDropdownItems.forEach((filterDropdownItem) => {
+			if (!filterDropdownItem.items) {
+				return null;
+			}
+
 			filterDropdownItem.items.forEach((item) => {
 				if (item.href) {
 					const urlParts = item.href.split('?');

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -90,6 +90,30 @@ function ManagementToolbar({
 
 	const searchButtonRef = useRef();
 
+	const updateFilterDropdownItems = () => {
+		filterDropdownItems.forEach((filterDropdownItem) => {
+			filterDropdownItem.items.forEach((item) => {
+				if (item.href) {
+					const urlParts = item.href.split('?');
+
+					const params = new URLSearchParams(urlParts[1]);
+
+					params.keys().forEach((key) => {
+						if (key.includes('resetCur')) {
+							params.set(key, true);
+						}
+					});
+
+					item.href = `${urlParts[0]}?${params.toString()}`;
+				}
+			});
+		});
+
+		return filterDropdownItems;
+	};
+
+	const updatedFilterDropdownItems = updateFilterDropdownItems();
+
 	useEffect(() => {
 		if (searchMobile) {
 			const searchButton = searchButtonRef.current;
@@ -124,7 +148,7 @@ function ManagementToolbar({
 							setActive={setActive}
 							showCheckBoxLabel={
 								!active &&
-								!filterDropdownItems &&
+								!updatedFilterDropdownItems &&
 								!sortingURL &&
 								!showSearch
 							}
@@ -135,7 +159,7 @@ function ManagementToolbar({
 					{!active && (
 						<FilterOrderControls
 							disabled={disabled}
-							filterDropdownItems={filterDropdownItems}
+							filterDropdownItems={updatedFilterDropdownItems}
 							onFilterDropdownItemClick={
 								onFilterDropdownItemClick
 							}


### PR DESCRIPTION
Hey,

This issue is quite well described [here](https://liferay.atlassian.net/browse/LPP-53343?focusedCommentId=2618997), specially in this sentence:

> What is happening is that when we filter, if the current page is higher than the results that we have after filtering, the results won’t appear, because in that page we don’t  have any results after filtering.

I think the only possibilities we have to fix this is either to set `resetCur` param to `true` or `cur` param to `1` so we always show the first page. Whichever param we update the result is the same.

However, I found this solution incredibly _hacky_ but I couldn't think about any other option, so you might have a different idea about how to approach this issue.

This could be very easily done by mgmt toolbar consumers, since they create those URLs and they'd just need to add such parameter, but I don't think this should be their responsability, and I think we should manage this internally inside ManagementToolbar component.

Please, let me know your thoughts.

Thanks!
