### PR TITLE
LPD-26851 - Feat. Prevent self-referenced branches in the treeview

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -65,30 +65,25 @@ function getValidFields({
 			const type = propertyValue.type;
 
 			if (propertyValue.items?.$ref) {
-				if (contextPath.includes(propertyKey)) {
-					fields.push({
-						label: propertyKey,
-						name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
-						sortable: false,
-						type: type ? type : 'array',
+				const field: IField = {
+					label: propertyKey,
+					name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
+					sortable: false,
+					type: type ? type : 'array',
+				};
+
+				if (!contextPath.includes(propertyKey)) {
+					field.children = getValidFields({
+						contextPath: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_DELIMITER}`,
+						schemaName: propertyValue.items.$ref.replace(
+							/^.*\//,
+							''
+						),
+						schemas,
 					});
 				}
-				else {
-					fields.push({
-						children: getValidFields({
-							contextPath: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_DELIMITER}`,
-							schemaName: propertyValue.items.$ref.replace(
-								/^.*\//,
-								''
-							),
-							schemas,
-						}),
-						label: propertyKey,
-						name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
-						sortable: false,
-						type: type ? type : 'array',
-					});
-				}
+
+				fields.push(field);
 
 				return;
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -65,20 +65,30 @@ function getValidFields({
 			const type = propertyValue.type;
 
 			if (propertyValue.items?.$ref) {
-				fields.push({
-					children: getValidFields({
-						contextPath: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_DELIMITER}`,
-						schemaName: propertyValue.items.$ref.replace(
-							/^.*\//,
-							''
-						),
-						schemas,
-					}),
-					label: propertyKey,
-					name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
-					sortable: false,
-					type: type ? type : 'array',
-				});
+				if (contextPath.includes(propertyKey)) {
+					fields.push({
+						label: propertyKey,
+						name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
+						sortable: false,
+						type: type ? type : 'array',
+					});
+				}
+				else {
+					fields.push({
+						children: getValidFields({
+							contextPath: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_DELIMITER}`,
+							schemaName: propertyValue.items.$ref.replace(
+								/^.*\//,
+								''
+							),
+							schemas,
+						}),
+						label: propertyKey,
+						name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
+						sortable: false,
+						type: type ? type : 'array',
+					});
+				}
 
 				return;
 			}


### PR DESCRIPTION
## Task
https://liferay.atlassian.net/browse/LPD-26851

## Issue
`StructuredContent` schema has self reference objects that causes an infinite loop, preventing the tree from loading in the DSM Visualization Modes pages.

## Solution
Prevent loading children if they are already part of the parent tree. 

This task fixes DataSetFragment#CanUseStructuredContentSchema test

## UI
[Screencast from 2024-05-28 14-39-42.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/b91fcfae-f166-4dd9-af55-d0e16de992da)

