### PR TITLE
LPD-23795 Add valid href to curernt page link in page-iterator for a11y

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -232,7 +232,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							<li class="page-item <%= (i == cur) ? "active" : StringPool.BLANK %>">
 								<c:choose>
 									<c:when test="<%= i == cur %>">
-										<a aria-current="page" class="page-link" tabindex="0">
+										<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" tabindex="0">
 									</c:when>
 									<c:otherwise>
 										<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
@@ -249,7 +249,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					</c:when>
 					<c:when test="<%= cur == 1 %>">
 						<li class="active page-item">
-							<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 						</li>
 						<li class="page-item">
 							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
@@ -325,7 +325,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
 						</li>
 						<li class="active page-item">
-							<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
 						</li>
 					</c:when>
 					<c:otherwise>
@@ -370,7 +370,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</c:if>
 
 						<li class="active page-item">
-							<a aria-current="page" class="page-link" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur %></a>
+							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur %></a>
 						</li>
 
 						<c:if test="<%= (cur + 1) < pages %>">


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-23795 - Accessibility issue with "links not crawlable" inside paginator

Based on feedback from https://liferay.atlassian.net/browse/LPP-53691?focusedCommentId=2633527, this adds a valid URL to the page link that is designated as the current page, in order to avoid accessibility errors about a non-crawlable link.

This basically reuses the `_getHREF` function to grab the page url and tries to maintain the consistency of parameters with its neighboring links. Please let me know if I should make any changes, thanks!