### PR TITLE
LPD-26667 Remove unnecessary TS ignores

### DIFF
--- a/modules/test/playwright/fixtures/accountSettingsPagesTest.ts
+++ b/modules/test/playwright/fixtures/accountSettingsPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {AccountSettingsPage} from '../pages/users-admin-web/AccountSettingsPage';

--- a/modules/test/playwright/fixtures/accountsPagesTest.ts
+++ b/modules/test/playwright/fixtures/accountsPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {AccountAccountGroupsPage} from '../pages/account-admin-web/AccountAccountGroupsPage';

--- a/modules/test/playwright/fixtures/commercePagesTest.ts
+++ b/modules/test/playwright/fixtures/commercePagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {CheckoutPage} from '../pages/commerce/commerce-checkout-web/checkoutPage';

--- a/modules/test/playwright/fixtures/contactsCenterPagesTest.ts
+++ b/modules/test/playwright/fixtures/contactsCenterPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {ContactsCenterPage} from '../pages/contacts-web/ContactsCenterPage';

--- a/modules/test/playwright/fixtures/documentLibraryPages.fixtures.ts
+++ b/modules/test/playwright/fixtures/documentLibraryPages.fixtures.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {DocumentLibraryEditFilePage} from '../pages/document-library-web/DocumentLibraryEditFilePage';

--- a/modules/test/playwright/fixtures/pageEditorPagesTest.ts
+++ b/modules/test/playwright/fixtures/pageEditorPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {PageEditorPage} from '../pages/layout-content-page-editor-web/PageEditorPage';

--- a/modules/test/playwright/fixtures/portalDefaultPermissionsPagesTest.ts
+++ b/modules/test/playwright/fixtures/portalDefaultPermissionsPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {PortalDefaultPermissionsConfigurationPage} from '../pages/portal-default-permissions-web/PortalDefaultPermissionsConfigurationPage';

--- a/modules/test/playwright/fixtures/portletConfigurationPermissionsPagesTest.ts
+++ b/modules/test/playwright/fixtures/portletConfigurationPermissionsPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {PortletConfigurationPermissionsPage} from '../pages/portlet-configuration-web/PortletConfigurationPermissionsPage';

--- a/modules/test/playwright/fixtures/productMenuPageTest.ts
+++ b/modules/test/playwright/fixtures/productMenuPageTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {ProductMenuPage} from '../pages/product-navigation-control-menu-web/ProductMenuPage';

--- a/modules/test/playwright/fixtures/serverAdministrationPageTest.ts
+++ b/modules/test/playwright/fixtures/serverAdministrationPageTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {ServerAdministrationPage} from '../pages/server-admin-web/ServerAdministrationPage';

--- a/modules/test/playwright/fixtures/sitesPageTest.ts
+++ b/modules/test/playwright/fixtures/sitesPageTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {SitesPage} from '../pages/site-admin-web/SitesPage';

--- a/modules/test/playwright/fixtures/systemSettingsPageTest.ts
+++ b/modules/test/playwright/fixtures/systemSettingsPageTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {SystemSettingsPage} from '../pages/configuration-admin-web/SystemSettingsPage';

--- a/modules/test/playwright/fixtures/uiElementsTest.ts
+++ b/modules/test/playwright/fixtures/uiElementsTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {UIElementsPage} from '../pages/uielements/UIElementsPage';

--- a/modules/test/playwright/fixtures/usersAdminItemSelectorPagesTest.ts
+++ b/modules/test/playwright/fixtures/usersAdminItemSelectorPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {UsersAdminItemSelectorPage} from '../pages/users-admin-item-selector-web/UsersAdminItemSelectorPage';

--- a/modules/test/playwright/fixtures/usersAndOrganizationsPagesTest.ts
+++ b/modules/test/playwright/fixtures/usersAndOrganizationsPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {ExportUserDataPage} from '../pages/user-associated-data-web/ExportUserDataPage';

--- a/modules/test/playwright/fixtures/webContentDisplayPageTest.ts
+++ b/modules/test/playwright/fixtures/webContentDisplayPageTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {WebContentDisplayPage} from '../pages/journal-content-web/WebContentDisplayPage';

--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Page} from '@playwright/test';
 
 import {liferayConfig} from '../liferay.config';

