### PR TITLE
LPD-24197 - Prevent complex object/array fields to be sortable

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -69,8 +69,6 @@ public class SaveFDSFieldsMVCResourceCommand
 			JSONObject creationDataJSONObject =
 				creationDataJSONArray.getJSONObject(i);
 
-			String type = String.valueOf(creationDataJSONObject.get("type"));
-
 			ObjectEntry objectEntry = _objectEntryService.addObjectEntry(
 				0, objectDefinition.getObjectDefinitionId(),
 				HashMapBuilder.<String, Serializable>put(
@@ -88,7 +86,7 @@ public class SaveFDSFieldsMVCResourceCommand
 				).put(
 					"sortable", (Boolean)creationDataJSONObject.get("sortable")
 				).put(
-					"type", type
+					"type", String.valueOf(creationDataJSONObject.get("type"))
 				).build(),
 				new ServiceContext());
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.Serializable;
@@ -87,7 +86,7 @@ public class SaveFDSFieldsMVCResourceCommand
 				).put(
 					"renderer", "default"
 				).put(
-					"sortable", !StringUtil.equals(type, "object")
+					"sortable", (Boolean)creationDataJSONObject.get("sortable")
 				).put(
 					"type", type
 				).build(),

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -78,6 +78,7 @@ function getValidFields({
 					}),
 					label: propertyKey,
 					name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
+					sortable: false,
 					type: type ? type : 'array',
 				});
 
@@ -93,6 +94,7 @@ function getValidFields({
 					}),
 					label: propertyKey,
 					name: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`,
+					sortable: false,
 					type: type ? type : 'object',
 				});
 
@@ -120,6 +122,7 @@ function getValidFields({
 						}),
 						label: propertyKey,
 						name: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`,
+						sortable: false,
 						type: schemas[parentSchemaName[0]]?.type || 'object',
 					});
 
@@ -131,6 +134,11 @@ function getValidFields({
 				format: propertyValue.format,
 				label: propertyKey,
 				name: `${contextPath}${propertyKey}`,
+				sortable:
+					type !== 'object' &&
+					type !== 'array' &&
+					!contextPath.includes(FDS_NESTED_FIELD_NAME_DELIMITER) &&
+					!contextPath.includes(FDS_ARRAY_FIELD_NAME_DELIMITER),
 				type,
 			});
 		});

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -479,7 +479,9 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 			setFDSSorts([...notOrdered, ...ordered]);
 
 			await getFields(fdsView).then((fields) => {
-				setFields(fields);
+				const nextFields = fields.filter((field) => field.sortable);
+
+				setFields(nextFields);
 			});
 
 			setLoading(false);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -35,8 +35,11 @@ import '../../../../css/TableVisualizationMode.scss';
 import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
 
