### PR TITLE
LPD-25676  Give proper feedback to screen reader users when using Field Base

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/common/FieldBase.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/common/FieldBase.tsx
@@ -121,6 +121,7 @@ export default function FieldBase({
 				<FieldFeedback
 					errorMessage={errorMessage}
 					helpMessage={helpMessage}
+					id={`${id}fieldFeedback`}
 					warningMessage={warningMessage}
 				/>
 			)}

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/common/FieldFeedback.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/forms/common/FieldFeedback.tsx
@@ -14,27 +14,16 @@ export default function FieldFeedback({
 	warningMessage,
 	...otherProps
 }: IProps) {
-	if (!errorMessage && !helpMessage && !warningMessage) {
-		return null;
-	}
+	const message = errorMessage ? errorMessage : warningMessage;
+	const symbol = errorMessage ? 'exclamation-full' : 'warning-full';
 
 	return (
 		<ClayForm.FeedbackGroup className="field-feedback" {...otherProps}>
-			{errorMessage && (
-				<ClayForm.FeedbackItem>
-					<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+			<ClayForm.FeedbackItem aria-live="assertive">
+				{message && <ClayForm.FeedbackIndicator symbol={symbol} />}
 
-					{errorMessage}
-				</ClayForm.FeedbackItem>
-			)}
-
-			{warningMessage && !errorMessage && (
-				<ClayForm.FeedbackItem>
-					<ClayForm.FeedbackIndicator symbol="warning-full" />
-
-					{warningMessage}
-				</ClayForm.FeedbackItem>
-			)}
+				{message}
+			</ClayForm.FeedbackItem>
 
 			{helpMessage && <div>{helpMessage}</div>}
 		</ClayForm.FeedbackGroup>

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/common/FieldFeedback.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/forms/common/FieldFeedback.d.ts
@@ -10,7 +10,7 @@ export default function FieldFeedback({
 	helpMessage,
 	warningMessage,
 	...otherProps
-}: IProps): JSX.Element | null;
+}: IProps): JSX.Element;
 interface IProps extends React.HTMLAttributes<HTMLDivElement> {
 	errorMessage?: string;
 	helpMessage?: string;


### PR DESCRIPTION
### References
[LPD-25676 Jira issue](https://liferay.atlassian.net/browse/LPD-25676)

### What is the goal of this PR?
Make the feedback field component accessible for screen users and return a proper feedback message.

### What does it look like?

https://github.com/liferay-frontend/liferay-portal/assets/47724428/21804a20-b817-4567-a7ca-6bc645ffae31


### Before PR
When using a Screen Reader, if an error or warning message is displayed, the screen reader doesn't give a proper message and users have no idea of what's shown on the screen.

### After PR
After the error or warning message is displayed, the Screen Reader reads the feedback message and the user becomes aware of the feedback.

### Steps to reproduce

- Add a Screen Reader extension on Chrome;
- Navigate to Control panel > Client Extension > Plus Button > Add JS;
- Press the "tab" key until you focus on the attribute field;
- Type "src" on the input and you will see the error;
- Press "tab" to the next element and expect to hear a feedback message after the screen reader describe the element.