### PR TITLE
LPD-24865 - Add boilerplate project for using node build scripts directly in portal

### DIFF
--- a/modules/.eslintrc.js
+++ b/modules/.eslintrc.js
@@ -27,6 +27,7 @@ config = {
 		MODULE_PATH: true,
 	},
 	rules: {
+		'@liferay/import-extensions': 'off',
 		'@liferay/no-extraneous-dependencies': [
 			'error',
 			[

--- a/modules/_node-scripts/bin.js
+++ b/modules/_node-scripts/bin.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {main} from './index.js';
+
+main().catch((error) => {
+	// eslint-disable-next-line no-console
+	console.log(error);
+
+	process.exit(1);
+});

--- a/modules/_node-scripts/index.js
+++ b/modules/_node-scripts/index.js
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import minimist from 'minimist';
+
+export async function main() {
+	const ARGS_ARRAY = process.argv.slice(2);
+
+	const {
+		_: [type],
+	} = minimist(ARGS_ARRAY);
+
+	// eslint-disable-next-line no-console
+	console.log(`You ran '${type}'!`);
+}

--- a/modules/_node-scripts/package.json
+++ b/modules/_node-scripts/package.json
@@ -5,7 +5,7 @@
 	"dependencies": {
 		"minimist": "^1.2.8"
 	},
-	"main": "index.js",
+	"exports": "./index.js",
 	"name": "@liferay/node-scripts",
 	"type": "module",
 	"version": "1.0.0"

--- a/modules/_node-scripts/package.json
+++ b/modules/_node-scripts/package.json
@@ -1,0 +1,12 @@
+{
+	"bin": {
+		"node-scripts": "./bin.js"
+	},
+	"dependencies": {
+		"minimist": "^1.2.8"
+	},
+	"main": "index.js",
+	"name": "@liferay/node-scripts",
+	"type": "module",
+	"version": "1.0.0"
+}

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -782,64 +782,34 @@ module.exports = {
 			'youtube-web',
 		],
 		'allowed-non-global-dependencies': [
+			'@liferay/npm-scripts',
+			'@vscode/ripgrep',
+			'alloy-ui',
+			'axios',
+			'browser-tabs-lock',
+			'ckeditor4',
 			'codemirror',
+			'core-js',
 			'd3',
+			'es-module-shims',
+			'fetch-mock',
+			'fs',
+			'gulp',
+			'hash.js',
 			'history',
 			'jest-fetch-mock',
-			'fetch-mock',
-			'gulp',
-			'liferay-theme-tasks',
-			'ckeditor4',
-			'alloy-ui',
-			'resize-observer-polyfill',
-			'webpack',
-			'react-dnd-test-utils',
-			'fs',
-
-			// Dependencies not expected to be shared
-
-			'@vscode/ripgrep',
-			'es-module-shims',
-			'liferay-font-awesome',
-			'swagger-ui-react',
-
-			// Needs to be removed
-
-			'axios',
-
-			// Causes bugs
-
-			'path-to-regexp',
-
-			// Doesn't support ESM
-
 			'leaflet',
-
-			// Node Shims
-
+			'liferay-font-awesome',
+			'liferay-theme-tasks',
+			'minimist',
 			'os-browserify',
 			'path-browserify',
-			'timers-browserify',
-
-			// Analytics Client Bundle
-
-			'browser-tabs-lock',
-			'hash.js',
-			'core-js',
-
-			'jest-fetch-mock',
-			'fetch-mock',
-			'gulp',
-			'liferay-theme-tasks',
-			'history',
-			'resize-observer-polyfill',
-			'ckeditor4',
-			'fetch-mock',
-			'@liferay/npm-scripts',
-			'webpack',
-			'alloy-ui',
+			'path-to-regexp',
 			'react-dnd-test-utils',
-			'minimist',
+			'resize-observer-polyfill',
+			'swagger-ui-react',
+			'timers-browserify',
+			'webpack',
 		],
 	},
 };

--- a/modules/npmscripts.config.js
+++ b/modules/npmscripts.config.js
@@ -839,6 +839,7 @@ module.exports = {
 			'webpack',
 			'alloy-ui',
 			'react-dnd-test-utils',
+			'minimist',
 		],
 	},
 };

--- a/modules/package.json
+++ b/modules/package.json
@@ -35,7 +35,8 @@
 			"apps/*/*/*",
 			"dxp/apps/*/*",
 			"dxp/apps/*/!(osb-faro/osb-faro-web)*/*",
-			"dxp/apps/osb/*/!(osb-faro/osb-faro-web)*/*"
+			"dxp/apps/osb/*/!(osb-faro/osb-faro-web)*/*",
+			"_node-scripts"
 		]
 	}
 }

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -10356,6 +10356,11 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+minimist@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 minipass@^2.2.1, minipass@^2.3.4:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"


### PR DESCRIPTION
The two options discussed for placement were
- tools/sdk/node-scripts
- modules/_node-scripts

The first location _did work_ with yarn and it handled it appropriately, however there was going to be a redundancy of configuration. Once we dropped below `./modules` we would need to set up SF all over again and add the same configs and ignores that we have in `./modules`. By having it at the same level as our root `package.json`, we can ensure we pick up the same configs and also have access to the root node_modules.