-import {EFieldType, IFDSField} from '../../../utils/types';
-import AddFieldsModalContent from './modal_content/AddFieldsModalContent';
+import {getFields} from '../../../api';
+import {EFieldType, IFDSField, IFieldTreeItem} from '../../../utils/types';
+import AddFieldsModalContent, {
+	visit,
+} from './modal_content/AddFieldsModalContent';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
@@ -111,6 +114,7 @@ interface IEditFDSFieldModalContentProps {
 	fdsField: IFDSField;
 	namespace: string;
 	onSave: Function;
+	sortable: boolean;
 }
 
 const EditFDSFieldModalContent = ({
@@ -119,12 +123,13 @@ const EditFDSFieldModalContent = ({
 	fdsField,
 	namespace,
 	onSave,
+	sortable,
 }: IEditFDSFieldModalContentProps) => {
 	const [selectedFDSFieldRenderer, setSelectedFDSFieldRenderer] = useState(
 		fdsField.renderer ?? 'default'
 	);
 
-	const [fdsFieldSortable, setFSDFieldSortable] = useState<boolean>(
+	const [fdsFieldSortable, setFDSFieldSortable] = useState<boolean>(
 		fdsField.sortable
 	);
 
@@ -306,11 +311,11 @@ const EditFDSFieldModalContent = ({
 				<ClayForm.Group>
 					<ClayCheckbox
 						checked={fdsFieldSortable}
-						disabled={!fdsFieldSortable}
+						disabled={!sortable}
 						inline
 						label={Liferay.Language.get('sortable')}
 						onChange={({target: {checked}}) =>
-							setFSDFieldSortable(checked)
+							setFDSFieldSortable(checked)
 						}
 					/>
 
@@ -355,6 +360,7 @@ function Table({
 	title,
 }: IFDSViewSectionProps & {title?: string}) {
 	const [fdsFields, setFDSFields] = useState<Array<IFDSField> | null>(null);
+	const [treeItems, setTreeItems] = useState<Array<IFieldTreeItem>>([]);
 
 	const reorderFDSFields = ({
 		fdsFieldsOrder,
@@ -526,6 +532,12 @@ function Table({
 	};
 
 	useEffect(() => {
+		getFields(fdsView).then((fields) => {
+			setTreeItems(fields);
+		});
+	}, [fdsView]);
+
+	useEffect(() => {
 		getFDSFields();
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -561,6 +573,7 @@ function Table({
 					}}
 					saveFDSFieldsURL={saveFDSFieldsURL}
 					savedFDSFields={fdsFields || []}
+					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',
@@ -612,6 +625,7 @@ function Table({
 										fdsField={item}
 										namespace={namespace}
 										onSave={onEditFDSField}
+										sortable={isSortable(treeItems, item)}
 									/>
 								),
 							});
@@ -684,6 +698,22 @@ function Table({
 	) : (
 		<ClayLoadingIndicator />
 	);
+}
+
+function isSortable(
+	treeItems: Array<IFieldTreeItem>,
+	selectedItem: IFDSField
+): boolean {
+	let isSortable = false;
+	visit(treeItems, (treeItem: IFieldTreeItem) => {
+		if (treeItem.name === selectedItem.name) {
+			isSortable = treeItem.sortable || false;
+
+			return;
+		}
+	});
+
+	return isSortable;
 }
 
 export function Fields(props: IFDSViewSectionProps) {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -125,7 +125,7 @@ const EditFDSFieldModalContent = ({
 	);
 
 	const [fdsFieldSortable, setFSDFieldSortable] = useState<boolean>(
-		fdsField.sortable ?? fdsField.type !== EFieldType.OBJECT
+		fdsField.sortable
 	);
 
 	const fdsInternalCellRendererNames = FDS_INTERNAL_CELL_RENDERERS.map(
@@ -306,7 +306,7 @@ const EditFDSFieldModalContent = ({
 				<ClayForm.Group>
 					<ClayCheckbox
 						checked={fdsFieldSortable}
-						disabled={fdsField.type === EFieldType.OBJECT}
+						disabled={!fdsFieldSortable}
 						inline
 						label={Liferay.Language.get('sortable')}
 						onChange={({target: {checked}}) =>

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
@@ -198,13 +198,18 @@ const AddFieldsModalContent = ({
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
 
-		const creationData: Array<{name: string; type: string}> = [];
+		const creationData: Array<{
+			name: string;
+			sortable: boolean;
+			type: string;
+		}> = [];
 		const deletionIds: Array<number> = [];
 
 		visit(initialFields || [], (field: IFieldTreeItem) => {
 			if (selectedKeys.has(field.name) && !field.savedId) {
 				creationData.push({
 					name: field.name,
+					sortable: !!field.sortable,
 					type: field.type || 'string',
 				});
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.tsx
@@ -15,21 +15,13 @@ import {fetch} from 'frontend-js-web';
 import React, {ComponentProps, useEffect, useState} from 'react';
 
 import {FDSViewType} from '../../../../FDSViews';
-import {getFields} from '../../../../api';
 import AutoSearch from '../../../../components/AutoSearch';
 import SearchResultsMessage from '../../../../components/SearchResultsMessage';
 import openDefaultFailureToast from '../../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../../utils/openDefaultSuccessToast';
-import {IFDSField, IField} from '../../../../utils/types';
+import {IFDSField, IField, IFieldTreeItem} from '../../../../utils/types';
 
-interface IFieldTreeItem extends IField {
-	children?: IFieldTreeItem[];
-	query?: string;
-	savedId?: number;
-	selected?: boolean;
-}
-
-function visit(fields: Array<IFieldTreeItem>, callback: Function) {
+export function visit(fields: Array<IFieldTreeItem>, callback: Function) {
 	fields.forEach((field) => {
 		callback(field);
 
@@ -167,6 +159,7 @@ const AddFieldsModalContent = ({
 	saveFDSFieldsURL,
 	savedFDSFields,
 	selectionMode = 'multiple',
+	treeItems,
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
@@ -181,10 +174,11 @@ const AddFieldsModalContent = ({
 	saveFDSFieldsURL: string;
 	savedFDSFields: Array<IFDSField>;
 	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
+	treeItems: Array<IFieldTreeItem> | null;
 }) => {
 	const [initialFields, setInitialFields] = useState<Array<
 		IFieldTreeItem
-	> | null>(null);
+	> | null>(treeItems);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
 		new Set<React.Key>()
@@ -209,7 +203,7 @@ const AddFieldsModalContent = ({
 			if (selectedKeys.has(field.name) && !field.savedId) {
 				creationData.push({
 					name: field.name,
-					sortable: !!field.sortable,
+					sortable: field.sortable || false,
 					type: field.type || 'string',
 				});
 			}
@@ -261,23 +255,18 @@ const AddFieldsModalContent = ({
 	};
 
 	useEffect(() => {
-		getFields(fdsView).then((fields) => {
-			if (fields) {
-				const [
-					initialSelectedKeys,
-					updatedFields,
-				] = applySavedFDSFields({
-					fields,
-					savedFDSFields,
-				});
+		if (treeItems) {
+			const [initialSelectedKeys, updatedFields] = applySavedFDSFields({
+				fields: treeItems,
+				savedFDSFields,
+			});
 
-				setSelectedKeys(initialSelectedKeys);
+			setSelectedKeys(initialSelectedKeys);
 
-				setInitialFields(updatedFields);
-				setFields(updatedFields);
-			}
-		});
-	}, [savedFDSFields, fdsView]);
+			setInitialFields(updatedFields);
+			setFields(updatedFields);
+		}
+	}, [savedFDSFields, treeItems]);
 
 	const onSearch = (query: string) => {
 		setQuery(query);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -44,6 +44,7 @@ export interface IField {
 	label?: string;
 	name: string;
 	selected?: boolean;
+	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -41,10 +41,10 @@ export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
 	id?: string;
+	sortable?: boolean;
 	label?: string;
 	name: string;
 	selected?: boolean;
-	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }
@@ -60,6 +60,13 @@ export interface IFDSField {
 	rendererLabel?: string;
 	sortable: boolean;
 	type: string;
+}
+
+export interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	query?: string;
+	savedId?: number;
+	selected?: boolean;
 }
 
 export interface IFilter {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -41,10 +41,10 @@ export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
 	id?: string;
-	sortable?: boolean;
 	label?: string;
 	name: string;
 	selected?: boolean;
+	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/modal_content/AddFieldsModalContent.d.ts
@@ -6,7 +6,11 @@
 import {TreeView} from '@clayui/core';
 import {ComponentProps} from 'react';
 import {FDSViewType} from '../../../../FDSViews';
-import {IFDSField} from '../../../../utils/types';
+import {IFDSField, IFieldTreeItem} from '../../../../utils/types';
+export declare function visit(
+	fields: Array<IFieldTreeItem>,
+	callback: Function
+): void;
 declare const AddFieldsModalContent: ({
 	closeModal,
 	fdsView,
@@ -15,6 +19,7 @@ declare const AddFieldsModalContent: ({
 	saveFDSFieldsURL,
 	savedFDSFields,
 	selectionMode,
+	treeItems,
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
@@ -29,5 +34,6 @@ declare const AddFieldsModalContent: ({
 	saveFDSFieldsURL: string;
 	savedFDSFields: Array<IFDSField>;
 	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
+	treeItems: Array<IFieldTreeItem> | null;
 }) => JSX.Element;
 export default AddFieldsModalContent;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -34,10 +34,10 @@ export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
 	id?: string;
-	sortable?: boolean;
 	label?: string;
 	name: string;
 	selected?: boolean;
+	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -34,10 +34,10 @@ export interface IField {
 	children?: Array<IField>;
 	format?: EFieldFormat;
 	id?: string;
+	sortable?: boolean;
 	label?: string;
 	name: string;
 	selected?: boolean;
-	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }
@@ -52,6 +52,12 @@ export interface IFDSField {
 	rendererLabel?: string;
 	sortable: boolean;
 	type: string;
+}
+export interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	query?: string;
+	savedId?: number;
+	selected?: boolean;
 }
 export interface IFilter {
 	fieldName: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -37,6 +37,7 @@ export interface IField {
 	label?: string;
 	name: string;
 	selected?: boolean;
+	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/tabs/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/tabs/VisualizationModesPage.ts
@@ -43,7 +43,7 @@ export class VisualizationModesPage {
 	}
 
 	async addChildField(path: string[], field: string) {
-		this.openParentField(path);
+		await this.openParentField(path);
 
 		await this.page
 			.locator(`[data-id$="${path.join('.')}.${field}"]`)
@@ -166,6 +166,27 @@ export class VisualizationModesPage {
 				await expandButton.click();
 			}
 		});
+	}
+
+	async searchAndSelecteField(path: string) {
+		const fieldSearch = await this.page
+			.getByRole('dialog', {name: 'Add Fields'})
+			.getByPlaceholder('Search');
+
+		const FDS_NESTED_FIELD_NAME_DELIMITER = '.';
+
+		const itemPath = path
+			.replace(/\[\]/g, '.')
+			.split(FDS_NESTED_FIELD_NAME_DELIMITER)
+			.filter((item) => item !== '*');
+
+		const selectedFieldName = itemPath[itemPath.length - 1];
+		await fieldSearch.fill(selectedFieldName);
+
+		await this.page
+			.locator(`[data-id$=",${path}"]`)
+			.getByText(selectedFieldName, {exact: true})
+			.check();
 	}
 
 	async selectTab(tabLabel: string) {

--- a/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
@@ -318,7 +318,7 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 					)
 					.locator('td')
 					.nth(SORTABLE_COLUMN_INDEX)
-			).toHaveText('true');
+			).toHaveText('false');
 		});
 
 		await test.step('Edit a field', async () => {
@@ -389,11 +389,16 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		});
 	});
 
-	test('Configure table visualization mode with scalar array fields @LPD-11769', async ({
+	test('Configure table visualization mode with array fields @LPD-11769', async ({
 		page,
 		visualizationModesPage,
 	}) => {
+		const SAMPLE_COMPLEX_ARRAY_FIELD = 'auditEvents[]*';
+		const SAMPLE_COMPLEX_ARRAY_CHILD_FIELD = 'auditEvents[]creator.name';
 		const SAMPLE_SCALAR_ARRAY_FIELD = 'keywords';
+		const SAMPLE_FULL_COMPLEX_FIELD = 'creator.*';
+		const SAMPLE_COMPLEX_OBJECT_CHILD_FIELD = 'creator.givenName';
+		const SORTABLE_COLUMN_INDEX = 5;
 		const TYPE_COLUMN_INDEX = 3;
 
 		await test.step('Navigate to table visualization mode page', async () => {
@@ -409,11 +414,23 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			).toBeVisible();
 		});
 
-		await test.step('Add scalar array field', async () => {
+		await test.step('Add array fields', async () => {
 			await visualizationModesPage.openAddFieldsModal();
 
-			await visualizationModesPage.addRootField(
+			await visualizationModesPage.searchAndSelecteField(
 				SAMPLE_SCALAR_ARRAY_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_COMPLEX_ARRAY_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_COMPLEX_ARRAY_CHILD_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_COMPLEX_OBJECT_CHILD_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_FULL_COMPLEX_FIELD
 			);
 
 			await saveFromModal({
@@ -421,13 +438,48 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			});
 		});
 
-		await test.step('Check if field shows the correct type', async () => {
+		await test.step('Check if fields show the correct type', async () => {
 			await expect(
 				visualizationModesPage
 					.getRowByText(SAMPLE_SCALAR_ARRAY_FIELD)
 					.locator('td')
 					.nth(TYPE_COLUMN_INDEX)
 			).toHaveText('array');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_ARRAY_FIELD)
+					.locator('td')
+					.nth(SORTABLE_COLUMN_INDEX)
+			).toHaveText('false');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_COMPLEX_ARRAY_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('array');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_COMPLEX_ARRAY_FIELD)
+					.locator('td')
+					.nth(SORTABLE_COLUMN_INDEX)
+			).toHaveText('false');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_COMPLEX_OBJECT_CHILD_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('string');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_FULL_COMPLEX_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('object');
 		});
 	});
 });


### PR DESCRIPTION
## Story / Task
[LPD-24163](https://liferay.atlassian.net/browse/LPD-24163) / [LPD-24197](https://liferay.atlassian.net/browse/LPD-24197)

## Goal
With the growing number of types that can be selected for the Table visualization mode, it is hard to know which fields, except scalar types appearing as root elements, can be used to sort the data. To avoid errors when the user applies a sorting option, we prevent setting fields of type `array`, `object` or any descendant of `array` and `object` as sortable.

## Technical details
- As we need to iterate over all available fields, it seemed appropriate to identify this trait so it could be used just after selecting the fields. This calculated value is used to store the information in the database.
This, also makes possible to filter out in the `Sorting` tab those fields than cannot be used to create sorts. 

## UI
![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/f7e0ce36-87fc-4e64-b307-83b929fa1ae4)
