### PR TITLE
LPD-23279 Order of FDS filters (and other items) may be inconsistent when created in DSM

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/fragment/renderer/FDSViewFragmentRenderer.java
@@ -347,25 +347,13 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		Set<ObjectEntry> objectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsCreationActionsOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSCreationActionRelationship"));
-
 		return JSONUtil.put(
 			"primaryItems",
 			JSONUtil.toJSONArray(
-				objectEntries,
+				_getSortedRelatedObjectEntries(
+					fdsViewObjectDefinition, fdsViewObjectEntry,
+					"fdsCreationActionsOrder",
+					"fdsViewFDSCreationActionRelationship"),
 				(ObjectEntry objectEntry) -> {
 					Map<String, Object> properties =
 						objectEntry.getProperties();
@@ -437,22 +425,9 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		Set<ObjectEntry> fdsFieldObjectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsFieldsOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		fdsFieldObjectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSFieldRelationship"));
-
-		return fdsFieldObjectEntries;
+		return _getSortedRelatedObjectEntries(
+			fdsViewObjectDefinition, fdsViewObjectEntry, "fdsFieldsOrder",
+			"fdsViewFDSFieldRelationship");
 	}
 
 	private JSONObject _getFDSListViewJSONObject(
@@ -580,31 +555,12 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			HttpServletRequest httpServletRequest)
 		throws Exception {
 
-		Set<ObjectEntry> objectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsFiltersOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSClientExtensionFilter"));
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSDateFilterRelationship"));
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSDynamicFilterRelationship"));
-
 		return JSONUtil.toJSONArray(
-			objectEntries,
+			_getSortedRelatedObjectEntries(
+				fdsViewObjectDefinition, fdsViewObjectEntry, "fdsFiltersOrder",
+				"fdsViewFDSClientExtensionFilter",
+				"fdsViewFDSDateFilterRelationship",
+				"fdsViewFDSDynamicFilterRelationship"),
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
@@ -761,23 +717,10 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
-		Set<ObjectEntry> objectEntries = new TreeSet<>(
-			new ObjectEntryComparator(
-				ListUtil.toList(
-					ListUtil.fromString(
-						MapUtil.getString(
-							fdsViewObjectEntry.getProperties(),
-							"fdsItemActionsOrder"),
-						StringPool.COMMA),
-					Long::parseLong)));
-
-		objectEntries.addAll(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
-				"fdsViewFDSItemActionRelationship"));
-
 		return JSONUtil.toJSONArray(
-			objectEntries,
+			_getSortedRelatedObjectEntries(
+				fdsViewObjectDefinition, fdsViewObjectEntry,
+				"fdsItemActionsOrder", "fdsViewFDSItemActionRelationship"),
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
@@ -965,14 +908,40 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 		return jsonArray;
 	}
 
+	private Set<ObjectEntry> _getSortedRelatedObjectEntries(
+			ObjectDefinition fdsViewObjectDefinition,
+			ObjectEntry fdsViewObjectEntry, String itemsOrderPropertyName,
+			String... relationshipNames)
+		throws Exception {
+
+		Set<ObjectEntry> objectEntries = new TreeSet<>(
+			new ObjectEntryComparator(
+				ListUtil.toList(
+					ListUtil.fromString(
+						MapUtil.getString(
+							fdsViewObjectEntry.getProperties(),
+							itemsOrderPropertyName),
+						StringPool.COMMA),
+					Long::parseLong)));
+
+		for (String relationshipName : relationshipNames) {
+			objectEntries.addAll(
+				_getRelatedObjectEntries(
+					fdsViewObjectDefinition, fdsViewObjectEntry,
+					relationshipName));
+		}
+
+		return objectEntries;
+	}
+
 	private JSONArray _getSortsJSONArray(
 			ObjectDefinition fdsViewObjectDefinition,
 			ObjectEntry fdsViewObjectEntry)
 		throws Exception {
 
 		return JSONUtil.toJSONArray(
-			_getRelatedObjectEntries(
-				fdsViewObjectDefinition, fdsViewObjectEntry,
+			_getSortedRelatedObjectEntries(
+				fdsViewObjectDefinition, fdsViewObjectEntry, "fdsSortsOrder",
 				"fdsViewFDSSortRelationship"),
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
@@ -1091,7 +1060,10 @@ public class FDSViewFragmentRenderer implements FragmentRenderer {
 			int index2 = _ids.indexOf(id2);
 
 			if ((index1 == -1) && (index2 == -1)) {
-				return Long.compare(id1, id2);
+				return objectEntry1.getDateCreated(
+				).compareTo(
+					objectEntry2.getDateCreated()
+				);
 			}
 
 			if (index1 == -1) {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -18,6 +18,8 @@ import ActionForm from './actions/ActionForm';
 import ActionList from './actions/ActionList';
 
 import '../../css/Actions.scss';
+import sortItems from '../utils/sortItems';
+import {IOrderable} from '../utils/types';
 
 const SECTIONS = {
 	CREATION_ACTIONS: 'creation-actions',
@@ -28,7 +30,7 @@ const SECTIONS = {
 	NEW_ITEM_ACTION: 'new-item-action',
 };
 
-interface IFDSAction {
+interface IFDSAction extends IOrderable {
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_CREATION_ACTION]?: any;
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_ITEM_ACTION]?: any;
 	actions: {
@@ -47,7 +49,6 @@ interface IFDSAction {
 		[key: string]: string;
 	};
 	icon: string;
-	id: number;
 	label: string;
 	label_i18n: {
 		[key: string]: string;
@@ -136,7 +137,7 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionProps) => {
 				? OBJECT_RELATIONSHIP.FDS_VIEW_FDS_ITEM_ACTION_ID
 				: OBJECT_RELATIONSHIP.FDS_VIEW_FDS_CREATION_ACTION_ID;
 
-		const url = `${API_URL.FDS_ACTIONS}?filter=(${relationshipID} eq '${fdsView.id}')&nestedFields=${relationShip}&sort=dateCreated:desc`;
+		const url = `${API_URL.FDS_ACTIONS}?filter=(${relationshipID} eq '${fdsView.id}')&nestedFields=${relationShip}&sort=dateCreated:asc`;
 
 		if (activeTab === 0) {
 			setActiveSection(SECTIONS.ITEM_ACTIONS);
@@ -159,33 +160,15 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionProps) => {
 
 		const storedFDSActions: IFDSAction[] = responseJSON.items;
 
-		let ordered = storedFDSActions;
-		let notOrdered: IFDSAction[] = [];
-
 		const actionTypeOrder =
 			activeTab === 0 ? 'fdsItemActionsOrder' : 'fdsCreationActionsOrder';
 
 		const fdsActionsOrder =
 			storedFDSActions?.[0]?.[relationShip]?.[actionTypeOrder];
 
-		if (fdsActionsOrder) {
-			const fdsActionsOrderArray = fdsActionsOrder.split(',') as string[];
-
-			ordered = fdsActionsOrderArray
-				.map((fdsActionId) =>
-					storedFDSActions.find(
-						(fdsAction) => fdsAction.id === Number(fdsActionId)
-					)
-				)
-				.filter(Boolean) as IFDSAction[];
-
-			notOrdered = storedFDSActions.filter(
-				(fdsAction) =>
-					!fdsActionsOrderArray.includes(String(fdsAction.id))
-			);
-		}
-
-		setFDSActions([...notOrdered, ...ordered]);
+		setFDSActions(
+			sortItems(storedFDSActions, fdsActionsOrder) as IFDSAction[]
+		);
 
 		setLoading(false);
 	};

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Actions.tsx
@@ -256,7 +256,15 @@ const Actions = ({fdsView, namespace, spritemap}: IFDSViewSectionProps) => {
 
 		const storedFDSActionsOrder = responseJSON?.[actionTypeOrder];
 
-		if (storedFDSActionsOrder && storedFDSActionsOrder === order) {
+		if (
+			fdsActions &&
+			storedFDSActionsOrder &&
+			storedFDSActionsOrder === order
+		) {
+			setFDSActions(
+				sortItems(fdsActions, storedFDSActionsOrder) as IFDSAction[]
+			);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -22,7 +22,8 @@ import {API_URL, OBJECT_RELATIONSHIP} from '../utils/constants';
 import getFields from '../utils/getFields';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
-import {IField} from '../utils/types';
+import sortItems from '../utils/sortItems';
+import {IField, IOrderable} from '../utils/types';
 
 interface IAddFDSSortModalContentInterface {
 	closeModal: Function;
@@ -37,11 +38,10 @@ interface IContentRendererProps {
 	query: string;
 }
 
-interface IFDSSort {
+interface IFDSSort extends IOrderable {
 	default: boolean;
 	externalReferenceCode: string;
 	fieldName: string;
-	id: number;
 	label: string;
 	label_i18n: Liferay.Language.LocalizedValue<string>;
 	orderType: string;
@@ -448,35 +448,19 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 	useEffect(() => {
 		const getFDSSort = async () => {
 			const response = await fetch(
-				`${API_URL.FDS_SORTS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT}&sort=dateCreated:desc`
+				`${API_URL.FDS_SORTS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT}&sort=dateCreated:asc`
 			);
 
 			const responseJSON = await response.json();
 
 			const storedFDSSorts: IFDSSort[] = responseJSON.items;
 
-			let ordered = storedFDSSorts;
-			let notOrdered: IFDSSort[] = [];
-
-			if (responseJSON.fdsSortsOrder) {
-				const fdsSortsOrderArray = responseJSON.fdsSortsOrder.split(
-					','
-				) as string[];
-
-				ordered = fdsSortsOrderArray
-					.map((fdsSortId) =>
-						storedFDSSorts.find(
-							(fdsSort) => fdsSort.id === Number(fdsSortId)
-						)
-					)
-					.filter(Boolean) as IFDSSort[];
-
-				notOrdered = storedFDSSorts.filter(
-					(filter) => !fdsSortsOrderArray.includes(String(filter.id))
-				);
-			}
-
-			setFDSSorts([...notOrdered, ...ordered]);
+			setFDSSorts(
+				sortItems(
+					storedFDSSorts,
+					responseJSON.fdsSortsOrder
+				) as IFDSSort[]
+			);
 
 			await getFields(fdsView).then((fields) => {
 				const nextFields = fields.filter((field) => field.sortable);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -589,7 +589,13 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 
 		const storedFDSSortsOrder = responseJSON?.fdsSortsOrder;
 
-		if (storedFDSSortsOrder && storedFDSSortsOrder === fdsSortsOrder) {
+		if (
+			fdsSorts &&
+			storedFDSSortsOrder &&
+			storedFDSSortsOrder === fdsSortsOrder
+		) {
+			setFDSSorts(sortItems(fdsSorts, storedFDSSortsOrder) as IFDSSort[]);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -458,7 +458,11 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 			setFDSSorts(
 				sortItems(
 					storedFDSSorts,
-					responseJSON.fdsSortsOrder
+
+					// @ts-ignore
+
+					storedFDSSorts?.[0]?.[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT]
+						?.fdsSortsOrder as string
 				) as IFDSSort[]
 			);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/SortingDeprecated.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/SortingDeprecated.tsx
@@ -21,7 +21,8 @@ import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../utils/constants';
 import getFields from '../utils/getFields';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
-import {IField} from '../utils/types';
+import sortItems from '../utils/sortItems';
+import {IField, IOrderable} from '../utils/types';
 
 interface IAddFDSSortModalContentInterface {
 	closeModal: Function;
@@ -35,10 +36,9 @@ interface IContentRendererProps {
 	query: string;
 }
 
-interface IFDSSort {
+interface IFDSSort extends IOrderable {
 	externalReferenceCode: string;
 	fieldName: string;
-	id: number;
 	sortingDirection: string;
 }
 
@@ -353,36 +353,23 @@ const SortingDeprecated = ({fdsView, namespace}: IFDSViewSectionProps) => {
 	useEffect(() => {
 		const getFDSSort = async () => {
 			const response = await fetch(
-				`${API_URL.FDS_SORTS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT}&sort=dateCreated:desc`
+				`${API_URL.FDS_SORTS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT}&sort=dateCreated:asc`
 			);
 
 			const responseJSON = await response.json();
 
 			const storedFDSSorts: IFDSSort[] = responseJSON.items;
 
-			let ordered = storedFDSSorts;
-			let notOrdered: IFDSSort[] = [];
+			setFDSSorts(
+				sortItems(
+					storedFDSSorts,
 
-			if (responseJSON.fdsSortsOrder) {
-				const fdsSortsOrderArray = responseJSON.fdsSortsOrder.split(
-					','
-				) as string[];
+					// @ts-ignore
 
-				ordered = fdsSortsOrderArray
-					.map((fdsSortId) =>
-						storedFDSSorts.find(
-							(fdsSort) => fdsSort.id === Number(fdsSortId)
-						)
-					)
-					.filter(Boolean) as IFDSSort[];
-
-				notOrdered = storedFDSSorts.filter(
-					(filter) => !fdsSortsOrderArray.includes(String(filter.id))
-				);
-			}
-
-			setFDSSorts([...notOrdered, ...ordered]);
-
+					storedFDSSorts?.[0]?.[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_SORT]
+						?.fdsSortsOrder as string
+				) as IFDSSort[]
+			);
 			setLoading(false);
 		};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/SortingDeprecated.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/SortingDeprecated.tsx
@@ -496,7 +496,13 @@ const SortingDeprecated = ({fdsView, namespace}: IFDSViewSectionProps) => {
 
 		const storedFDSSortsOrder = responseJSON?.fdsSortsOrder;
 
-		if (storedFDSSortsOrder && storedFDSSortsOrder === fdsSortsOrder) {
+		if (
+			fdsSorts &&
+			storedFDSSortsOrder &&
+			storedFDSSortsOrder === fdsSortsOrder
+		) {
+			setFDSSorts(sortItems(fdsSorts, storedFDSSortsOrder) as IFDSSort[]);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -41,6 +41,7 @@ import SelectionFilterModalContent from './modal_content/selection_filter/Select
 
 import '../../../css/Filters.scss';
 import RequiredMark from '../../components/RequiredMark';
+import sortItems from '../../utils/sortItems';
 
 type FilterCollection = Array<
 	IClientExtensionFilter | IDateFilter | ISelectionFilter
@@ -672,26 +673,11 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 				})),
 			];
 
-			if (fdsView.fdsFiltersOrder) {
-				const order = fdsView.fdsFiltersOrder.split(',');
-
-				let notOrdered: FilterCollection = [];
-
-				notOrdered = filtersOrdered.filter(
-					(filter) => !order.includes(String(filter.id))
-				);
-
-				filtersOrdered = fdsView.fdsFiltersOrder
-					.split(',')
-					.map((fdsFilterId) =>
-						filtersOrdered.find(
-							(filter) => filter.id === Number(fdsFilterId)
-						)
-					)
-					.filter(Boolean) as FilterCollection;
-
-				filtersOrdered = [...notOrdered, ...filtersOrdered];
-			}
+			filtersOrdered = sortItems(
+				filtersOrdered,
+				fdsView.fdsFiltersOrder,
+				true
+			) as FilterCollection;
 
 			setFilters(
 				filtersOrdered.map((filter) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -675,7 +675,7 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 
 			filtersOrdered = sortItems(
 				filtersOrdered,
-				fdsView.fdsFiltersOrder,
+				responseJSON.fdsFiltersOrder,
 				true
 			) as FilterCollection;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -728,9 +728,18 @@ function Filters({fdsFilterClientExtensions, fdsView, namespace}: IProps) {
 		const storedFDSFiltersOrder = responseJSON?.fdsFiltersOrder;
 
 		if (
+			filters &&
 			storedFDSFiltersOrder &&
 			storedFDSFiltersOrder === fdsFiltersOrder
 		) {
+			setFilters(
+				sortItems(
+					filters,
+					storedFDSFiltersOrder,
+					true
+				) as FilterCollection
+			);
+
 			openDefaultSuccessToast();
 		}
 		else {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
@@ -38,6 +38,7 @@ import '../../../../css/TableVisualizationMode.scss';
 import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
 
+import sortItems from '../../../utils/sortItems';
 import {
 	EFieldType,
 	IFDSField,
@@ -369,41 +370,9 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 	const [fdsFields, setFDSFields] = useState<Array<IFDSField> | null>(null);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
-	const reorderFDSFields = ({
-		fdsFieldsOrder,
-		storedFDSFields,
-	}: {
-		fdsFieldsOrder: string;
-		storedFDSFields: Array<IFDSField>;
-	}): Array<IFDSField> => {
-		const storedOrderedFDSFieldIds = fdsFieldsOrder.split(',');
-
-		const orderedFDSFields: Array<IFDSField> = [];
-
-		const orderedFDSFieldIds: Array<number> = [];
-
-		storedOrderedFDSFieldIds.forEach((fdsFieldId: string) => {
-			storedFDSFields.forEach((storedFDSField: IFDSField) => {
-				if (fdsFieldId === String(storedFDSField.id)) {
-					orderedFDSFields.push(storedFDSField);
-
-					orderedFDSFieldIds.push(storedFDSField.id);
-				}
-			});
-		});
-
-		storedFDSFields.forEach((storedFDSField: IFDSField) => {
-			if (!orderedFDSFieldIds.includes(storedFDSField.id)) {
-				orderedFDSFields.push(storedFDSField);
-			}
-		});
-
-		return orderedFDSFields;
-	};
-
 	const getFDSFields = async () => {
 		const response = await fetch(
-			`${API_URL.FDS_FIELDS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD}`
+			`${API_URL.FDS_FIELDS}?filter=(${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD_ID} eq '${fdsView.id}')&nestedFields=${OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD}&sort=dateCreated:asc`
 		);
 
 		if (!response.ok) {
@@ -414,7 +383,7 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 
 		const responseJSON = await response.json();
 
-		const storedFDSFields = responseJSON?.items;
+		const storedFDSFields: IFDSField[] = responseJSON?.items;
 
 		if (!storedFDSFields) {
 			openDefaultFailureToast();
@@ -423,20 +392,13 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 		}
 
 		const fdsFieldsOrder =
+
+			// @ts-ignore
+
 			storedFDSFields?.[0]?.[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_FIELD]
 				?.fdsFieldsOrder;
 
-		if (fdsFieldsOrder) {
-			const orderedFDSFields = reorderFDSFields({
-				fdsFieldsOrder,
-				storedFDSFields,
-			});
-
-			setFDSFields(orderedFDSFields);
-		}
-		else {
-			setFDSFields(storedFDSFields);
-		}
+		setFDSFields(sortItems(storedFDSFields, fdsFieldsOrder) as IFDSField[]);
 	};
 
 	const onDeleteButtonClick = ({item}: {item: IFDSField}) => {
@@ -603,12 +565,9 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 			storedFDSFieldsOrder &&
 			storedFDSFieldsOrder === fdsFieldsOrder
 		) {
-			const orderedFDSFields = reorderFDSFields({
-				fdsFieldsOrder,
-				storedFDSFields,
-			});
-
-			setFDSFields(orderedFDSFields);
+			setFDSFields(
+				sortItems(storedFDSFields, fdsFieldsOrder) as IFDSField[]
+			);
 
 			openDefaultSuccessToast();
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
@@ -558,15 +558,13 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 
 		const storedFDSFieldsOrder = responseJSON?.fdsFieldsOrder;
 
-		const storedFDSFields = fdsFields;
-
 		if (
-			storedFDSFields &&
+			fdsFields &&
 			storedFDSFieldsOrder &&
 			storedFDSFieldsOrder === fdsFieldsOrder
 		) {
 			setFDSFields(
-				sortItems(storedFDSFields, fdsFieldsOrder) as IFDSField[]
+				sortItems(fdsFields, storedFDSFieldsOrder) as IFDSField[]
 			);
 
 			openDefaultSuccessToast();

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/sortItems.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/sortItems.ts
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IOrderable} from './types';
+
+/**
+ * sorts the provided items array according to the itemsOrder comma-separated list of ids.
+ * If array contains items not included in the list of ids, then those are appended after
+ * Example:
+ * 		items = [ {id: 1}, {id: 4}, {id: 2}, {id: 3} ]
+ * 		itemsOrder = "2, 3, 1"
+ * 		output is [ {id: 2}, {id: 3}, {id: 1}, {id: 4} ]
+ * Optionally, not included items can be sorted by creation date
+ *
+ * @param items {IOrderable[]}
+ * @param itemsOrder {string}
+ * @param useCreationDate {boolean}
+ * @returns {Array}
+ */
+export default function sortItems(
+	items: IOrderable[],
+	itemsOrder: string,
+	useCreationDate: boolean = false
+): IOrderable[] {
+	const itemsOrderArray = itemsOrder?.split(',') || ([] as string[]);
+
+	let included: IOrderable[] = [];
+	let notIncluded: IOrderable[] = [];
+
+	included = itemsOrderArray
+		.map((itemId) => items.find((item) => item.id === Number(itemId)))
+		.filter(Boolean) as IOrderable[];
+
+	notIncluded = items.filter(
+		(item) => !itemsOrderArray.includes(String(item.id))
+	);
+
+	if (useCreationDate) {
+		const creationDates = {} as {[key: number]: number};
+
+		notIncluded.forEach((item) => {
+			creationDates[item.id] = Date.parse(item.dateCreated);
+		});
+
+		notIncluded = notIncluded.sort(
+			(item1, item2) => creationDates[item1.id] - creationDates[item2.id]
+		);
+	}
+
+	return [...included, ...notIncluded];
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -53,10 +53,9 @@ export interface IField {
 	visible?: boolean;
 }
 
-export interface IFDSField {
+export interface IFDSField extends IOrderable {
 	contextPath: string;
 	externalReferenceCode: string;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	name: string;
@@ -74,10 +73,9 @@ export interface IFieldTreeItem extends IField {
 	selected?: boolean;
 }
 
-export interface IFilter {
+export interface IFilter extends IOrderable {
 	fieldName: string;
 	filterType?: EFilterType;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	type: string;
@@ -98,6 +96,11 @@ export interface ISelectionFilter extends IFilter {
 	preselectedValues: string;
 	source: string;
 	sourceType: ESelectionFilterSourceType;
+}
+
+export interface IOrderable {
+	dateCreated: string;
+	id: number;
 }
 
 export interface IPickList {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/fds_view/Actions.d.ts
@@ -8,6 +8,7 @@
 import {IFDSViewSectionProps} from '../FDSView';
 import {OBJECT_RELATIONSHIP} from '../utils/constants';
 import '../../css/Actions.scss';
+import {IOrderable} from '../utils/types';
 declare const SECTIONS: {
 	CREATION_ACTIONS: string;
 	EDIT_CREATION_ACTION: string;
@@ -16,7 +17,7 @@ declare const SECTIONS: {
 	NEW_CREATION_ACTION: string;
 	NEW_ITEM_ACTION: string;
 };
-interface IFDSAction {
+interface IFDSAction extends IOrderable {
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_CREATION_ACTION]?: any;
 	[OBJECT_RELATIONSHIP.FDS_VIEW_FDS_ITEM_ACTION]?: any;
 	actions: {
@@ -35,7 +36,6 @@ interface IFDSAction {
 		[key: string]: string;
 	};
 	icon: string;
-	id: number;
 	label: string;
 	label_i18n: {
 		[key: string]: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/sortItems.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/sortItems.d.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IOrderable} from './types';
+
+/**
+ * sorts the provided items array according to the itemsOrder comma-separated list of ids.
+ * If array contains items not included in the list of ids, then those are appended after
+ * Example:
+ * 		items = [ {id: 1}, {id: 4}, {id: 2}, {id: 3} ]
+ * 		itemsOrder = "2, 3, 1"
+ * 		output is [ {id: 2}, {id: 3}, {id: 1}, {id: 4} ]
+ * Optionally, not included items can be sorted by creation date
+ *
+ * @param items {IOrderable[]}
+ * @param itemsOrder {string}
+ * @param useCreationDate {boolean}
+ * @returns {Array}
+ */
+export default function sortItems(
+	items: IOrderable[],
+	itemsOrder: string,
+	useCreationDate?: boolean
+): IOrderable[];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -44,10 +44,9 @@ export interface IField {
 	type?: string;
 	visible?: boolean;
 }
-export interface IFDSField {
+export interface IFDSField extends IOrderable {
 	contextPath: string;
 	externalReferenceCode: string;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	name: string;
@@ -63,10 +62,9 @@ export interface IFieldTreeItem extends IField {
 	savedId?: string;
 	selected?: boolean;
 }
-export interface IFilter {
+export interface IFilter extends IOrderable {
 	fieldName: string;
 	filterType?: EFilterType;
-	id: number;
 	label: string;
 	label_i18n: LocalizedValue<string>;
 	type: string;
@@ -84,6 +82,10 @@ export interface ISelectionFilter extends IFilter {
 	preselectedValues: string;
 	source: string;
 	sourceType: ESelectionFilterSourceType;
+}
+export interface IOrderable {
+	dateCreated: string;
+	id: number;
 }
 export interface IPickList {
 	externalReferenceCode: string;


### PR DESCRIPTION
### References
 * https://liferay.atlassian.net/browse/LPD-23279
 * https://liferay.atlassian.net/issues/LPD-24088
 * https://liferay.atlassian.net/issues/LPD-17876

This PR completes https://github.com/liferay-frontend/liferay-portal/pull/4165 draft. Proposal manages an order of items in various lists administered via DSM: mapped table fields, filters, creation actions, item actions and sorts. In all these lists, DSM admin creates/deletes items and can specify a **relative order** between them, which is saved in the Data Set View object.

### Main goals

- To avoid 2 requests when items are added/deleted (one for the item and other to update the relative order)
- To ensure Fragment renders the items in the order shown in the DSM

This means relative order might not be in sync with current list of items, thus becoming a [partial order](https://en.wikipedia.org/wiki/Partially_ordered_set)

### How it works

For all of them, we define a [total order](https://en.wikipedia.org/wiki/Total_order) convention as follows:

- When adding a new item, it is added to the *bottom* of the list. So, newest items are the last ones.
- Relative item order is only persisted when user changes it via drag/drop. This is how it works now.
- Items that are not referred to in the relative order will be sorted by `createDate`
- Convention holds both in the DSM UI and in the fragment logic that prepares FDS configuration.

In short, when relative item order is available, it's used. Otherwise, `createDate` dictates item order. Note relative order is total when updated, however, items can be added later on, turning it into a partial order.

In this PR we also ensure this convention is consistently applied both in the DSM and in the fragment. In doing so, we pay special attention to the react component state because it has to be re-set whenever component is rendered. This includes the moment when relative order is persisted and when items are re-fetched. In both cases, current value of relative order must be used even if the FDSView containing it has not been re-fetched yet.

### How it looks like

Any list can be manipulated at will. DSM UI keeps the right state and so does fragment.

Example with table fields

[fields-order-2024-05-06_16.24.46.webm](https://github.com/liferay-frontend/liferay-portal/assets/861014/64f9aa41-e0fd-42f9-bcc5-544748f215f9)

Example with item actions

[item-actions-order-2024-05-06_16.26.12-sampled.webm](https://github.com/liferay-frontend/liferay-portal/assets/861014/1808fe6b-82d1-4519-9e52-0de6b3d3f1c0)

### Additional notes

Tests will be added in a separate task (likely https://liferay.atlassian.net/browse/LPD-20895 to centralize effort)

@markocikos @juanjofgliferay  @fortunatomaldonado @thektan