### PR TITLE
LPD-30215 Use new portlet name in DSM poshi tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
@@ -919,14 +919,14 @@ definition {
 
 	@summary = "Default summary"
 	macro goToDataSetAdminPage() {
-		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet");
+		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet");
 	}
 
 	@summary = "Default summary"
 	macro goToDataSetViewAdminPage(dataSetName = null) {
 		var dataSetEntryId = JSONDataSet._getDataSetEntryIdByName(dataSetName = ${dataSetName});
 
-		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet&p_p_lifecycle=0&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_mvcPath=%2Ffds_views.jsp&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_fdsEntryId=${dataSetEntryId}");
+		Navigator.openWithAppendToBaseURL(urlAppend = "group/control_panel/manage?p_p_id=com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet&p_p_lifecycle=0&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_mvcPath=%2Ffds_views.jsp&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_fdsEntryId=${dataSetEntryId}");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -2088,7 +2088,7 @@ definition {
 			Type(
 				key_fieldId = "URL",
 				locator1 = "TextArea#ANY_ID",
-				value1 = "http://localhost:8080/group/guest/~/control_panel/manage?p_p_id=com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet&p_p_lifecycle=0&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_mvcPath=%2Ffds_view.jsp&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_fdsEntryId=33344&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_fdsEntryLabel=Data+Set+Test&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_fdsViewId=33346&_com_liferay_frontend_data_set_views_web_internal_portlet_FDSViewsPortlet_fdsViewLabel=View+Test");
+				value1 = "http://localhost:8080/group/guest/~/control_panel/manage?p_p_id=com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet&p_p_lifecycle=0&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_mvcPath=%2Ffds_view.jsp&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_fdsEntryId=33344&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_fdsEntryLabel=Data+Set+Test&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_fdsViewId=33346&_com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet_fdsViewLabel=View+Test");
 
 			PortletEntry.save();
 		}


### PR DESCRIPTION
In this pr we are changing the portlet name in poshi for DSM tests so that we prevent some tenths of them to suddenly fail, and so our ability to migrate them in an ordered way