### PR TITLE
LPD-29155 API headless fixes

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -126,7 +126,7 @@ function Body({
 		multiple || (!multiple && !(preselectedValues.length > 1));
 
 	async function getAPIValues(source: string) {
-		const response = await fetch(`/o${source}`);
+		const response = await fetch(`${source}`);
 
 		if (!response.ok) {
 			openDefaultFailureToast();
@@ -250,7 +250,10 @@ function Body({
 						itemKey: selectedItemKey,
 						itemLabel: selectedItemLabel,
 						preselectedValues: JSON.stringify(
-							preselectedValues.map((item: any) => item.value)
+							preselectedValues.map((item: any) => ({
+								label: item.label,
+								value: item.value,
+							}))
 						),
 						restApplication: selectedRESTApplication,
 						restEndpoint: selectedRESTEndpoint,
@@ -295,18 +298,23 @@ function Body({
 	};
 
 	useEffect(() => {
-		if (source && sourceType === ESelectionFilterSourceType.API_HEADLESS) {
+		const isValidSource =
+			sourceType === ESelectionFilterSourceType.API_HEADLESS &&
+			source &&
+			!(source as string).match(/\{[A-Za-z0-9]+\}/g);
+
+		if (isValidSource && selectedItemKey && selectedItemLabel) {
 			getAPIValues(source as string).then((apiValues) => {
 				setFilteredSourceItems(
 					!apiValues.items.length
 						? []
 						: apiValues.items
-								.filter((item: any) =>
-									fuzzy.match(
+								.filter((item: any) => {
+									return fuzzy.match(
 										preselectedValueInput,
 										item[selectedItemLabel]
-									)
-								)
+									);
+								})
 								.map((item: any) => {
 									return {
 										label: item[selectedItemLabel],
@@ -378,12 +386,16 @@ function Body({
 				source &&
 				sourceType === ESelectionFilterSourceType.API_HEADLESS
 			) {
+				const filterPreselectedValues = JSON.parse(
+					(filter as ISelectionFilter).preselectedValues || '[]'
+				);
+
 				validSavedPreselectedValues = filteredSourceItems.filter(
 					(item) =>
-						JSON.parse(
-							(filter as ISelectionFilter).preselectedValues ||
-								'[]'
-						).includes(item.value)
+						filterPreselectedValues.find(
+							(filterValue: {label: string; value: string}) =>
+								filterValue.value === item.value
+						)
 				);
 			}
 
@@ -425,6 +437,16 @@ function Body({
 			);
 		}
 	}, [preselectedValueInput, source, sourceType]);
+
+	useEffect(() => {
+		if (selectedRESTApplication && selectedRESTEndpoint) {
+			setSource(
+				`/o${selectedRESTApplication.replace('v1.0/', '')}${selectedRESTEndpoint}`
+			);
+
+			setSourceValidationError(false);
+		}
+	}, [selectedRESTApplication, selectedRESTEndpoint]);
 
 	if (
 		!Liferay.FeatureFlags['LPD-10754'] &&
@@ -593,39 +615,32 @@ function Body({
 												selectedRESTEndpoint,
 												selectedRESTSchema,
 											}) => {
-												let apiSource;
-
-												if (
-													selectedRESTApplication &&
-													selectedRESTEndpoint
-												) {
-													apiSource = `${selectedRESTApplication}${selectedRESTEndpoint}`;
-													setSource(apiSource);
-													setSourceValidationError(
+												setSelectedRESTApplication(
+													selectedRESTApplication
+												);
+												if (selectedRESTApplication) {
+													setRequiredRESTApplicationValidationError(
 														false
 													);
 												}
 
-												setSelectedRESTApplication(
-													selectedRESTApplication
-												);
-												setRequiredRESTApplicationValidationError(
-													!selectedRESTApplication
-												);
-
 												setSelectedRESTEndpoint(
 													selectedRESTEndpoint
 												);
-												setRESTEndpointValidationError(
-													!selectedRESTEndpoint
-												);
+												if (selectedRESTEndpoint) {
+													setRESTEndpointValidationError(
+														false
+													);
+												}
 
 												setSelectedRESTSchema(
 													selectedRESTSchema
 												);
-												setRESTSchemaValidationError(
-													!selectedRESTSchema
-												);
+												if (selectedRESTSchema) {
+													setRESTSchemaValidationError(
+														false
+													);
+												}
 
 												setSelectedItemKey(
 													selectedItemKey
@@ -716,12 +731,8 @@ function Body({
 															ESelectionFilterSourceType.API_HEADLESS
 														) {
 															valueItem = {
-																label: item[
-																	selectedItemLabel
-																],
-																value: item[
-																	selectedItemKey
-																],
+																label: item.label,
+																value: item.value,
 															};
 														}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -312,13 +312,13 @@ function Body({
 								.filter((item: any) => {
 									return fuzzy.match(
 										preselectedValueInput,
-										item[selectedItemLabel]
+										String(item[selectedItemLabel])
 									);
 								})
 								.map((item: any) => {
 									return {
-										label: item[selectedItemLabel],
-										value: item[selectedItemKey],
+										label: String(item[selectedItemLabel]),
+										value: String(item[selectedItemKey]),
 									};
 								})
 				);
@@ -615,8 +615,14 @@ function Body({
 												selectedRESTEndpoint,
 												selectedRESTSchema,
 											}) => {
+												const restApplication =
+													selectedRESTApplication!.replace(
+														'/v1.0',
+														''
+													);
+
 												setSelectedRESTApplication(
-													selectedRESTApplication
+													restApplication
 												);
 												if (selectedRESTApplication) {
 													setRequiredRESTApplicationValidationError(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -14,14 +14,12 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
-import {fetch} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
 import CheckboxMultiSelect from '../../../../components/CheckboxMultiSelect';
 import RequiredMark from '../../../../components/RequiredMark';
 import getAllPicklists from '../../../../utils/getAllPicklists';
-import openDefaultFailureToast from '../../../../utils/openDefaultFailureToast';
 import {
 	ESelectionFilterSourceType,
 	IField,
@@ -124,20 +122,6 @@ function Body({
 
 	const isValidSingleMode =
 		multiple || (!multiple && !(preselectedValues.length > 1));
-
-	async function getAPIValues(source: string) {
-		const response = await fetch(`${source}`);
-
-		if (!response.ok) {
-			openDefaultFailureToast();
-
-			return [];
-		}
-
-		const responseJSON = await response.json();
-
-		return responseJSON;
-	}
 
 	const isi18nFilterLabelsValid = (
 		i18nFilterLabels: Partial<Liferay.Language.FullyLocalizedValue<string>>
@@ -297,40 +281,20 @@ function Body({
 		}
 	};
 
-	useEffect(() => {
-		const isValidSource =
-			sourceType === ESelectionFilterSourceType.API_HEADLESS &&
-			source &&
-			!(source as string).match(/\{[A-Za-z0-9]+\}/g);
-
-		if (isValidSource && selectedItemKey && selectedItemLabel) {
-			getAPIValues(source as string).then((apiValues) => {
-				setFilteredSourceItems(
-					!apiValues.items.length
-						? []
-						: apiValues.items
-								.filter((item: any) => {
-									return fuzzy.match(
-										preselectedValueInput,
-										String(item[selectedItemLabel])
-									);
-								})
-								.map((item: any) => {
-									return {
-										label: String(item[selectedItemLabel]),
-										value: String(item[selectedItemKey]),
-									};
-								})
-				);
-			});
+	function setAPISource(
+		restApplication: string | null,
+		restEndpoint: string | null
+	): string | null {
+		if (!restApplication || !restEndpoint) {
+			return null;
 		}
-	}, [
-		preselectedValueInput,
-		selectedItemKey,
-		selectedItemLabel,
-		source,
-		sourceType,
-	]);
+
+		const source = `/o${restApplication.replace('v1.0/', '')}${restEndpoint}`;
+		setSource(source);
+		setSourceValidationError(false);
+
+		return source;
+	}
 
 	useEffect(() => {
 		if (
@@ -438,16 +402,6 @@ function Body({
 		}
 	}, [preselectedValueInput, source, sourceType]);
 
-	useEffect(() => {
-		if (selectedRESTApplication && selectedRESTEndpoint) {
-			setSource(
-				`/o${selectedRESTApplication.replace('v1.0/', '')}${selectedRESTEndpoint}`
-			);
-
-			setSourceValidationError(false);
-		}
-	}, [selectedRESTApplication, selectedRESTEndpoint]);
-
 	if (
 		!Liferay.FeatureFlags['LPD-10754'] &&
 		sourceType === ESelectionFilterSourceType.API_HEADLESS &&
@@ -533,6 +487,7 @@ function Body({
 
 											setSource(undefined);
 											setPreselectedValueInput('');
+
 											setPreselectedValues([]);
 										}}
 										options={[
@@ -614,6 +569,7 @@ function Body({
 												selectedRESTApplication,
 												selectedRESTEndpoint,
 												selectedRESTSchema,
+												sourceItems,
 											}) => {
 												const restApplication =
 													selectedRESTApplication!.replace(
@@ -639,6 +595,11 @@ function Body({
 													);
 												}
 
+												setAPISource(
+													restApplication,
+													selectedRESTEndpoint
+												);
+
 												setSelectedRESTSchema(
 													selectedRESTSchema
 												);
@@ -661,7 +622,15 @@ function Body({
 												setItemLabelValidationError(
 													false
 												);
+
+												setPreselectedValues([]);
+												setFilteredSourceItems(
+													sourceItems
+												);
 											}}
+											preselectedValueInput={
+												preselectedValueInput
+											}
 											requiredRESTApplicationValidationError={
 												requiredRESTApplicationValidationError
 											}
@@ -672,6 +641,7 @@ function Body({
 											restSchemaValidationError={
 												restSchemaValidationError
 											}
+											source={source as string}
 										/>
 									)}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -281,7 +281,7 @@ function Body({
 		}
 	};
 
-	function setAPISource(
+	function getAPIHeadlessSourceURL(
 		restApplication: string | null,
 		restEndpoint: string | null
 	): string | null {
@@ -289,11 +289,7 @@ function Body({
 			return null;
 		}
 
-		const source = `/o${restApplication.replace('v1.0/', '')}${restEndpoint}`;
-		setSource(source);
-		setSourceValidationError(false);
-
-		return source;
+		return `/o${restApplication.replace('v1.0/', '')}${restEndpoint}`;
 	}
 
 	useEffect(() => {
@@ -595,10 +591,14 @@ function Body({
 													);
 												}
 
-												setAPISource(
-													restApplication,
-													selectedRESTEndpoint
-												);
+												const source =
+													getAPIHeadlessSourceURL(
+														restApplication,
+														selectedRESTEndpoint
+													);
+
+												setSource(source as string);
+												setSourceValidationError(false);
 
 												setSelectedRESTSchema(
 													selectedRESTSchema

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
@@ -104,7 +104,6 @@ function ApiRestApplication({
 		if (!restApplication) {
 			return;
 		}
-
 		const response = await fetch(`/o${restApplication}/openapi.json`);
 
 		if (!response.ok) {
@@ -341,7 +340,9 @@ function ApiRestApplication({
 				}
 			});
 		}
-	}, [selectedRESTApplication, selectedRESTSchema]);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [selectedRESTSchema]);
 
 	const ItemKeyDropdownMenu = ({
 		itemKeys: initialItemKeys,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
@@ -6,10 +6,11 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm from '@clayui/form';
+import {TItem} from '@clayui/form/lib/SelectBox';
 import classNames from 'classnames';
 import {fetch} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 
 import RequiredMark from '../../../../../components/RequiredMark';
 import ValidationFeedback from '../../../../../components/ValidationFeedback';
@@ -36,17 +37,21 @@ interface IApiRestApplicationModalContentProps {
 		selectedRESTApplication,
 		selectedRESTEndpoint,
 		selectedRESTSchema,
+		sourceItems,
 	}: {
 		selectedItemKey: string;
 		selectedItemLabel: string;
 		selectedRESTApplication: string | null;
 		selectedRESTEndpoint: string | null;
 		selectedRESTSchema: string | null;
+		sourceItems: TItem[];
 	}) => void;
+	preselectedValueInput: string;
 	requiredRESTApplicationValidationError: boolean;
 	restApplications: string[];
 	restEndpointValidationError: boolean;
 	restSchemaValidationError: boolean;
+	source: string;
 }
 
 function ApiRestApplication({
@@ -55,10 +60,12 @@ function ApiRestApplication({
 	itemLabelValidationError,
 	namespace,
 	onChange,
+	preselectedValueInput,
 	requiredRESTApplicationValidationError,
 	restApplications,
 	restEndpointValidationError,
 	restSchemaValidationError,
+	source,
 }: IApiRestApplicationModalContentProps) {
 	const [fields, setFields] = useState<IField[]>([]);
 	const [selectedItemKey, setSelectedItemKey] = useState<string>(
@@ -99,6 +106,61 @@ function ApiRestApplication({
 
 		return true;
 	};
+
+	async function getAPIValues(source: string) {
+		const response = await fetch(source);
+
+		if (!response.ok) {
+			openDefaultFailureToast();
+
+			return [];
+		}
+
+		const responseJSON = await response.json();
+
+		return responseJSON;
+	}
+
+	async function getSourceItems({
+		preselectedValueInput,
+		selectedItemKey,
+		selectedItemLabel,
+		source,
+	}: {
+		preselectedValueInput: string;
+		selectedItemKey: string;
+		selectedItemLabel: string;
+		source: string | null;
+	}) {
+		const isValidSource =
+			source && !(source as string).match(/\{[A-Za-z0-9]+\}/g);
+
+		if (!isValidSource || !selectedItemKey || !selectedItemLabel) {
+			return;
+		}
+
+		const sourceItems = await getAPIValues(source as string).then(
+			(apiValues) => {
+				return !apiValues.items.length
+					? []
+					: apiValues.items
+							.filter((item: any) => {
+								return fuzzy.match(
+									preselectedValueInput,
+									String(item[selectedItemLabel])
+								);
+							})
+							.map((item: any) => {
+								return {
+									label: String(item[selectedItemLabel]),
+									value: String(item[selectedItemKey]),
+								};
+							});
+			}
+		);
+
+		return sourceItems;
+	}
 
 	const getRESTSchemas = async (restApplication: string) => {
 		if (!restApplication) {
@@ -141,6 +203,9 @@ function ApiRestApplication({
 			});
 		});
 
+		setSelectedItemKey('');
+		setSelectedItemLabel('');
+
 		if (schemaEndpoints.size === 0) {
 			setSelectedRESTSchema(null);
 			setSelectedRESTEndpoint(null);
@@ -148,11 +213,12 @@ function ApiRestApplication({
 			setNoEnpointsRESTApplicationValidationError(true);
 
 			onChange({
-				selectedItemKey,
-				selectedItemLabel,
+				selectedItemKey: '',
+				selectedItemLabel: '',
 				selectedRESTApplication: restApplication,
 				selectedRESTEndpoint: null,
 				selectedRESTSchema: null,
+				sourceItems: [],
 			});
 		}
 		else if (schemaEndpoints.size === 1) {
@@ -169,13 +235,31 @@ function ApiRestApplication({
 			setNoEnpointsRESTApplicationValidationError(false);
 
 			onChange({
-				selectedItemKey,
-				selectedItemLabel,
+				selectedItemKey: '',
+				selectedItemLabel: '',
 				selectedRESTApplication: restApplication,
 				selectedRESTEndpoint:
 					paths?.length === 1 ? paths[0] : selectedRESTEndpoint,
 				selectedRESTSchema: schema,
+				sourceItems: [],
 			});
+
+			if (restApplication && schema) {
+				getFields({
+					restApplication,
+					restSchema: schema,
+				}).then((fields: IField[]) => {
+					if (fields) {
+						setFields(
+							fields.filter(
+								(field) =>
+									field.type !== 'array' &&
+									field.type !== 'object'
+							)
+						);
+					}
+				});
+			}
 		}
 		else {
 			setSelectedRESTSchema(null);
@@ -184,11 +268,12 @@ function ApiRestApplication({
 			setNoEnpointsRESTApplicationValidationError(false);
 
 			onChange({
-				selectedItemKey,
-				selectedItemLabel,
+				selectedItemKey: '',
+				selectedItemLabel: '',
 				selectedRESTApplication: restApplication,
 				selectedRESTEndpoint: null,
 				selectedRESTSchema: null,
+				sourceItems: [],
 			});
 		}
 
@@ -230,6 +315,7 @@ function ApiRestApplication({
 						selectedRESTApplication: item,
 						selectedRESTEndpoint,
 						selectedRESTSchema,
+						sourceItems: [],
 					});
 				}}
 				restApplications={restApplications}
@@ -279,7 +365,25 @@ function ApiRestApplication({
 								? endpoint
 								: selectedRESTEndpoint,
 						selectedRESTSchema: item,
+						sourceItems: [],
 					});
+
+					if (selectedRESTApplication && item) {
+						getFields({
+							restApplication: selectedRESTApplication,
+							restSchema: item,
+						}).then((fields: IField[]) => {
+							if (fields) {
+								setFields(
+									fields.filter(
+										(field) =>
+											field.type !== 'array' &&
+											field.type !== 'object'
+									)
+								);
+							}
+						});
+					}
 				}}
 				restSchemas={Array.from(restSchemaEndpoints.keys())}
 			/>
@@ -314,6 +418,7 @@ function ApiRestApplication({
 						selectedRESTApplication,
 						selectedRESTEndpoint: item,
 						selectedRESTSchema,
+						sourceItems: [],
 					});
 				}}
 				restEndpoints={
@@ -322,27 +427,6 @@ function ApiRestApplication({
 			/>
 		</ClayDropDown>
 	);
-
-	useEffect(() => {
-		if (selectedRESTApplication && selectedRESTSchema) {
-			getFields({
-				restApplication: selectedRESTApplication,
-				restSchema: selectedRESTSchema,
-			}).then((fields: IField[]) => {
-				if (fields) {
-					setFields(
-						fields.filter(
-							(field) =>
-								field.type !== 'array' &&
-								field.type !== 'object'
-						)
-					);
-				}
-			});
-		}
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [selectedRESTSchema]);
 
 	const ItemKeyDropdownMenu = ({
 		itemKeys: initialItemKeys,
@@ -593,13 +677,21 @@ function ApiRestApplication({
 									onItemClick={(item: string) => {
 										setSelectedItemKey(item);
 
-										onChange({
+										getSourceItems({
+											preselectedValueInput,
 											selectedItemKey: item,
 											selectedItemLabel,
-											selectedRESTApplication,
-											selectedRESTEndpoint,
-											selectedRESTSchema,
-										});
+											source,
+										}).then((sourceItems) =>
+											onChange({
+												selectedItemKey: item,
+												selectedItemLabel,
+												selectedRESTApplication,
+												selectedRESTEndpoint,
+												selectedRESTSchema,
+												sourceItems,
+											})
+										);
 									}}
 								/>
 							</ClayDropDown>
@@ -646,13 +738,21 @@ function ApiRestApplication({
 									onItemClick={(item: string) => {
 										setSelectedItemLabel(item);
 
-										onChange({
+										getSourceItems({
+											preselectedValueInput,
 											selectedItemKey,
 											selectedItemLabel: item,
-											selectedRESTApplication,
-											selectedRESTEndpoint,
-											selectedRESTSchema,
-										});
+											source,
+										}).then((sourceItems) =>
+											onChange({
+												selectedItemKey: item,
+												selectedItemLabel,
+												selectedRESTApplication,
+												selectedRESTEndpoint,
+												selectedRESTSchema,
+												sourceItems,
+											})
+										);
 									}}
 								/>
 							</ClayDropDown>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
@@ -107,20 +107,6 @@ function ApiRestApplication({
 		return true;
 	};
 
-	async function getAPIValues(source: string) {
-		const response = await fetch(source);
-
-		if (!response.ok) {
-			openDefaultFailureToast();
-
-			return [];
-		}
-
-		const responseJSON = await response.json();
-
-		return responseJSON;
-	}
-
 	async function getSourceItems({
 		preselectedValueInput,
 		selectedItemKey,
@@ -139,8 +125,19 @@ function ApiRestApplication({
 			return;
 		}
 
-		const sourceItems = await getAPIValues(source as string).then(
-			(apiValues) => {
+		const sourceItems = await fetch(source as string)
+			.then((response) => {
+				if (!response.ok) {
+					openDefaultFailureToast();
+
+					return [];
+				}
+
+				const responseJSON = response.json();
+
+				return responseJSON;
+			})
+			.then((apiValues) => {
 				return !apiValues.items.length
 					? []
 					: apiValues.items
@@ -156,8 +153,7 @@ function ApiRestApplication({
 									value: String(item[selectedItemKey]),
 								};
 							});
-			}
-		);
+			});
 
 		return sourceItems;
 	}
@@ -745,8 +741,8 @@ function ApiRestApplication({
 											source,
 										}).then((sourceItems) =>
 											onChange({
-												selectedItemKey: item,
-												selectedItemLabel,
+												selectedItemKey,
+												selectedItemLabel: item,
 												selectedRESTApplication,
 												selectedRESTEndpoint,
 												selectedRESTSchema,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -96,7 +96,7 @@ export interface ISelectionFilter extends IFilter {
 	itemKey: string;
 	itemLabel: string;
 	multiple: boolean;
-	preselectedValues: string;
+	preselectedValues: any;
 	restApplication: string;
 	restEndpoint: string;
 	restSchema: string;

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/FiltersPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/FiltersPage.ts
@@ -211,14 +211,15 @@ export class FiltersPage {
 		await this.newSelectionFilterModal.restSchemaField.waitFor();
 		await this.newSelectionFilterModal.restSchemaField.click();
 
-		await this.newSelectionFilterModal.restSchemaOptions.waitFor();
 		await this.newSelectionFilterModal.restSchemaOptions
 			.getByRole('option', {exact: true, name: restSchema})
 			.click();
+		await this.newSelectionFilterModal.restSchemaField.click();
 
+		await this.newSelectionFilterModal.restEndpointField.waitFor();
 		await this.newSelectionFilterModal.restEndpointField.click();
-		await this.newSelectionFilterModal.restEndpointOptions.waitFor();
-		await this.page
+
+		await this.newSelectionFilterModal.restEndpointOptions
 			.getByRole('option', {exact: true, name: restEndpoint})
 			.click();
 		await this.newSelectionFilterModal.restEndpointField.click();

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
@@ -71,7 +71,10 @@ test.afterEach(async ({dataSetManagerApiHelpers, picklistApiHelpers}) => {
 });
 
 test.describe('Filters in Data Set Manager', () => {
-	test('Can create a selection filter', async ({filtersPage, page}) => {
+	test('Can create a selection filter from picklist source', async ({
+		filtersPage,
+		page,
+	}) => {
 		await test.step('Create a selection filter from picklist source', async () => {
 			await filtersPage.createSelectionFilterPicklist({
 				filterBy: 'externalReferenceCode',


### PR DESCRIPTION
This PR contains fixes for product review -> https://liferay.atlassian.net/browse/LPD-16054

- Select `headless-admin-user/v.01` application thrown an error
- `data-set-manager/data-sets` application don't show preselected values and thrown an error
- Select `data-set-manager/data-sets` application and use `id` as key and label doesn’t show default values and trigger errors
- `data-set-manager/data-sets` application and use dates as keys and labels shows default values but trigger errors
- Selecting a preselected value crashes the modal
- Fixes Preselected Value selection and storage
- Controls /openapi.json requests to prevent unnecessary ones
- Controls getFields operations only when REST Schema has changed, to prevent errors when REST Application changes and Schema doesn't 