### PR TITLE
[DO NOT MERGE] LPD-23279 / LPD-24088 Unified management of sorting in DSM item lists

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -60,11 +60,13 @@ import java.io.Writer;
 
 import java.sql.Timestamp;
 
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -347,25 +349,14 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		Set<ObjectEntry> objectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsCreationActionsOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSCreationActionRelationship"));
-
 		return JSONUtil.put(
 			"primaryItems",
 			JSONUtil.toJSONArray(
-				objectEntries,
+				_sortObjectEntries(
+					_getRelatedObjectEntries(
+						fdsViewObjectDefinition, fdsViewObjectEntry,
+						"fdsViewFDSCreationActionRelationship"),
+					fdsViewObjectEntry, "fdsCreationActionsOrder"),
 				(ObjectEntry objectEntry) -> {
 					Map<String, Object> properties =
 						objectEntry.getProperties();
@@ -437,22 +428,11 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		Set<ObjectEntry> fdsFieldObjectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsFieldsOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		fdsFieldObjectEntries.addAll(
+		return _sortObjectEntries(
 			_getRelatedObjectEntries(
 				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSFieldRelationship"));
-
-		return fdsFieldObjectEntries;
+				"fdsViewFDSFieldRelationship"),
+			fdsViewObjectEntry, "fdsViewFDSFieldRelationship");
 	}
 
 	private JSONObject _getFDSListViewJSONObject(
@@ -580,15 +560,7 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
-		Set<ObjectEntry> objectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsFiltersOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
+		List<ObjectEntry> objectEntries = new ArrayList<>();
 
 		objectEntries.addAll(
 			_getRelatedObjectEntries(
@@ -604,7 +576,8 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 				"fdsViewFDSDynamicFilterRelationship"));
 
 		return JSONUtil.toJSONArray(
-			objectEntries,
+			_sortObjectEntries(
+				objectEntries, fdsViewObjectEntry, "fdsFiltersOrder"),
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
@@ -761,23 +734,12 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		Set<ObjectEntry> objectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsItemActionsOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSItemActionRelationship"));
-
 		return JSONUtil.toJSONArray(
-			objectEntries,
+			_sortObjectEntries(
+				_getRelatedObjectEntries(
+					fdsViewObjectDefinition, fdsViewObjectEntry,
+					"fdsViewFDSItemActionRelationship"),
+				fdsViewObjectEntry, "fdsItemActionsOrder"),
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
@@ -971,9 +933,11 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		throws Exception {
 
 		return JSONUtil.toJSONArray(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSSortRelationship"),
+			_sortObjectEntries(
+				_getRelatedObjectEntries(
+					fdsViewObjectDefinition, fdsViewObjectEntry,
+					"fdsViewFDSSortRelationship"),
+				fdsViewObjectEntry, "fdsSortsOrder"),
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
@@ -1045,6 +1009,43 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		return apiURL;
 	}
 
+	private Set<ObjectEntry> _sortObjectEntries(
+		Collection<ObjectEntry> objectEntries, ObjectEntry fdsViewObjectEntry,
+		String itemsOrderPropertyName) {
+
+		List<Long> ids = ListUtil.toList(
+			ListUtil.fromString(
+				MapUtil.getString(
+					fdsViewObjectEntry.getProperties(), itemsOrderPropertyName),
+				StringPool.COMMA),
+			Long::parseLong);
+
+		Set<ObjectEntry> includedObjectEntries = new TreeSet<>(
+			new ObjectEntryOrderedIdsComparator(ids));
+
+		includedObjectEntries.addAll(
+			ListUtil.filter(
+				ListUtil.fromCollection(objectEntries),
+				objectEntry -> ids.contains(objectEntry.getId())));
+
+		Set<ObjectEntry> notIncludedObjectEntries = new TreeSet<>(
+			new ObjectEntryCreationDateComparator());
+
+		notIncludedObjectEntries.addAll(
+			ListUtil.filter(
+				ListUtil.fromCollection(objectEntries),
+				objectEntry -> !ids.contains(objectEntry.getId())));
+
+		Set<ObjectEntry> sortedObjectEntries = new LinkedHashSet<>(
+			includedObjectEntries.size() + notIncludedObjectEntries.size());
+
+		sortedObjectEntries.addAll(includedObjectEntries);
+
+		sortedObjectEntries.addAll(notIncludedObjectEntries);
+
+		return sortedObjectEntries;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		FDSViewFragmentRenderer.class);
 
@@ -1075,10 +1076,23 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 	@Reference
 	private ReactRenderer _reactRenderer;
 
-	private static class ObjectEntryComparator
+	private static class ObjectEntryCreationDateComparator
 		implements Comparator<ObjectEntry> {
 
-		public ObjectEntryComparator(List<Long> ids) {
+		@Override
+		public int compare(ObjectEntry objectEntry1, ObjectEntry objectEntry2) {
+			return objectEntry1.getDateCreated(
+			).compareTo(
+				objectEntry2.getDateCreated()
+			);
+		}
+
+	}
+
+	private static class ObjectEntryOrderedIdsComparator
+		implements Comparator<ObjectEntry> {
+
+		public ObjectEntryOrderedIdsComparator(List<Long> ids) {
 			_ids = ids;
 		}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -18,6 +18,8 @@ import ActionForm from './actions/ActionForm';
 import ActionList from './actions/ActionList';
 
 import '../../css/Actions.scss';
+import sortItems from '../utils/sortItems';
+import {IOrderable} from '../utils/types';
 
 const SECTIONS = {
 	CREATION_ACTIONS: 'creation-actions',
@@ -28,7 +30,7 @@ const SECTIONS = {
 	NEW_ITEM_ACTION: 'new-item-action',
 };
 
-interface IFDSAction {
+interface IFDSAction extends IOrderable {
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_CREATION_ACTION]?: any;
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_ITEM_ACTION]?: any;
 	actions: {
@@ -47,7 +49,6 @@ interface IFDSAction {
 		[key: string]: string;
 	};
 	icon: string;
-	id: number;
 	label: string;
 	label_i18n: {
 		[key: string]: string;
@@ -136,7 +137,7 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionProps) => {
 				? OBJECT_RELATIONSHIP.FDS_VIEW_FDS_ITEM_ACTION_ID
 				: OBJECT_RELATIONSHIP.FDS_VIEW_FDS_CREATION_ACTION_ID;
 
-		const url = `${API_URL.FDS_ACTIONS}?filter=(${relationshipID} eq '${fdsView.id}')&nestedFields=${relationShip}&sort=dateCreated:desc`;
+		const url = `${API_URL.FDS_ACTIONS}?filter=(${relationshipID} eq '${fdsView.id}')&nestedFields=${relationShip}&sort=dateCreated:asc`;
 
 		if (activeTab === 0) {
 			setActiveSection(SECTIONS.ITEM_ACTIONS);
@@ -159,33 +160,15 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionProps) => {
 
 		const storedFDSActions: IFDSAction[] = responseJSON.items;
 
-		let ordered = storedFDSActions;
-		let notOrdered: IFDSAction[] = [];
-
 		const actionTypeOrder =
 			activeTab === 0 ? 'fdsItemActionsOrder' : 'fdsCreationActionsOrder';
 
 		const fdsActionsOrder =
 			storedFDSActions?.[0]?.[relationShip]?.[actionTypeOrder];
 
-		if (fdsActionsOrder) {
-			const fdsActionsOrderArray = fdsActionsOrder.split(',') as string[];
-
-			ordered = fdsActionsOrderArray
-				.map((fdsActionId) =>
-					storedFDSActions.find(
-						(fdsAction) => fdsAction.id === Number(fdsActionId)
-					)
-				)
-				.filter(Boolean) as IFDSAction[];
-
-			notOrdered = storedFDSActions.filter(
-				(fdsAction) =>
-					!fdsActionsOrderArray.includes(String(fdsAction.id))
-			);
-		}
-
-		setFDSActions([...notOrdered, ...ordered]);
+		setFDSActions(
+			sortItems(storedFDSActions, fdsActionsOrder) as IFDSAction[]
+		);
 
 		setLoading(false);
 	};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -256,7 +256,15 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionProps) => {
 
 		const storedFDSActionsOrder = responseJSON?.[actionTypeOrder];
 
-		if (storedFDSActionsOrder && storedFDSActionsOrder === order) {
+		if (
+			fdsActions &&
+			storedFDSActionsOrder &&
+			storedFDSActionsOrder === order
+		) {
+			setFDSActions(
+				sortItems(fdsActions, storedFDSActionsOrder) as IFDSAction[]
+			);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -587,7 +587,13 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 
 		const storedFDSSortsOrder = responseJSON?.fdsSortsOrder;
 
-		if (storedFDSSortsOrder && storedFDSSortsOrder === fdsSortsOrder) {
+		if (
+			fdsSorts &&
+			storedFDSSortsOrder &&
+			storedFDSSortsOrder === fdsSortsOrder
+		) {
+			setFDSSorts(sortItems(fdsSorts, storedFDSSortsOrder) as IFDSSort[]);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -458,7 +458,11 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 			setFDSSorts(
 				sortItems(
 					storedFDSSorts,
-					responseJSON.fdsSortsOrder
+
+					// @ts-ignore
+
+					storedFDSSorts?.[0]?.[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT]
+						?.fdsSortsOrder as string
 				) as IFDSSort[]
 			);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -22,7 +22,8 @@ import RequiredMark from '../components/RequiredMark';
 import {API_URL, OBJECT_RELATIONSHIP} from '../utils/constants';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
-import {IField} from '../utils/types';
+import sortItems from '../utils/sortItems';
+import {IField, IOrderable} from '../utils/types';
 
 interface IAddFDSSortModalContentInterface {
 	closeModal: Function;
@@ -37,11 +38,10 @@ interface IContentRendererProps {
 	query: string;
 }
 
-interface IFDSSort {
+interface IFDSSort extends IOrderable {
 	default: boolean;
 	externalReferenceCode: string;
 	fieldName: string;
-	id: number;
 	label: string;
 	label_i18n: Liferay.Language.LocalizedValue<string>;
 	orderType: string;
@@ -448,35 +448,19 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 	useEffect(() => {
 		const getFDSSort = async () => {
 			const response = await fetch(
-				`${API_URL.FDS_SORTS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT}&sort=dateCreated:desc`
+				`${API_URL.FDS_SORTS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT}&sort=dateCreated:asc`
 			);
 
 			const responseJSON = await response.json();
 
 			const storedFDSSorts: IFDSSort[] = responseJSON.items;
 
-			let ordered = storedFDSSorts;
-			let notOrdered: IFDSSort[] = [];
-
-			if (responseJSON.fdsSortsOrder) {
-				const fdsSortsOrderArray = responseJSON.fdsSortsOrder.split(
-					','
-				) as string[];
-
-				ordered = fdsSortsOrderArray
-					.map((fdsSortId) =>
-						storedFDSSorts.find(
-							(fdsSort) => fdsSort.id === Number(fdsSortId)
-						)
-					)
-					.filter(Boolean) as IFDSSort[];
-
-				notOrdered = storedFDSSorts.filter(
-					(filter) => !fdsSortsOrderArray.includes(String(filter.id))
-				);
-			}
-
-			setFDSSorts([...notOrdered, ...ordered]);
+			setFDSSorts(
+				sortItems(
+					storedFDSSorts,
+					responseJSON.fdsSortsOrder
+				) as IFDSSort[]
+			);
 
 			await getFields(fdsView).then((fields) => {
 				setFields(fields);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -508,7 +508,7 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 
 			filtersOrdered = sortItems(
 				filtersOrdered,
-				fdsView.fdsFiltersOrder,
+				responseJSON.fdsFiltersOrder,
 				true
 			) as FilterCollection;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -38,6 +38,7 @@ import DateRangeFilterModalContent from './modal_content/DateRangeFilter';
 import SelectionFilterModalContent from './modal_content/SelectionFilter';
 
 import '../../../css/Filters.scss';
+import sortItems from '../../utils/sortItems';
 
 type FilterCollection = Array<
 	IClientExtensionFilter | IDateFilter | ISelectionFilter
@@ -505,26 +506,11 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				})),
 			];
 
-			if (fdsView.fdsFiltersOrder) {
-				const order = fdsView.fdsFiltersOrder.split(',');
-
-				let notOrdered: FilterCollection = [];
-
-				notOrdered = filtersOrdered.filter(
-					(filter) => !order.includes(String(filter.id))
-				);
-
-				filtersOrdered = fdsView.fdsFiltersOrder
-					.split(',')
-					.map((fdsFilterId) =>
-						filtersOrdered.find(
-							(filter) => filter.id === Number(fdsFilterId)
-						)
-					)
-					.filter(Boolean) as FilterCollection;
-
-				filtersOrdered = [...notOrdered, ...filtersOrdered];
-			}
+			filtersOrdered = sortItems(
+				filtersOrdered,
+				fdsView.fdsFiltersOrder,
+				true
+			) as FilterCollection;
 
 			setFilters(
 				filtersOrdered.map((filter) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -561,9 +561,14 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 		const storedFDSFiltersOrder = responseJSON?.fdsFiltersOrder;
 
 		if (
+			filters &&
 			storedFDSFiltersOrder &&
 			storedFDSFiltersOrder === fdsFiltersOrder
 		) {
+			setFilters(
+				sortItems(filters, storedFDSFiltersOrder, true) as FilterCollection
+			);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -36,7 +36,7 @@ import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
 
 import sortItems from '../../../utils/sortItems';
-import {EFieldType, IFDSField, IOrderable} from '../../../utils/types';
+import {EFieldType, IFDSField} from '../../../utils/types';
 import AddFieldsModalContent from './modal_content/AddFieldsModalContent';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
@@ -466,15 +466,13 @@ function Table({
 
 		const storedFDSFieldsOrder = responseJSON?.fdsFieldsOrder;
 
-		const storedFDSFields = fdsFields;
-
 		if (
-			storedFDSFields &&
+			fdsFields &&
 			storedFDSFieldsOrder &&
 			storedFDSFieldsOrder === fdsFieldsOrder
 		) {
 			setFDSFields(
-				sortItems(storedFDSFields, fdsFieldsOrder) as IFDSField[]
+				sortItems(fdsFields, storedFDSFieldsOrder) as IFDSField[]
 			);
 
 			openDefaultSuccessToast();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -35,7 +35,8 @@ import '../../../../css/TableVisualizationMode.scss';
 import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
 
-import {EFieldType, IFDSField} from '../../../utils/types';
+import sortItems from '../../../utils/sortItems';
+import {EFieldType, IFDSField, IOrderable} from '../../../utils/types';
 import AddFieldsModalContent from './modal_content/AddFieldsModalContent';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
@@ -356,38 +357,6 @@ function Table({
 }: IFDSViewSectionProps & {title?: string}) {
 	const [fdsFields, setFDSFields] = useState<Array<IFDSField> | null>(null);
 
-	const reorderFDSFields = ({
-		fdsFieldsOrder,
-		storedFDSFields,
-	}: {
-		fdsFieldsOrder: string;
-		storedFDSFields: Array<IFDSField>;
-	}): Array<IFDSField> => {
-		const storedOrderedFDSFieldIds = fdsFieldsOrder.split(',');
-
-		const orderedFDSFields: Array<IFDSField> = [];
-
-		const orderedFDSFieldIds: Array<number> = [];
-
-		storedOrderedFDSFieldIds.forEach((fdsFieldId: string) => {
-			storedFDSFields.forEach((storedFDSField: IFDSField) => {
-				if (fdsFieldId === String(storedFDSField.id)) {
-					orderedFDSFields.push(storedFDSField);
-
-					orderedFDSFieldIds.push(storedFDSField.id);
-				}
-			});
-		});
-
-		storedFDSFields.forEach((storedFDSField: IFDSField) => {
-			if (!orderedFDSFieldIds.includes(storedFDSField.id)) {
-				orderedFDSFields.push(storedFDSField);
-			}
-		});
-
-		return orderedFDSFields;
-	};
-
 	const getFDSFields = async () => {
 		const response = await fetch(
 			`${API_URL.FDS_FIELDS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD}`
@@ -401,7 +370,7 @@ function Table({
 
 		const responseJSON = await response.json();
 
-		const storedFDSFields = responseJSON?.items;
+		const storedFDSFields: IFDSField[] = responseJSON?.items;
 
 		if (!storedFDSFields) {
 			openDefaultFailureToast();
@@ -410,20 +379,13 @@ function Table({
 		}
 
 		const fdsFieldsOrder =
+
+			// @ts-ignore
+
 			storedFDSFields?.[0]?.[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD]
 				?.fdsFieldsOrder;
 
-		if (fdsFieldsOrder) {
-			const orderedFDSFields = reorderFDSFields({
-				fdsFieldsOrder,
-				storedFDSFields,
-			});
-
-			setFDSFields(orderedFDSFields);
-		}
-		else {
-			setFDSFields(storedFDSFields);
-		}
+		setFDSFields(sortItems(storedFDSFields, fdsFieldsOrder) as IFDSField[]);
 	};
 
 	const handleDelete = ({item}: {item: IFDSField}) => {
@@ -511,12 +473,9 @@ function Table({
 			storedFDSFieldsOrder &&
 			storedFDSFieldsOrder === fdsFieldsOrder
 		) {
-			const orderedFDSFields = reorderFDSFields({
-				fdsFieldsOrder,
-				storedFDSFields,
-			});
-
-			setFDSFields(orderedFDSFields);
+			setFDSFields(
+				sortItems(storedFDSFields, fdsFieldsOrder) as IFDSField[]
+			);
 
 			openDefaultSuccessToast();
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/sortItems.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/sortItems.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IOrderable} from './types';
+
+/**
+ * sorts the provided items array according to the itemsOrder comma-separated list of ids.
+ * If array contains items not included in the list of ids, then those are appended after
+ * Example:
+ * 		items = [ {id: 1}, {id: 4}, {id: 2}, {id: 3} ]
+ * 		itemsOrder = "2, 3, 1"
+ * 		output is [ {id: 2}, {id: 3}, {id: 1}, {id: 4} ]
+ * Optionally, not included items can be sorted by creation date
+ *
+ * @param items {IOrderable[]}
+ * @param itemsOrder {string}
+ * @param useCreationDate {boolean}
+ * @returns {Array}
+ */
+export default function sortItems(
+	items: IOrderable[],
+	itemsOrder: string,
+	useCreationDate: boolean = false
+): IOrderable[] {
+	const itemsOrderArray = itemsOrder?.split(',') || ([] as string[]);
+
+	let included: IOrderable[] = [];
+	let notIncluded: IOrderable[] = [];
+
+	included = itemsOrderArray
+		.map((itemId) => items.find((item) => item.id === Number(itemId)))
+		.filter(Boolean) as IOrderable[];
+
+	notIncluded = items.filter(
+		(item) => !itemsOrderArray.includes(String(item.id))
+	);
+
+	if (useCreationDate) {
+		const notIncludedIdsMap = {} as {[key: number]: number};
+
+		notIncluded.forEach((item) => {
+			notIncludedIdsMap[item.id] = Date.parse(item.dateCreated);
+		});
+
+		notIncluded = notIncluded.sort((item1, item2) =>
+			notIncludedIdsMap[item1.id] > notIncludedIdsMap[item2.id]
+				? 1
+				: notIncludedIdsMap[item1.id] < notIncludedIdsMap[item2.id]
+				? -1
+				: 0
+		);
+	}
+
+	return [...included, ...notIncluded];
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -48,10 +48,9 @@ export interface IField {
 	visible?: boolean;
 }
 
-export interface IFDSField {
+export interface IFDSField extends IOrderable {
 	contextPath: string;
 	externalReferenceCode: string;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	name: string;
@@ -61,10 +60,9 @@ export interface IFDSField {
 	type: string;
 }
 
-export interface IFilter {
+export interface IFilter extends IOrderable {
 	fieldName: string;
 	filterType?: EFilterType;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	type: string;
@@ -84,6 +82,11 @@ export interface ISelectionFilter extends IFilter {
 	listTypeDefinitionERC: string;
 	multiple: boolean;
 	preselectedValues: string;
+}
+
+export interface IOrderable {
+	dateCreated: string;
+	id: number;
 }
 
 export interface IPickList {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
@@ -8,6 +8,7 @@
 import {IFDSViewSectionProps} from '../FDSView';
 import {OBJECT_RELATIONSHIP} from '../utils/constants';
 import '../../css/Actions.scss';
+import {IOrderable} from '../utils/types';
 declare const SECTIONS: {
 	CREATION_ACTIONS: string;
 	EDIT_CREATION_ACTION: string;
@@ -16,7 +17,7 @@ declare const SECTIONS: {
 	NEW_CREATION_ACTION: string;
 	NEW_ITEM_ACTION: string;
 };
-interface IFDSAction {
+interface IFDSAction extends IOrderable {
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_CREATION_ACTION]?: any;
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_ITEM_ACTION]?: any;
 	actions: {
@@ -35,7 +36,6 @@ interface IFDSAction {
 		[key: string]: string;
 	};
 	icon: string;
-	id: number;
 	label: string;
 	label_i18n: {
 		[key: string]: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/sortItems.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/sortItems.d.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IOrderable} from './types';
+
+/**
+ * sorts the provided items array according to the itemsOrder comma-separated list of ids.
+ * If array contains items not included in the list of ids, then those are appended after
+ * Example:
+ * 		items = [ {id: 1}, {id: 4}, {id: 2}, {id: 3} ]
+ * 		itemsOrder = "2, 3, 1"
+ * 		output is [ {id: 2}, {id: 3}, {id: 1}, {id: 4} ]
+ * Optionally, not included items can be sorted by creation date
+ *
+ * @param items {IOrderable[]}
+ * @param itemsOrder {string}
+ * @param useCreationDate {boolean}
+ * @returns {Array}
+ */
+export default function sortItems(
+	items: IOrderable[],
+	itemsOrder: string,
+	useCreationDate?: boolean
+): IOrderable[];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -40,10 +40,9 @@ export interface IField {
 	type?: string;
 	visible?: boolean;
 }
-export interface IFDSField {
+export interface IFDSField extends IOrderable {
 	contextPath: string;
 	externalReferenceCode: string;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	name: string;
@@ -52,10 +51,9 @@ export interface IFDSField {
 	sortable: boolean;
 	type: string;
 }
-export interface IFilter {
+export interface IFilter extends IOrderable {
 	fieldName: string;
 	filterType?: EFilterType;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	type: string;
@@ -72,6 +70,10 @@ export interface ISelectionFilter extends IFilter {
 	listTypeDefinitionERC: string;
 	multiple: boolean;
 	preselectedValues: string;
+}
+export interface IOrderable {
+	dateCreated: string;
+	id: number;
 }
 export interface IPickList {
 	externalReferenceCode: string;


### PR DESCRIPTION
In this draft PR we want to showcase a different way to manage sort in various lists of items in the DSM. (see https://github.com/liferay-frontend/liferay-portal/pull/4158 as the starting point of this)

Basic idea:
* When adding a new item, we add it to the bottom of the list
* We don't store item order unless user changes it via drag/drop
* Items that are not referred to in ther `order` field will be sorted by `createDate`
* Previous sort holds in the DSM UI and in the fragment

This way we don't need to update order field when creating a new Action, Filter or Sort (neither when deleting)