--- a/modules/test/playwright/pages/account-admin-web/AccountAccountGroupsPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/AccountAccountGroupsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class AccountAccountGroupsPage {

--- a/modules/test/playwright/pages/account-admin-web/AccountContactAddressPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/AccountContactAddressPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class AccountContactAddressPage {

--- a/modules/test/playwright/pages/account-admin-web/AccountsPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/AccountsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/account-admin-web/EditAccountContactAddressPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountContactAddressPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountContactAddressPage {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountContactInformationPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountContactInformationPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountContactInformationPage {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountContactPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountContactPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountContactPage {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountEmailAddressPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountEmailAddressPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountEmailAddressPage {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountPage {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountPhonePage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountPhonePage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountPhonePage {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountWebsitePage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountWebsitePage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class EditAccountWebsitePage {

--- a/modules/test/playwright/pages/commerce/commerceAdminChannelDetailsCountriesPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminChannelDetailsCountriesPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/commerce/commerceAdminChannelDetailsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminChannelDetailsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/commerce/commerceAdminChannelsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminChannelsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/commerce/commerceAdminOrderDetailsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminOrderDetailsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class CommerceAdminOrderDetailsPage {

--- a/modules/test/playwright/pages/commerce/commerceAdminOrdersPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminOrdersPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
+++ b/modules/test/playwright/pages/configuration-admin-web/SystemSettingsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/contacts-web/ContactsCenterPage.ts
+++ b/modules/test/playwright/pages/contacts-web/ContactsCenterPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApiHelpers, DataApiHelpers} from '../../helpers/ApiHelpers';

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page, expect} from '@playwright/test';
 
 import {liferayConfig} from '../../liferay.config';

--- a/modules/test/playwright/pages/portal-default-permissions-web/PortalDefaultPermissionsConfigurationPage.ts
+++ b/modules/test/playwright/pages/portal-default-permissions-web/PortalDefaultPermissionsConfigurationPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/portal-default-permissions-web/PortalDefaultPermissionsSiteConfigurationPage.ts
+++ b/modules/test/playwright/pages/portal-default-permissions-web/PortalDefaultPermissionsSiteConfigurationPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
 export class PortalDefaultPermissionsSiteConfigurationPage {

--- a/modules/test/playwright/pages/portlet-configuration-web/PortletConfigurationPermissionsPage.ts
+++ b/modules/test/playwright/pages/portlet-configuration-web/PortletConfigurationPermissionsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {ProductMenuPage} from '../product-navigation-control-menu-web/ProductMenuPage';

--- a/modules/test/playwright/pages/product-navigation-control-menu-web/ProductMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-control-menu-web/ProductMenuPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class ProductMenuPage {

--- a/modules/test/playwright/pages/user-associated-data-web/ExportUserDataPage.ts
+++ b/modules/test/playwright/pages/user-associated-data-web/ExportUserDataPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class ExportUserDataPage {

--- a/modules/test/playwright/pages/users-admin-item-selector-web/UsersAdminItemSelectorPage.ts
+++ b/modules/test/playwright/pages/users-admin-item-selector-web/UsersAdminItemSelectorPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/users-admin-web/AccountSettingsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/AccountSettingsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class AccountSettingsPage {

--- a/modules/test/playwright/pages/users-admin-web/EditOrganizationPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/EditOrganizationPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';

--- a/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {searchTableRowByValue} from './UsersAndOrganizationsPage';

--- a/modules/test/playwright/pages/users-admin-web/ServiceAccountsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/ServiceAccountsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/pages/users-admin-web/UsersAndOrganizationsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/UsersAndOrganizationsPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';

--- a/modules/test/playwright/tests/account-admin-web/accountGroups.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accountGroups.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {accountsPagesTest} from '../../fixtures/accountsPagesTest';

--- a/modules/test/playwright/tests/account-admin-web/accounts.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accounts.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {accountsPagesTest} from '../../fixtures/accountsPagesTest';

--- a/modules/test/playwright/tests/account-admin-web/config.ts
+++ b/modules/test/playwright/tests/account-admin-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/commerce/commerce-product-content-search-web/specificationFacet.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-search-web/specificationFacet.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/commerce/commerce-product-definitions-web/attachment.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-definitions-web/attachment.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 import * as path from 'path';
 

--- a/modules/test/playwright/tests/commerce/commerce-product-definitions-web/commerceAdminProductVersioning.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-definitions-web/commerceAdminProductVersioning.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/commerce/commerceAdminChannelDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceAdminChannelDetails.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/commerce/commerceAdminOrderDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceAdminOrderDetails.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/commerce/commerceAdminProductRelations.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceAdminProductRelations.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/commerce/commerceMiniCart.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceMiniCart.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';

--- a/modules/test/playwright/tests/export-import-web/config.ts
+++ b/modules/test/playwright/tests/export-import-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/export-import-web/fixtures/exportImportPagesTest.ts
+++ b/modules/test/playwright/tests/export-import-web/fixtures/exportImportPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {ExportImportFramePage} from '../pages/ExportImportFramePage';

--- a/modules/test/playwright/tests/export-import-web/import.spec.ts
+++ b/modules/test/playwright/tests/export-import-web/import.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 import * as path from 'path';
 

--- a/modules/test/playwright/tests/export-import-web/pages/ExportImportFramePage.ts
+++ b/modules/test/playwright/tests/export-import-web/pages/ExportImportFramePage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Page} from '@playwright/test';
 
 import {zipFolder} from '../../../utils/zip';

--- a/modules/test/playwright/tests/headless-builder-impl/config.ts
+++ b/modules/test/playwright/tests/headless-builder-impl/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/headless-builder-web/config.ts
+++ b/modules/test/playwright/tests/headless-builder-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/layout-admin-web/fixtures/pagesPagesTest.ts
+++ b/modules/test/playwright/tests/layout-admin-web/fixtures/pagesPagesTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {StaticPagesPage} from '../pages/StaticPagesPage';

--- a/modules/test/playwright/tests/layout-admin-web/pages/StaticPagesPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/StaticPagesPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
 import {liferayConfig} from '../../../liferay.config';

--- a/modules/test/playwright/tests/layout-admin-web/pages/UtilityPageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/UtilityPageConfigurationPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';

--- a/modules/test/playwright/tests/layout-admin-web/pages/UtilityPagesPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/UtilityPagesPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';

--- a/modules/test/playwright/tests/layout-set-prototype-web/fixtures/layoutSetPrototypePageTest.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/fixtures/layoutSetPrototypePageTest.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {test} from '@playwright/test';
 
 import {LayoutSetPrototypePage} from '../pages/LayoutSetPrototypePage';

--- a/modules/test/playwright/tests/layout-set-prototype-web/pages/LayoutSetPrototypePage.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/pages/LayoutSetPrototypePage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 export class LayoutSetPrototypePage {

--- a/modules/test/playwright/tests/login-web/pages/UtilityPagesPage.ts
+++ b/modules/test/playwright/tests/login-web/pages/UtilityPagesPage.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';

--- a/modules/test/playwright/tests/portal-default-permissions-web/config.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/portal-default-permissions-web/defaultPermissionsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/defaultPermissionsConfiguration.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';

--- a/modules/test/playwright/tests/portlet-configuration-web/config.ts
+++ b/modules/test/playwright/tests/portlet-configuration-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/portlet-configuration-web/rolePermissions.spec.ts
+++ b/modules/test/playwright/tests/portlet-configuration-web/rolePermissions.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {loginTest} from '../../fixtures/loginTest';

--- a/modules/test/playwright/tests/product-navigation-user-personal-bar-web/config.ts
+++ b/modules/test/playwright/tests/product-navigation-user-personal-bar-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/style-book-web/config.ts
+++ b/modules/test/playwright/tests/style-book-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/users-admin-web/accountSettingsRoles.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/accountSettingsRoles.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {accountSettingsPagesTest} from '../../fixtures/accountSettingsPagesTest';

--- a/modules/test/playwright/tests/users-admin-web/config.ts
+++ b/modules/test/playwright/tests/users-admin-web/config.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {devices} from '@playwright/test';
 
 export const config = {

--- a/modules/test/playwright/tests/users-admin-web/editOrganization.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/editOrganization.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/gdpr.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 import {createReadStream} from 'fs';
 import path from 'node:path';

--- a/modules/test/playwright/tests/users-admin-web/login.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/login.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect} from '@playwright/test';
 
 import {LoginOptions, loginTest} from '../../fixtures/loginTest';

--- a/modules/test/playwright/tests/users-admin-web/serviceAccounts.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/serviceAccounts.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/users-admin-web/usersAndOrganizations.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/usersAndOrganizations.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';

--- a/modules/test/playwright/tests/users-admin-web/usersItemSelector.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/usersItemSelector.spec.ts
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-// @ts-ignore
-
 import {expect, mergeTests} from '@playwright/test';
 
 import {loginTest} from '../../fixtures/loginTest';


### PR DESCRIPTION
### References

- [Related Slack discussion](https://liferay.slack.com/archives/C06A59K5D46/p1715848986873389)

### What is the goal of this PR?

Removing 83 unnecessary TS ignores. TS should be fully implemented everywhere. Few legitimate ignores are still in after this PR.