### PR TITLE
LPD-28898 Image added via rich text editor on Wiki tool losing reference.

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -285,7 +285,10 @@
 					let imagePath = r[1];
 					const imagePathPrefix = options ? options.imagePrefix : '';
 
-					if (imagePathPrefix) {
+					if (
+						imagePathPrefix &&
+						!imagePath.startsWith('data:image/')
+					) {
 						if (!/^https?:\/\//gi.test(imagePath)) {
 							imagePath = imagePathPrefix + imagePath;
 						}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/creole/creole_parser.js
@@ -287,11 +287,10 @@
 
 					if (
 						imagePathPrefix &&
-						!imagePath.startsWith('data:image/')
+						!imagePath.startsWith('data:image/') &&
+						!/^https?:\/\//gi.test(imagePath)
 					) {
-						if (!/^https?:\/\//gi.test(imagePath)) {
-							imagePath = imagePathPrefix + imagePath;
-						}
+						imagePath = imagePathPrefix + imagePath;
 					}
 
 					const image = document.createElement('img');


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-28898

There is an error when we are adding an image using copy paste and we should take into account when we are parsing it using creole parser. So, this PR include the necessary  code to perform it. 

# How am I fixing it?

1. Take into account when we are parsing xhtml for image nodes that including images content in base64. Sent to content management repo here : https://github.com/liferay-content-management/liferay-portal/pull/5598/
2. Take into account in creole ckeditor when we are parsing images in base64. 

# How can you verify that it works?

Run included tests included here :https://github.com/liferay-content-management/liferay-portal/pull/5598/