### PR TITLE
LPD-27048 - Refactor. Update reference to the correct .jsp file

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/display/context/FDSViewsDisplayContext.java
@@ -98,7 +98,7 @@ public class FDSViewsDisplayContext {
 				_renderRequest, FDSViewsPortletKeys.FDS_VIEWS,
 				RenderRequest.RENDER_PHASE)
 		).setMVCPath(
-			"/fds_entries.jsp"
+			"/data_sets.jsp"
 		).buildString();
 	}
 


### PR DESCRIPTION
## Task
https://liferay.atlassian.net/browse/LPD-27048

## Issue
Navigating with `feature.flag.LPD-15729=false` causes the Data Set Views back button to point to `fds_entries.jsp` that has been removed.

This causes some tests to fail:
[#CanGoToViewPage](https://testray.liferay.com/home/-/testray/case_results/2573078530?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2573078197%26cur%3D1%26delta%3D200%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc)
[#CanClickOnDataSetNameCreated](https://testray.liferay.com/home/-/testray/case_results/2573078519?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2573078197%26cur%3D1%26delta%3D200%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc)
[#](https://testray.liferay.com/home/-/testray/case_results/2573078519?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2573078197%26cur%3D1%26delta%3D200%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc)[CanViewCreatedDataSet](https://testray.liferay.com/home/-/testray/case_results/2573078406?redirect=https%3A%2F%2Ftestray.liferay.com%2Fhome%2F-%2Ftestray%2Fcase_results%2Findex%3FtestrayBuildId%3D2573078197%26cur%3D1%26delta%3D200%26orderByCol%3Dstatus_sortable%26orderByType%3Dasc)

![Screenshot from 2024-05-29 08-57-28](https://github.com/liferay-frontend/liferay-portal/assets/132653342/f81f0ca1-626d-45a7-a47d-a56c2988a2ac)
