### PR TITLE
LPD-23920 - Add default data to prevent FDS configuration errors

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-views-web/creationActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/creationActions.spec.ts
@@ -220,7 +220,22 @@ export const fragmentTest = mergeTests(
 fragmentTest.describe('Creation Actions in the fragment', () => {
 	fragmentTest(
 		'Creation Action button does not appear if no creation action is defined',
-		async ({apiHelpers, fdsFragmentPage, site}) => {
+		async ({
+			apiHelpers,
+			dataSetManagerApiHelpers,
+			fdsFragmentPage,
+			site,
+		}) => {
+			await fragmentTest.step('Create table field', async () => {
+				await dataSetManagerApiHelpers.createDataSetViewFields({
+					label_i18n: {en_US: 'Id'},
+					name: 'id',
+					r_fdsViewFDSFieldRelationship_c_fdsViewERC:
+						actionsDataSetViewERC,
+					type: 'string',
+				});
+			});
+
 			const layout = await fragmentTest.step(
 				'Create a new page',
 				async () => {
@@ -265,6 +280,16 @@ fragmentTest.describe('Creation Actions in the fragment', () => {
 			page,
 			site,
 		}) => {
+			await fragmentTest.step('Create table field', async () => {
+				await dataSetManagerApiHelpers.createDataSetViewFields({
+					label_i18n: {en_US: 'Id'},
+					name: 'id',
+					r_fdsViewFDSFieldRelationship_c_fdsViewERC:
+						actionsDataSetViewERC,
+					type: 'string',
+				});
+			});
+
 			const actionLabel = 'Custom Creation Action';
 
 			await fragmentTest.step('Create Creation Action', async () => {
@@ -338,6 +363,16 @@ fragmentTest.describe('Creation Actions in the fragment', () => {
 			fdsFragmentPage,
 			site,
 		}) => {
+			await fragmentTest.step('Create table field', async () => {
+				await dataSetManagerApiHelpers.createDataSetViewFields({
+					label_i18n: {en_US: 'Id'},
+					name: 'id',
+					r_fdsViewFDSFieldRelationship_c_fdsViewERC:
+						actionsDataSetViewERC,
+					type: 'string',
+				});
+			});
+
 			const firstActionLabel = 'Custom Creation Action';
 			const secondActionLabel = 'Another Creation Action';
 

--- a/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/itemActions.spec.ts
@@ -137,7 +137,22 @@ export const fragmentTest = mergeTests(
 fragmentTest.describe('Item Actions in the fragment', () => {
 	fragmentTest(
 		'Item Action button does not appear if there is no item action',
-		async ({apiHelpers, fdsFragmentPage, site}) => {
+		async ({
+			apiHelpers,
+			dataSetManagerApiHelpers,
+			fdsFragmentPage,
+			site,
+		}) => {
+			await fragmentTest.step('Create table field', async () => {
+				await dataSetManagerApiHelpers.createDataSetViewFields({
+					label_i18n: {en_US: 'Id'},
+					name: 'id',
+					r_fdsViewFDSFieldRelationship_c_fdsViewERC:
+						actionsDataSetViewERC,
+					type: 'string',
+				});
+			});
+
 			const layout = await fragmentTest.step(
 				'Create a new page',
 				async () => {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
@@ -209,41 +209,6 @@ export const fragmentTest = mergeTests(
 
 fragmentTest.describe('Data Set Default Visualization Mode in fragment', () => {
 	fragmentTest(
-		'Default Visualization Mode is not configured (no field for any section). FDS does not appear.',
-		async ({apiHelpers, fdsFragmentPage, page, site}) => {
-			const layout = await fragmentTest.step(
-				'Create a new page',
-				async () => {
-					const pageLayout =
-						await apiHelpers.headlessDelivery.createSitePage({
-							siteId: site.id,
-							title: getRandomString(),
-						});
-
-					return pageLayout;
-				}
-			);
-
-			await fragmentTest.step(
-				'Configure Data Set in the page',
-				async () => {
-					await fdsFragmentPage.configureDataSetFragment({
-						layout,
-						site,
-						viewLabel: settingsDataSetViewLabel,
-					});
-				}
-			);
-
-			fragmentTest.step('No Data Set is in the page', async () => {
-				await expect(
-					page.locator('.data-set-wrapper')
-				).not.toBeVisible();
-			});
-		}
-	);
-
-	fragmentTest(
 		'When there is only one visualization mode defined, that will be the default one. Cards',
 		async ({
 			apiHelpers,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/settings.spec.ts
@@ -209,18 +209,8 @@ export const fragmentTest = mergeTests(
 
 fragmentTest.describe('Data Set Default Visualization Mode in fragment', () => {
 	fragmentTest(
-		'Default Visualization Mode is not configured (no field for any section). Use Table as default',
-		async ({
-			apiHelpers,
-			dataSetManagerApiHelpers,
-			fdsFragmentPage,
-			page,
-			site,
-		}) => {
-			await test.step('Create random data (fields) for other Data Sets', async () => {
-				await dataSetManagerApiHelpers.createDataSetViewFields({});
-			});
-
+		'Default Visualization Mode is not configured (no field for any section). FDS does not appear.',
+		async ({apiHelpers, fdsFragmentPage, page, site}) => {
 			const layout = await fragmentTest.step(
 				'Create a new page',
 				async () => {
@@ -245,16 +235,10 @@ fragmentTest.describe('Data Set Default Visualization Mode in fragment', () => {
 				}
 			);
 
-			fragmentTest.step('Empty Data Set is in the page', async () => {
-				await expect(page.locator('.data-set-wrapper')).toBeVisible();
-
-				expect(
-					await page
-						.locator('.dnd-tbody > div')
-						.first()
-						.locator('.dnd-td')
-						.allInnerTexts()
-				).toEqual([]);
+			fragmentTest.step('No Data Set is in the page', async () => {
+				await expect(
+					page.locator('.data-set-wrapper')
+				).not.toBeVisible();
 			});
 		}
 	);


### PR DESCRIPTION
## Task
https://liferay.atlassian.net/browse/LPD-23920

## Goal
We need to provide data for every Data Set we need to test in the fragment. Otherwise, the FDS component will fail silently and the fragment will not receive the correct configuration.

Remove Settings test that was expecting an empty view. There is an ongoing conversation to fix that. [See slack thread](https://liferay.slack.com/archives/C3JBR21HA/p1713781391888969)
