### PR TITLE
LPD-19503 LPD-25463 Show translated labels using current user's locale instead of instance setting language

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -1006,6 +1006,16 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
+				String label = (String)properties.get("label");
+
+				if (label.equals(StringPool.BLANK)) {
+					Map<String, String> labelI18n =
+						(Map<String, String>)properties.get("label_i18n");
+
+					label = labelI18n.get(
+						LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
+				}
+
 				if (FeatureFlagManagerUtil.isEnabled("LPD-19465")) {
 					return JSONUtil.put(
 						"active", properties.get("default")
@@ -1016,7 +1026,7 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					).put(
 						"key", properties.get("fieldName")
 					).put(
-						"label", properties.get("label")
+						"label", label
 					);
 				}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -879,8 +879,8 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 
 		DTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
-				false, null, null, null, null, LocaleUtil.getSiteDefault(),
-				null, null);
+				false, null, null, null, null,
+				LocaleUtil.getMostRelevantLocale(), null, null);
 
 		DefaultObjectEntryManager defaultObjectEntryManager =
 			DefaultObjectEntryManagerProvider.provide(
@@ -918,8 +918,8 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 
 		DTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
-				false, null, null, null, null, LocaleUtil.getSiteDefault(),
-				null, null);
+				false, null, null, null, null,
+				LocaleUtil.getMostRelevantLocale(), null, null);
 
 		DefaultObjectEntryManager defaultObjectEntryManager =
 			DefaultObjectEntryManagerProvider.provide(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -450,7 +450,14 @@ const Sorting = ({
 	useEffect(() => {
 		const getFDSSort = async () => {
 			const response = await fetch(
-				`${API_URL.SORTS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_SORT_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_SORT}&sort=dateCreated:asc`
+				`${API_URL.SORTS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_SORT_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_SORT}&sort=dateCreated:asc`,
+				{
+					headers: {
+						'Accept': 'application/json',
+						'Accept-Language':
+							Liferay.ThemeDisplay.getBCP47LanguageId(),
+					},
+				}
 			);
 
 			const responseJSON = await response.json();

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -12,13 +12,18 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {InputLocalized} from 'frontend-js-components-web';
 import {fetch, openModal} from 'frontend-js-web';
+import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
 import {IDataSet} from '../../DataSets';
 import {FDSViewType} from '../../FDSViews';
 import OrderableTable from '../../components/OrderableTable';
 import RequiredMark from '../../components/RequiredMark';
-import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {
+	API_URL,
+	FUZZY_OPTIONS,
+	OBJECT_RELATIONSHIP,
+} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import sortItems from '../../utils/sortItems';
@@ -59,6 +64,37 @@ const DefaultComponent = ({item}: IContentRendererProps) => {
 				? Liferay.Language.get('yes')
 				: Liferay.Language.get('no')}
 		</ClayLabel>
+	);
+};
+
+const LabelComponent = ({item, query}: IContentRendererProps) => {
+	const label =
+		item.label ||
+		item.label_i18n[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
+		'';
+
+	const fuzzyMatch = fuzzy.match(query, label, FUZZY_OPTIONS);
+
+	return (
+		<span className="table-list-title">
+			{fuzzyMatch ? (
+				<span
+					dangerouslySetInnerHTML={{
+						__html: fuzzyMatch.rendered,
+					}}
+				/>
+			) : (
+				<span>{label}</span>
+			)}
+		</span>
+	);
+};
+
+const labelTextMatch = (item: IFDSSort) => {
+	return (
+		item.label ||
+		item.label_i18n[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
+		''
 	);
 };
 
@@ -643,7 +679,10 @@ const Sorting = ({
 						]}
 						fields={[
 							{
-								headingTitle: true,
+								contentRenderer: {
+									component: LabelComponent,
+									textMatch: labelTextMatch,
+								},
 								label: Liferay.Language.get('label'),
 								name: 'label',
 							},

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/helpers/DataSetManagerApiHelpers.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/helpers/DataSetManagerApiHelpers.ts
@@ -316,7 +316,6 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 			[SORT_DATA_SET_RELATIONSHIP]: dataSetERC,
 			default: defaultValue,
 			fieldName,
-			label: label_i18n[Object.keys(label_i18n)[0]],
 			label_i18n,
 			orderType,
 		};

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
@@ -42,17 +42,16 @@ test.afterEach(async ({dataSetManagerApiHelpers}) => {
 });
 
 test.describe('Sorting in Data Set Manager', () => {
-	test.beforeEach(async ({sortingPage}) => {
+	test('Save and cancel buttons are not present @LPD-9468', async ({
+		page,
+		sortingPage,
+	}) => {
 		await test.step('Navigate to Sorting section', async () => {
 			await sortingPage.goto({
 				dataSetLabel,
 			});
 		});
-	});
 
-	test('Save and cancel buttons are not present @LPD-9468', async ({
-		page,
-	}) => {
 		await test.step('Check that save and cancel buttons are not present', async () => {
 			await expect(
 				page.getByRole('button', {name: 'Save'})
@@ -140,6 +139,12 @@ test.describe('Sorting in Data Set Manager', () => {
 		page,
 		sortingPage,
 	}) => {
+		await test.step('Navigate to Sorting section', async () => {
+			await sortingPage.goto({
+				dataSetLabel,
+			});
+		});
+
 		await test.step('Open new sort modal', async () => {
 			await sortingPage.openAddSortingModal();
 		});
@@ -157,6 +162,12 @@ test.describe('Sorting in Data Set Manager', () => {
 		page,
 		sortingPage,
 	}) => {
+		await test.step('Navigate to Sorting section', async () => {
+			await sortingPage.goto({
+				dataSetLabel,
+			});
+		});
+
 		await test.step('Open new sort modal', async () => {
 			await sortingPage.openAddSortingModal();
 		});
@@ -228,6 +239,109 @@ test.describe('Sorting in Data Set Manager', () => {
 				page.getByText('Date Created').first()
 			).not.toBeVisible();
 		});
+	});
+
+	test('Sorting label in the table is not blank after changing default site language @LPD-25464', async ({
+		page,
+		sortingPage,
+	}) => {
+		let spanishLanguage = false;
+
+		try {
+			await test.step('Navigate to Instance Settings Localization', async () => {
+				await page
+					.getByLabel('Open Applications MenuCtrl+Alt+A')
+					.click();
+
+				await page.getByRole('tab', {name: 'Control Panel'}).click();
+
+				await page
+					.getByRole('menuitem', {name: 'Instance Settings'})
+					.click();
+
+				await page.getByRole('link', {name: 'Localization'}).click();
+			});
+
+			await test.step('Change default site language to Spanish', async () => {
+				await page.getByLabel('Default Language').selectOption('es_ES');
+
+				await page.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					page.getByText(
+						'Success:Your request completed successfully.'
+					)
+				).toBeVisible();
+
+				spanishLanguage = true;
+
+				// Reload page for language changes to take affect.
+				// Otherwise the Label language selector will still default to
+				// en_US.
+
+				await page.reload();
+			});
+
+			await test.step('Navigate to Sorting section', async () => {
+				await sortingPage.goto({
+					dataSetLabel,
+				});
+			});
+
+			await test.step('Open new sort modal', async () => {
+				await sortingPage.openAddSortingModal();
+			});
+
+			await test.step('Input values', async () => {
+				await page.getByLabel('Label').fill('Nombre');
+				await page.getByLabel('Sort By').selectOption('name');
+			});
+
+			await test.step('Save changes', async () => {
+				await saveFromModal({
+					page,
+				});
+			});
+
+			await test.step('Label in the table is not blank', async () => {
+				await expect(page.getByText('Nombre').first()).toBeVisible();
+			});
+		}
+		finally {
+			if (spanishLanguage) {
+				await test.step('Navigate to Instance Settings Localization', async () => {
+					await page
+						.getByLabel('Open Applications MenuCtrl+Alt+A')
+						.click();
+
+					await page
+						.getByRole('tab', {name: 'Control Panel'})
+						.click();
+
+					await page
+						.getByRole('menuitem', {name: 'Instance Settings'})
+						.click();
+
+					await page
+						.getByRole('link', {name: 'Localization'})
+						.click();
+				});
+
+				await test.step('Change default site language back to English', async () => {
+					await page
+						.getByLabel('Default Language')
+						.selectOption('en_US');
+
+					await page.getByRole('button', {name: 'Save'}).click();
+
+					await expect(
+						page.getByText(
+							'Success:Your request completed successfully.'
+						)
+					).toBeVisible();
+				});
+			}
+		}
 	});
 });
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
@@ -222,7 +222,15 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 			});
 
 			await test.step('Change user account default language to Spanish', async () => {
-				await accountSettingsPage.goToAccountSettings();
+
+				// This method should be used, but since it uses it a different
+				// configured `testIdAttribute`, a locator has to be used.
+				//
+				// await accountSettingsPage.goToAccountSettings();
+
+				await page.locator('[data-qa-id="userPersonalMenu"]').click();
+
+				await accountSettingsPage.accountSettingsMenuItem.click();
 
 				await page.getByLabel('Language').selectOption('es_ES');
 
@@ -257,7 +265,9 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 		finally {
 			if (spanishLanguage) {
 				await test.step('Change user account default language back to English', async () => {
-					await page.getByTestId('userPersonalMenu').click();
+					await page
+						.locator('[data-qa-id="userPersonalMenu"]')
+						.click(); // This is using `locator` instead of `getByTestId` because of the difference in `testIdAttribute` names.
 
 					await page
 						.getByRole('menuitem', {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
@@ -5,6 +5,7 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {accountSettingsPagesTest} from '../../../../fixtures/accountSettingsPagesTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
@@ -13,6 +14,7 @@ import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelp
 import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 
 export const test = mergeTests(
+	accountSettingsPagesTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
 		'LPD-19465': true,
@@ -163,5 +165,117 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 
 			expect(firstNameTextAscending < lastNameTextAscending).toBeTruthy();
 		});
+	});
+
+	test('When the current page language is changed, the current translation is used and fallbacks to the site default language @LPD-25464', async ({
+		accountSettingsPage,
+		dataSetManagerApiHelpers,
+		fdsFragmentPage,
+		layout,
+		page,
+	}) => {
+		let spanishLanguage = false;
+
+		try {
+			await test.step('Create sorting', async () => {
+				await dataSetManagerApiHelpers.createDataSetSort({
+					dataSetERC,
+					defaultValue: true,
+					fieldName: 'id',
+					label_i18n: {en_US: 'ID'},
+					orderType: 'asc',
+				});
+
+				await dataSetManagerApiHelpers.createDataSetSort({
+					dataSetERC,
+					defaultValue: false,
+					fieldName: 'name',
+					label_i18n: {en_US: 'Name', es_ES: 'Nombre'},
+				});
+			});
+
+			await test.step('Add fields, so data is displayed', async () => {
+				await dataSetManagerApiHelpers.createDataSetField({
+					dataSetERC,
+					label_i18n: {
+						en_US: 'ID',
+					},
+					name: 'id',
+					sortable: true,
+					type: 'string',
+				});
+
+				await dataSetManagerApiHelpers.createDataSetField({
+					dataSetERC,
+					label_i18n: {en_US: 'Name'},
+					name: 'name',
+					sortable: true,
+					type: 'string',
+				});
+			});
+
+			await test.step('Configure Data Set fragment', async () => {
+				await fdsFragmentPage.configureDataSetFragment({
+					dataSetLabel,
+					layout,
+				});
+			});
+
+			await test.step('Change user account default language to Spanish', async () => {
+				await accountSettingsPage.goToAccountSettings();
+
+				await page.getByLabel('Language').selectOption('es_ES');
+
+				await page.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					page.getByText('Éxito:Su petición ha terminado con éxito.')
+				).toBeVisible();
+
+				spanishLanguage = true;
+			});
+
+			await test.step('Go to Data Set fragment page', async () => {
+				await fdsFragmentPage.goToPage({layout});
+
+				await page
+					.locator('.data-set-content-wrapper')
+					.waitFor({state: 'visible'});
+			});
+
+			await test.step('Check that the correct translations are displayed in the dropdown', async () => {
+				await page.getByRole('button', {name: 'Pedido'}).click();
+
+				await expect(
+					page.getByRole('menuitem', {name: 'ID'})
+				).toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Nombre'})
+				).toBeVisible();
+			});
+		}
+		finally {
+			if (spanishLanguage) {
+				await test.step('Change user account default language back to English', async () => {
+					await page.getByTestId('userPersonalMenu').click();
+
+					await page
+						.getByRole('menuitem', {
+							name: 'Mi cuenta',
+						})
+						.click();
+
+					await page.getByLabel('Lenguaje').selectOption('en_US');
+
+					await page.getByRole('button', {name: 'Guardar'}).click();
+
+					await expect(
+						page.getByText(
+							'Success:Your request completed successfully.'
+						)
+					).toBeVisible();
+				});
+			}
+		}
 	});
 });


### PR DESCRIPTION
**Bug Ticket:** https://liferay.atlassian.net/browse/LPD-25464

---

**Fixes 2 issues:**
1. ([LPD-25463](https://liferay.atlassian.net/browse/LPD-25463)) Order dropdown labels are using site default instead of the current user's locale leading to different translations.

**Before Fix:**
![Screenshot 2024-06-06 at 5 12 46 PM](https://github.com/liferay-frontend/liferay-portal/assets/4496722/8ae836eb-fe16-4606-8399-7e2040a16957)

**After Fix:**
<img width="1284" alt="Screenshot 2024-06-26 at 10 21 56 AM" src="https://github.com/liferay-frontend/liferay-portal/assets/4496722/6b24ff8f-52e9-4ab2-9b63-668fa29d22c2">


2. [LPD-25464](https://liferay.atlassian.net/browse/LPD-25464) In DSM, labels are blank after changing the instance's default language and creating a new sorting item.

**Before Fix:**
![Screenshot 2024-06-06 at 8 08 40 PM](https://github.com/liferay-frontend/liferay-portal/assets/4496722/28baf5cd-4355-46bd-956e-1a7c4c25e2f1)

**After Fix:**
<img width="1287" alt="Screenshot 2024-06-26 at 10 23 42 AM" src="https://github.com/liferay-frontend/liferay-portal/assets/4496722/ea953f8e-520c-4446-a620-fe75d74304f7">


## Notes
- ~I made changes to the `object-rest-impl` module to fallback to using the site's default locale instead of only using the provided locale as well. Otherwise the response `label` property can be blank if a translation is missing. Only the site's default locale is required so it made sense to me to fallback to this value and it seems like this type of behavior (falling back to the site default) is one I've seen throughout portal as well. I dug around the code and found this seems to happen as well for places that use `LocalizationUtil.getLocalization`.~
- **Update as of June 12, 2024:** Changes are only made on `frontend-data-set-views-web` now to fallback to the site default label using `label_i18n`.
- Rebased on top of https://github.com/brianchandotcom/liferay-portal/pull/151839 to fix any conflicts

