### PR TITLE
LPD-24197 - Prevent complex object/array fields to be sortable

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -20,7 +20,6 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.io.Serializable;
@@ -70,8 +69,6 @@ public class SaveFDSFieldsMVCResourceCommand
 			JSONObject creationDataJSONObject =
 				creationDataJSONArray.getJSONObject(i);
 
-			String type = String.valueOf(creationDataJSONObject.get("type"));
-
 			ObjectEntry objectEntry = _objectEntryService.addObjectEntry(
 				0, objectDefinition.getObjectDefinitionId(),
 				HashMapBuilder.<String, Serializable>put(
@@ -87,9 +84,9 @@ public class SaveFDSFieldsMVCResourceCommand
 				).put(
 					"renderer", "default"
 				).put(
-					"sortable", !StringUtil.equals(type, "object")
+					"sortable", (Boolean)creationDataJSONObject.get("sortable")
 				).put(
-					"type", type
+					"type", String.valueOf(creationDataJSONObject.get("type"))
 				).build(),
 				new ServiceContext());
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -11,7 +11,6 @@ import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {FDSViewType} from './FDSViews';
-import {getFields} from './api';
 import Actions from './fds_view/Actions';
 import Details from './fds_view/Details';
 import Pagination from './fds_view/Pagination';
@@ -21,6 +20,7 @@ import SortingDeprecated from './fds_view/SortingDeprecated';
 import Filters from './fds_view/filters/Filters';
 import VisualizationModes from './fds_view/visualization_modes/VisualizationModes';
 import {API_URL, OBJECT_RELATIONSHIP} from './utils/constants';
