### PR TITLE
LPD-27917 - Management Toolbar Clear results button does not show cursor pointer

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
@@ -15,7 +15,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	<p>Management toolbar is an extension of Toolbar. A combination of different components as filters, orders, search, visualization select and other actions, that allow to manage dataset.</p>
 </blockquote>
 
-<section id="management_toolbar_default_state">
+<section id="managementToolbarDefaultState">
 	<h3>DEFAULT STATE</h3>
 
 	<clay:management-toolbar
@@ -32,7 +32,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	/>
 </section>
 
-<section id="management_toolbar_active_state">
+<section id="managementToolbarActiveState">
 	<h3>ACTIVE STATE</h3>
 
 	<clay:management-toolbar
@@ -45,7 +45,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	/>
 </section>
 
-<section id="management_toolbar_with_results_bar">
+<section id="managementToolbarWithResultsBar">
 	<h3>WITH RESULTS BAR</h3>
 
 	<clay:management-toolbar
@@ -65,7 +65,7 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	/>
 </section>
 
-<section id="management_toolbar_using_display_context">
+<section id="managementToolbarUsingDisplayContext">
 	<h3>USING DISPLAY CONTEXT</h3>
 
 	<clay:management-toolbar

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/resources/META-INF/resources/partials/management_toolbars.jsp
@@ -15,53 +15,61 @@ ClaySampleManagementToolbarsDisplayContext managementToolbarsDisplayContext = ne
 	<p>Management toolbar is an extension of Toolbar. A combination of different components as filters, orders, search, visualization select and other actions, that allow to manage dataset.</p>
 </blockquote>
 
-<h3>DEFAULT STATE</h3>
+<section id="management_toolbar_default_state">
+	<h3>DEFAULT STATE</h3>
 
-<clay:management-toolbar
-	creationMenu="<%= managementToolbarsDisplayContext.getCreationMenu() %>"
-	filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
-	orderDropdownItems="<%= managementToolbarsDisplayContext.getOrderDropdownItems() %>"
-	searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
-	searchFormName="mySearchName"
-	searchInputAutoFocus="<%= true %>"
-	searchInputName="mySearchInputName"
-	selectable="<%= true %>"
-	sortingOrder="desc"
-	viewTypeItems="<%= managementToolbarsDisplayContext.getViewTypeItems() %>"
-/>
+	<clay:management-toolbar
+		creationMenu="<%= managementToolbarsDisplayContext.getCreationMenu() %>"
+		filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
+		orderDropdownItems="<%= managementToolbarsDisplayContext.getOrderDropdownItems() %>"
+		searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
+		searchFormName="mySearchName"
+		searchInputAutoFocus="<%= true %>"
+		searchInputName="mySearchInputName"
+		selectable="<%= true %>"
+		sortingOrder="desc"
+		viewTypeItems="<%= managementToolbarsDisplayContext.getViewTypeItems() %>"
+	/>
+</section>
 
-<h3>ACTIVE STATE</h3>
+<section id="management_toolbar_active_state">
+	<h3>ACTIVE STATE</h3>
 
-<clay:management-toolbar
-	actionDropdownItems="<%= managementToolbarsDisplayContext.getActionDropdownItems() %>"
-	checkboxStatus="checked"
-	itemsTotal="<%= 42 %>"
-	selectable="<%= true %>"
-	selectedItems="<%= 14 %>"
-	showSelectAllButton="<%= true %>"
-/>
+	<clay:management-toolbar
+		actionDropdownItems="<%= managementToolbarsDisplayContext.getActionDropdownItems() %>"
+		checkboxStatus="checked"
+		itemsTotal="<%= 42 %>"
+		selectable="<%= true %>"
+		selectedItems="<%= 14 %>"
+		showSelectAllButton="<%= true %>"
+	/>
+</section>
 
-<h3>WITH RESULTS BAR</h3>
+<section id="management_toolbar_with_results_bar">
+	<h3>WITH RESULTS BAR</h3>
 
