### PR TITLE
LPD-21465 Show the first page of results after filtering in management toolbar

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -60,12 +60,13 @@ const _handleOnSelect = ({data, portletNamespace, selection}) => {
 		selection = Object.values(selection).filter((item) => !item.unchecked);
 	}
 
-	const url = new URL(		
-			_getRedirectURLWithParams({
+	const url = new URL(
+		_getRedirectURLWithParams({
 			data,
 			portletNamespace,
 			selection,
-		}));
+		})
+	);
 
 	const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
 
@@ -97,8 +98,10 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 
 					const url = new URL(redirectURL);
 
-					const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
-		
+					const resetCurParam = `_${url.searchParams.get(
+						'p_p_id'
+					)}_resetCur`;
+
 					url.searchParams.set(resetCurParam, 'true');
 
 					navigate(url.href);
@@ -148,8 +151,10 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 
 				const url = new URL(redirectURL);
 
-				const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
-	
+				const resetCurParam = `_${url.searchParams.get(
+					'p_p_id'
+				)}_resetCur`;
+
 				url.searchParams.set(resetCurParam, 'true');
 
 				navigate(url.href);
@@ -166,17 +171,17 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			height: '70vh',
 			id: `${portletNamespace}selectedScopeIdItem`,
 			onSelect: (selectedItem) => {
-				const redirectURL = (
-					addParams(
-						`${portletNamespace}scopeId=${selectedItem.groupid}`,
-						itemData?.redirectURL
-					)
+				const redirectURL = addParams(
+					`${portletNamespace}scopeId=${selectedItem.groupid}`,
+					itemData?.redirectURL
 				);
 
 				const url = new URL(redirectURL);
 
-				const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
-	
+				const resetCurParam = `_${url.searchParams.get(
+					'p_p_id'
+				)}_resetCur`;
+
 				url.searchParams.set(resetCurParam, 'true');
 
 				navigate(url.href);

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -60,13 +60,18 @@ const _handleOnSelect = ({data, portletNamespace, selection}) => {
 		selection = Object.values(selection).filter((item) => !item.unchecked);
 	}
 
-	navigate(
-		_getRedirectURLWithParams({
+	let url = new URL(		
+			_getRedirectURLWithParams({
 			data,
 			portletNamespace,
 			selection,
-		})
-	);
+		}));
+
+	const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+
+	url.searchParams.set(resetCurParam, 'true');
+
+	navigate(url.href);
 };
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
@@ -90,7 +95,13 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						);
 					});
 
-					navigate(redirectURL);
+					let url = new URL(redirectURL);
+
+					const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+		
+					url.searchParams.set(resetCurParam, 'true');
+
+					navigate(url.href);
 				}
 			},
 			selectEventName: `${portletNamespace}selectedAuthorItem`,
@@ -135,7 +146,13 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					);
 				});
 
-				navigate(redirectURL);
+				let url = new URL(redirectURL);
+
+				const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+	
+				url.searchParams.set(resetCurParam, 'true');
+
+				navigate(url.href);
 			},
 			selectEventName: `${portletNamespace}selectedContentDashboardItemSubtype`,
 			size: 'md',