+import getFields from './utils/getFields';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 import {IFieldTreeItem} from './utils/types';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -65,12 +65,12 @@ interface IFDSViewSectionProps {
 	fdsFilterClientExtensions: IClientExtensionRenderer[];
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
+	fieldTreeItems: Array<IFieldTreeItem>;
 	namespace: string;
 	onActiveSectionChange: (section: number) => void;
 	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 	spritemap: string;
-	treeItems: Array<IFieldTreeItem>;
 }
 
 interface IFDSViewProps {
@@ -94,8 +94,10 @@ const FDSView = ({
 }: IFDSViewProps) => {
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
+	const [fieldTreeItems, setFieldTreeItems] = useState<Array<IFieldTreeItem>>(
+		[]
+	);
 	const [loading, setLoading] = useState(true);
-	const [treeItems, setTreeItems] = useState<Array<IFieldTreeItem>>([]);
 
 	useEffect(() => {
 		const getFDSView = async () => {
@@ -114,7 +116,7 @@ const FDSView = ({
 				setFDSView(responseJSON);
 
 				getFields(responseJSON).then((fields) => {
-					setTreeItems(fields);
+					setFieldTreeItems(fields);
 
 					setLoading(false);
 				});
@@ -157,6 +159,7 @@ const FDSView = ({
 						fdsFilterClientExtensions={fdsFilterClientExtensions}
 						fdsView={fdsView}
 						fdsViewsURL={fdsViewsURL}
+						fieldTreeItems={fieldTreeItems}
 						namespace={namespace}
 						onActiveSectionChange={(tab) => setActiveIndex(tab)}
 						onFDSViewUpdate={(updatedFdsViewData) => {
@@ -164,7 +167,6 @@ const FDSView = ({
 						}}
 						saveFDSFieldsURL={saveFDSFieldsURL}
 						spritemap={spritemap}
-						treeItems={treeItems}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/FDSView.tsx
@@ -11,6 +11,7 @@ import {fetch} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {FDSViewType} from './FDSViews';
+import {getFields} from './api';
 import Actions from './fds_view/Actions';
 import Details from './fds_view/Details';
 import Pagination from './fds_view/Pagination';
@@ -21,6 +22,7 @@ import Filters from './fds_view/filters/Filters';
 import VisualizationModes from './fds_view/visualization_modes/VisualizationModes';
 import {API_URL, OBJECT_RELATIONSHIP} from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
+import {IFieldTreeItem} from './utils/types';
 
 const NAVIGATION_BAR_ITEMS = [
 	{
@@ -68,6 +70,7 @@ interface IFDSViewSectionProps {
 	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 	spritemap: string;
+	treeItems: Array<IFieldTreeItem>;
 }
 
 interface IFDSViewProps {
@@ -92,6 +95,7 @@ const FDSView = ({
 	const [activeIndex, setActiveIndex] = useState(0);
 	const [fdsView, setFDSView] = useState<FDSViewType>();
 	const [loading, setLoading] = useState(true);
+	const [treeItems, setTreeItems] = useState<Array<IFieldTreeItem>>([]);
 
 	useEffect(() => {
 		const getFDSView = async () => {
@@ -109,7 +113,11 @@ const FDSView = ({
 			if (responseJSON?.id) {
 				setFDSView(responseJSON);
 
-				setLoading(false);
+				getFields(responseJSON).then((fields) => {
+					setTreeItems(fields);
+
+					setLoading(false);
+				});
 			}
 			else {
 				openDefaultFailureToast();
@@ -156,6 +164,7 @@ const FDSView = ({
 						}}
 						saveFDSFieldsURL={saveFDSFieldsURL}
 						spritemap={spritemap}
+						treeItems={treeItems}
 					/>
 				)
 			)}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -78,6 +78,7 @@ function getValidFields({
 					}),
 					label: propertyKey,
 					name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
+					sortable: false,
 					type: type ? type : 'array',
 				});
 
@@ -93,6 +94,7 @@ function getValidFields({
 					}),
 					label: propertyKey,
 					name: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`,
+					sortable: false,
 					type: type ? type : 'object',
 				});
 
@@ -120,6 +122,7 @@ function getValidFields({
 						}),
 						label: propertyKey,
 						name: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`,
+						sortable: false,
 						type: schemas[parentSchemaName[0]]?.type || 'object',
 					});
 
@@ -131,6 +134,11 @@ function getValidFields({
 				format: propertyValue.format,
 				label: propertyKey,
 				name: `${contextPath}${propertyKey}`,
+				sortable:
+					type !== 'object' &&
+					type !== 'array' &&
+					!contextPath.includes(FDS_NESTED_FIELD_NAME_DELIMITER) &&
+					!contextPath.includes(FDS_ARRAY_FIELD_NAME_DELIMITER),
 				type,
 			});
 		});

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -15,21 +15,12 @@ import {sub} from 'frontend-js-web';
 import React, {ComponentProps, useEffect, useState} from 'react';
 
 import {FDSViewType} from '../FDSViews';
-import {getFields} from '../api';
-import {IField} from '../utils/types';
+import {IField, IFieldTreeItem} from '../utils/types';
 import AutoSearch from './AutoSearch';
 
 import '../../css/components/FieldSelectModalContent.scss';
 
-interface IFieldTreeItem extends IField {
-	children?: IFieldTreeItem[];
-	initialChildren?: IFieldTreeItem[];
-	query?: string;
-	savedId?: string;
-	selected?: boolean;
-}
-
-function visit(fields: Array<IFieldTreeItem>, callback: Function) {
+export function visit(fields: Array<IFieldTreeItem>, callback: Function) {
 	fields.forEach((field) => {
 		callback(field);
 
@@ -170,11 +161,11 @@ const Highlight = ({query, text}: {query?: string; text?: string}) => {
 
 const FieldSelectModalContent = ({
 	closeModal,
-	fdsView,
 	onSaveButtonClick,
 	saveButtonDisabled,
 	selectedFields,
 	selectionMode = 'single',
+	treeItems,
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
@@ -186,10 +177,11 @@ const FieldSelectModalContent = ({
 	saveButtonDisabled: boolean;
 	selectedFields: Array<IField>;
 	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
+	treeItems: Array<IFieldTreeItem>;
 }) => {
 	const [initialFields, setInitialFields] = useState<Array<
 		IFieldTreeItem
-	> | null>(null);
+	> | null>(treeItems);
 	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
 		new Set<React.Key>()
 	);
@@ -200,19 +192,16 @@ const FieldSelectModalContent = ({
 	const [expandedKeys, setExpandedKeys] = useState<Array<React.Key>>([]);
 
 	useEffect(() => {
-		getFields(fdsView).then((fields) => {
-			if (fields) {
-				const [initialSelectedKeys, updatedFields] = initializeFields({
-					fields,
-					selectedFields,
-				});
+		if (fields) {
+			const [initialSelectedKeys, updatedFields] = initializeFields({
+				fields,
+				selectedFields,
+			});
 
-				setSelectedKeys(initialSelectedKeys);
+			setSelectedKeys(initialSelectedKeys);
 
-				setInitialFields(updatedFields);
-				setFields(updatedFields);
-			}
-		});
+			setFields(updatedFields);
+		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.tsx
@@ -161,14 +161,15 @@ const Highlight = ({query, text}: {query?: string; text?: string}) => {
 
 const FieldSelectModalContent = ({
 	closeModal,
+	fieldTreeItems,
 	onSaveButtonClick,
 	saveButtonDisabled,
 	selectedFields,
 	selectionMode = 'single',
-	treeItems,
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
+	fieldTreeItems: Array<IFieldTreeItem>;
 	onSaveButtonClick: ({
 		selectedFields,
 	}: {
@@ -177,11 +178,10 @@ const FieldSelectModalContent = ({
 	saveButtonDisabled: boolean;
 	selectedFields: Array<IField>;
 	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
-	treeItems: Array<IFieldTreeItem>;
 }) => {
 	const [initialFields, setInitialFields] = useState<Array<
 		IFieldTreeItem
-	> | null>(treeItems);
+	> | null>(fieldTreeItems);
 	const [selectedKeys, setSelectedKeys] = useState<Set<React.Key>>(
 		new Set<React.Key>()
 	);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -479,7 +479,9 @@ const Sorting = ({fdsView, namespace}: IFDSViewSectionProps) => {
 			setFDSSorts([...notOrdered, ...ordered]);
 
 			await getFields(fdsView).then((fields) => {
-				setFields(fields);
+				const nextFields = fields.filter((field) => field.sortable);
+
+				setFields(nextFields);
 			});
 
 			setLoading(false);

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/Sorting.tsx
@@ -16,10 +16,10 @@ import React, {useEffect, useState} from 'react';
 
 import {IFDSViewSectionProps} from '../FDSView';
 import {FDSViewType} from '../FDSViews';
-import {getFields} from '../api';
 import OrderableTable from '../components/OrderableTable';
 import RequiredMark from '../components/RequiredMark';
 import {API_URL, OBJECT_RELATIONSHIP} from '../utils/constants';
+import getFields from '../utils/getFields';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 import {IField} from '../utils/types';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/SortingDeprecated.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/SortingDeprecated.tsx
@@ -15,10 +15,10 @@ import React, {useEffect, useState} from 'react';
 
 import {IFDSViewSectionProps} from '../FDSView';
 import {FDSViewType} from '../FDSViews';
-import {getFields} from '../api';
 import OrderableTable from '../components/OrderableTable';
 import RequiredMark from '../components/RequiredMark';
 import {API_URL, FUZZY_OPTIONS, OBJECT_RELATIONSHIP} from '../utils/constants';
+import getFields from '../utils/getFields';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../utils/openDefaultSuccessToast';
 import {IField} from '../utils/types';

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/filters/Filters.tsx
@@ -16,10 +16,11 @@ import {fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import {FDSViewType} from '../../FDSViews';
-import {getAllPicklists, getFields} from '../../api';
 import OrderableTable from '../../components/OrderableTable';
 import ValidationFeedback from '../../components/ValidationFeedback';
 import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import getAllPicklists from '../../utils/getAllPicklists';
+import getFields from '../../utils/getFields';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Cards.tsx
@@ -29,23 +29,23 @@ interface IFDSCardsSection {
 interface ICardsSection {
 	externalReferenceCode?: IFDSCardsSection['externalReferenceCode'];
 	field?: IField;
+	fieldTreeItems: Array<IFieldTreeItem>;
 	label: string;
 	name: IFDSCardsSection['name'];
-	treeItems: Array<IFieldTreeItem>;
 }
 
 export default function Cards(props: IFDSViewSectionProps) {
-	const {fdsView, treeItems} = props;
+	const {fdsView, fieldTreeItems} = props;
 
 	const [cardsSections, setCardsSections] = useState<Array<ICardsSection>>([
-		{label: Liferay.Language.get('title'), name: 'title', treeItems},
+		{fieldTreeItems, label: Liferay.Language.get('title'), name: 'title'},
 		{
+			fieldTreeItems,
 			label: Liferay.Language.get('description'),
 			name: 'description',
-			treeItems,
 		},
-		{label: Liferay.Language.get('image'), name: 'image', treeItems},
-		{label: Liferay.Language.get('symbol'), name: 'symbol', treeItems},
+		{fieldTreeItems, label: Liferay.Language.get('image'), name: 'image'},
+		{fieldTreeItems, label: Liferay.Language.get('symbol'), name: 'symbol'},
 	]);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
@@ -79,9 +79,9 @@ export default function Cards(props: IFDSViewSectionProps) {
 
 				if (!fdsCardsSection) {
 					return {
+						fieldTreeItems,
 						label: cardsSection.label,
 						name: cardsSection.name,
-						treeItems,
 					};
 				}
 
@@ -298,7 +298,7 @@ function CardsSection({
 	onSelect,
 	saveButtonDisabled,
 }: ICardsSectionProps) {
-	const {field, label, treeItems} = cardsSection;
+	const {field, fieldTreeItems, label} = cardsSection;
 
 	const openSelectFieldModal = () => {
 		openModal({
@@ -306,6 +306,7 @@ function CardsSection({
 				<FieldSelectModalContent
 					{...modalProps}
 					closeModal={closeModal}
+					fieldTreeItems={fieldTreeItems}
 					onSaveButtonClick={({
 						selectedFields,
 					}: {
@@ -318,7 +319,6 @@ function CardsSection({
 					}}
 					saveButtonDisabled={saveButtonDisabled}
 					selectedFields={field ? [field] : []}
-					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Cards.tsx
@@ -17,7 +17,7 @@ import FieldSelectModalContent from '../../../components/FieldSelectModalContent
 import {API_URL, OBJECT_RELATIONSHIP} from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
-import {IField} from '../../../utils/types';
+import {IField, IFieldTreeItem} from '../../../utils/types';
 import FieldAssignmentControls from '../components/FieldAssignmentControls';
 
 interface IFDSCardsSection {
@@ -31,16 +31,21 @@ interface ICardsSection {
 	field?: IField;
 	label: string;
 	name: IFDSCardsSection['name'];
+	treeItems: Array<IFieldTreeItem>;
 }
 
 export default function Cards(props: IFDSViewSectionProps) {
-	const {fdsView} = props;
+	const {fdsView, treeItems} = props;
 
 	const [cardsSections, setCardsSections] = useState<Array<ICardsSection>>([
-		{label: Liferay.Language.get('title'), name: 'title'},
-		{label: Liferay.Language.get('description'), name: 'description'},
-		{label: Liferay.Language.get('image'), name: 'image'},
-		{label: Liferay.Language.get('symbol'), name: 'symbol'},
+		{label: Liferay.Language.get('title'), name: 'title', treeItems},
+		{
+			label: Liferay.Language.get('description'),
+			name: 'description',
+			treeItems,
+		},
+		{label: Liferay.Language.get('image'), name: 'image', treeItems},
+		{label: Liferay.Language.get('symbol'), name: 'symbol', treeItems},
 	]);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
@@ -73,7 +78,11 @@ export default function Cards(props: IFDSViewSectionProps) {
 				);
 
 				if (!fdsCardsSection) {
-					return {label: cardsSection.label, name: cardsSection.name};
+					return {
+						label: cardsSection.label,
+						name: cardsSection.name,
+						treeItems,
+					};
 				}
 
 				return {
@@ -289,7 +298,7 @@ function CardsSection({
 	onSelect,
 	saveButtonDisabled,
 }: ICardsSectionProps) {
-	const {field, label} = cardsSection;
+	const {field, label, treeItems} = cardsSection;
 
 	const openSelectFieldModal = () => {
 		openModal({
@@ -309,6 +318,7 @@ function CardsSection({
 					}}
 					saveButtonDisabled={saveButtonDisabled}
 					selectedFields={field ? [field] : []}
+					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/List.tsx
@@ -29,23 +29,23 @@ interface IFDSListSection {
 interface IListSection {
 	externalReferenceCode?: IFDSListSection['externalReferenceCode'];
 	field?: IField;
+	fieldTreeItems: Array<IFieldTreeItem>;
 	label: string;
 	name: IFDSListSection['name'];
-	treeItems: Array<IFieldTreeItem>;
 }
 
 export default function List(props: IFDSViewSectionProps) {
-	const {fdsView, treeItems} = props;
+	const {fdsView, fieldTreeItems} = props;
 
 	const [listSections, setListSections] = useState<Array<IListSection>>([
-		{label: Liferay.Language.get('title'), name: 'title', treeItems},
+		{fieldTreeItems, label: Liferay.Language.get('title'), name: 'title'},
 		{
+			fieldTreeItems,
 			label: Liferay.Language.get('description'),
 			name: 'description',
-			treeItems,
 		},
-		{label: Liferay.Language.get('image'), name: 'image', treeItems},
-		{label: Liferay.Language.get('symbol'), name: 'symbol', treeItems},
+		{fieldTreeItems, label: Liferay.Language.get('image'), name: 'image'},
+		{fieldTreeItems, label: Liferay.Language.get('symbol'), name: 'symbol'},
 	]);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
@@ -79,9 +79,9 @@ export default function List(props: IFDSViewSectionProps) {
 
 				if (!fdsListSection) {
 					return {
+						fieldTreeItems,
 						label: listSection.label,
 						name: listSection.name,
-						treeItems,
 					};
 				}
 
@@ -297,7 +297,7 @@ function ListSection({
 	onSelect,
 	saveButtonDisabled,
 }: IListSectionProps) {
-	const {field, label, treeItems} = listSection;
+	const {field, fieldTreeItems, label} = listSection;
 
 	const openSelectFieldModal = () => {
 		openModal({
@@ -305,6 +305,7 @@ function ListSection({
 				<FieldSelectModalContent
 					{...modalProps}
 					closeModal={closeModal}
+					fieldTreeItems={fieldTreeItems}
 					onSaveButtonClick={({
 						selectedFields,
 					}: {
@@ -317,7 +318,6 @@ function ListSection({
 					}}
 					saveButtonDisabled={saveButtonDisabled}
 					selectedFields={field ? [field] : []}
-					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/List.tsx
@@ -17,7 +17,7 @@ import FieldSelectModalContent from '../../../components/FieldSelectModalContent
 import {API_URL, OBJECT_RELATIONSHIP} from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
-import {IField} from '../../../utils/types';
+import {IField, IFieldTreeItem} from '../../../utils/types';
 import FieldAssignmentControls from '../components/FieldAssignmentControls';
 
 interface IFDSListSection {
@@ -31,16 +31,21 @@ interface IListSection {
 	field?: IField;
 	label: string;
 	name: IFDSListSection['name'];
+	treeItems: Array<IFieldTreeItem>;
 }
 
 export default function List(props: IFDSViewSectionProps) {
-	const {fdsView} = props;
+	const {fdsView, treeItems} = props;
 
 	const [listSections, setListSections] = useState<Array<IListSection>>([
-		{label: Liferay.Language.get('title'), name: 'title'},
-		{label: Liferay.Language.get('description'), name: 'description'},
-		{label: Liferay.Language.get('image'), name: 'image'},
-		{label: Liferay.Language.get('symbol'), name: 'symbol'},
+		{label: Liferay.Language.get('title'), name: 'title', treeItems},
+		{
+			label: Liferay.Language.get('description'),
+			name: 'description',
+			treeItems,
+		},
+		{label: Liferay.Language.get('image'), name: 'image', treeItems},
+		{label: Liferay.Language.get('symbol'), name: 'symbol', treeItems},
 	]);
 	const [saveButtonDisabled, setSaveButtonDisabled] = useState(false);
 
@@ -73,7 +78,11 @@ export default function List(props: IFDSViewSectionProps) {
 				);
 
 				if (!fdsListSection) {
-					return listSection;
+					return {
+						label: listSection.label,
+						name: listSection.name,
+						treeItems,
+					};
 				}
 
 				return {
@@ -288,7 +297,7 @@ function ListSection({
 	onSelect,
 	saveButtonDisabled,
 }: IListSectionProps) {
-	const {field, label} = listSection;
+	const {field, label, treeItems} = listSection;
 
 	const openSelectFieldModal = () => {
 		openModal({
@@ -308,6 +317,7 @@ function ListSection({
 					}}
 					saveButtonDisabled={saveButtonDisabled}
 					selectedFields={field ? [field] : []}
+					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
@@ -360,10 +360,10 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 	const {
 		fdsClientExtensionCellRenderers,
 		fdsView,
+		fieldTreeItems,
 		namespace,
 		saveFDSFieldsURL,
 		title,
-		treeItems,
 	} = props;
 
 	const [fdsFields, setFDSFields] = useState<Array<IFDSField> | null>(null);
@@ -629,6 +629,7 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 				<FieldSelectModalContent
 					{...props}
 					closeModal={closeModal}
+					fieldTreeItems={fieldTreeItems}
 					onSaveButtonClick={({
 						selectedFields,
 					}: {
@@ -646,7 +647,6 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 							: []
 					}
 					selectionMode="multiple"
-					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',
@@ -679,7 +679,7 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 							}) || null
 						);
 					}}
-					sortable={isSortable(treeItems, item)}
+					sortable={isSortable(fieldTreeItems, item)}
 				/>
 			),
 		});
@@ -782,13 +782,13 @@ export function Fields(props: IFDSViewSectionProps) {
 }
 
 function isSortable(
-	treeItems: Array<IFieldTreeItem>,
+	fieldTreeItems: Array<IFieldTreeItem>,
 	selectedItem: IFDSField
 ): boolean {
 	let isSortable = false;
-	visit(treeItems, (treeItem: IFieldTreeItem) => {
-		if (treeItem.name === selectedItem.name) {
-			isSortable = treeItem.sortable || false;
+	visit(fieldTreeItems, (fieldTreeItem: IFieldTreeItem) => {
+		if (fieldTreeItem.name === selectedItem.name) {
+			isSortable = fieldTreeItem.sortable || false;
 
 			return;
 		}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
@@ -111,6 +111,7 @@ interface IEditFDSFieldModalContentProps {
 	fdsField: IFDSField;
 	namespace: string;
 	onSaveButtonClick: Function;
+	sortable: boolean;
 }
 
 const EditFDSFieldModalContent = ({
@@ -119,13 +120,14 @@ const EditFDSFieldModalContent = ({
 	fdsField,
 	namespace,
 	onSaveButtonClick,
+	sortable,
 }: IEditFDSFieldModalContentProps) => {
 	const [selectedFDSFieldRenderer, setSelectedFDSFieldRenderer] = useState(
 		fdsField.renderer ?? 'default'
 	);
 
 	const [fdsFieldSortable, setFSDFieldSortable] = useState<boolean>(
-		fdsField.sortable ?? fdsField.type !== EFieldType.OBJECT
+		fdsField.sortable
 	);
 
 	const fdsInternalCellRendererNames = FDS_INTERNAL_CELL_RENDERERS.map(
@@ -306,7 +308,7 @@ const EditFDSFieldModalContent = ({
 				<ClayForm.Group>
 					<ClayCheckbox
 						checked={fdsFieldSortable}
-						disabled={fdsField.type === EFieldType.OBJECT}
+						disabled={!sortable}
 						inline
 						label={Liferay.Language.get('sortable')}
 						onChange={({target: {checked}}) =>
@@ -485,13 +487,18 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 	}) => {
 		setSaveButtonDisabled(true);
 
-		const creationData: Array<{name: string; type: string}> = [];
+		const creationData: Array<{
+			name: string;
+			sortable: boolean;
+			type: string;
+		}> = [];
 		const deletionIds: Array<number> = [];
 
 		fields.forEach((field) => {
 			if (!field.id) {
 				creationData.push({
 					name: field.name,
+					sortable: field.sortable || false,
 					type: field.type || 'string',
 				});
 			}
@@ -663,6 +670,7 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 							}) || null
 						);
 					}}
+					sortable={isSortable(treeItems, item)}
 				/>
 			),
 		});
@@ -762,6 +770,22 @@ export function Fields(props: IFDSViewSectionProps) {
 			<Table {...props} title={Liferay.Language.get('fields')} />
 		</ClayLayout.ContainerFluid>
 	);
+}
+
+function isSortable(
+	treeItems: Array<IFieldTreeItem>,
+	selectedItem: IFDSField
+): boolean {
+	let isSortable = false;
+	visit(treeItems, (treeItem: IFieldTreeItem) => {
+		if (treeItem.name === selectedItem.name) {
+			isSortable = treeItem.sortable || false;
+
+			return;
+		}
+	});
+
+	return isSortable;
 }
 
 export default Table;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/modes/Table.tsx
@@ -21,7 +21,9 @@ import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
 import {IFDSViewSectionProps} from '../../../FDSView';
-import FieldSelectModalContent from '../../../components/FieldSelectModalContent';
+import FieldSelectModalContent, {
+	visit,
+} from '../../../components/FieldSelectModalContent';
 import OrderableTable from '../../../components/OrderableTable';
 import {
 	API_URL,
@@ -36,7 +38,12 @@ import '../../../../css/TableVisualizationMode.scss';
 import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
 
-import {EFieldType, IFDSField, IField} from '../../../utils/types';
+import {
+	EFieldType,
+	IFDSField,
+	IField,
+	IFieldTreeItem,
+} from '../../../utils/types';
 
 const defaultLanguageId = Liferay.ThemeDisplay.getDefaultLanguageId();
 
@@ -356,6 +363,7 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 		namespace,
 		saveFDSFieldsURL,
 		title,
+		treeItems,
 	} = props;
 
 	const [fdsFields, setFDSFields] = useState<Array<IFDSField> | null>(null);
@@ -638,6 +646,7 @@ function Table(props: IFDSViewSectionProps & {title?: string}) {
 							: []
 					}
 					selectionMode="multiple"
+					treeItems={treeItems}
 				/>
 			),
 			size: 'full-screen',

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+import openDefaultFailureToast from './openDefaultFailureToast';
+import {IPickList} from './types';
+
+export default async function getAllPicklists(
+	page: number = 1,
+	items: IPickList[] = []
+) {
+	const response = await fetch(
+		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=100&page=${page}`
+	);
+
+	if (!response.ok) {
+		openDefaultFailureToast();
+
+		return [];
+	}
+
+	const responseJSON = await response.json();
+
+	items = [...items, ...responseJSON.items];
+
+	if (responseJSON.lastPage > page) {
+		items = await getAllPicklists(page + 1, items);
+	}
+
+	return items;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -14,7 +14,7 @@ import {fetch} from 'frontend-js-web';
 import {FDSViewType} from '../FDSViews';
 import {OBJECT_RELATIONSHIP} from './constants';
 import openDefaultFailureToast from './openDefaultFailureToast';
-import {EFieldFormat, EFieldType, IField, IPickList} from './types';
+import {EFieldFormat, EFieldType, IField} from './types';
 
 const INVALID_FIELDS = ['actions', 'scopeKey', 'x-class-name', 'x-schema-name'];
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -11,10 +11,10 @@ import {
 } from '@liferay/frontend-data-set-web';
 import {fetch} from 'frontend-js-web';
 
-import {FDSViewType} from './FDSViews';
-import {OBJECT_RELATIONSHIP} from './utils/constants';
-import openDefaultFailureToast from './utils/openDefaultFailureToast';
-import {EFieldFormat, EFieldType, IField, IPickList} from './utils/types';
+import {FDSViewType} from '../FDSViews';
+import {OBJECT_RELATIONSHIP} from './constants';
+import openDefaultFailureToast from './openDefaultFailureToast';
+import {EFieldFormat, EFieldType, IField, IPickList} from './types';
 
 const INVALID_FIELDS = ['actions', 'scopeKey', 'x-class-name', 'x-schema-name'];
 
@@ -146,7 +146,7 @@ function getValidFields({
 	return fields;
 }
 
-export async function getFields(fdsView: FDSViewType) {
+export default async function getFields(fdsView: FDSViewType) {
 	const {restApplication, restSchema} = fdsView[
 		OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW
 	];
@@ -174,29 +174,4 @@ export async function getFields(fdsView: FDSViewType) {
 		schemaName: restSchema,
 		schemas,
 	});
-}
-
-export async function getAllPicklists(
-	page: number = 1,
-	items: IPickList[] = []
-) {
-	const response = await fetch(
-		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=100&page=${page}`
-	);
-
-	if (!response.ok) {
-		openDefaultFailureToast();
-
-		return [];
-	}
-
-	const responseJSON = await response.json();
-
-	items = [...items, ...responseJSON.items];
-
-	if (responseJSON.lastPage > page) {
-		items = await getAllPicklists(page + 1, items);
-	}
-
-	return items;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -44,6 +44,7 @@ export interface IField {
 	label?: string;
 	name: string;
 	selected?: boolean;
+	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -62,6 +62,14 @@ export interface IFDSField {
 	type: string;
 }
 
+export interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	initialChildren?: IFieldTreeItem[];
+	query?: string;
+	savedId?: string;
+	selected?: boolean;
+}
+
 export interface IFilter {
 	fieldName: string;
 	filterType?: EFilterType;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -13,12 +13,12 @@ interface IFDSViewSectionProps {
 	fdsFilterClientExtensions: IClientExtensionRenderer[];
 	fdsView: FDSViewType;
 	fdsViewsURL: string;
+	fieldTreeItems: Array<IFieldTreeItem>;
 	namespace: string;
 	onActiveSectionChange: (section: number) => void;
 	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 	spritemap: string;
-	treeItems: Array<IFieldTreeItem>;
 }
 interface IFDSViewProps {
 	fdsClientExtensionCellRenderers: IClientExtensionRenderer[];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/FDSView.d.ts
@@ -7,6 +7,7 @@
 
 import {IClientExtensionRenderer} from '@liferay/frontend-data-set-web';
 import {FDSViewType} from './FDSViews';
+import {IFieldTreeItem} from './utils/types';
 interface IFDSViewSectionProps {
 	fdsClientExtensionCellRenderers: IClientExtensionRenderer[];
 	fdsFilterClientExtensions: IClientExtensionRenderer[];
@@ -17,6 +18,7 @@ interface IFDSViewSectionProps {
 	onFDSViewUpdate: (data: FDSViewType) => void;
 	saveFDSFieldsURL: string;
 	spritemap: string;
+	treeItems: Array<IFieldTreeItem>;
 }
 interface IFDSViewProps {
 	fdsClientExtensionCellRenderers: IClientExtensionRenderer[];

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
@@ -14,14 +14,15 @@ export declare function visit(
 ): void;
 declare const FieldSelectModalContent: ({
 	closeModal,
+	fieldTreeItems,
 	onSaveButtonClick,
 	saveButtonDisabled,
 	selectedFields,
 	selectionMode,
-	treeItems,
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
+	fieldTreeItems: Array<IFieldTreeItem>;
 	onSaveButtonClick: ({
 		selectedFields,
 	}: {
@@ -30,6 +31,5 @@ declare const FieldSelectModalContent: ({
 	saveButtonDisabled: boolean;
 	selectedFields: Array<IField>;
 	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
-	treeItems: Array<IFieldTreeItem>;
 }) => JSX.Element;
 export default FieldSelectModalContent;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/components/FieldSelectModalContent.d.ts
@@ -6,22 +6,19 @@
 import {TreeView} from '@clayui/core';
 import {ComponentProps} from 'react';
 import {FDSViewType} from '../FDSViews';
-import {IField} from '../utils/types';
+import {IField, IFieldTreeItem} from '../utils/types';
 import '../../css/components/FieldSelectModalContent.scss';
-interface IFieldTreeItem extends IField {
-	children?: IFieldTreeItem[];
-	initialChildren?: IFieldTreeItem[];
-	query?: string;
-	savedId?: string;
-	selected?: boolean;
-}
+export declare function visit(
+	fields: Array<IFieldTreeItem>,
+	callback: Function
+): void;
 declare const FieldSelectModalContent: ({
 	closeModal,
-	fdsView,
 	onSaveButtonClick,
 	saveButtonDisabled,
 	selectedFields,
 	selectionMode,
+	treeItems,
 }: {
 	closeModal: Function;
 	fdsView: FDSViewType;
@@ -33,5 +30,6 @@ declare const FieldSelectModalContent: ({
 	saveButtonDisabled: boolean;
 	selectedFields: Array<IField>;
 	selectionMode?: ComponentProps<typeof TreeView>['selectionMode'];
+	treeItems: Array<IFieldTreeItem>;
 }) => JSX.Element;
 export default FieldSelectModalContent;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/getAllPicklists.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/getAllPicklists.d.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {FDSViewType} from './FDSViews';
-import {IField, IPickList} from './utils/types';
-export declare function getFields(fdsView: FDSViewType): Promise<IField[]>;
-export declare function getAllPicklists(
+import {IPickList} from './types';
+export default function getAllPicklists(
 	page?: number,
 	items?: IPickList[]
 ): Promise<IPickList[]>;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/getFields.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/getFields.d.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FDSViewType} from '../FDSViews';
+import {IField} from './types';
+export default function getFields(fdsView: FDSViewType): Promise<IField[]>;

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/utils/types.d.ts
@@ -37,6 +37,7 @@ export interface IField {
 	label?: string;
 	name: string;
 	selected?: boolean;
+	sortable?: boolean;
 	type?: string;
 	visible?: boolean;
 }
@@ -51,6 +52,13 @@ export interface IFDSField {
 	rendererLabel?: string;
 	sortable: boolean;
 	type: string;
+}
+export interface IFieldTreeItem extends IField {
+	children?: IFieldTreeItem[];
+	initialChildren?: IFieldTreeItem[];
+	query?: string;
+	savedId?: string;
+	selected?: boolean;
 }
 export interface IFilter {
 	fieldName: string;

--- a/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/tabs/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/pages/view/tabs/VisualizationModesPage.ts
@@ -143,6 +143,27 @@ export class VisualizationModesPage {
 			.waitFor();
 	}
 
+	async searchAndSelecteField(path: string) {
+		const fieldSearch = await this.page
+			.getByRole('dialog', {name: 'Select Field'})
+			.getByPlaceholder('Search');
+
+		const FDS_NESTED_FIELD_NAME_DELIMITER = '.';
+
+		const itemPath = path
+			.replace(/\[\]/g, '.')
+			.split(FDS_NESTED_FIELD_NAME_DELIMITER)
+			.filter((item) => item !== '*');
+
+		const selectedFieldName = itemPath[itemPath.length - 1];
+		await fieldSearch.fill(selectedFieldName);
+
+		await this.page
+			.locator(`[data-id$=",${path}"]`)
+			.getByText(selectedFieldName, {exact: true})
+			.check();
+	}
+
 	async selectField({
 		dataId,
 		fieldName,

--- a/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-views-web/visualizationModes.spec.ts
@@ -307,7 +307,7 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 					)
 					.locator('td')
 					.nth(SORTABLE_COLUMN_INDEX)
-			).toHaveText('true');
+			).toHaveText('false');
 		});
 
 		await test.step('Edit a field', async () => {
@@ -378,11 +378,16 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		});
 	});
 
-	test('Configure table visualization mode with scalar array fields @LPD-11769', async ({
+	test('Configure table visualization mode with array fields @LPD-11769', async ({
 		page,
 		visualizationModesPage,
 	}) => {
+		const SAMPLE_COMPLEX_ARRAY_FIELD = 'auditEvents[]*';
+		const SAMPLE_COMPLEX_ARRAY_CHILD_FIELD = 'auditEvents[]creator.name';
 		const SAMPLE_SCALAR_ARRAY_FIELD = 'keywords';
+		const SAMPLE_FULL_COMPLEX_FIELD = 'creator.*';
+		const SAMPLE_COMPLEX_OBJECT_CHILD_FIELD = 'creator.givenName';
+		const SORTABLE_COLUMN_INDEX = 5;
 		const TYPE_COLUMN_INDEX = 3;
 
 		await test.step('Navigate to table visualization mode page', async () => {
@@ -401,22 +406,69 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		await test.step('Add scalar array field', async () => {
 			await visualizationModesPage.openAddFieldsModal();
 
-			await visualizationModesPage.selectField({
-				fieldName: SAMPLE_SCALAR_ARRAY_FIELD,
-			});
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_SCALAR_ARRAY_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_COMPLEX_ARRAY_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_COMPLEX_ARRAY_CHILD_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_COMPLEX_OBJECT_CHILD_FIELD
+			);
+			await visualizationModesPage.searchAndSelecteField(
+				SAMPLE_FULL_COMPLEX_FIELD
+			);
 
 			await saveFromModal({
 				page,
 			});
 		});
 
-		await test.step('Check if field shows the correct type', async () => {
+		await test.step('Check if fields show the correct type', async () => {
 			await expect(
 				visualizationModesPage
 					.getRowByText(SAMPLE_SCALAR_ARRAY_FIELD)
 					.locator('td')
 					.nth(TYPE_COLUMN_INDEX)
 			).toHaveText('array');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_ARRAY_FIELD)
+					.locator('td')
+					.nth(SORTABLE_COLUMN_INDEX)
+			).toHaveText('false');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_COMPLEX_ARRAY_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('array');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_COMPLEX_ARRAY_FIELD)
+					.locator('td')
+					.nth(SORTABLE_COLUMN_INDEX)
+			).toHaveText('false');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_COMPLEX_OBJECT_CHILD_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('string');
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_FULL_COMPLEX_FIELD)
+					.locator('td')
+					.nth(TYPE_COLUMN_INDEX)
+			).toHaveText('object');
 		});
 	});
 });


### PR DESCRIPTION
Continuation of https://github.com/liferay-frontend/liferay-portal/pull/4163

## Story / Task
[LPD-24163](https://liferay.atlassian.net/browse/LPD-24163) / [LPD-24197](https://liferay.atlassian.net/browse/LPD-24197)

## Goal
With the growing number of types that can be selected for the Table visualization mode, it is hard to know which fields, except scalar types appearing as root elements, can be used to sort the data. To avoid errors when the user applies a sorting option, we prevent setting fields of type `array`, `object` or any descendant of `array` and `object` as sortable.

## Technical details
- As we need to iterate over all available fields, it seemed appropriate to identify this trait so it could be used just after selecting the fields. This calculated value is used to store the information in the database.
This, also makes possible to filter out in the `Sorting` tab those fields than cannot be used to create sorts. 
- Move fields request (openapi.json) to `FDSView` so we only need one request to display the modal with the tree view for all different visualization modes.

## UI
![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/f7e0ce36-87fc-4e64-b307-83b929fa1ae4)
