### PR TITLE
LPD-29159 Prevent infinite recursion in schema scanning for all types of properties

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -37,113 +37,96 @@ interface ISchemas {
 	};
 }
 
+const filterSchemaProperty = (propertyKey: string) => {
+	return (
+		!INVALID_FIELDS.includes(propertyKey) &&
+		!propertyKey.includes(LOCALIZABLE_PROPERTY_SUFFIX)
+	);
+};
+
 function getValidFields({
 	contextPath,
 	schemaName,
+	schemaStack,
 	schemas,
 }: {
 	contextPath: string;
 	schemaName: string;
+	schemaStack: string[];
 	schemas: ISchemas;
 }): Array<IField> {
 	const fields: Array<IField> = [];
 
 	const properties: IProperties = schemas[schemaName]?.properties;
 
-	properties &&
-		Object.keys(properties).map((propertyKey) => {
+	if (!properties) {
+		return fields;
+	}
+
+	Object.keys(properties)
+		.filter(filterSchemaProperty)
+		.map((propertyKey) => {
 			const propertyValue = properties[propertyKey];
-
-			if (INVALID_FIELDS.includes(propertyKey)) {
-				return;
-			}
-
-			if (propertyKey.includes(LOCALIZABLE_PROPERTY_SUFFIX)) {
-				return;
-			}
 
 			const type = propertyValue.type;
 
+			const field: IField = {
+				format: propertyValue.format,
+				label: propertyKey,
+				name: `${contextPath}${propertyKey}`,
+				type,
+			};
+
+			let targetSchemaName;
+
 			if (propertyValue.items?.$ref) {
-				const field: IField = {
-					label: propertyKey,
-					name: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`,
-					sortable: false,
-					type: type ? type : 'array',
-				};
-
-				if (!contextPath.includes(propertyKey)) {
-					field.children = getValidFields({
-						contextPath: `${contextPath}${propertyKey}${FDS_ARRAY_FIELD_NAME_DELIMITER}`,
-						schemaName: propertyValue.items.$ref.replace(
-							/^.*\//,
-							''
-						),
-						schemas,
-					});
-				}
-
-				fields.push(field);
-
-				return;
+				field.name = `${field.name}${FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX}`;
+				field.type = type ? type : 'array';
+				targetSchemaName = propertyValue.items.$ref.replace(
+					/^.*\//,
+					''
+				);
 			}
-
-			if (propertyValue.$ref) {
-				fields.push({
-					children: getValidFields({
-						contextPath: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_DELIMITER}`,
-						schemaName: propertyValue.$ref.replace(/^.*\//, ''),
-						schemas,
-					}),
-					label: propertyKey,
-					name: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`,
-					sortable: false,
-					type: type ? type : 'object',
-				});
-
-				return;
+			else if (propertyValue.$ref) {
+				field.name = `${field.name}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`;
+				field.type = type ? type : 'object';
+				targetSchemaName = propertyValue.$ref.replace(/^.*\//, '');
 			}
-
-			if (
+			else if (
 				propertyValue.extensions &&
 				propertyValue.extensions['x-parent-map'] === 'properties'
 			) {
 				const schemaNames = Object.keys(schemas);
-				const parentSchemaName = schemaNames.filter((schemaName) => {
+				const parentSchemaName = schemaNames.find((schemaName) => {
 					return (
 						schemaName.toLowerCase() ===
 						propertyKey.toLocaleLowerCase()
 					);
 				});
 
-				if (parentSchemaName.length) {
-					fields.push({
-						children: getValidFields({
-							contextPath: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_DELIMITER}`,
-							schemaName: parentSchemaName[0],
-							schemas,
-						}),
-						label: propertyKey,
-						name: `${contextPath}${propertyKey}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`,
-						sortable: false,
-						type: schemas[parentSchemaName[0]]?.type || 'object',
-					});
-
-					return;
+				if (parentSchemaName) {
+					field.name = `${field.name}${FDS_NESTED_FIELD_NAME_PARENT_SUFFIX}`;
+					field.type = schemas[parentSchemaName]?.type || 'object';
+					targetSchemaName = parentSchemaName;
 				}
 			}
 
-			fields.push({
-				format: propertyValue.format,
-				label: propertyKey,
-				name: `${contextPath}${propertyKey}`,
-				sortable:
-					type !== 'object' &&
-					type !== 'array' &&
-					!contextPath.includes(FDS_NESTED_FIELD_NAME_DELIMITER) &&
-					!contextPath.includes(FDS_ARRAY_FIELD_NAME_DELIMITER),
-				type,
-			});
+			field.sortable =
+				type !== 'object' &&
+				type !== 'array' &&
+				!contextPath.includes(FDS_NESTED_FIELD_NAME_DELIMITER) &&
+				!contextPath.includes(FDS_ARRAY_FIELD_NAME_DELIMITER);
+
+			if (targetSchemaName && !schemaStack.includes(targetSchemaName)) {
+				field.children = getValidFields({
+					contextPath: field.name,
+					schemaName: targetSchemaName,
+					schemaStack: [...schemaStack, targetSchemaName],
+					schemas,
+				});
+			}
+
+			fields.push(field);
 		});
 
 	return fields;
