### PR TITLE
LPD-19449 - frontend-data-set-web - Add an ArrayRenderer

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ArrayRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ArrayRenderer.js
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+function ArrayRenderer({value}) {
+	return (
+		<div>
+			{value.map((item, index) => (
+				<span key={item.id}>
+					{item.name}
+
+					{index < value.length - 1 ? ', ' : ''}
+				</span>
+			))}
+		</div>
+	);
+}
+
+ArrayRenderer.propTypes = {
+	value: PropTypes.arrayOf({
+		id: PropTypes.string.isRequired,
+		name: PropTypes.string.isRequired,
+	}),
+};
+
+export default ArrayRenderer;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
@@ -11,6 +11,10 @@ import ActionsLinkRenderer from './ActionLinkRenderer';
 
 // @ts-ignore
 
+import ArrayRenderer from './ArrayRenderer';
+
+// @ts-ignore
+
 import BooleanRenderer from './BooleanRenderer';
 
 // @ts-ignore
@@ -47,6 +51,12 @@ export const INTERNAL_CELL_RENDERERS: Array<IInternalRenderer> = [
 		component: ActionsLinkRenderer,
 		label: Liferay.Language.get('action-link'),
 		name: 'actionLink',
+		type: 'internal',
+	},
+	{
+		component: ArrayRenderer,
+		label: Liferay.Language.get('array'),
+		name: 'array',
 		type: 'internal',
 	},
 	{


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-19449

In order to reproduce locally, we need to delete this if check from [api.js](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts#L64-L66) to enable array fields to show in the Fields selector.

```js
if (type === EFieldType.ARRAY) {
	return;
}
```

Application: `/headless-admin-user/v1.0`
Schema: `UserAccount`
Endpoint: `v1.0/user-accounts`

In the image below, we can see three typical situations - empty array, several items, and just one item.

<img width="1476" alt="image" src="https://github.com/liferay-frontend/liferay-portal/assets/24564752/32118670-0d3a-4b2a-b75b-1d185243f963">