### PR TITLE
LPD-22818 - Allow mapping scalar array fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -21,6 +21,7 @@ const LOCALIZABLE_PROPERTY_SUFFIX = '_i18n';
 interface IProperty {
 	$ref?: string;
 	format?: EFieldFormat;
+	items?: any;
 	type: EFieldType;
 }
 
@@ -62,7 +63,9 @@ function getValidFields({
 		const type = propertyValue.type;
 
 		if (type === EFieldType.ARRAY) {
-			return;
+			if (propertyValue.items && propertyValue.items.$ref) {
+				return;
+			}
 		}
 
 		if (propertyValue.$ref) {

--- a/modules/test/playwright/tests/commerce/commerceSearchSuggestions.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceSearchSuggestions.spec.ts
@@ -36,7 +36,9 @@ test('LPD-18809 search suggestions should filter by product visibility with the 
 
 	// setup
 
-	const site = await apiHelpers.headlessSite.createSite(getRandomString());
+	const site = await apiHelpers.headlessSite.createSite({
+		name: getRandomString(),
+	});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/helpers/DataSetManagerApiHelpers.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/helpers/DataSetManagerApiHelpers.ts
@@ -132,11 +132,13 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 	}
 
 	async createDataSetViewFields({
+		extraBodyParams = {},
 		label_i18n = {en_US: 'Title'},
 		name = 'title',
 		r_fdsViewFDSFieldRelationship_c_fdsViewERC = DEFAULT_DATA_SET_ERC,
 		type = 'string',
 	}: {
+		extraBodyParams?: any;
 		label_i18n?: {[key: string]: string};
 		name?: string;
 		r_fdsViewFDSFieldRelationship_c_fdsViewERC?: string;
@@ -149,6 +151,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 			name,
 			r_fdsViewFDSFieldRelationship_c_fdsViewERC,
 			type,
+			...extraBodyParams,
 		};
 
 		return this.post(url, data);

--- a/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
@@ -374,6 +374,45 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			await visualizationModesPage.cancelAddFieldsModal();
 		});
 	});
+
+	test('Configure table visualization mode with scalar array fields @LPD-11769', async ({
+		visualizationModesPage,
+	}) => {
+		const SAMPLE_SCALAR_ARRAY_FIELD = 'keywords';
+		const TYPE_COLUMN_INDEX = 3;
+
+		await test.step('Navigate to table visualization mode page', async () => {
+			await visualizationModesPage.goto({
+				dataSetLabel,
+				viewLabel,
+			});
+
+			await visualizationModesPage.selectTab('Table');
+
+			await expect(
+				visualizationModesPage.page.getByPlaceholder('Search')
+			).toBeVisible();
+		});
+
+		await test.step('Add scalar array field', async () => {
+			await visualizationModesPage.openAddFieldsModal();
+
+			await visualizationModesPage.addRootField(
+				SAMPLE_SCALAR_ARRAY_FIELD
+			);
+
+			await visualizationModesPage.saveAddFieldsModal();
+		});
+
+		await test.step('Check if field shows the correct type', async () => {
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_ARRAY_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('array');
+		});
+	});
 });
 
 export const fragmentTest = mergeTests(
@@ -563,123 +602,83 @@ fragmentTest.describe('Visualization Modes in the fragment', () => {
 			);
 		}
 	);
-});
 
