### PR TITLE
LPD-28097 update FI team codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,3 @@
-modules/apps/foundation/configuration-admin/*    @jorgeferrer
-modules/apps/foundation/contacts/*    @jorgeferrer
-modules/apps/foundation/password-policies-admin/*    @jorgeferrer
-modules/apps/foundation/plugins-admin/*    @jorgeferrer
-modules/apps/foundation/portal-configuration/*    @jorgeferrer
-modules/apps/foundation/portal-instances/*    @jorgeferrer
-modules/apps/foundation/portal-settings/*    @jorgeferrer
-modules/apps/foundation/roles/*    @jorgeferrer
-modules/apps/foundation/server/*    @jorgeferrer
-modules/apps/foundation/user-groups-admin/*    @jorgeferrer
-modules/apps/foundation/users-admin/*    @jorgeferrer
+modules/apps/frontend-data-set/*    @liferay-frontend
+modules/apps/frontend-editor/*    @liferay-frontend
+modules/apps/frontend-taglib/*    @liferay-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,11 @@
-modules/apps/frontend-data-set/*    @liferay-frontend
-modules/apps/frontend-editor/*    @liferay-frontend
-modules/apps/frontend-taglib/*    @liferay-frontend
+modules/apps/cookies/cookies-banner-web    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-data-set/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-editor/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-js/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib-aui-form-extension-sample/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib-clay/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib-clay-test-alert-toast-sample-web/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib-react/*    @liferay/frontend-infrastructure-core-developers
+modules/apps/frontend-taglib/frontend-taglib-util/*    @liferay/frontend-infrastructure-core-developers


### PR DESCRIPTION
Simple draft to update .github/CODEOWNERS to start working on module ownership

- Deleted current content as the present user was no longer part of the organization
- Added some modules to Frontend Infra User

TODO:
- Keep adding correct modules to the team
- Check if we can add a Org team as codeowners instead of the user owner of the FI fork