### PR TITLE
LPD-24093 Removes attributes from request

### DIFF
--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -458,6 +458,12 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 
 		httpServletRequest.removeAttribute(
 			"liferay-ui:icon-menu:showWhenSingleIcon");
+		httpServletRequest.removeAttribute(
+			"liferay-ui:icon-menu:triggerAriaLabel");
+		httpServletRequest.removeAttribute(
+			"liferay-ui:icon-menu:triggerCssClass");
+		httpServletRequest.removeAttribute("liferay-ui:icon-menu:triggerLabel");
+		httpServletRequest.removeAttribute("liferay-ui:icon-menu:triggerType");
 
 		return EVAL_PAGE;
 	}


### PR DESCRIPTION
Motivation
-----
If we have two liferay-ui:icon-menu rendered in the same page, one in a fragment and another one in a widget, the one in a widget is taking the values for the first one. It is because fragments don't have namespace, since those are not rendered inside a widget.

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-24093)

Proposed Solution
-----
Removes attributes from request after rendering the tag, in that way if we have another taglib rendered after it we are going to have the correct values.
