### PR TITLE
LPD-22034  Actions from Cards View are not working properly

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -4,17 +4,12 @@
  */
 
 import {IItemsActions} from '..';
-import {navigate, openConfirmModal} from 'frontend-js-web';
 import React, {useContext, useState} from 'react';
 
 import FrontendDataSetContext, {
 	IFrontendDataSetContext,
 } from '../FrontendDataSetContext';
-import {ACTION_ITEM_TARGETS} from '../utils/actionItems/constants';
 import filterItemActions from '../utils/actionItems/filterItemActions';
-import formatActionURL from '../utils/actionItems/formatActionURL';
-import {openPermissionsModal} from '../utils/modals/openPermissionsModal';
-import {resolveModalSize} from '../utils/modals/resolveModalSize';
 
 // @ts-ignore
 
@@ -23,9 +18,8 @@ import ViewsContext from '../views/ViewsContext';
 // @ts-ignore
 
 import ActionsDropdown from './ActionsDropdown';
+import handleActionClick from './HandleActionClick';
 import QuickActions from './QuickActions';
-
-const {MODAL_PERMISSIONS} = ACTION_ITEM_TARGETS;
 
 const QUICK_ACTIONS_MAX_NUMBER = 3;
 
@@ -85,117 +79,21 @@ function Actions({
 		closeMenu: any;
 		event: any;
 	}) => {
-		const {data, href, method, onClick, target} = action;
-
-		const {
-			confirmationMessage,
-			errorMessage,
-			size,
-			status,
-			successMessage,
-			title,
-		} = data ?? {};
-
-		const url = formatActionURL(href, itemData);
-
-		const doAction = ({defaultPrevented}: {defaultPrevented: boolean}) => {
-			if (target?.includes('modal')) {
-				event.preventDefault();
-
-				if (target === MODAL_PERMISSIONS) {
-					openPermissionsModal(url);
-				}
-				else {
-					openModal({
-						size: size || resolveModalSize(target),
-						title,
-						url,
-					});
-				}
-			}
-			else if (target === 'sidePanel') {
-				event.preventDefault();
-
-				highlightItems([itemId]);
-
-				openSidePanel({
-					size: 'lg',
-					title,
-					url,
-				});
-			}
-			else if (target === 'async' || target === 'headless') {
-				event.preventDefault();
-
-				setLoading(true);
-
-				executeAsyncItemAction({
-					errorMessage,
-					method: method ?? data?.method,
-					setActionItemLoading: setLoading,
-					successMessage,
-					url,
-				});
-			}
-			else if (target === 'inlineEdit') {
-				event.preventDefault();
-
-				toggleItemInlineEdit(itemId);
-			}
-			else if (target === 'blank') {
-				event.preventDefault();
-
-				window.open(url);
-			}
-
-			const exposedProps = {
-				action,
-				event,
-				itemData,
-				loadData,
-				openSidePanel,
-			};
-
-			if (onClick) {
-				onClick(exposedProps);
-			}
-
-			if (onActionDropdownItemClick) {
-				onActionDropdownItemClick(exposedProps);
-			}
-
-			if (target === 'link' && defaultPrevented) {
-				navigate(url);
-			}
-		};
-
-		if (confirmationMessage) {
-			let defaultPrevented = false;
-
-			if (target === 'link') {
-				event.preventDefault();
-
-				defaultPrevented = true;
-			}
-
-			openConfirmModal({
-				message: confirmationMessage,
-				onConfirm: (isConfirmed) => {
-					if (isConfirmed) {
-						doAction({defaultPrevented});
-					}
-				},
-				status,
-				title,
-			});
-		}
-		else {
-			doAction({defaultPrevented: false});
-		}
-
-		if (closeMenu) {
-			closeMenu();
-		}
+		handleActionClick({
+			action,
+			closeMenu,
+			event,
+			executeAsyncItemAction,
+			highlightItems,
+			itemData,
+			itemId,
+			loadData,
+			onActionDropdownItemClick,
+			openModal,
+			openSidePanel,
+			setLoading,
+			toggleItemInlineEdit,
+		});
 	};
 
 	return (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/HandleActionClick.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/HandleActionClick.ts
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {navigate, openConfirmModal} from 'frontend-js-web';
+
+import {IItemsActions} from '../index';
+import {ACTION_ITEM_TARGETS} from '../utils/actionItems/constants';
+import formatActionURL from '../utils/actionItems/formatActionURL';
+import {openPermissionsModal} from '../utils/modals/openPermissionsModal';
+import {resolveModalSize} from '../utils/modals/resolveModalSize';
+
+const {MODAL_PERMISSIONS} = ACTION_ITEM_TARGETS;
+
+const handleActionClick = ({
+	action,
+	closeMenu,
+	event,
+	executeAsyncItemAction,
+	highlightItems,
+	itemData,
+	itemId,
+	loadData,
+	onActionDropdownItemClick,
+	openModal,
+	openSidePanel,
+	setLoading,
+	toggleItemInlineEdit,
+}: {
+	action: IItemsActions;
+	closeMenu?: any;
+	event: Event;
+	executeAsyncItemAction: Function;
+	highlightItems: Function;
+	itemData: any;
+	itemId: string | number;
+	loadData: Function;
+	onActionDropdownItemClick: Function;
+	openModal: Function;
+	openSidePanel: Function;
+	setLoading?: Function;
+	toggleItemInlineEdit: Function;
+}) => {
+	const {data, href, method, onClick, target} = action;
+
+	const {
+		confirmationMessage,
+		errorMessage,
+		size,
+		status,
+		successMessage,
+		title,
+	} = data ?? {};
+
+	const url = formatActionURL(href, itemData);
+
+	const doAction = ({defaultPrevented}: {defaultPrevented: boolean}) => {
+		if (target?.includes('modal')) {
+			event.preventDefault();
+
+			if (target === MODAL_PERMISSIONS) {
+				openPermissionsModal(url);
+			}
+			else {
+				openModal({
+					size: size || resolveModalSize(target),
+					title,
+					url,
+				});
+			}
+		}
+		else if (target === 'sidePanel') {
+			event.preventDefault();
+
+			highlightItems([itemId]);
+
+			openSidePanel({
+				size: 'lg',
+				title,
+				url,
+			});
+		}
+		else if (target === 'async' || target === 'headless') {
+			event.preventDefault();
+
+			setLoading && setLoading(true);
+
+			executeAsyncItemAction({
+				errorMessage,
+				method: method ?? data?.method,
+				setActionItemLoading: setLoading,
+				successMessage,
+				url,
+			});
+		}
+		else if (target === 'inlineEdit') {
+			event.preventDefault();
+
+			toggleItemInlineEdit(itemId);
+		}
+		else if (target === 'blank') {
+			event.preventDefault();
+
+			window.open(url);
+		}
+
+		const exposedProps = {
+			action,
+			event,
+			itemData,
+			loadData,
+			openSidePanel,
+		};
+
+		if (onClick) {
+			onClick(exposedProps);
+		}
+
+		if (onActionDropdownItemClick) {
+			onActionDropdownItemClick(exposedProps);
+		}
+
+		if (target === 'link' && defaultPrevented) {
+			navigate(url);
+		}
+	};
+
+	if (confirmationMessage) {
+		let defaultPrevented = false;
+
+		if (target === 'link') {
+			event.preventDefault();
+
+			defaultPrevented = true;
+		}
+
+		openConfirmModal({
+			message: confirmationMessage,
+			onConfirm: (isConfirmed) => {
+				if (isConfirmed) {
+					doAction({defaultPrevented});
+				}
+			},
+			status,
+			title,
+		});
+	}
+	else {
+		doAction({defaultPrevented: false});
+	}
+
+	if (closeMenu) {
+		closeMenu();
+	}
+};
+
+export default handleActionClick;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import React, {useContext, useRef} from 'react';
 
 import FrontendDataSetContext from '../../FrontendDataSetContext';
+import handleActionClick from '../../actions/HandleActionClick';
 import {getLocalizedValue} from '../../utils/getLocalizedValue';
 import isLink from '../../utils/isLink';
 
@@ -47,14 +48,18 @@ const Cards = ({items, schema}) => {
 
 const Card = ({item, schema}) => {
 	const {
+		executeAsyncItemAction,
+		highlightItems,
 		itemsActions,
 		loadData,
 		onActionDropdownItemClick,
+		openModal,
 		openSidePanel,
 		selectItems,
 		selectable,
 		selectedItemsKey,
 		selectedItemsValue,
+		toggleItemInlineEdit,
 	} = useContext(FrontendDataSetContext);
 
 	const actionsRef = useRef(
@@ -78,6 +83,21 @@ const Card = ({item, schema}) => {
 							itemData: item,
 							loadData,
 							openSidePanel,
+						});
+					}
+					else {
+						handleActionClick({
+							action,
+							event,
+							executeAsyncItemAction,
+							highlightItems,
+							itemData: item,
+							itemId: item[selectedItemsKey],
+							loadData,
+							onActionDropdownItemClick,
+							openModal,
+							openSidePanel,
+							toggleItemInlineEdit,
 						});
 					}
 				},

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.js
@@ -11,6 +11,7 @@ import React, {useContext, useRef} from 'react';
 
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import handleActionClick from '../../actions/HandleActionClick';
+import filterItemActions from '../../utils/actionItems/filterItemActions';
 import {getLocalizedValue} from '../../utils/getLocalizedValue';
 import isLink from '../../utils/isLink';
 
@@ -70,9 +71,11 @@ const Card = ({item, schema}) => {
 		?.value;
 	const localizedTitle = getLocalizedValue(item, schema.title)?.value || '';
 
+	const formattedActions = filterItemActions(actionsRef.current, item);
+
 	return (
 		<ClayCardWithInfo
-			actions={actionsRef.current?.map((action) => ({
+			actions={formattedActions?.map((action) => ({
 				...action,
 				href: isLink(action.target, null) ? action.href : null,
 				onClick: (event) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/actions/HandleActionClick.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/actions/HandleActionClick.d.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IItemsActions} from '../index';
+declare const handleActionClick: ({
+	action,
+	closeMenu,
+	event,
+	executeAsyncItemAction,
+	highlightItems,
+	itemData,
+	itemId,
+	loadData,
+	onActionDropdownItemClick,
+	openModal,
+	openSidePanel,
+	setLoading,
+	toggleItemInlineEdit,
+}: {
+	action: IItemsActions;
+	closeMenu?: any;
+	event: Event;
+	executeAsyncItemAction: Function;
+	highlightItems: Function;
+	itemData: any;
+	itemId: string | number;
+	loadData: Function;
+	onActionDropdownItemClick: Function;
+	openModal: Function;
+	openSidePanel: Function;
+	setLoading?: Function | undefined;
+	toggleItemInlineEdit: Function;
+}) => void;
+export default handleActionClick;


### PR DESCRIPTION
Reference: 

-  https://liferay.atlassian.net/issues/LPD-22034

In this PR, cards view action behavior is harmonized with that of Table and List. Because of how we compose the different views, both Table and List reuse an <Action> react component as part of the table row and list item respective compositions. However this is not possible in Cards because this view is based on <ClayCardWithInfo> which takes actions as a prop, not as a children dropdown.

A consequence of the above is that action treatment is completely different, namely:

- No account for action filtering
- No account for modals, async, headless
- A flexible click handler can though be provided to the Cards, as we do in the `frontend-data-set-sample-web` module


To do so:

- The action click handler has been abstracted out to a standalone function
- Both <Actions> and <Card> components are rewired to use such handler

Other notes:

- I went through the simplest, minimal solution, i.e. Cards was not migrated to TS.
- Nevertheless, the new click handler uses TS as it's also being called from a .tsx component