-<clay:management-toolbar
-	creationMenu="<%= managementToolbarsDisplayContext.getCreationMenu() %>"
-	filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
-	filterLabelItems="<%= managementToolbarsDisplayContext.getFilterLabelItems() %>"
-	itemsTotal="<%= 42 %>"
-	orderDropdownItems="<%= managementToolbarsDisplayContext.getOrderDropdownItems() %>"
-	searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
-	searchFormName="mySearchName"
-	searchInputName="mySearchInputName"
-	searchValue="my search"
-	selectable="<%= true %>"
-	showResultsBar="<%= true %>"
-	sortingOrder="desc"
-	viewTypeItems="<%= managementToolbarsDisplayContext.getViewTypeItems() %>"
-/>
+	<clay:management-toolbar
+		creationMenu="<%= managementToolbarsDisplayContext.getCreationMenu() %>"
+		filterDropdownItems="<%= managementToolbarsDisplayContext.getFilterDropdownItems() %>"
+		filterLabelItems="<%= managementToolbarsDisplayContext.getFilterLabelItems() %>"
+		itemsTotal="<%= 42 %>"
+		orderDropdownItems="<%= managementToolbarsDisplayContext.getOrderDropdownItems() %>"
+		searchActionURL="mySearchActionURL?key1=val1&key2=val2&key3=val3"
+		searchFormName="mySearchName"
+		searchInputName="mySearchInputName"
+		searchValue="my search"
+		selectable="<%= true %>"
+		showResultsBar="<%= true %>"
+		sortingOrder="desc"
+		viewTypeItems="<%= managementToolbarsDisplayContext.getViewTypeItems() %>"
+	/>
+</section>
 
-<h3>USING DISPLAY CONTEXT</h3>
+<section id="management_toolbar_using_display_context">
+	<h3>USING DISPLAY CONTEXT</h3>
 
-<clay:management-toolbar
-	managementToolbarDisplayContext="<%= managementToolbarsDisplayContext %>"
-	propsTransformer="{ClaySampleManagementToolbarPropsTransformer} from frontend-taglib-clay-sample-web"
-/>
+	<clay:management-toolbar
+		managementToolbarDisplayContext="<%= managementToolbarsDisplayContext %>"
+		propsTransformer="{ClaySampleManagementToolbarPropsTransformer} from frontend-taglib-clay-sample-web"
+	/>
+</section>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ResultsBar.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton from '@clayui/button';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
-import ClayLink from '@clayui/link';
 import {ManagementToolbar} from 'frontend-js-components-web';
 import {navigate, sub} from 'frontend-js-web';
 import React, {useEffect, useRef} from 'react';
@@ -133,7 +133,7 @@ const ResultsBar = ({
 				))}
 
 				<ManagementToolbar.ResultsBarItem>
-					<ClayLink
+					<ClayButton
 						aria-label={sub(
 							itemsTotal === 1
 								? Liferay.Language.get('clear-x-result-for-x')
@@ -144,6 +144,7 @@ const ResultsBar = ({
 								: filterLabelItems?.map((item) => item.label)
 						)}
 						className="component-link tbar-link"
+						displayType="unstyled"
 						onClick={(event) => {
 							event.preventDefault();
 
@@ -163,7 +164,7 @@ const ResultsBar = ({
 						tabIndex={0}
 					>
 						{Liferay.Language.get('clear')}
-					</ClayLink>
+					</ClayButton>
 				</ManagementToolbar.ResultsBarItem>
 			</ManagementToolbar.ResultsBar>
 

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -25,6 +25,7 @@ import {config as featureFlagWebConfig} from './tests/feature-flag-web/config';
 import {config as frontendDataSetViewsWebConfig} from './tests/frontend-data-set-views-web/config';
 import {config as frontendDataSetWebConfig} from './tests/frontend-data-set-web/config';
 import {config as frontendJsSpaWebConfig} from './tests/frontend-js-spa-web/config';
+import {config as frontendTaglibClayConfig} from './tests/frontend-taglib-clay/config';
 import {config as headlessBuilderImplConfig} from './tests/headless-builder-impl/config';
 import {config as headlessBuilderWebConfig} from './tests/headless-builder-web/config';
 import {config as journalWebConfig} from './tests/journal-web/config';
@@ -79,6 +80,7 @@ export default defineConfig({
 		frontendDataSetViewsWebConfig,
 		frontendDataSetWebConfig,
 		frontendJsSpaWebConfig,
+		frontendTaglibClayConfig,
 		headlessBuilderImplConfig,
 		headlessBuilderWebConfig,
 		journalWebConfig,

--- a/modules/test/playwright/tests/frontend-taglib-clay/config.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'frontend-taglib-clay',
+	testDir: 'tests/frontend-taglib-clay',
+};

--- a/modules/test/playwright/tests/frontend-taglib-clay/managementToolbar.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/managementToolbar.spec.ts
@@ -61,7 +61,7 @@ test.describe('Management Toolbar With Results', () => {
 
 		await test.step('Select Management Toolbar with results section', async () => {
 			const clearButton = page
-				.locator('#management_toolbar_with_results_bar')
+				.locator('#managementToolbarWithResultsBar')
 				.getByLabel('Clear');
 
 			await expect(clearButton).toBeVisible();

--- a/modules/test/playwright/tests/frontend-taglib-clay/managementToolbar.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/managementToolbar.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {liferayConfig} from '../../liferay.config';
+import getRandomString from '../../utils/getRandomString';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test.describe('Management Toolbar With Results', () => {
+	test('Clear button has a cursor of type pointer', async ({
+		apiHelpers,
+		page,
+		site,
+	}) => {
+		let layout: Layout;
+
+		await test.step('Create a content site and the frontend taglib clay widget', async () => {
+			const widgetDefinition = getWidgetDefinition({
+				id: getRandomString(),
+				widgetName:
+					'com_liferay_clay_sample_web_portlet_ClaySamplePortlet',
+			});
+
+			layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([widgetDefinition]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Select Management Toolbars tab ', async () => {
+			await page.goto(
+				`${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+			);
+
+			const tabHeading = page
+				.getByRole('tablist')
+				.getByText('Management Toolbars');
+
+			await expect(tabHeading).toBeInViewport();
+
+			await tabHeading.click();
+		});
+
+		await test.step('Select Management Toolbar with results section', async () => {
+			const clearButton = page
+				.locator('#management_toolbar_with_results_bar')
+				.getByLabel('Clear');
+
+			await expect(clearButton).toBeVisible();
+
+			const cursorType = await clearButton.evaluate((element) =>
+				window.getComputedStyle(element).getPropertyValue('cursor')
+			);
+
+			await expect(cursorType).toEqual('pointer');
+		});
+	});
+});

--- a/modules/test/playwright/tests/frontend-taglib-clay/test.properties
+++ b/modules/test/playwright/tests/frontend-taglib-clay/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Frontend Taglib Clay

--- a/modules/test/playwright/tests/frontend-taglib-clay/test.properties
+++ b/modules/test/playwright/tests/frontend-taglib-clay/test.properties
@@ -2,4 +2,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Frontend Taglib Clay
+    testray.main.component.name=User Interface

--- a/test.properties
+++ b/test.properties
@@ -934,7 +934,7 @@
         feature-flag-web,\
         frontend-data-set-views-web,\
         frontend-data-set-web,\
-        frontend-tag-lib,\
+        frontend-taglib,\
         headless-builder-impl,\
         headless-builder-web,\
         journal-web,\

--- a/test.properties
+++ b/test.properties
@@ -934,6 +934,7 @@
         feature-flag-web,\
         frontend-data-set-views-web,\
         frontend-data-set-web,\
+        frontend-tag-lib,\
         headless-builder-impl,\
         headless-builder-web,\
         journal-web,\

--- a/test.properties
+++ b/test.properties
@@ -934,7 +934,7 @@
         feature-flag-web,\
         frontend-data-set-views-web,\
         frontend-data-set-web,\
-        frontend-taglib,\
+        frontend-taglib-clay,\
         headless-builder-impl,\
         headless-builder-web,\
         journal-web,\


### PR DESCRIPTION
## Task
[LPD-27917](https://liferay.atlassian.net/browse/LPD-27917) / [LPP-54403](https://liferay.atlassian.net/browse/LPP-54403)

## Issue
Clear results button does not show the cursor pointer when hovering over it. It is caused because we are using a link element without `href` attribute. 
It seems to be a regression issue, as it started having an href attribute that was changed to use a callback handler.

## Solution
Replace the link by a button, to trigger the handler and that displays the cursor of type pointer by default.

![image](https://github.com/liferay-frontend/liferay-portal/assets/132653342/f6205c54-4e0c-4f0d-85a5-10c0de5a3c95)