-test('Configure table visualization mode @LPD-11049', async ({
-	visualizationModesPage,
-}) => {
-	const SAMPLE_SCALAR_FIELD = 'id';
-	const SAMPLE_OBJECT_FIELD = 'fdsViewFDSFieldRelationship';
-	const SAMPLE_OBJECT_CHILD_FIELD = 'id';
-	const SORTABLE_COLUMN_INDEX = 5;
+	fragmentTest(
+		'Show mapped scalar array field in the fragment @LPD-11769',
+		async ({
+			apiHelpers,
+			dataSetManagerApiHelpers,
+			fdsFragmentPage,
+			page,
+			site,
+		}) => {
+			const SAMPLE_SCALAR_ARRAY_FIELD = 'keywords';
+			const SAMPLE_SCALAR_ARRAY_CONTENT = ['one', 'two', 'three'];
 
-	await test.step('Navigate to table visualization mode page', async () => {
-		await visualizationModesPage.goto({
-			dataSetLabel,
-			viewLabel,
-		});
+			await fragmentTest.step('Create table fields', async () => {
+				await dataSetManagerApiHelpers.createDataSetViewFields({
+					extraBodyParams: {
+						keywords: SAMPLE_SCALAR_ARRAY_CONTENT,
+					},
+					label_i18n: {en_US: SAMPLE_SCALAR_ARRAY_FIELD},
+					name: SAMPLE_SCALAR_ARRAY_FIELD,
+					r_fdsViewFDSFieldRelationship_c_fdsViewERC: viewERC,
+					type: 'array',
+				});
+			});
 
-		await visualizationModesPage.selectTab('Table');
+			const layout = await fragmentTest.step(
+				'Create a new page',
+				async () => {
+					const pageLayout =
+						await apiHelpers.headlessDelivery.createSitePage({
+							siteId: site.id,
+							title: getRandomString(),
+						});
 
-		await expect(
-			visualizationModesPage.page.getByPlaceholder('Search')
-		).toBeVisible();
-	});
+					return pageLayout;
+				}
+			);
 
-	await test.step('Add fields', async () => {
-		await visualizationModesPage.openAddFieldsModal();
+			await fragmentTest.step(
+				'Configure Data Set in the page',
+				async () => {
+					await fdsFragmentPage.configureDataSetFragment({
+						layout,
+						site,
+						viewLabel,
+					});
+				}
+			);
 
-		await visualizationModesPage.addRootField(SAMPLE_SCALAR_FIELD);
-		await visualizationModesPage.addRootField(SAMPLE_OBJECT_FIELD);
-		await visualizationModesPage.addChildField(
-			[SAMPLE_OBJECT_FIELD],
-			SAMPLE_OBJECT_CHILD_FIELD
-		);
+			await fragmentTest.step(
+				'Data Set Table is in the page',
+				async () => {
+					await fdsFragmentPage.fdsTableWrapper.waitFor({
+						state: 'visible',
+					});
 
-		await visualizationModesPage.saveAddFieldsModal();
-	});
+					expect(
+						await fdsFragmentPage.fdsTableWrapper
+					).toBeInViewport();
 
-	await test.step('Check if field defaults are correct', async () => {
-		await expect(
-			visualizationModesPage
-				.getRowByText(SAMPLE_SCALAR_FIELD)
-				.locator('td')
-				.nth(SORTABLE_COLUMN_INDEX)
-		).toHaveText('true');
+					expect(
+						await page
+							.locator('.dnd-thead > div')
+							.first()
+							.locator('.dnd-th')
+							.allInnerTexts()
+					).toEqual([SAMPLE_SCALAR_ARRAY_FIELD, '']);
 
-		await expect(
-			visualizationModesPage
-				.getRowByText(`${SAMPLE_OBJECT_FIELD}.*`)
-				.locator('td')
-				.nth(SORTABLE_COLUMN_INDEX)
-		).toHaveText('false');
-
-		await expect(
-			visualizationModesPage
-				.getRowByText(
-					`${SAMPLE_OBJECT_FIELD}.${SAMPLE_OBJECT_CHILD_FIELD}`
-				)
-				.locator('td')
-				.nth(SORTABLE_COLUMN_INDEX)
-		).toHaveText('true');
-	});
-
-	await test.step('Edit a field', async () => {
-		await visualizationModesPage
-			.getRowByText(SAMPLE_SCALAR_FIELD)
-			.locator('.actions-cell button')
-			.click();
-
-		const editButton = visualizationModesPage.page.getByRole('menuitem', {
-			name: 'Edit',
-		});
-
-		await expect(editButton).toBeInViewport();
-
-		await editButton.click();
-
-		const sortableInput =
-			visualizationModesPage.page.getByLabel('Sortable');
-
-		await expect(sortableInput).toBeInViewport();
-		await expect(sortableInput).toBeEnabled();
-		await expect(sortableInput).toBeChecked();
-
-		await sortableInput.click();
-
-		await expect(sortableInput).not.toBeChecked();
-
-		await visualizationModesPage.saveAddFieldsModal();
-
-		await expect(
-			visualizationModesPage
-				.getRowByText(SAMPLE_SCALAR_FIELD)
-				.locator('td')
-				.nth(SORTABLE_COLUMN_INDEX)
-		).toHaveText('false');
-	});
-
-	await test.step('Check if object field has disabled sortable option', async () => {
-		await visualizationModesPage
-			.getRowByText(`${SAMPLE_OBJECT_FIELD}.*`)
-			.locator('.actions-cell button')
-			.click();
-
-		const editButton = visualizationModesPage.page.getByRole('menuitem', {
-			name: 'Edit',
-		});
-
-		await expect(editButton).toBeInViewport();
-
-		await editButton.click();
-
-		const sortableLabel =
-			visualizationModesPage.page.getByLabel('Sortable');
-
-		await expect(sortableLabel).toBeInViewport();
-
-		await expect(sortableLabel).toBeDisabled();
-
-		await visualizationModesPage.cancelAddFieldsModal();
-	});
+					expect(
+						await page
+							.locator('.dnd-tbody > div')
+							.first()
+							.locator('.dnd-td')
+							.allInnerTexts()
+					).toEqual(['["one","two","three"]', '']);
+				}
+			);
+		}
+	);
 });


### PR DESCRIPTION
## Story / Task
[LPD-11769](https://liferay.atlassian.net/browse/LPD-11769) / [LPD-22818](https://liferay.atlassian.net/browse/LPD-22818)

## Goal
Allow users to select fields of type array that contains collection of primitive values (string, numbers, booleans, ...) and map the field to any visualization mode.

## Use case doc
https://docs.google.com/spreadsheets/d/1fHkpa5p4j31-LheAgEJ3ax2yk45yPhwSYvnCzlkJCL4/edit#gid=0

## UI

![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/2caba1ff-4a3e-4663-89cd-7b47d6fb2dc1)

![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/6c36ddb0-d440-4283-8377-9cf7d67f03eb)


![Screenshot from 2024-04-11 14-57-13](https://github.com/liferay-frontend/liferay-portal/assets/132653342/9cd51b38-1656-4688-b8b3-a74026abe4f5)
