### PR TITLE
LPD-26720 Fix menu

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -702,6 +702,8 @@ AUI.add(
 				if (!trigger.hasClass('disabled')) {
 					const menu = menuInstance._getMenu(trigger);
 
+					menuInstance._closeActiveMenu();
+
 					menuInstance._activeMenu = menu;
 					menuInstance._activeTrigger = trigger;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-26720


Hello team,

We found a frontend team bug through one of our portlets.

If you implement multiple `liferay-ui:icon-menu` as part of a search container, the ellipsis persists when clicked and will not close when you click on other ellipsis menu.

Sincerely,
Brian I. Kim