### PR TITLE
LPD-26697 - Fix Client Extension FDS Filter tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtension.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtension.path
@@ -71,6 +71,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>REMOTE_TABLE_SVG_ELLIPSIS</td>
+	<td>//div[@class='dnd-table fixed table-style-fluid']//button[1]//*[name()='svg'][contains(@class,'icon-ellipsis')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>TABLE_ENTRY_CONFIGURED_FROM_SPECIFIC</td>
 	<td>xpath=(//div[contains(@class,'dnd-tr')][.//div[contains(@class,'table-list-title') and contains(.,'${key_tableEntryName}')]]//div[contains(@class,'dnd-td')])[4]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionFDSFilter.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionFDSFilter.testcase
@@ -187,7 +187,7 @@ definition {
 		}
 
 		task ("And delete the Date Filter Improvements entry") {
-			Click(locator1 = "Icon#SVG_ELLIPSIS");
+			Click(locator1 = "ClientExtension#REMOTE_TABLE_SVG_ELLIPSIS");
 
 			MenuItem.clickNoError(menuItem = "Delete");
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionFDSFilter.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionFDSFilter.testcase
@@ -242,7 +242,7 @@ definition {
 		}
 
 		task ("And go to the edit page of the Extension client created ") {
-			Click(locator1 = "Icon#SVG_ELLIPSIS");
+			Click(locator1 = "ClientExtension#REMOTE_TABLE_SVG_ELLIPSIS");
 
 			MenuItem.click(menuItem = "Edit");
 		}


### PR DESCRIPTION
## Task
https://liferay.atlassian.net/browse/LPD-26696

## Issue
Wrong selector opens a that does not contain the required options. `Icon#SVG_ELLIPSIS` locator selects the header ellipsis button.

## Solution
Update locator to match the menu with the correct options

This will fix [ClientExtensionFDSFilter#CanEditCXFilterEntry](https://testray.liferay.com/home/-/testray/case_results/2571363026?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2571362887%26cur%3D1%26delta%3D200%26tab%3Druns%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc) and [ClientExtensionFDSFilter#CanDeleteACXFilterEntry](https://testray.liferay.com/home/-/testray/case_results/2571363020?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2571362887%26cur%3D1%26delta%3D200%26tab%3Druns%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc)