### PR TITLE
LPD-26994 - Fix ClientExtensionOSGI#HasViewAction test

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtension.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/remoteapps/ClientExtension.path
@@ -66,6 +66,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DROPDOWN_OPTION_START_WITH</td>
+	<td>//*[contains(@class,'dropdown-item') and starts-with(text(), '${key_option}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>REMOTE_TABLE_ELLIPSIS</td>
 	<td>//button[contains(@class,'component-action')]//span[contains(.,'Actions')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionOSGI.testcase
@@ -80,7 +80,7 @@ definition {
 		task ("And Then Edit action is not an available option field information is displayed correctly") {
 			AssertElementNotPresent(
 				key_option = "Edit",
-				locator1 = "ClientExtension#DROPDOWN_OPTIONS");
+				locator1 = "ClientExtension#DROPDOWN_OPTION_START_WITH");
 		}
 	}
 


### PR DESCRIPTION
## Task
https://liferay.atlassian.net/browse/LPD-26994

## Issue
`AssertElementNotPresent` -> 'Edit' finds 'Add Editor Config Contributor' and makes the test fail. 

## Solution
Try text exact match