### PR TITLE
LPD-31378 Extend cell size by 4rem if cell is below 70px

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
@@ -17,6 +17,8 @@ import ViewsContext, {
 import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
 import TableContext from './TableContext';
 
+const MINIMUM_COLUMN_WIDTH = 140;
+
 const Cell = ({
 	children,
 	className,
@@ -52,6 +54,13 @@ const Cell = ({
 	useEffect(() => {
 		if (columnName && heading && !isFixed && cellRef.current) {
 			const boundingClientRect = cellRef.current.getBoundingClientRect();
+
+			if (
+				columnName !== 'item-actions' &&
+				boundingClientRect.width < MINIMUM_COLUMN_WIDTH
+			) {
+				boundingClientRect.width = MINIMUM_COLUMN_WIDTH;
+			}
 
 			viewsDispatch({
 				type: VIEWS_ACTION_TYPES.UPDATE_FIELD,

--- a/modules/test/playwright/tests/frontend-data-set-web/styles.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/styles.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {commercePagesTest} from '../../fixtures/commercePagesTest';
+import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../fixtures/loginTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	applicationsMenuPageTest,
+	commercePagesTest,
+	dataApiHelpersTest,
+	loginTest()
+);
+
+test('LPD-31378 Width of columns with very small header text is increased', async ({
+	apiHelpers,
+	applicationsMenuPage,
+	page,
+}) => {
+	await test.step('Create commerce site', async () => {
+		const site = await apiHelpers.headlessSite.createSite({
+			name: 'Minium',
+			templateKey: 'minium-initializer',
+			templateType: 'site-initializer',
+		});
+
+		apiHelpers.data.push({id: site.id, type: 'site'});
+
+		await applicationsMenuPage.goToSite('Minium');
+	});
+
+	await test.step('Create account', async () => {
+		const accountButton = page.getByRole('button', {
+			name: 'Select Account & Order',
+		});
+
+		await accountButton.waitFor({state: 'visible'});
+		await accountButton.click();
+
+		const newAccountButton = page.getByRole('button', {
+			name: 'Create New Account',
+		});
+
+		await newAccountButton.waitFor({state: 'visible'});
+		await newAccountButton.click();
+
+		const accountNameField = page.locator('input[name="accountName"]');
+
+		await accountNameField.waitFor({state: 'visible'});
+		await accountNameField.fill('test');
+
+		await page.getByRole('button', {exact: true, name: 'Create'}).click();
+	});
+
+	await test.step('Add transmission to shopping cart', async () => {
+		const transmissionButton = page
+			.locator('#wwxc_column_2d_2_1_add_to_cart')
+			.getByRole('button', {name: 'Add to Cart'});
+
+		await transmissionButton.waitFor({state: 'visible'});
+		await transmissionButton.click();
+
+		const cartButton = page.locator('[data-qa-id="miniCartButton"]');
+
+		await cartButton.waitFor({state: 'visible'});
+		await cartButton.click();
+	});
+
+	await test.step('Check SKU width length', async () => {
+		const viewDetailsButton = page.getByRole('button', {
+			name: 'View Details',
+		});
+
+		await viewDetailsButton.waitFor({state: 'visible'});
+		await viewDetailsButton.click();
+
+		const skuTableHeader = page
+			.getByTestId('visualization-mode-table')
+			.getByText('SKU');
+
+		await skuTableHeader.waitFor({state: 'visible'});
+
+		const skuTableHeaderBoundingBox = await skuTableHeader.boundingBox();
+
+		const skuTableHeaderWidth = skuTableHeaderBoundingBox.width;
+
+		expect(skuTableHeaderWidth).toEqual(140);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-31378
https://liferay.atlassian.net/browse/LPP-54602

Since the table cell size are based on the Titles length, some content can be cut. This can be seen in commerce with the SKU being trimmed.

I found increasing the length of the cell by 4rem should help the SKU cells display content that is 8 - 12 characters long. I also limited this increase to cells that are below 70px to prevent cell resizing for big sized cells.

cc @dsanz 

