### PR TITLE
LPD-25320 Fix/quarantine `creator` related tests in DataSetViewFilters.testcase

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -2641,6 +2641,8 @@ definition {
 	@description = "LPS-183621. Confirm that by selecting the radio button Multiple and selecting more than one item, the filter can be saved ."
 	@priority = 4
 	test SelectionTypeWithSelectionMultipleField {
+		property portal.upstream = "quarantine";
+
 		task ("And creating a picklist And Add items to the created picklist") {
 			DataSetAdmin.setUpPicklistforDataSet(
 				picklistItemList = "bike,car,bus",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -2172,7 +2172,7 @@ definition {
 				dropdownLabel = "Select",
 				locator1 = "Dropdown#ANY_DROPDOWN_LABEL");
 
-			DropdownMenuItem.viewDisabledItem(itemList = "creator,externalReferenceCode,status");
+			DropdownMenuItem.viewDisabledItem(itemList = "externalReferenceCode,fieldName,label");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -2191,12 +2191,12 @@ definition {
 			DataSetAdmin.createFilters(
 				filterName = "Test Filter",
 				filterType = "Selection",
-				key_filterList = "creator,label,status");
+				key_filterList = "externalReferenceCode,label,fieldName");
 		}
 
 		task ("And edits one of them") {
 			Click(
-				key_fieldName = "creator",
+				key_fieldName = "externalReferenceCode",
 				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
 
 			MenuItem.click(menuItem = "Edit");
@@ -2204,7 +2204,7 @@ definition {
 			Type(
 				key_text = "Name",
 				locator1 = "TextInput#ANY",
-				value1 = "creator edited");
+				value1 = "externalReferenceCode edited");
 
 			Click(
 				key_text = "Save",
@@ -2235,16 +2235,16 @@ definition {
 
 		task ("When the user reorder the filters") {
 			DragAndDrop.javaScriptDragAndDropToBottom(
-				key_nameField = "creator edited",
+				key_nameField = "externalReferenceCode edited",
 				key_position = 2,
-				keyName = "status",
+				keyName = "fieldName",
 				locator1 = "DataSet#SELECT_DATASET",
 				locator2 = "DataSet#FIELDS_TABLE");
 		}
 
 		task ("Then the filters are ordered accordingly to the changes") {
 			AssertElementPresent(
-				chosenFilter = "status",
+				chosenFilter = "fieldName",
 				key_tableColumn = 1,
 				key_tableRow = 1,
 				locator1 = "DataSet#FILTER_TABLE_CELL");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -2701,6 +2701,8 @@ definition {
 	@description = "LPS-183621. Confirm that when you select the Single radio button and select more than one item, an error message is displayed."
 	@priority = 4
 	test SelectionTypeWithSelectionSingleFieldAndMultipleItem {
+		property portal.upstream = "quarantine";
+
 		task ("And creating a picklist And Add items to the created picklist") {
 			DataSetAdmin.setUpPicklistforDataSet(
 				picklistItemList = "bike,car,bus",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -2500,6 +2500,8 @@ definition {
 	@description = "LPS-183621. Confirm that by editing the filter and selecting Multiple, other items can be added and saved."
 	@priority = 4
 	test SelectionTypeAfterEditFilterChangeSelectionToMultiple {
+		property portal.upstream = "quarantine";
+
 		task ("And creating a picklist And Add items to the created picklist") {
 			DataSetAdmin.setUpPicklistforDataSet(
 				picklistItemList = "bike,car,bus",
@@ -2543,6 +2545,8 @@ definition {
 	@description = "LPS-183621. Confirm that Single works when there is only one item left in Preselected values."
 	@priority = 4
 	test SelectionTypeAfterEditFilterChangeSelectionToSingle {
+		property portal.upstream = "quarantine";
+
 		task ("And creating a picklist And Add items to the created picklist") {
 			DataSetAdmin.setUpPicklistforDataSet(
 				picklistItemList = "bike,car,bus",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-25320

The quarantined tests are failing due to Picklist UI being different, specifically the `+` to add a picklist doesn't directly open a modal but instead offers options.