### PR TITLE
LPD-28612 - Configure API Headless filters in fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -650,7 +650,7 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 						Objects.equals(sourceType, "API_HEADLESS")) {
 
 						return selectionFilterJSONObject.put(
-							"apiURL", "/o" + properties.get("source")
+							"apiURL", properties.get("source")
 						).put(
 							"itemKey", properties.get("itemKey")
 						).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -619,10 +619,12 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 				}
 
 				String listTypeDefinitionERC = null;
+				String sourceType = null;
 
 				if (FeatureFlagManagerUtil.isEnabled("LPD-10754")) {
 					listTypeDefinitionERC = MapUtil.getString(
 						properties, "source");
+					sourceType = MapUtil.getString(properties, "sourceType");
 				}
 				else {
 					listTypeDefinitionERC = MapUtil.getString(
@@ -630,6 +632,52 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 				}
 
 				if (Validator.isNotNull(listTypeDefinitionERC)) {
+					JSONObject selectionFilterJSONObject = JSONUtil.put(
+						"autocompleteEnabled", true
+					).put(
+						"entityFieldType", FDSEntityFieldTypes.STRING
+					).put(
+						"id", properties.get("fieldName")
+					).put(
+						"label", _getValue("label", "fieldName", properties)
+					).put(
+						"multiple", properties.get("multiple")
+					).put(
+						"type", "selection"
+					);
+
+					if (Validator.isNotNull(sourceType) &&
+						Objects.equals(sourceType, "API_HEADLESS")) {
+
+						return selectionFilterJSONObject.put(
+							"apiURL", "/o" + properties.get("source")
+						).put(
+							"itemKey", properties.get("itemKey")
+						).put(
+							"itemLabel", properties.get("itemLabel")
+						).put(
+							"preloadedData",
+							() -> {
+								JSONArray selectedItemsJSONArray =
+									_jsonFactory.createJSONArray(
+										MapUtil.getString(
+											properties, "preselectedValues"));
+
+								if (JSONUtil.isEmpty(selectedItemsJSONArray)) {
+									return null;
+								}
+
+								return JSONUtil.put(
+									"exclude",
+									() -> Boolean.FALSE.equals(
+										(Boolean)properties.get("include"))
+								).put(
+									"selectedItems", selectedItemsJSONArray
+								);
+							}
+						);
+					}
+
 					ThemeDisplay themeDisplay =
 						(ThemeDisplay)httpServletRequest.getAttribute(
 							WebKeys.THEME_DISPLAY);
@@ -644,13 +692,7 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 						_listTypeEntryLocalService.getListTypeEntries(
 							listTypeDefinition.getListTypeDefinitionId());
 
-					return JSONUtil.put(
-						"autocompleteEnabled", true
-					).put(
-						"entityFieldType", FDSEntityFieldTypes.STRING
-					).put(
-						"id", properties.get("fieldName")
-					).put(
+					return selectionFilterJSONObject.put(
 						"items",
 						JSONUtil.toJSONArray(
 							listTypeEntries,
@@ -662,10 +704,6 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 							).put(
 								"value", listTypeEntry.getKey()
 							))
-					).put(
-						"label", _getValue("label", "fieldName", properties)
-					).put(
-						"multiple", properties.get("multiple")
 					).put(
 						"preloadedData",
 						() -> {
@@ -687,8 +725,6 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 								"selectedItems", selectedItemsJSONArray
 							);
 						}
-					).put(
-						"type", "selection"
 					);
 				}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -336,7 +336,7 @@ function SelectionFilter({
 		actionType === 'delete' ||
 		(!selectedData && selectedItems.length) ||
 		(selectedData &&
-			isValuesArrayChanged(selectedData.selectedItems, selectedItems)) ||
+			isValuesArrayChanged(selectedData?.selectedItems, selectedItems)) ||
 		(selectedData &&
 			selectedItems.length &&
 			selectedData.exclude !== exclude)

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -172,7 +172,7 @@ function SelectionFilter({
 	);
 	const [items, setItems] = useState(apiURL ? [] : initialItems);
 	const [localItems, setLocalItems] = useState(
-		initialItems.length ? initialItems : []
+		initialItems?.length ? initialItems : []
 	);
 	const [loading, setLoading] = useState(false);
 	const [total, setTotal] = useState(apiURL ? 0 : initialItems?.length);

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/helpers/DataSetManagerApiHelpers.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/helpers/DataSetManagerApiHelpers.ts
@@ -186,6 +186,8 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 		dataSetERC = DEFAULT_DATA_SET_ERC,
 		fieldName,
 		include = true,
+		itemKey,
+		itemLabel,
 		label_i18n,
 		multiple = false,
 		preselectedValues = '[]',
@@ -195,6 +197,8 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 		dataSetERC?: string;
 		fieldName: string;
 		include?: boolean;
+		itemKey?: string;
+		itemLabel?: string;
 		label_i18n?: {[key: string]: string};
 		multiple?: boolean;
 		preselectedValues?: string;
@@ -207,6 +211,8 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 			[SELECTION_FILTER_DATA_SET_RELATIONSHIP]: dataSetERC,
 			fieldName,
 			include,
+			itemKey,
+			itemLabel,
 			label_i18n,
 			multiple,
 			preselectedValues,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -294,7 +294,7 @@ test.describe('Selection filters in Data Set fragment', () => {
 				itemLabel: 'type',
 				label_i18n: {en_US: filterLabel},
 				multiple: true,
-				source: `/${apiHeadlessURL}`,
+				source: `/o/${apiHeadlessURL}`,
 				sourceType: 'API_HEADLESS',
 			});
 		});

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -17,8 +17,11 @@ import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 const picklistBooleanOption = 'Boolean';
 const picklistDefaultOption = 'Default';
 
