### PR TITLE
LPD-22678 FIX LocalFile.CPCommerceChannels#CanPaginatePaymentAndShippingRestrictions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -104,6 +104,10 @@ const Cards = ({items, schema}: {items: Array<any>; schema: ICardSchema}) => {
 		FrontendDataSetContext
 	);
 
+	if (!items?.length) {
+		return null;
+	}
+
 	return (
 		<div
 			className={classNames(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/emails_list/EmailsList.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/emails_list/EmailsList.js
@@ -140,6 +140,10 @@ function EmailsList({dataLoading, frontendDataSetContext, items}) {
 		return <ClayLoadingIndicator className="mt-7" />;
 	}
 
+	if (!items?.length) {
+		return null;
+	}
+
 	return (
 		<ClayList
 			className={classNames(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -20,6 +20,10 @@ import {getLocalizedValue} from '../../utils/getLocalizedValue';
 const List = ({header, items, schema}) => {
 	const {selectedItemsKey} = useContext(FrontendDataSetContext);
 
+	if (!items?.length) {
+		return null;
+	}
+
 	return (
 		<ClayLayout.Sheet
 			className={classNames('list-sheet', {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/selectable_table/SelectableTable.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/selectable_table/SelectableTable.js
@@ -55,6 +55,10 @@ function SelectableTable({dataLoading, items: itemsProp, schema, style}) {
 		return <ClayLoadingIndicator className="mt-7" />;
 	}
 
+	if (!items?.length) {
+		return null;
+	}
+
 	return (
 		<div className={`table-style-${style}`}>
 			<ClayTable borderless hover={false} responsive={false}>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/timeline/Timeline.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/timeline/Timeline.js
@@ -41,6 +41,10 @@ TimelineEntry.propTypes = {
 TimelineEntry.defaultProps = {};
 
 function Timeline({frontendDataSetContext, items}) {
+	if (!items?.length) {
+		return null;
+	}
+
 	return (
 		<ClayList className={classNames('mb-0', 'timeline')}>
 			{items.map((item, i) => (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/views/cards/Cards.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/views/cards/Cards.d.ts
@@ -19,5 +19,5 @@ declare const Cards: ({
 }: {
 	items: Array<any>;
 	schema: ICardSchema;
-}) => JSX.Element;
+}) => JSX.Element | null;
 export default Cards;


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-22678

In this PR we apply a more defensive approach in the FDS view components to account for the case where there are no supplied items.

Background: once empty state management [was centralized at the topmost level](https://github.com/liferay-frontend/liferay-portal/pull/4110/commits/d575283758651cd2300dbc7d54e2a0fdfb669c5b), views components are not meant to render when there are no items. However, internal state changes may trigger such view re-renderings. One of them caused https://liferay.atlassian.net/browse/LPD-22678.

Solution:

- Add back the `items` non-null check before rendering the view for all affected view components.
