### PR TITLE
LPD-24031 - Redirect users to the page where the action was triggered

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/ActionsDropdown.tsx
@@ -163,7 +163,7 @@ function ActionsDropdown({
 						action.target,
 						action.onClick ? action.onClick : null
 					)
-						? formatActionURL(action.href, itemData)
+						? formatActionURL(action.href, itemData, action.target)
 						: null
 				}
 				monospaced={Boolean(action.icon)}
@@ -203,7 +203,10 @@ function ActionsDropdown({
 					key={i}
 					onClick={onClick}
 					setLoading={setLoading}
-					url={item.href && formatActionURL(item.href, itemData)}
+					url={
+						item.href &&
+						formatActionURL(item.href, itemData, item.target)
+					}
 				/>
 			);
 		});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/QuickActions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/QuickActions.tsx
@@ -21,7 +21,11 @@ function QuickActions({actions, itemData, itemId, onClick}: IQuickActions) {
 						displayType="unstyled"
 						href={
 							action.href &&
-							formatActionURL(action.href, itemData)
+							formatActionURL(
+								action.href,
+								itemData,
+								action.target
+							)
 						}
 						key={action.data?.id || action.label}
 						monospaced={false}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
@@ -50,7 +50,8 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 	}
 
 	const formattedHref =
-		currentAction.href && formatActionURL(currentAction.href, itemData);
+		currentAction.href &&
+		formatActionURL(currentAction.href, itemData, currentAction.target);
 
 	function handleClickOnLink(event) {
 		const doAction = () => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
@@ -53,33 +53,37 @@ const formatActionURL = function (
 
 	if (target === 'link' && replacedURL.includes('?')) {
 		const redirectionURL = window.location.href;
-		const backURL = '_backURL';
-		const redirect = '_redirect';
-		const backURLRegexp = new RegExp(backURL);
-		const redirectRegexp = new RegExp(redirect);
-
 		const searchParams = new URLSearchParams(
 			replacedURL.slice(replacedURL.indexOf('?'))
 		);
-		const p_p_id = searchParams.get('p_p_id');
 
-		if (redirectRegexp.test(url) || backURLRegexp.test(url)) {
+		const p_p_id = searchParams.get('p_p_id');
+		const backURLParam = `_${p_p_id}_backURL`;
+		const redirectParam = `_${p_p_id}_redirect`;
+
+		const backURLRegexp = new RegExp(backURLParam);
+		const redirectRegexp = new RegExp(redirectParam);
+
+		if (
+			redirectRegexp.test(replacedURL) ||
+			backURLRegexp.test(replacedURL)
+		) {
 			for (const key of searchParams.keys()) {
-				if (
-					redirectRegexp.test(`${p_p_id}${key}`) ||
-					backURLRegexp.test(`${p_p_id}${key}`)
-				) {
+				if (redirectRegexp.test(key) || backURLRegexp.test(key)) {
 					searchParams.set(key, redirectionURL);
 				}
 			}
 		}
 		else if (p_p_id) {
-			searchParams.set(`${p_p_id}${redirect}`, redirectionURL);
-			searchParams.set(`${p_p_id}${backURL}`, redirectionURL);
+			searchParams.set(redirectParam, redirectionURL);
+			searchParams.set(backURLParam, redirectionURL);
 		}
 
 		const updatedURL = decodeURIComponent(
-			`${url.slice(0, url.indexOf('?'))}?${searchParams.toString()}`
+			`${replacedURL.slice(
+				0,
+				replacedURL.indexOf('?')
+			)}?${searchParams.toString()}`
 		);
 
 		return updatedURL;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
@@ -10,6 +10,7 @@
  *
  * @param url URI with an optional number of interpolated parameters
  * @param item object with properties that could match interpolated parameters
+ * @param target string that indicates the type of the action: link, modal, sidepanel
  *
  * @example
  * url = '/o/data-sample/{id}
@@ -27,7 +28,11 @@
 
 import getValueFromItem from '../getValueFromItem';
 
-const formatActionURL = function (url: string | undefined, item: any): string {
+const formatActionURL = function (
+	url: string | undefined,
+	item: any,
+	target?: string
+): string {
 	if (!url) {
 		return '';
 	}
@@ -46,7 +51,7 @@ const formatActionURL = function (url: string | undefined, item: any): string {
 		)
 	);
 
-	if (replacedURL.includes('?')) {
+	if (target === 'link' && replacedURL.includes('?')) {
 		const redirectionURL = window.location.href;
 		const backURL = '_backURL';
 		const redirect = '_redirect';
@@ -60,7 +65,10 @@ const formatActionURL = function (url: string | undefined, item: any): string {
 
 		if (redirectRegexp.test(url) || backURLRegexp.test(url)) {
 			for (const key of searchParams.keys()) {
-				if (redirectRegexp.test(key) || backURLRegexp.test(key)) {
+				if (
+					redirectRegexp.test(`${p_p_id}${key}`) ||
+					backURLRegexp.test(`${p_p_id}${key}`)
+				) {
 					searchParams.set(key, redirectionURL);
 				}
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
@@ -61,15 +61,9 @@ const formatActionURL = function (
 		const backURLParam = `_${p_p_id}_backURL`;
 		const redirectParam = `_${p_p_id}_redirect`;
 
-		const backURLRegexp = new RegExp(backURLParam);
-		const redirectRegexp = new RegExp(redirectParam);
-
-		if (
-			redirectRegexp.test(replacedURL) ||
-			backURLRegexp.test(replacedURL)
-		) {
+		if (searchParams.has(redirectParam) || searchParams.has(backURLParam)) {
 			for (const key of searchParams.keys()) {
-				if (redirectRegexp.test(key) || backURLRegexp.test(key)) {
+				if (key === backURLParam || key === redirectParam) {
 					searchParams.set(key, redirectionURL);
 				}
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
@@ -37,19 +37,19 @@ const formatActionURL = function (
 		return '';
 	}
 
-	const replacedURL = url.replace(new RegExp('{(.*?)}', 'mg'), (matched) =>
-		getValueFromItem(
-			item,
-			matched.substring(1, matched.length - 1).split('.')
+	const replacedURL = url
+		.replace(new RegExp('{(.*?)}', 'mg'), (matched) =>
+			getValueFromItem(
+				item,
+				matched.substring(1, matched.length - 1).split('.')
+			)
 		)
-	);
-
-	replacedURL.replace(new RegExp('(%7B.*?%7D)', 'mg'), (matched) =>
-		getValueFromItem(
-			item,
-			matched.substring(3, matched.length - 3).split('.')
-		)
-	);
+		.replace(new RegExp('(%7B.*?%7D)', 'mg'), (matched) =>
+			getValueFromItem(
+				item,
+				matched.substring(3, matched.length - 3).split('.')
+			)
+		);
 
 	if (target === 'link' && replacedURL.includes('?')) {
 		const redirectionURL = window.location.href;
@@ -57,18 +57,24 @@ const formatActionURL = function (
 			replacedURL.slice(replacedURL.indexOf('?'))
 		);
 
-		const p_p_id = searchParams.get('p_p_id');
-		const backURLParam = `_${p_p_id}_backURL`;
-		const redirectParam = `_${p_p_id}_redirect`;
+		const backURL = 'backURL';
+		const redirect = 'redirect';
+		const backURLRegexp = new RegExp(backURL);
+		const redirectRegexp = new RegExp(redirect);
 
-		if (searchParams.has(redirectParam) || searchParams.has(backURLParam)) {
+		const p_p_id = searchParams.get('p_p_id');
+
+		if (redirectRegexp.test(url) || backURLRegexp.test(url)) {
 			for (const key of searchParams.keys()) {
-				if (key === backURLParam || key === redirectParam) {
+				if (redirectRegexp.test(key) || backURLRegexp.test(key)) {
 					searchParams.set(key, redirectionURL);
 				}
 			}
 		}
 		else if (p_p_id) {
+			const backURLParam = `_${p_p_id}_${backURL}`;
+			const redirectParam = `_${p_p_id}_${redirect}`;
+
 			searchParams.set(redirectParam, redirectionURL);
 			searchParams.set(backURLParam, redirectionURL);
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
@@ -4,7 +4,9 @@
  */
 
 /**
- * Try to replace interpolated url arguments with item properties
+ * Try to replace interpolated url arguments with item properties.
+ * Set _redirect and/or backURL parameters to allow navigating back
+ * to the FDS component that triggered the action
  *
  * @param url URI with an optional number of interpolated parameters
  * @param item object with properties that could match interpolated parameters
@@ -37,12 +39,45 @@ const formatActionURL = function (url: string | undefined, item: any): string {
 		)
 	);
 
-	return replacedURL.replace(new RegExp('(%7B.*?%7D)', 'mg'), (matched) =>
+	replacedURL.replace(new RegExp('(%7B.*?%7D)', 'mg'), (matched) =>
 		getValueFromItem(
 			item,
 			matched.substring(3, matched.length - 3).split('.')
 		)
 	);
+
+	if (replacedURL.includes('?')) {
+		const redirectionURL = window.location.href;
+		const backURL = '_backURL';
+		const redirect = '_redirect';
+		const backURLRegexp = new RegExp(backURL);
+		const redirectRegexp = new RegExp(redirect);
+
+		const searchParams = new URLSearchParams(
+			replacedURL.slice(replacedURL.indexOf('?'))
+		);
+		const p_p_id = searchParams.get('p_p_id');
+
+		if (redirectRegexp.test(url) || backURLRegexp.test(url)) {
+			for (const key of searchParams.keys()) {
+				if (redirectRegexp.test(key) || backURLRegexp.test(key)) {
+					searchParams.set(key, redirectionURL);
+				}
+			}
+		}
+		else if (p_p_id) {
+			searchParams.set(`${p_p_id}${redirect}`, redirectionURL);
+			searchParams.set(`${p_p_id}${backURL}`, redirectionURL);
+		}
+
+		const updatedURL = decodeURIComponent(
+			`${url.slice(0, url.indexOf('?'))}?${searchParams.toString()}`
+		);
+
+		return updatedURL;
+	}
+
+	return replacedURL;
 };
 
 export default formatActionURL;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/handleActionClick.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/handleActionClick.ts
@@ -53,7 +53,7 @@ const handleActionClick = ({
 		title,
 	} = data ?? {};
 
-	const url = formatActionURL(href, itemData);
+	const url = formatActionURL(href, itemData, target);
 
 	const doAction = ({defaultPrevented}: {defaultPrevented: boolean}) => {
 		if (target?.includes('modal')) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/triggerAction.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/triggerAction.ts
@@ -10,6 +10,7 @@ import {ICreationActionItem} from '../../management_bar/controls/CreationMenu';
 import {OPEN_MODAL, OPEN_SIDE_PANEL} from '../../utils/eventsDefinitions';
 import {resolveModalSize} from '../../utils/modals/resolveModalSize';
 import {ACTION_ITEM_TARGETS} from './constants';
+import formatActionURL from './formatActionURL';
 
 const {
 	BLANK,
@@ -56,7 +57,7 @@ export function triggerAction(
 			Liferay.fire(actionTargetURL);
 			break;
 		default:
-			navigate(actionTargetURL);
+			navigate(formatActionURL(actionTargetURL, item));
 			break;
 	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/triggerAction.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/triggerAction.ts
@@ -57,7 +57,7 @@ export function triggerAction(
 			Liferay.fire(actionTargetURL);
 			break;
 		default:
-			navigate(formatActionURL(actionTargetURL, item));
+			navigate(formatActionURL(actionTargetURL, item, actionTarget));
 			break;
 	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
@@ -52,23 +52,23 @@ describe('formatActionURL helper', () => {
 
 	it('returns the URL, changing the _redirect parameter to use the actual URL', () => {
 		const URLWithRedirect =
-			'/test/page?p_p_id=random&random_redirect=http://www.somewhere.com';
+			'/test/page?p_p_id=random&_random_redirect=http://www.somewhere.com';
 		const target = 'link';
 		const formattedURL = formatActionURL(URLWithRedirect, testItem, target);
 
 		expect(formattedURL).toEqual(
-			'/test/page?p_p_id=random&random_redirect=http://localhost/'
+			'/test/page?p_p_id=random&_random_redirect=http://localhost/'
 		);
 	});
 
 	it('returns the URL, changing the _backURL parameter to use the actual URL', () => {
 		const URLWithRedirect =
-			'/test/page?p_p_id=random&random_backURL=http://www.somewhere.com';
+			'/test/page?p_p_id=random&_random_backURL=http://www.somewhere.com';
 		const target = 'link';
 		const formattedURL = formatActionURL(URLWithRedirect, testItem, target);
 
 		expect(formattedURL).toEqual(
-			'/test/page?p_p_id=random&random_backURL=http://localhost/'
+			'/test/page?p_p_id=random&_random_backURL=http://localhost/'
 		);
 	});
 
@@ -82,13 +82,13 @@ describe('formatActionURL helper', () => {
 		);
 
 		expect(formattedURL).toEqual(
-			'/test/page?p_p_id=random&random_redirect=http://localhost/&random_backURL=http://localhost/'
+			'/test/page?p_p_id=random&_random_redirect=http://localhost/&_random_backURL=http://localhost/'
 		);
 	});
 
 	it('returns the URL, without changing the _redirect and _backURL parameters if the target is different from "link"', () => {
 		const URLWithBackURL =
-			'/test/page?p_p_id=random&random_backURL=http://www.somewhere.com';
+			'/test/page?p_p_id=random&_random_backURL=http://www.somewhere.com';
 		const modalTarget = 'modal';
 		const formattedURL = formatActionURL(
 			URLWithBackURL,
@@ -99,7 +99,7 @@ describe('formatActionURL helper', () => {
 		expect(formattedURL).toEqual(URLWithBackURL);
 
 		const URLWithRedirect =
-			'/test/page?p_p_id=random&random_redirect=http://www.somewhere.com';
+			'/test/page?p_p_id=random&_random_redirect=http://www.somewhere.com';
 		const panelTarget = 'sidePanel';
 		const anotherFormattedURL = formatActionURL(
 			URLWithRedirect,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
@@ -38,4 +38,33 @@ describe('formatActionURL helper', () => {
 			`/o/data-test/${testItem.id}/${testItem.name}`
 		);
 	});
+
+	it('returns the URL, changing the _redirect parameter to use the actual URL', () => {
+		const URLWithRedirect =
+			'/test/page?p_p_id=random&random_redirect=http://www.somewhere.com';
+		const formattedURL = formatActionURL(URLWithRedirect, testItem);
+
+		expect(formattedURL).toEqual(
+			'/test/page?p_p_id=random&random_redirect=http://localhost/'
+		);
+	});
+
+	it('returns the URL, changing the _backURL parameter to use the actual URL', () => {
+		const URLWithRedirect =
+			'/test/page?p_p_id=random&random_backURL=http://www.somewhere.com';
+		const formattedURL = formatActionURL(URLWithRedirect, testItem);
+
+		expect(formattedURL).toEqual(
+			'/test/page?p_p_id=random&random_backURL=http://localhost/'
+		);
+	});
+
+	it('returns the URL, adding the _redirect and _backURL parameters to use the actual URL if the url includes a p_p_id parameter', () => {
+		const URLWithRedirect = '/test/page?p_p_id=random';
+		const formattedURL = formatActionURL(URLWithRedirect, testItem);
+
+		expect(formattedURL).toEqual(
+			'/test/page?p_p_id=random&random_redirect=http://localhost/&random_backURL=http://localhost/'
+		);
+	});
 });

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
@@ -61,7 +61,7 @@ describe('formatActionURL helper', () => {
 		);
 	});
 
-	it('returns the URL, changing the _backURL parameter to use the actual URL', () => {
+	it('returns the URL, changing the portlet_ns_backURL parameter to use the actual URL', () => {
 		const URLWithRedirect =
 			'/test/page?p_p_id=random&_random_backURL=http://www.somewhere.com';
 		const target = 'link';
@@ -70,6 +70,14 @@ describe('formatActionURL helper', () => {
 		expect(formattedURL).toEqual(
 			'/test/page?p_p_id=random&_random_backURL=http://localhost/'
 		);
+	});
+
+	it('returns the URL, changing any _backURL parameter to use the actual URL', () => {
+		const URLWithRedirect = '/test/page?backURL=http://www.somewhere.com';
+		const target = 'link';
+		const formattedURL = formatActionURL(URLWithRedirect, testItem, target);
+
+		expect(formattedURL).toEqual('/test/page?backURL=http://localhost/');
 	});
 
 	it('returns the URL, adding the _redirect and _backURL parameters to use the actual URL if the url includes a p_p_id parameter', () => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
@@ -13,26 +13,37 @@ const testItem = {
 describe('formatActionURL helper', () => {
 	it('returns an empty string if no URL is provided', () => {
 		const givenURL = undefined;
-		const formattedURL = formatActionURL(givenURL, testItem);
+		const target = 'link';
+		const formattedURL = formatActionURL(givenURL, testItem, target);
 
 		expect(formattedURL).toEqual('');
 	});
 
 	it('returns the raw URL if there is no interpolation argument', () => {
 		const givenURL = 'https://www.liferay.com';
-		const formattedURL = formatActionURL(givenURL, testItem);
+		const target = 'link';
+		const formattedURL = formatActionURL(givenURL, testItem, target);
 
 		expect(formattedURL).toEqual(givenURL);
 	});
 
 	it('returns the URL with interpolate values', () => {
 		const URLWithParam = '/o/data-test/{id}';
-		const formattedURLWithParam = formatActionURL(URLWithParam, testItem);
+		const target = 'link';
+		const formattedURLWithParam = formatActionURL(
+			URLWithParam,
+			testItem,
+			target
+		);
 
 		expect(formattedURLWithParam).toEqual(`/o/data-test/${testItem.id}`);
 
 		const URLWithParams = '/o/data-test/{id}/{name}';
-		const formattedURLWithParams = formatActionURL(URLWithParams, testItem);
+		const formattedURLWithParams = formatActionURL(
+			URLWithParams,
+			testItem,
+			target
+		);
 
 		expect(formattedURLWithParams).toEqual(
 			`/o/data-test/${testItem.id}/${testItem.name}`
@@ -42,7 +53,8 @@ describe('formatActionURL helper', () => {
 	it('returns the URL, changing the _redirect parameter to use the actual URL', () => {
 		const URLWithRedirect =
 			'/test/page?p_p_id=random&random_redirect=http://www.somewhere.com';
-		const formattedURL = formatActionURL(URLWithRedirect, testItem);
+		const target = 'link';
+		const formattedURL = formatActionURL(URLWithRedirect, testItem, target);
 
 		expect(formattedURL).toEqual(
 			'/test/page?p_p_id=random&random_redirect=http://localhost/'
@@ -52,7 +64,8 @@ describe('formatActionURL helper', () => {
 	it('returns the URL, changing the _backURL parameter to use the actual URL', () => {
 		const URLWithRedirect =
 			'/test/page?p_p_id=random&random_backURL=http://www.somewhere.com';
-		const formattedURL = formatActionURL(URLWithRedirect, testItem);
+		const target = 'link';
+		const formattedURL = formatActionURL(URLWithRedirect, testItem, target);
 
 		expect(formattedURL).toEqual(
 			'/test/page?p_p_id=random&random_backURL=http://localhost/'
@@ -60,11 +73,61 @@ describe('formatActionURL helper', () => {
 	});
 
 	it('returns the URL, adding the _redirect and _backURL parameters to use the actual URL if the url includes a p_p_id parameter', () => {
-		const URLWithRedirect = '/test/page?p_p_id=random';
-		const formattedURL = formatActionURL(URLWithRedirect, testItem);
+		const URLWithoutRedirect = '/test/page?p_p_id=random';
+		const target = 'link';
+		const formattedURL = formatActionURL(
+			URLWithoutRedirect,
+			testItem,
+			target
+		);
 
 		expect(formattedURL).toEqual(
 			'/test/page?p_p_id=random&random_redirect=http://localhost/&random_backURL=http://localhost/'
 		);
+	});
+
+	it('returns the URL, without changing the _redirect and _backURL parameters if the target is different from "link"', () => {
+		const URLWithBackURL =
+			'/test/page?p_p_id=random&random_backURL=http://www.somewhere.com';
+		const modalTarget = 'modal';
+		const formattedURL = formatActionURL(
+			URLWithBackURL,
+			testItem,
+			modalTarget
+		);
+
+		expect(formattedURL).toEqual(URLWithBackURL);
+
+		const URLWithRedirect =
+			'/test/page?p_p_id=random&random_redirect=http://www.somewhere.com';
+		const panelTarget = 'sidePanel';
+		const anotherFormattedURL = formatActionURL(
+			URLWithRedirect,
+			testItem,
+			panelTarget
+		);
+
+		expect(anotherFormattedURL).toEqual(URLWithRedirect);
+	});
+
+	it('returns the URL, without adding the _redirect and _backURL parameters if the target is different from "link"', () => {
+		const URLWithoutRedirect = '/test/page?p_p_id=random';
+		const modalTarget = 'modal';
+		const formattedURL = formatActionURL(
+			URLWithoutRedirect,
+			testItem,
+			modalTarget
+		);
+
+		expect(formattedURL).toEqual('/test/page?p_p_id=random');
+
+		const panelTarget = 'sidePanel';
+		const anotherFormattedURL = formatActionURL(
+			URLWithoutRedirect,
+			testItem,
+			panelTarget
+		);
+
+		expect(anotherFormattedURL).toEqual('/test/page?p_p_id=random');
 	});
 });

--- a/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/types/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.d.ts
@@ -3,5 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-declare const formatActionURL: (url: string | undefined, item: any) => string;
+declare const formatActionURL: (
+	url: string | undefined,
+	item: any,
+	target?: string | undefined
+) => string;
 export default formatActionURL;


### PR DESCRIPTION
## Story / Task
[LPD-16459](https://liferay.atlassian.net/browse/LPD-16459) / [LPD-24031](https://liferay.atlassian.net/browse/LPD-24031)

## Goal
Modify URL so actions can be redirected where they were triggered. 
Liferay uses a couple of parameters to handle redirections accross the portal. Those parameter names usually are composed by the portlet name, a suffix (`_replace`, `_backURL`) and a URL to go to (`p_p_id=<portlet_name>` -> `portlet_name_redirect=URL`). 
In this PR we try to update those parameters to set the URL of the page where the FDS component is loaded so it can go back.
We try to cover the following use cases:
- there is a `_redirect` parameter, so we update the URL
- there is a `_backURL` parameter, so we update the URL
- there is a `backURL` parameter, so we update the URL
- there are more than one `*backURL` parameter, so we update the URL of all
- there is a `p_p_id` parameter, without `_redirect` or `_backURL` so we set both of them
- there is no `p_p_id`, do nothing

## Concerns
- [Commerce](https://github.com/liferay/liferay-portal/blob/master/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/index.js#L115) and [Objects](https://github.com/liferay/liferay-portal/blob/master/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/utils/fds.ts#L25) use their own version of `formatActionURL` 
- Data Sets app does not use `_backURL` nor `_redirect` 

## UI
[Screencast from 2024-04-24 14-46-27.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/1d35372f-b0f6-4dae-b2a8-b6d9670451c6)
