### PR TITLE
LPD-26435 Close active menu when clicking another menu

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -691,6 +691,7 @@ AUI.add(
 						if (portlet) {
 							portlet.removeClass(CSS_OPEN);
 						}
+						menuInstance._closeActiveMenu();
 					}
 					else {
 						menuInstance._closeActiveMenu();

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -42,6 +42,7 @@ import {config as productNavigationUserPersonalBarWebConfig} from './tests/produ
 import {config as stableConfig} from './tests/stable/config';
 import {config as stylebookConfig} from './tests/style-book-web/config';
 import {config as usersAdminWebConfig} from './tests/users-admin-web/config';
+import {config as wikiWebConfig} from './tests/wiki-web/config';
 
 const setupProjects = [wemSiteSetup, wemSiteTeardown];
 
@@ -87,6 +88,7 @@ export default defineConfig({
 		stableConfig,
 		stylebookConfig,
 		usersAdminWebConfig,
+		wikiWebConfig,
 		...setupProjects,
 	],
 	reporter: [

--- a/modules/test/playwright/tests/wiki-web/config.ts
+++ b/modules/test/playwright/tests/wiki-web/config.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {devices} from '@playwright/test';
+
+export const config = {
+	name: 'wiki-web',
+	testDir: 'tests/wiki-web',
+	use: {
+		...devices['Desktop Chrome'],
+	},
+};

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../fixtures/loginTest';
+import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
+
+export const test = mergeTests(loginTest(), systemSettingsPageTest);
+
+test('@LPD-26435 Icon menu should close when another icon menu is open', async ({
+	page,
+}) => {
+	await test.step('Go to wiki', async () => {
+		const openProductMenu = page.getByLabel('Open Product Menu');
+
+		const contentAndData = page.getByRole('menuitem', {
+			name: 'Content & Data',
+		});
+
+		if (await openProductMenu.isVisible()) {
+			openProductMenu.click();
+		}
+
+		await contentAndData.waitFor({state: 'visible'});
+		await contentAndData.click();
+
+		const wiki = page.getByRole('menuitem', {name: 'Wiki'});
+
+		await wiki.waitFor({state: 'visible'});
+		wiki.click();
+	});
+
+	await test.step('Create new wiki', async () => {
+		const newWikiButton = page.getByRole('link', {name: 'Add Wiki'});
+
+		await newWikiButton.waitFor({state: 'visible'});
+		await newWikiButton.click();
+
+		const nameInput = page.getByLabel('Name');
+
+		await nameInput.waitFor({state: 'visible'});
+		await nameInput.click();
+		await nameInput.fill('test');
+
+		await page.getByRole('button', {name: 'Save'}).click();
+	});
+
+	await test.step('Check menu gets closed', async () => {
+		const menuOneButton = page.locator(
+			'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
+		);
+
+		await menuOneButton.waitFor({state: 'visible'});
+		await menuOneButton.click();
+
+		const menuOne = page.locator(
+			'[aria-labelledby="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
+		);
+
+		await menuOne.waitFor({state: 'visible'});
+
+		const menuTwoButton = page.locator(
+			'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_2_menu"]'
+		);
+
+		await menuTwoButton.click();
+
+		const menuTwo = page.locator(
+			'[aria-labelledby="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_2_menu"]'
+		);
+
+		await menuTwo.waitFor({state: 'visible'});
+
+		await expect(menuOne).toBeHidden();
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-26435
https://liferay.atlassian.net/browse/LPP-54153


Using liferay-ui:icon-menu, the menus will not be hidden if another menu is opened leaving two menu on screen. We need to close the active menu when a new menu is clicked.

Please let me know if there are any questions or comments about this.
Thank you!