### PR TITLE
LPD-24865 - Add boilerplate project for using node build scripts directly in portal

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -27,6 +27,7 @@ config = {
 		MODULE_PATH: true,
 	},
 	rules: {
+		'@liferay/import-extensions': 'off',
 		'@liferay/no-extraneous-dependencies': [
 			'error',
 			[

--- a/modules/node-scripts/bin.js
+++ b/modules/node-scripts/bin.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {main} from './index.js';
+
+main().catch((error) => {
+	// eslint-disable-next-line no-console
+	console.log(error);
+
+	process.exit(1);
+});

--- a/modules/node-scripts/index.js
+++ b/modules/node-scripts/index.js
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import minimist from 'minimist';
+
+export async function main() {
+	const ARGS_ARRAY = process.argv.slice(2);
+
+	const {
+		_: [type],
+	} = minimist(ARGS_ARRAY);
+
+	// eslint-disable-next-line no-console
+	console.log(`You ran '${type}'!`);
+}

--- a/modules/node-scripts/package.json
+++ b/modules/node-scripts/package.json
@@ -1,0 +1,12 @@
+{
+	"bin": {
+		"node-scripts": "./bin.js"
+	},
+	"dependencies": {
+		"minimist": "^1.2.8"
+	},
+	"main": "index.js",
+	"name": "@liferay/node-scripts",
+	"type": "module",
+	"version": "1.0.0"
+}

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -839,6 +839,7 @@ module.exports = {
 			'webpack',
 			'alloy-ui',
 			'react-dnd-test-utils',
+			'minimist',
 		],
 	},
 };

--- a/modules/package.json
+++ b/modules/package.json
@@ -35,7 +35,8 @@
 			"apps/*/*/*",
 			"dxp/apps/*/*",
 			"dxp/apps/*/!(osb-faro/osb-faro-web)*/*",
-			"dxp/apps/osb/*/!(osb-faro/osb-faro-web)*/*"
+			"dxp/apps/osb/*/!(osb-faro/osb-faro-web)*/*",
+			"node-scripts"
 		]
 	}
 }

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10356,6 +10356,11 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-24864

The long term goal is to move things from liferay-npm-scripts directly into liferay-portal and no longer have to import a separate npm package.

This npm project in liferay-portal allows us to call `yarn run node-scripts foo bar baz` from any module within portal without having to rely on an external npm package(`@liferay/npm-scripts`). 