### PR TITLE
LPD-26774 Delete poshi tests already covered

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFilters.testcase
@@ -251,40 +251,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-190851. Confirm that the filter options are shown after clicking on the Create Filter button"
-	@priority = 3
-	test AssertOptionsAfterClickingCreateButton {
-		task ("And clicks to add a new filter") {
-			Click(
-				key_text = "Create Filter",
-				locator1 = "Button#ANY");
-		}
-
-		task ("Then 3 options is displayed") {
-			MenuItem.viewPresent(menuItem = "Date Range");
-
-			MenuItem.viewPresent(menuItem = "Client Extension");
-
-			MenuItem.viewPresent(menuItem = "Selection");
-		}
-	}
-
-	@description = "LPS-190851. Confirm that the filter options are shown after clicking on the button plus"
-	@priority = 3
-	test AssertOptionsAfterClickingPlusButton {
-		task ("And clicks to add a new filter") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("Then 3 options is displayed") {
-			MenuItem.viewPresent(menuItem = "Date Range");
-
-			MenuItem.viewPresent(menuItem = "Client Extension");
-
-			MenuItem.viewPresent(menuItem = "Selection");
-		}
-	}
-
 	@description = "LPS-186878 Confirm that the translated option appears when selecting pt_BR in the translation modal"
 	@ignore = "true"
 	@priority = 3


### PR DESCRIPTION
In this PR we are deleting 2 poshi tests that are already being covered by playwright. They are in charge of checking the UI offers the available filter options. Existing pw tests will fail when those are not available, rendering poshi counterpart redundant