### PR TITLE
LPD-30366

### DIFF
--- a/modules/_node-scripts/bundle/sass/getSassBinaryArchMap.mjs
+++ b/modules/_node-scripts/bundle/sass/getSassBinaryArchMap.mjs
@@ -39,7 +39,7 @@ export default async function getSassBinaryArchMap() {
 
 	archMap = archMap[os.arch()];
 
-	if (archMap === null) {
+	if (!archMap) {
 		return null;
 	}
 

--- a/modules/_node-scripts/package.json
+++ b/modules/_node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "5d5933f654dcfc1c441f532bb0604290d4946715db711bbbb134ea60f3afbf5f"
+		"sha256": "e35719077c85593a0c72fffb213453455989fa571d63805d527e141b6f30c024"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",


### PR DESCRIPTION
Motivation
-----
In Mac with arm64 technology the binary sass compiler is not being downloaded and the build falls back to the node based one.

[Link to the ticket](https://liferay.atlassian.net/browse/LPD-30220)

Proposed Solution
-----
Change if condition to not fail if the architecture doesn't exist.