### PR TITLE
LPD-27477 Relocate source maps

### DIFF
--- a/modules/_node-scripts/build/esbuild/bundleJavaScriptExports.mjs
+++ b/modules/_node-scripts/build/esbuild/bundleJavaScriptExports.mjs
@@ -3,19 +3,23 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import path from 'path';
+
 import {BUILD_MAIN_EXPORTS_PATH} from '../../util/constants.mjs';
 import getFlatName from '../../util/getFlatName.mjs';
 import getEntryPoint from './getEntryPoint.mjs';
 import getExternals from './getExternals.mjs';
 import getExactAliasPlugin from './plugins/getExactAliasPlugin.mjs';
 import getImportBridgesPlugin from './plugins/getImportBridgesPlugin.mjs';
+import relocateSourcemap from './relocateSourcemap.mjs';
 import runEsbuild from './runEsbuild.mjs';
 import writeExportBridge from './writeExportBridge.mjs';
 
 export default async function bundleJavaScriptExports(
 	globalImports,
 	overridenPackageSymbols,
-	projectExports
+	projectExports,
+	projectWebContextPath
 ) {
 	if (!projectExports.length) {
 		return;
@@ -25,12 +29,12 @@ export default async function bundleJavaScriptExports(
 		projectExports
 			.filter((moduleName) => !moduleName.endsWith('.css'))
 			.map((moduleName) =>
-				bundle(globalImports, overridenPackageSymbols, moduleName)
+				bundle(globalImports, overridenPackageSymbols, projectWebContextPath, moduleName)
 			)
 	);
 }
 
-async function bundle(globalImports, overridenPackageSymbols, moduleName) {
+async function bundle(globalImports, overridenPackageSymbols, projectWebContextPath, moduleName) {
 	const esbuildConfig = {
 		bundle: true,
 		entryPoints: [getEntryPoint(moduleName)],
@@ -47,5 +51,12 @@ async function bundle(globalImports, overridenPackageSymbols, moduleName) {
 
 	await writeExportBridge(overridenPackageSymbols, moduleName);
 
-	return runEsbuild(esbuildConfig, getFlatName(moduleName));
+	const flatModuleName = getFlatName(moduleName);
+
+	await runEsbuild(esbuildConfig, flatModuleName);
+
+	await relocateSourcemap(
+		path.join(BUILD_MAIN_EXPORTS_PATH, 'exports', `${flatModuleName}.js.map`),
+		projectWebContextPath
+	);
 }

--- a/modules/_node-scripts/build/esbuild/bundleJavaScriptMain.mjs
+++ b/modules/_node-scripts/build/esbuild/bundleJavaScriptMain.mjs
@@ -11,6 +11,7 @@ import getCssLoaderPlugin from './plugins/getCssLoaderPlugin.mjs';
 import getExactAliasPlugin from './plugins/getExactAliasPlugin.mjs';
 import getImportBridgesPlugin from './plugins/getImportBridgesPlugin.mjs';
 import getScssLoaderPlugin from './plugins/getScssLoaderPlugin.mjs';
+import relocateSourcemap from './relocateSourcemap.mjs';
 import runEsbuild from './runEsbuild.mjs';
 
 export default async function bundleJavaScriptMain(
@@ -47,5 +48,10 @@ export default async function bundleJavaScriptMain(
 		target: ['es2020'],
 	};
 
-	return runEsbuild(esbuildConfig, 'main');
+	await runEsbuild(esbuildConfig, 'main');
+
+	await relocateSourcemap(
+		path.join(BUILD_MAIN_EXPORTS_PATH, 'index.js.map'),
+		projectWebContextPath
+	);
 }

--- a/modules/_node-scripts/build/esbuild/relocateSourcemap.mjs
+++ b/modules/_node-scripts/build/esbuild/relocateSourcemap.mjs
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fs from 'fs/promises';
+
+export default async function relocateSourcemap(filePath, projectWebContextPath) {
+	const sourcemap = JSON.parse(await fs.readFile(filePath, 'utf-8'));
+
+	const prefix = `/sourcemap${projectWebContextPath}`;
+
+	for (let i=0; i<sourcemap.sources.length; i++) {
+		sourcemap.sources[i] = 
+			sourcemap.sources[i]
+				.replace(
+					regexp('/node_modules/'),
+					`${prefix}/node_modules/`
+				)
+				.replace(
+					regexp('/node-scripts/export/'),
+					`${prefix}/generated/export/`
+				)
+				.replace(
+					regexp('/\\$/bridge/for/'),
+					`${prefix}/generated/bridge/for/`
+				)
+				.replace(
+					regexp('/src/main/resources/META-INF/resources/'),
+					`${prefix}/src/`
+				);
+	}
+
+	await fs.writeFile(filePath, JSON.stringify(sourcemap), 'utf-8');
+}
+
+function regexp(pathPrefix) {
+	return new RegExp(`[\.\/]*${pathPrefix}`);
+}

--- a/modules/_node-scripts/build/index.mjs
+++ b/modules/_node-scripts/build/index.mjs
@@ -57,7 +57,8 @@ export default async function main() {
 		bundleJavaScriptExports(
 			globalImports,
 			overridenPackageSymbols,
-			projectExports
+			projectExports,
+			projectWebContextPath
 		),
 
 		// CSS Bundling


### PR DESCRIPTION
This is how sourcemaps look like now:

![image](https://github.com/liferay-frontend/liferay-portal/assets/3273630/2c463d6f-5611-4253-b0dd-3050b6e4e6b7)

All relevant information is under `sourcemap` directory, classified by project web context path (eg: `frontend-js-react-web`) and each project contains a `generated` folder for intermediate stuff that is fed to `esbuild` (not really useful from the POV of the developer, but there it is :shrug: ), a `node_modules` folder for external packages, and a `src` folder for the project's source code.