### PR TITLE
LPD-26354 Prevent SPA from running when page is in excludePath

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/SPATopHeadJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/SPATopHeadJSPDynamicInclude.java
@@ -7,6 +7,7 @@ package com.liferay.frontend.js.spa.web.internal.servlet.taglib;
 
 import com.liferay.frontend.js.loader.modules.extender.esm.ESImportUtil;
 import com.liferay.frontend.js.spa.web.internal.servlet.taglib.helper.SPAHelper;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
@@ -19,6 +20,7 @@ import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -49,6 +51,20 @@ public class SPATopHeadJSPDynamicInclude extends BaseJSPDynamicInclude {
 		throws IOException {
 
 		SPAHelper spaHelper = _spaHelperSnapshot.get();
+
+		JSONArray excludedPathsJSONArray =
+			spaHelper.getExcludedPathsJSONArray();
+
+		String urlPath = _portal.getCurrentURL(httpServletRequest);
+
+		for (Object excludedPath : excludedPathsJSONArray) {
+			String excludedPathString = excludedPath.toString();
+
+			if (excludedPathString.equals(urlPath)) {
+				return;
+			}
+		}
+
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
@@ -63,7 +79,7 @@ public class SPATopHeadJSPDynamicInclude extends BaseJSPDynamicInclude {
 		).put(
 			"debugEnabled", spaHelper.isDebugEnabled()
 		).put(
-			"excludedPaths", spaHelper.getExcludedPathsJSONArray()
+			"excludedPaths", excludedPathsJSONArray
 		).put(
 			"excludedTargetPortlets",
 			spaHelper.getExcludedTargetPortletsJSONArray()
@@ -152,6 +168,9 @@ public class SPATopHeadJSPDynamicInclude extends BaseJSPDynamicInclude {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private Props _props;

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -21,6 +21,7 @@ import {config as dynamicDataMappingFormWebConfig} from './tests/dynamic-data-ma
 import {config as exportImportWebConfig} from './tests/export-import-web/config';
 import {config as frontendDataSetViewsWebConfig} from './tests/frontend-data-set-views-web/config';
 import {config as frontendDataSetWebConfig} from './tests/frontend-data-set-web/config';
+import {config as frontendJsSpaWebConfig} from './tests/frontend-js-spa-web/config';
 import {config as headlessBuilderImplConfig} from './tests/headless-builder-impl/config';
 import {config as headlessBuilderWebConfig} from './tests/headless-builder-web/config';
 import {config as journalWebConfig} from './tests/journal-web/config';
@@ -66,6 +67,7 @@ export default defineConfig({
 		exportImportWebConfig,
 		frontendDataSetViewsWebConfig,
 		frontendDataSetWebConfig,
+		frontendJsSpaWebConfig,
 		headlessBuilderImplConfig,
 		headlessBuilderWebConfig,
 		journalWebConfig,

--- a/modules/test/playwright/tests/frontend-js-spa-web/config.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/config.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	name: 'frontend-js-spa-web',
+	testDir: 'tests/frontend-js-spa-web',
+	use: {
+		...devices['Desktop Chrome'],
+	},
+};

--- a/modules/test/playwright/tests/frontend-js-spa-web/customExcludePaths.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/customExcludePaths.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+
+export const test = mergeTests(
+	isolatedLayoutTest(),
+	loginTest(),
+	systemSettingsPageTest
+);
+
+test('@LPD-26354 Custom Exclude Path', async ({
+	layout,
+	page,
+	systemSettingsPage,
+}) => {
+	await test.step('Check SPA is enabled', async () => {
+		await page.goto(layout.friendlyURL);
+
+		// @ts-ignore
+
+		const liferaySPAOutput = await page.evaluate(() => Liferay.SPA);
+
+		expect(liferaySPAOutput).not.toEqual(undefined);
+	});
+
+	await test.step('Exclude path in SPA Settings', async () => {
+		await systemSettingsPage.goToSystemSetting(
+			'Infrastructure',
+			'Frontend SPA Infrastructure'
+		);
+
+		const customExcludedPathsInput = page.getByLabel(
+			'Custom Excluded Paths',
+			{
+				exact: true,
+			}
+		);
+
+		await customExcludedPathsInput.waitFor({state: 'visible'});
+		await customExcludedPathsInput.click();
+		await customExcludedPathsInput.fill(layout.friendlyURL);
+
+		const updateButton = page.getByRole('button', {
+			name: 'Update',
+		});
+
+		await updateButton.isVisible();
+		await updateButton.click();
+
+		await waitForSuccessAlert(page);
+	});
+
+	await test.step('Go to page and check SPA', async () => {
+		await page.goto(layout.friendlyURL);
+
+		await page.reload();
+
+		// @ts-ignore
+
+		const liferaySPAOutput = await page.evaluate(() => Liferay.SPA);
+
+		expect(liferaySPAOutput).toEqual(undefined);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-54145
https://liferay.atlassian.net/browse/LPD-26354

SPA is still enabled when a page is added to the excludePath. SPA needs to check if the current page is in the excludePath and return before setting up SPA.

I had to use `// @ts-ignore` or else an format error would be thrown for Liferay.SPA. Let me know if this is the correct way to go about doing this.
Please let me know if there are any questions or comments about this.
Thank you!
