### PR TITLE
LPD-23493 Remove attributes from panel-container causing a11y errors

### DIFF
--- a/portal-web/docroot/html/taglib/ui/panel_container/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel_container/start.jsp
@@ -7,4 +7,4 @@
 
 <%@ include file="/html/taglib/ui/panel_container/init.jsp" %>
 
-<div aria-multiselectable="true" class="panel-group <%= cssClass %>" id="<%= id %>" role="tablist">
+<div class="panel-group <%= cssClass %>" id="<%= id %>">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23493 - Accessibility issue on liferay-ui:panel-container

When using `liferay-ui:panel-container` or `@liferay_ui["panel-container"]` taglib, an accessibility error would occur since its `role=tablist` would expect children with a role of `tab` only, and `button` role was not allowed. Additionally, there is another a11y issue with setting `aria-multiselectable=true`.

<img width="699" alt="Screenshot 2024-04-16 at 2 28 47 PM" src="https://github.com/liferay-frontend/liferay-portal/assets/14063502/9b96802c-1c8a-4ba8-bee2-bf456a747a70">
<img width="718" alt="Screenshot 2024-04-16 at 2 28 16 PM" src="https://github.com/liferay-frontend/liferay-portal/assets/14063502/d547b30d-d5c1-416a-9e5a-0d8e0099bf4c">

It seems like the simplest fix might be to remove these attributes, since it would be difficult to enforce all descendants of `panel-container` being only one role, and multiselectable does not seem to apply to `panel-container`. It looks like this taglib has not been changed for several years, so please let me know if this works. Thanks!