@@ -149,12 +166,20 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			height: '70vh',
 			id: `${portletNamespace}selectedScopeIdItem`,
 			onSelect: (selectedItem) => {
-				navigate(
+				let redirectURL = (
 					addParams(
 						`${portletNamespace}scopeId=${selectedItem.groupid}`,
 						itemData?.redirectURL
 					)
 				);
+
+				let url = new URL(redirectURL);
+
+				const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+	
+				url.searchParams.set(resetCurParam, 'true');
+
+				navigate(url.href);
 			},
 			selectEventName: `${portletNamespace}selectedScopeIdItem`,
 			size: 'lg',
@@ -168,7 +193,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		onFilterDropdownItemClick(_event, {item = {}}) {
 			const {data} = item;
 
-			if (!Object.keys(data).length) {
+			if (!data || !Object.keys(data).length) {
 				return;
 			}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ContentDashboardManagementToolbarPropsTransformer.js
@@ -60,7 +60,7 @@ const _handleOnSelect = ({data, portletNamespace, selection}) => {
 		selection = Object.values(selection).filter((item) => !item.unchecked);
 	}
 
-	let url = new URL(		
+	const url = new URL(		
 			_getRedirectURLWithParams({
 			data,
 			portletNamespace,
@@ -95,7 +95,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						);
 					});
 
-					let url = new URL(redirectURL);
+					const url = new URL(redirectURL);
 
 					const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
 		
@@ -146,7 +146,7 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 					);
 				});
 
-				let url = new URL(redirectURL);
+				const url = new URL(redirectURL);
 
 				const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
 	
@@ -166,14 +166,14 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			height: '70vh',
 			id: `${portletNamespace}selectedScopeIdItem`,
 			onSelect: (selectedItem) => {
-				let redirectURL = (
+				const redirectURL = (
 					addParams(
 						`${portletNamespace}scopeId=${selectedItem.groupid}`,
 						itemData?.redirectURL
 					)
 				);
 
-				let url = new URL(redirectURL);
+				const url = new URL(redirectURL);
 
 				const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
 	

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLManagementToolbarPropsTransformer.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/js/document_library/DLManagementToolbarPropsTransformer.js
@@ -198,9 +198,17 @@ export default function propsTransformer({
 		openSelectionModal({
 			onSelect(selectedItem) {
 				if (selectedItem) {
+					const destinationURL = new URL(viewFileEntryTypeURL);
+
+					const resetCurParam = `_${destinationURL.searchParams.get(
+						'p_p_id'
+					)}_resetCur`;
+
+					destinationURL.searchParams.set(resetCurParam, 'true');
+
 					const url = addParams(
 						`${portletNamespace}fileEntryTypeId=${selectedItem.value}`,
-						viewFileEntryTypeURL
+						destinationURL.href
 					);
 					navigate(url);
 				}
@@ -227,7 +235,15 @@ export default function propsTransformer({
 						selectExtensionURL
 					);
 
-					navigate(url);
+					const destinationUrl = new URL(url);
+
+					const resetCurParam = `_${destinationUrl.searchParams.get(
+						'p_p_id'
+					)}_resetCur`;
+
+					destinationUrl.searchParams.set(resetCurParam, 'true');
+
+					navigate(destinationUrl.href);
 				}
 			},
 			selectEventName: `${portletNamespace}selectedFileExtension`,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/openCategorySelectionModal.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/openCategorySelectionModal.ts
@@ -47,14 +47,18 @@ export default function openCategorySelectionModal({
 				return;
 			}
 
-			let url = redirectURL;
+			let url = new URL(redirectURL);
+
+			const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+
+			url.searchParams.set(resetCurParam, 'true');
 
 			const assetCategories = Object.keys(selectedItems);
 
 			assetCategories.forEach((assetCategory) => {
 				url = addParams(
 					`${portletNamespace}assetCategoryId=${selectedItems[assetCategory].categoryId}`,
-					url
+					url.href
 				);
 			});
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/openTagSelectionModal.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/commands/openTagSelectionModal.ts
@@ -42,7 +42,11 @@ export default function openTagSelectionModal({
 				return;
 			}
 
-			let url = redirectURL;
+			let url = new URL(redirectURL);
+
+			const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+
+			url.searchParams.set(resetCurParam, 'true');
 
 			const assetTags = selectedItems.map((tag) => tag.value);
 
@@ -51,7 +55,7 @@ export default function openTagSelectionModal({
 
 				url = addParams(
 					`${portletNamespace}assetTagId=${selectedValue.tagName}`,
-					url
+					url.href
 				);
 			});
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -90,28 +90,29 @@ function ManagementToolbar({
 
 	const searchButtonRef = useRef();
 
-	const updateFilterDropdownItems = () => {
-		filterDropdownItems?.forEach((filterDropdownItem) => {
-			filterDropdownItem.items?.forEach((item) => {
-				if (item.href) {				
-					const url = new URL(item.href);
+	const updatedFilterDropdownItems = useMemo(() => {
+		const updateFilterDropdownItems = () => {
+			filterDropdownItems?.forEach((filterDropdownItem) => {
+				filterDropdownItem.items?.forEach((item) => {
+					if (item.href) {
+						const url = new URL(item.href);
 
-					const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+						const resetCurParam = `_${url.searchParams.get(
+							'p_p_id'
+						)}_resetCur`;
 
-					url.searchParams.set(resetCurParam, 'true');
+						url.searchParams.set(resetCurParam, 'true');
 
-					item.href = url.href;
-				}
+						item.href = url.href;
+					}
+				});
 			});
-		});
 
-		return filterDropdownItems;
-	};
+			return filterDropdownItems;
+		};
 
-	const updatedFilterDropdownItems = useMemo(
-		() => updateFilterDropdownItems(),
-		[filterDropdownItems]
-	);
+		updateFilterDropdownItems();
+	}, [filterDropdownItems]);
 
 	useEffect(() => {
 		if (searchMobile) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.js
@@ -90,6 +90,29 @@ function ManagementToolbar({
 
 	const searchButtonRef = useRef();
 
+	const updateFilterDropdownItems = () => {
+		filterDropdownItems?.forEach((filterDropdownItem) => {
+			filterDropdownItem.items?.forEach((item) => {
+				if (item.href) {				
+					const url = new URL(item.href);
+
+					const resetCurParam = `_${url.searchParams.get('p_p_id')}_resetCur`;
+
+					url.searchParams.set(resetCurParam, 'true');
+
+					item.href = url.href;
+				}
+			});
+		});
+
+		return filterDropdownItems;
+	};
+
+	const updatedFilterDropdownItems = useMemo(
+		() => updateFilterDropdownItems(),
+		[filterDropdownItems]
+	);
+
 	useEffect(() => {
 		if (searchMobile) {
 			const searchButton = searchButtonRef.current;
@@ -124,7 +147,7 @@ function ManagementToolbar({
 							setActive={setActive}
 							showCheckBoxLabel={
 								!active &&
-								!filterDropdownItems &&
+								!updatedFilterDropdownItems &&
 								!sortingURL &&
 								!showSearch
 							}
@@ -135,7 +158,7 @@ function ManagementToolbar({
 					{!active && (
 						<FilterOrderControls
 							disabled={disabled}
-							filterDropdownItems={filterDropdownItems}
+							filterDropdownItems={updatedFilterDropdownItems}
 							onFilterDropdownItemClick={
 								onFilterDropdownItemClick
 							}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -212,12 +212,20 @@ export default function propsTransformer({
 						if (selectedItem) {
 							const itemValue = JSON.parse(selectedItem.value);
 
+							const url = new URL(viewDDMStructureArticlesURL);
+
+							const resetCurParam = `_${url.searchParams.get(
+								'p_p_id'
+							)}_resetCur`;
+
+							url.searchParams.set(resetCurParam, 'true');
+
 							navigate(
 								addParams(
 									{
 										[`${portletNamespace}ddmStructureId`]: itemValue.ddmstructureid,
 									},
-									viewDDMStructureArticlesURL
+									url.href
 								)
 							);
 						}


### PR DESCRIPTION
[Previous pull request](https://github.com/liferay-frontend/liferay-portal/pull/4105)

Hey,

After a deeper analysis of this case I could identify three cases (although I wouldn't discard there is something else):
* Filter is done through a direct option in management toolbar (_Expired_, _approved_, _mine_, ...)
* Filter is done through a modal window for either tags or categories
* Filter is done through a modal window for whatever else (_type of asset_, _structure_, _author_, ...)

I've committed changes for every case in a different commit so it's easier to identify them. 

The big issue here is the third case since that's part of client code so I had to fix the case in D&M, Journal and Content Dashboard. There are some other cases where they are using a modal window to filter some content but this issue is not reproducible for different reasons (i.e, they don't navigate after filtering), so I haven't modify them.

Initially I thought about creating some sort of util with this solution, but it could not be use everywhere because there are a few particular cases, so I thought it would be better this way.

Thanks.

Regards.