### PR TITLE
LPD-24044 GeoLocationField in expando-taglib isn't working (broken import)

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -309,7 +309,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										"mapName", portletDisplay.getNamespace() + "ExpandoAttribute--" + mapDisplayName + "--"
 									).build()
 								%>'
-								module="{default as GeoLocationField} from expando-taglib"
+								module="{GeoLocationField} from expando-taglib"
 							/>
 
 							<aui:input name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>' type="hidden" value="<%= HtmlUtil.escape(value.toString()) %>" />
@@ -789,7 +789,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									"mapName", portletDisplay.getNamespace() + "ExpandoAttribute--" + mapDisplayName + "--"
 								).build()
 							%>'
-							module="{default as GeoLocationField} from expando-taglib"
+							module="{GeoLocationField} from expando-taglib"
 						/>
 					</div>
 				</c:if>

--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -309,7 +309,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										"mapName", portletDisplay.getNamespace() + "ExpandoAttribute--" + mapDisplayName + "--"
 									).build()
 								%>'
-								module="{GeoLocationField} from expando-taglib"
+								module="{default as GeoLocationField} from expando-taglib"
 							/>
 
 							<aui:input name='<%= "ExpandoAttribute--" + HtmlUtil.escapeAttribute(name) + "--" %>' type="hidden" value="<%= HtmlUtil.escape(value.toString()) %>" />
@@ -789,7 +789,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 									"mapName", portletDisplay.getNamespace() + "ExpandoAttribute--" + mapDisplayName + "--"
 								).build()
 							%>'
-							module="{GeoLocationField} from expando-taglib"
+							module="{default as GeoLocationField} from expando-taglib"
 						/>
 					</div>
 				</c:if>

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/GeoLocationField.js
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/GeoLocationField.js
@@ -5,7 +5,7 @@
 
 import {MapBase} from '@liferay/map-common';
 
-export default function ({inputName, mapName}) {
+export function GeoLocationField({inputName, mapName}) {
 	MapBase.get(mapName, (map) => {
 		map.on('positionChange', (event) => {
 			const inputNode = document.querySelector(

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/js/index.js
@@ -4,4 +4,4 @@
  */
 
 export {default as ExpandoManagementToolbarPropsTransformer} from './ExpandoManagementToolbarPropsTransformer';
-export {default as GeoLocationField} from './GeoLocationField';
+export {GeoLocationField} from './GeoLocationField';


### PR DESCRIPTION
# Issue: [BUG LPD-24044](https://liferay.atlassian.net/browse/LPD-24044) ([LPP-53621](https://liferay.atlassian.net/browse/LPP-53621))

Hi guys, I fixed the broken import over expando-taglib.

I think it's caused by 769a97ea98e2da79348a24f0b9ab8172566ab0cf / [LPS-206108](https://liferay.atlassian.net/browse/LPS-206108).

## Before PR
![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/4c90fe6a-4119-4c2f-9a4e-5d014a441d38)

## After PR
![image](https://github.com/liferay-frontend/liferay-portal/assets/67901/390f76a9-82fb-42d7-a824-7f221708e2b3)