+const apiHeadlessName = 'FieldType';
+const apiHeadlessURL = `c/${apiHeadlessName.toLocaleLowerCase()}s`;
 let dataSetERC: string;
 let dataSetLabel: string;
+let objectDefinition: any;
 let picklistName: string;
 
 export const test = mergeTests(
@@ -33,43 +36,105 @@ export const test = mergeTests(
 	picklistApiHelpersTest
 );
 
-test.beforeEach(async ({dataSetManagerApiHelpers, picklistApiHelpers}) => {
-	dataSetERC = getRandomString();
-	dataSetLabel = getRandomString();
-	picklistName = getRandomString();
+test.beforeEach(
+	async ({apiHelpers, dataSetManagerApiHelpers, picklistApiHelpers}) => {
+		dataSetERC = getRandomString();
+		dataSetLabel = getRandomString();
+		picklistName = getRandomString();
 
-	await dataSetManagerApiHelpers.createDataSet({
-		erc: dataSetERC,
-		label: dataSetLabel,
-	});
-
-	await test.step('Create and populate a picklist', async () => {
-		await picklistApiHelpers.createPicklist({
-			name: picklistName,
+		await dataSetManagerApiHelpers.createDataSet({
+			erc: dataSetERC,
+			label: dataSetLabel,
 		});
 
-		await picklistApiHelpers.editPicklist({
-			key: picklistBooleanOption.toLocaleLowerCase(),
-			name: picklistName,
-			value: picklistBooleanOption,
+		await test.step('Create and populate a picklist', async () => {
+			await picklistApiHelpers.createPicklist({
+				name: picklistName,
+			});
+
+			await picklistApiHelpers.editPicklist({
+				key: picklistBooleanOption.toLocaleLowerCase(),
+				name: picklistName,
+				value: picklistBooleanOption,
+			});
+
+			await picklistApiHelpers.editPicklist({
+				key: picklistDefaultOption.toLocaleLowerCase(),
+				name: picklistName,
+				value: picklistDefaultOption,
+			});
 		});
 
-		await picklistApiHelpers.editPicklist({
-			key: picklistDefaultOption.toLocaleLowerCase(),
-			name: picklistName,
-			value: picklistDefaultOption,
+		await test.step('Create API Headless application and populate with filter values', async () => {
+			objectDefinition =
+				await apiHelpers.objectAdmin.postObjectDefinition({
+					enableLocalization: true,
+					label: {
+						en_US: 'Field Type',
+					},
+					modifiable: true,
+					name: apiHeadlessName,
+					objectFields: [
+						{
+							DBType: 'String',
+							businessType: 'Text',
+							indexed: true,
+							indexedAsKeyword: true,
+							label: {
+								en_US: 'type',
+							},
+							localized: true,
+							name: 'type',
+							required: false,
+							state: false,
+						},
+					],
+					pluralLabel: {en_US: `${apiHeadlessName}s`},
+					scope: 'company',
+				});
+
+			await apiHelpers.objectAdmin.postObjectDefinitionPublish(
+				objectDefinition.id
+			);
+
+			await apiHelpers.objectEntry.postObjectEntry(
+				{type: 'array'},
+				apiHeadlessURL
+			);
+			await apiHelpers.objectEntry.postObjectEntry(
+				{type: 'boolean'},
+				apiHeadlessURL
+			);
+			await apiHelpers.objectEntry.postObjectEntry(
+				{type: 'integer'},
+				apiHeadlessURL
+			);
+			await apiHelpers.objectEntry.postObjectEntry(
+				{type: 'object'},
+				apiHeadlessURL
+			);
+			await apiHelpers.objectEntry.postObjectEntry(
+				{type: 'string'},
+				apiHeadlessURL
+			);
 		});
-	});
-});
+	}
+);
 
-test.afterEach(async ({dataSetManagerApiHelpers, picklistApiHelpers}) => {
-	await dataSetManagerApiHelpers.deleteDataSet({erc: dataSetERC});
+test.afterEach(
+	async ({apiHelpers, dataSetManagerApiHelpers, picklistApiHelpers}) => {
+		await dataSetManagerApiHelpers.deleteDataSet({erc: dataSetERC});
 
-	await picklistApiHelpers.deletePicklist(picklistName);
-});
+		await picklistApiHelpers.deletePicklist(picklistName);
 
-test.describe('Filters in Data Set fragment', () => {
-	test('Selection filter is displayed in fragment, and applied to data @LPD-10754', async ({
+		await apiHelpers.objectAdmin.deleteObjectDefinition(
+			objectDefinition.id
+		);
+	}
+);
+
+test.describe('Selection filters in Data Set fragment', () => {
+	test('Picklist filter is displayed in fragment, and applied to data @LPD-10754', async ({
 		dataSetManagerApiHelpers,
 		fdsFragmentPage,
 		layout,
@@ -187,6 +252,207 @@ test.describe('Filters in Data Set fragment', () => {
 
 			await expect(
 				fdsFragmentPage.page.getByText('Showing 1 to 1 of 1 entries.')
+			).toBeVisible();
+		});
+	});
+
+	test('API Headless filter is displayed in fragment, and applied to data @LPD-10754', async ({
+		dataSetManagerApiHelpers,
+		fdsFragmentPage,
+		layout,
+	}) => {
+		const filterLabel = getRandomString();
+
+		await test.step('Add a field, so FDS has something to show', async () => {
+			await dataSetManagerApiHelpers.createDataSetField({
+				dataSetERC,
+				label_i18n: {en_US: 'Id'},
+				name: 'id',
+				type: 'integer',
+			});
+
+			await dataSetManagerApiHelpers.createDataSetField({
+				dataSetERC,
+				label_i18n: {en_US: 'Type'},
+				name: 'type',
+				type: 'string',
+			});
+
+			await dataSetManagerApiHelpers.createDataSetField({
+				dataSetERC,
+				label_i18n: {en_US: 'Sortable'},
+				name: 'sortable',
+				type: 'boolean',
+			});
+		});
+
+		await test.step('Create a new API Headless selection filter', async () => {
+			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+				dataSetERC,
+				fieldName: 'type',
+				itemKey: 'type',
+				itemLabel: 'type',
+				label_i18n: {en_US: filterLabel},
+				multiple: true,
+				source: `/${apiHeadlessURL}`,
+				sourceType: 'API_HEADLESS',
+			});
+		});
+
+		await test.step('Configure Data Set fragment', async () => {
+			await fdsFragmentPage.configureDataSetFragment({
+				dataSetLabel,
+				layout,
+			});
+		});
+
+		await test.step('Check current items in the Frontend Data Set', async () => {
+			await fdsFragmentPage.fdsPaginationResults.scrollIntoViewIfNeeded();
+
+			await expect(
+				fdsFragmentPage.fdsPaginationResults.getByText(
+					'Showing 1 to 3 of 3 entries.'
+				)
+			).toBeVisible();
+		});
+
+		await test.step('Filters are available in the fragment', async () => {
+			await expect(
+				fdsFragmentPage.page.getByRole('button', {
+					name: 'Filter',
+				})
+			).toBeVisible();
+		});
+
+		await test.step('Open filters component', async () => {
+			await fdsFragmentPage.page
+				.getByRole('button', {exact: true, name: 'Filter'})
+				.click();
+		});
+
+		await test.step('Select filter', async () => {
+			await expect(
+				fdsFragmentPage.page.getByRole('menuitem', {
+					name: filterLabel,
+				})
+			).toBeVisible();
+			await fdsFragmentPage.page
+				.getByRole('menuitem', {name: filterLabel})
+				.click();
+			await expect(
+				fdsFragmentPage.page.getByRole('checkbox', {
+					name: 'array',
+				})
+			).toBeVisible();
+			await expect(
+				fdsFragmentPage.page.getByRole('checkbox', {
+					name: 'boolean',
+				})
+			).toBeVisible();
+			await expect(
+				fdsFragmentPage.page.getByRole('checkbox', {
+					name: 'integer',
+				})
+			).toBeVisible();
+			await expect(
+				fdsFragmentPage.page.getByRole('checkbox', {
+					name: 'object',
+				})
+			).toBeVisible();
+			await expect(
+				fdsFragmentPage.page.getByRole('checkbox', {
+					name: 'string',
+				})
+			).toBeVisible();
+
+			await fdsFragmentPage.page
+				.getByRole('checkbox', {name: 'integer'})
+				.check();
+			await fdsFragmentPage.page
+				.getByRole('button', {name: 'Add filter'})
+				.click();
+
+			// Close filter
+
+			await fdsFragmentPage.page.keyboard.press('Escape');
+		});
+
+		await test.step('Check that the filter works', async () => {
+			await fdsFragmentPage.page
+				.locator('.filter-resume')
+				.waitFor({state: 'visible'});
+
+			await expect(
+				fdsFragmentPage.page.getByRole('button', {
+					name: `${filterLabel}: integer`,
+				})
+			).toBeVisible();
+
+			await expect(
+				fdsFragmentPage.page
+					.locator('.dnd-tr')
+					.filter({
+						has: fdsFragmentPage.page
+							.getByText('integer', {exact: true})
+							.first(),
+					})
+					.locator('.dnd-td')
+					.nth(1)
+			).toHaveText(['integer']);
+
+			await expect(
+				fdsFragmentPage.page.getByText('Showing 1 to 1 of 1 entries.')
+			).toBeVisible();
+		});
+
+		await test.step('Open filters component', async () => {
+			await fdsFragmentPage.page
+				.getByRole('button', {exact: true, name: 'Filter'})
+				.click();
+		});
+
+		await test.step('Select filter', async () => {
+			await expect(
+				fdsFragmentPage.page.getByRole('checkbox', {name: 'boolean'})
+			).toBeVisible();
+
+			await fdsFragmentPage.page
+				.getByRole('checkbox', {name: 'boolean'})
+				.check();
+			await fdsFragmentPage.page
+				.getByRole('button', {name: 'Add filter'})
+				.click();
+
+			// Close filter
+
+			await fdsFragmentPage.page.keyboard.press('Escape');
+		});
+
+		await test.step('Check that the filter works', async () => {
+			await fdsFragmentPage.page
+				.locator('.filter-resume')
+				.waitFor({state: 'visible'});
+
+			await expect(
+				fdsFragmentPage.page.getByRole('button', {
+					name: `${filterLabel}: integer, boolean`,
+				})
+			).toBeVisible();
+
+			await expect(
+				fdsFragmentPage.page
+					.locator('.dnd-tr')
+					.filter({
+						has: fdsFragmentPage.page
+							.getByText('boolean', {exact: true})
+							.first(),
+					})
+					.locator('.dnd-td')
+					.nth(1)
+			).toHaveText(['boolean']);
+
+			await expect(
+				fdsFragmentPage.page.getByText('Showing 1 to 2 of 2 entries.')
 			).toBeVisible();
 		});
 	});


### PR DESCRIPTION
## Story / Task
[LPD-19880](https://liferay.atlassian.net/browse/LPD-19880) / [LPD-28612](https://liferay.atlassian.net/browse/LPD-28612)

> [!CAUTION]
> @chestofwonders https://github.com/liferay-frontend/liferay-portal/pull/4270/ changes need to be merged before.
> 

## Goal
Process API Headless filters information to be able to use them in the FDS component.
API Headless filters will retrieve the options from an external URL and setup the preselected values if needed.

## UI
[Screencast from 2024-06-20 13-06-31.webm](https://github.com/liferay-frontend/liferay-portal/assets/132653342/d2485adb-db8d-4fe0-a154-e46923c74258)

## Playwright
![apifiltertest](https://github.com/liferay-frontend/liferay-portal/assets/132653342/7405baad-7a49-4e98-98df-bf558615095b)