@@ -177,6 +160,7 @@ export default async function getFields({
 	return getValidFields({
 		contextPath: '',
 		schemaName: restSchema,
+		schemaStack: [],
 		schemas,
 	});
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -14,7 +14,12 @@ import {fetch} from 'frontend-js-web';
 import openDefaultFailureToast from './openDefaultFailureToast';
 import {EFieldFormat, EFieldType, IField} from './types';
 
-const INVALID_FIELDS = ['actions', 'scopeKey', 'x-class-name', 'x-schema-name'];
+export const INVALID_FIELDS = [
+	'actions',
+	'scopeKey',
+	'x-class-name',
+	'x-schema-name',
+];
 
 const LOCALIZABLE_PROPERTY_SUFFIX = '_i18n';
 
@@ -23,14 +28,14 @@ interface IProperty {
 	extensions?: any;
 	format?: EFieldFormat;
 	items?: any;
-	type: EFieldType;
+	type?: EFieldType;
 }
 
 interface IProperties {
 	[key: string]: IProperty;
 }
 
-interface ISchemas {
+export interface ISchemas {
 	[key: string]: {
 		properties: IProperties;
 		type: string;
@@ -44,7 +49,7 @@ const filterSchemaProperty = (propertyKey: string) => {
 	);
 };
 
-function getValidFields({
+export function getValidFields({
 	contextPath,
 	schemaName,
 	schemaStack,

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -14,6 +14,7 @@ export enum EFilterType {
 export enum EFieldFormat {
 	DATE = 'date',
 	DATE_TIME = 'date-time',
+	INT32 = 'int32',
 	INT64 = 'int64',
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/test/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/test/utils/getFields.ts
@@ -1,0 +1,271 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	INVALID_FIELDS,
+	getValidFields, ISchemas,
+} from '../../src/main/resources/META-INF/resources/js/utils/getFields';
+import {IField} from '../../src/main/resources/META-INF/resources/js/utils/types';
+
+/*
+ * A points to B using scalar field via $ref
+ * A points to C using scalar field via 'x-parent-map' and implied target schema name
+ * B points to C using scalar field via $ref
+ * C points to A using array field via $ref
+ */
+const nestedSchemas : ISchemas = {
+	A: {
+		properties: {
+			a_b: {
+				$ref: '#/components/schemas/B',
+				extensions: {
+					'x-parent-map': 'properties',
+				},
+				type: 'object',
+			},
+			c: {
+				extensions: {
+					'x-parent-map': 'properties',
+				},
+				type: 'string',
+			},
+		},
+		type: 'object',
+	},
+	B: {
+		properties: {
+			b_c: {
+				$ref: '#/components/schemas/C',
+				type: 'object',
+			},
+		},
+		type: 'object',
+	},
+	C: {
+		properties: {
+			c_a: {
+				items: {
+					$ref: '#/components/schemas/A',
+				},
+				type: 'array',
+			},
+		},
+		type: 'object',
+	},
+} as ISchemas;
+
+const simpleSchema = {
+	Simple: {
+		properties: {
+			'code': {
+				format: 'int32',
+				type: 'integer',
+			},
+			'label': {
+				type: 'string',
+			},
+			'label_i18n': {
+				additionalProperties: {
+					type: 'string',
+				},
+				type: 'object',
+			},
+			'old_codes': {
+				items: {
+					format: 'int32',
+					type: 'integer',
+				},
+				type: 'array',
+			},
+			'userNames': {
+				additionalProperties: {
+					type: 'string',
+				},
+				type: 'object',
+			},
+			'x-class-name': {
+				default: 'com.liferay.object.rest.dto.v1_0.Simple',
+				type: 'string',
+			},
+		},
+		type: 'object',
+	},
+} as ISchemas;
+
+function assertChildren(f: IField, childrenNames: string[]) {
+	if (childrenNames.length) {
+		expect(f.children).toBeDefined();
+		expect(f.children?.length).toEqual(childrenNames.length);
+		childrenNames.forEach((childName, index) =>
+			expect(f.children[index]?.name).toEqual(childName)
+		);
+	}
+	else {
+		expect(f).not.toHaveProperty('children');
+	}
+}
+
+describe('getValidFields', () => {
+	it('Function is defined', () => {
+		expect(getValidFields).toBeDefined();
+	});
+
+	it('Returns only valid fields from the schemas of an application', () => {
+		const result = getValidFields({
+			contextPath: '',
+			schemaName: 'Simple',
+			schemaStack: [],
+			schemas: simpleSchema,
+		});
+
+		const expectedValidFields = result.map((item) => item.label);
+
+		expect(Object.keys(simpleSchema.Simple.properties)).toEqual([
+			'code',
+			'label',
+			'label_i18n',
+			'old_codes',
+			'userNames',
+			'x-class-name',
+		]);
+
+		expect(expectedValidFields).toEqual([
+			'code',
+			'label',
+			'old_codes',
+			'userNames',
+		]);
+
+		expect(expectedValidFields).not.toContain('label_i18n');
+
+		expect(expectedValidFields).not.toContain(INVALID_FIELDS);
+	});
+
+	it('Non scalar (arrays and object) fields are not sortable, scalar fields are', () => {
+		const result = getValidFields({
+			contextPath: '',
+			schemaName: 'Simple',
+			schemaStack: [],
+			schemas: simpleSchema,
+		});
+
+		const expectedValidScalarFields = result.filter(
+			(item) => item.type !== 'object' && item.type !== 'array'
+		);
+
+		expect(expectedValidScalarFields.map((item) => item.sortable)).toEqual([
+			true,
+			true,
+		]);
+
+		const expectedValidNonScalarFields = result.filter(
+			(item) => item.type === 'object' || item.type === 'array'
+		);
+
+		expect(
+			expectedValidNonScalarFields.map((item) => item.sortable)
+		).toEqual([false, false]);
+	});
+
+	it('Include children properties from schemas referenced via $ref property, no loops', () => {
+		const result = getValidFields({
+			contextPath: '',
+			schemaName: 'A',
+			schemaStack: [],
+			schemas: nestedSchemas,
+		});
+
+		/* Excerpt of tree for field a_b:
+			{
+				name: "a_b.*",
+				children:[
+					{
+						name: "a_b.*b_c.*",
+						children:[
+							{
+								name: "a_b.*b_c.*c_a[]*",
+								children:[
+									{
+										name: "a_b.*b_c.*c_a[]*a_b.*",
+										// no children, B schema already visited!
+									},
+									{
+										name: "a_b.*b_c.*c_a[]*c.*",
+										// no children, C schema already visited!
+									}
+								]
+							}
+						]
+					}
+				]
+			};
+		 */
+
+		const a_b = result.find((item) => item.label === 'a_b');
+		expect(a_b.name).toEqual('a_b.*');
+		assertChildren(a_b, ['a_b.*b_c.*']);
+
+		const b_c = a_b.children[0];
+		assertChildren(b_c, ['a_b.*b_c.*c_a[]*']);
+
+		const c_a = b_c.children[0];
+		assertChildren(c_a, ['a_b.*b_c.*c_a[]*a_b.*', 'a_b.*b_c.*c_a[]*c.*']);
+
+		// no loops
+
+		assertChildren(c_a.children[0], []);
+		assertChildren(c_a.children[1], []);
+	});
+
+	it('Include children properties from schemas referenced via x-map-properties property, no loops', () => {
+		const result = getValidFields({
+			contextPath: '',
+			schemaName: 'A',
+			schemaStack: [],
+			schemas: nestedSchemas,
+		});
+
+		/* Excerpt of tree for field c
+			{
+				name: "c.*",
+				children: [
+					{
+						name: "c.*c_a[]*",
+						children:[
+							{
+								name: "c.*c_a[]*a_b.*",
+								children:[
+									{
+										name: "c.*c_a[]*a_b.*b_c.*",
+										// no children, C schema already visited!
+									}
+								]
+							},
+							{
+								name: "c.*c_a[]*c.*",
+								// no children, C schema already visited!
+							}
+						]
+					}
+				]
+			};
+		*/
+
+		const c = result.find((item) => item.label === 'c');
+		expect(c.name).toEqual('c.*');
+		assertChildren(c, ['c.*c_a[]*']);
+
+		const c_a = c.children[0];
+		assertChildren(c_a, ['c.*c_a[]*a_b.*', 'c.*c_a[]*c.*']);
+
+		const a_b = c_a.children[0];
+		assertChildren(a_b, ['c.*c_a[]*a_b.*b_c.*']);
+
+		// no loops
+
+		assertChildren(a_b.children[0], []);
+		assertChildren(c_a.children[1], []);
+	});
+});

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -50,44 +50,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-179282. Confirm that metadata fields are not present for the user "
-	@priority = 3
-	test AssertNotPresentMetadataFields {
-		property portal.upstream = "quarantine";
-
-		task ("And Clicking to Add a new field") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("Then Confirm the fields are visible and present: creator,name,id") {
-			AssertElementPresent(
-				key_name = "name",
-				locator1 = "DataSet#FIELDS_ITEM");
-
-			AssertElementPresent(
-				key_name = "creator",
-				locator1 = "DataSet#FIELDS_ITEM");
-
-			AssertElementPresent(
-				key_name = "id",
-				locator1 = "DataSet#FIELDS_ITEM");
-		}
-
-		task ("And is not present metadata fields:x-class-name, x-schema-name and scopeKey") {
-			AssertElementNotPresent(
-				key_name = "x-class-name",
-				locator1 = "DataSet#FIELDS_ITEM");
-
-			AssertElementNotPresent(
-				key_name = "x-schema-name",
-				locator1 = "DataSet#FIELDS_ITEM");
-
-			AssertElementNotPresent(
-				key_name = "scopeKey",
-				locator1 = "DataSet#FIELDS_ITEM");
-		}
-	}
-
 	@description = "LPS-194126 Confirm that a new translation field has been created"
 	@priority = 3
 	test AssertTheNewFieldTranslation {


### PR DESCRIPTION
In this PR we are improving the schema scanning of the DSM tool. This is a key piece in charge of providing the "tree of fields" available for mapping in the viz modes, from the selected schema used to create a Data Set. 

Such schema contains different types of fields: scalar, objects, arrays and references to other schemas. Processing these fields in presence of arbitrary references implies avoiding cycles as otherwise we'd end up with infinite recursion as detected in https://liferay.atlassian.net/browse/LPD-29159

So far we were doing this check as follows:

- Ensure field name being processed is not part of the current `contextPath`
- Check this when the field is an array of schema references

This pull improves the above as follows:

- Rather than checking `contextPath` does not contain the field name, we track the visited schemas in a stack, so when a field references an already visited schema in the stack, no children fields are processed and field is treated as a leaf.
- This check affects any field no matter its type, as long as it references a different schema. This covers the case detected in  https://liferay.atlassian.net/browse/LPD-29159, where a circular schema reference from a non-array field in `UserAccount` schema was being processed.
- In addition, the code has been reorganized in the hope algorithm implementation is simpler to follow

@juanjofgliferay please test this one thoroughly through the cases we discussed