### PR TITLE
LPD-20679 BUG WebContent geo structure / Liferay Map Taglib

### DIFF
--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/init.jsp
@@ -15,6 +15,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.map.google.maps.internal.display.context.GoogleMapsDisplayContext" %><%@
+page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
+page import="com.liferay.portal.kernel.json.JSONObject" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/js/MapGoogleMaps.js
@@ -50,7 +50,7 @@ class MapGoogleMaps extends MapBase {
 			Object.assign(mapConfig, controlsConfig)
 		);
 
-		if (this.data && this.data.features) {
+		if (this.data?.features?.length) {
 			const bounds = new google.maps.LatLngBounds();
 
 			this.data.features.forEach((feature) =>

--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -16,6 +16,12 @@ double longitude = (Double)request.getAttribute("liferay-map:map:longitude");
 String name = (String)request.getAttribute("liferay-map:map:name");
 String points = (String)request.getAttribute("liferay-map:map:points");
 
+JSONObject pointsJSONObject = null;
+
+if (Validator.isNotNull(points)) {
+	pointsJSONObject = JSONFactoryUtil.createJSONObject(points);
+}
+
 name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + name;
 %>
 
@@ -54,7 +60,7 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 		HashMapBuilder.<String, Object>put(
 			"boundingBox", "#" + HtmlUtil.escapeJS(name) + "Map"
 		).put(
-			"data", points
+			"data", pointsJSONObject
 		).put(
 			"geolocation", geolocation
 		).put(

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/init.jsp
@@ -12,9 +12,12 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
+<%@ page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
+page import="com.liferay.portal.kernel.json.JSONObject" %><%@
+page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.servlet.BrowserSnifferUtil" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
 

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.js
@@ -70,7 +70,7 @@ class MapOpenStreetMap extends MapBase {
 			Object.assign(mapConfig, controlsConfig)
 		);
 
-		if (this.data && this.data.features) {
+		if (this.data?.features?.length) {
 			const bounds = new L.LatLngBounds();
 
 			this.data.features.forEach((feature) =>

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/view.jsp
@@ -1,4 +1,3 @@
-<%--
 /**
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
@@ -13,6 +12,12 @@ double latitude = (Double)request.getAttribute("liferay-map:map:latitude");
 double longitude = (Double)request.getAttribute("liferay-map:map:longitude");
 String name = (String)request.getAttribute("liferay-map:map:name");
 String points = (String)request.getAttribute("liferay-map:map:points");
+
+JSONObject pointsJSONObject = null;
+
+if (Validator.isNotNull(points)) {
+	pointsJSONObject = JSONFactoryUtil.createJSONObject(points);
+}
 
 name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + name;
 %>
@@ -30,7 +35,7 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 		HashMapBuilder.<String, Object>put(
 			"boundingBox", "#" + HtmlUtil.escapeJS(name) + "Map"
 		).put(
-			"data", points
+			"data", pointsJSONObject
 		).put(
 			"geolocation", geolocation
 		).put(


### PR DESCRIPTION
Followup https://github.com/liferay-frontend/liferay-portal/pull/4115 after conversation with @boton, where:

- Code manages the transformation of `points` data item to a JSON object in the backend (JSP)
- This makes not necessary to parse such object in the `mapbase`, keeping original API intact