### PR TITLE
LPD-29982 text truncation inside an <a>, not viceversa

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/view.jsp
@@ -52,14 +52,11 @@ ViewAccountEntriesManagementToolbarDisplayContext viewAccountEntriesManagementTo
 
 				<liferay-ui:search-container-column-text
 					cssClass="autofit-col-expand table-title"
+					href="<%= rowURL %>"
 					name="name"
-				>
-					<a class="d-inline-block" href="<%= rowURL %>" style="max-width: 15.625rem;">
-						<span class="text-truncate">
-							<%= HtmlUtil.escape(accountEntryDisplay.getName()) %>
-						</span>
-					</a>
-				</liferay-ui:search-container-column-text>
+					truncate="<%= true %>"
+					value="<%= accountEntryDisplay.getName() %>"
+				/>
 
 				<liferay-ui:search-container-column-text
 					cssClass="table-cell-expand-smallest"

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceEntry.path
@@ -722,7 +722,7 @@
 </tr>
 <tr>
 	<td>BODY_VERTICAL_ELLIPSIS_ACCOUNT</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='${key_name}']/../../..//*[*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='${key_name}']/../../..//*[*[name()='svg'][contains(@class,'icon-ellipsis')]]</td>
 	<td></td>
 </tr>
 <tr>
@@ -817,12 +817,12 @@
 </tr>
 <tr>
 	<td>ENTRY_NAME_BODY_VERTICAL_ELLIPSIS</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='${key_entryName}']/../../following-sibling::div//button</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='${key_entryName}']/../../following-sibling::div//button</td>
 	<td></td>
 </tr>
 <tr>
 	<td>ENTRY_NAME_BODY_VERTICAL_ELLIPSIS_2</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='${key_entryName}']//..//..//div[contains(@class,'dropdown')]/a</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='${key_entryName}']//..//..//div[contains(@class,'dropdown')]/a</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
@@ -37,7 +37,7 @@
 </tr>
 <tr>
 	<td>ENTRY_NAME</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[contains(., '${key_entryName}')]</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='${key_entryName}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/paths/CommerceNavigation.path
@@ -37,12 +37,12 @@
 </tr>
 <tr>
 	<td>ENTRY_NAME</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='${key_entryName}']</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='${key_entryName}']</td>
 	<td></td>
 </tr>
 <tr>
 	<td>ENTRY_NAME_EXACT_MATCH</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='${key_entryName}']</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='${key_entryName}']</td>
 	<td></td>
 </tr>
 <tr>
@@ -52,7 +52,7 @@
 </tr>
 <tr>
 	<td>ENTRY_NAME_WITH_UOM</td>
-	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//div[contains(@class,'dnd-td') and contains(text(),'${key_uom}')]//..//a[text()='${key_entryName}']</td>
+	<td>//div[@class='data-set-wrapper' or @class='searchcontainer-content']//div[contains(@class,'dnd-td') and contains(text(),'${key_uom}')]//..//*[text()='${key_entryName}']</td>
 	<td></td>
 </tr>
 <tr>

--- a/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommercePendingOrdersEditProductOptions.testcase
+++ b/modules/apps/commerce/commerce-product-test/src/testFunctional/tests/CommercePendingOrdersEditProductOptions.testcase
@@ -284,7 +284,7 @@ definition {
 		}
 
 		task ("And the price and inventory of generated SKUs are configured for the options product") {
-			if (IsElementPresent(locator1 = "//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='VALUE3VALUE1']")) {
+			if (IsElementPresent(locator1 = "//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='VALUE3VALUE1']")) {
 				CommerceNavigator.gotoEntry(entryName = "VALUE3VALUE1");
 
 				CommerceSKUs.editSkuName(
@@ -293,7 +293,7 @@ definition {
 					publish = "true");
 			}
 
-			if (IsElementPresent(locator1 = "//div[@class='data-set-wrapper' or @class='searchcontainer-content']//a[text()='VALUE4VALUE2']")) {
+			if (IsElementPresent(locator1 = "//div[@class='data-set-wrapper' or @class='searchcontainer-content']//*[text()='VALUE4VALUE2']")) {
 				CommerceNavigator.gotoEntry(entryName = "VALUE4VALUE2");
 
 				CommerceSKUs.editSkuName(

--- a/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/macros/Workflow.macro
+++ b/modules/apps/portal-workflow/portal-workflow-test/src/testFunctional/macros/Workflow.macro
@@ -1222,7 +1222,7 @@ definition {
 
 		AssertElementPresent(locator1 = "MyWorkflowTasks#ASSIGNED_TO_ME_TABLE_END_DATE");
 
-		AssertElementNotPresent(locator1 = "//div[@id='_158_workflowInstancesSearchContainer']//tr[contains(.,'${key_workflowAssetTitle}')]/td[7]/span/a[contains(@id,'menu_withdraw-submission')]/span");
+		AssertElementNotPresent(locator1 = "//div[@id='_158_workflowInstancesSearchContainer']//tr[contains(.,'${key_workflowAssetTitle}')]/td[7]/a[contains(@id,'menu_withdraw-submission')]/span");
 
 		AssertTextNotPresent(value1 = "Withdraw Submission");
 	}

--- a/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/list.jsp
@@ -320,24 +320,11 @@ if (fixedHeader) {
 						%>
 
 							<td class="<%= columnClassName %>" colspan="<%= entry.getColspan() %>">
-								<c:choose>
-									<c:when test="<%= truncate %>">
-										<span class="text-truncate">
 
-											<%
-											entry.print(pageContext.getOut(), request, response);
-											%>
+								<%
+								entry.print(pageContext.getOut(), request, response);
+								%>
 
-										</span>
-									</c:when>
-									<c:otherwise>
-
-										<%
-										entry.print(pageContext.getOut(), request, response);
-										%>
-
-									</c:otherwise>
-								</c:choose>
 							</td>
 
 						<%

--- a/util-taglib/src/com/liferay/taglib/search/TextSearchEntry.java
+++ b/util-taglib/src/com/liferay/taglib/search/TextSearchEntry.java
@@ -105,7 +105,16 @@ public class TextSearchEntry extends SearchEntry {
 			}
 
 			sb.append(">");
-			sb.append(getName(httpServletRequest));
+
+			if (isTruncate()) {
+				sb.append("<span class=\"text-truncate\">");
+				sb.append(getName(httpServletRequest));
+				sb.append("</span>");
+			}
+			else {
+				sb.append(getName(httpServletRequest));
+			}
+
 			sb.append("</a>");
 
 			writer.write(sb.toString());


### PR DESCRIPTION
Hello guys. I hereby request your review for this change, as it'll allow the `SearchContainerColumnTextTag` to correctly display truncated text with the right HTML structure for `table-title` Clay CSS class to be applied correctly (according to [these changes](https://github.com/liferay/clay/commit/3e0ed1df192e0c4b05950fcb958cbf7b8673f8f4)).

This PR stems from [this ticket](https://liferay.atlassian.net/browse/LPD-29982), which in turn stems from [this conversation](https://liferay.slack.com/archives/CNBG06JS3/p1718616362669729) in #t-dxp-frontend-infra with @juanjofgliferay.