### PR TITLE
LPD-30051 - Delete DataSetViewFields tests

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/VisualizationModesPage.ts
@@ -224,4 +224,11 @@ export class VisualizationModesPage {
 	}) {
 		await this.checkField({dataId, expected: false, fieldName});
 	}
+
+	async unSelectSelectedFields() {
+		await this.page
+			.getByRole('dialog', {name: 'Select Field'})
+			.getByRole('button', {name: 'Deselect All'})
+			.click();
+	}
 }

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -487,7 +487,7 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		});
 	});
 
-	test('Configure table visualization mode with array fields @LPD-11769', async ({
+	test('Configure table visualization mode using search with array fields @LPD-11769, @LPS-185231, LPS-185227', async ({
 		page,
 		visualizationModesPage,
 	}) => {
@@ -884,7 +884,7 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		});
 	});
 
-	test('Check modal field selection allows field search, check and uncheck fields @LPS-174141, @LPS-185228, @LPS-179282, @LPS-185231, LPS-185227', async ({
+	test('Check modal field selection allows check and uncheck fields @LPS-174141, @LPS-185228, @LPS-179282', async ({
 		page,
 		visualizationModesPage,
 	}) => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -883,4 +883,80 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			).toHaveText('Boolean');
 		});
 	});
+
+	test('Check modal field selection allows field search, check and uncheck fields @LPS-174141, @LPS-185228, @LPS-179282, @LPS-185231, LPS-185227', async ({
+		page,
+		visualizationModesPage,
+	}) => {
+		const SAMPLE_SCALAR_FIELD = 'externalReferenceCode';
+		const SAMPLE_FIELD = 'name';
+
+		await test.step('Navigate to table visualization mode page', async () => {
+			await visualizationModesPage.goto({
+				dataSetLabel,
+			});
+
+			await visualizationModesPage.selectTab('Table');
+
+			await expect(
+				visualizationModesPage.page.getByPlaceholder('Search')
+			).toBeVisible();
+		});
+
+		await test.step('Can check and uncheck fields in the field selection modal', async () => {
+			await visualizationModesPage.openAddFieldsModal();
+
+			await visualizationModesPage.selectField({fieldName: SAMPLE_FIELD});
+
+			const checkbox =
+				visualizationModesPage.getFieldCheckboxByLabel(SAMPLE_FIELD);
+
+			await expect(checkbox).toBeChecked();
+
+			await visualizationModesPage.unSelectField({
+				fieldName: SAMPLE_FIELD,
+			});
+
+			await expect(checkbox).not.toBeChecked();
+
+			await saveFromModal({
+				page,
+			});
+		});
+
+		await test.step('Can check some fields and uncheck all selected fields using Deselect All button', async () => {
+			await visualizationModesPage.openAddFieldsModal();
+
+			await visualizationModesPage.selectField({fieldName: SAMPLE_FIELD});
+
+			const sampleFieldCheckbox =
+				visualizationModesPage.getFieldCheckboxByLabel(SAMPLE_FIELD);
+
+			await expect(sampleFieldCheckbox).toBeChecked();
+
+			await visualizationModesPage.selectField({
+				fieldName: SAMPLE_SCALAR_FIELD,
+			});
+
+			const sampleScalarFieldCheckbox =
+				visualizationModesPage.getFieldCheckboxByLabel(
+					SAMPLE_SCALAR_FIELD
+				);
+
+			await expect(sampleScalarFieldCheckbox).toBeChecked();
+
+			await visualizationModesPage.unSelectSelectedFields();
+
+			await expect(sampleFieldCheckbox).not.toBeChecked();
+			await expect(sampleScalarFieldCheckbox).not.toBeChecked();
+
+			await saveFromModal({
+				page,
+			});
+		});
+
+		await test.step('Check there is no field added', async () => {
+			await visualizationModesPage.assertTableFieldRowCount(0);
+		});
+	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -701,11 +701,12 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		});
 	});
 
-	test('Check field edition in table visualization mode', async ({
+	test('Check field edition in table visualization mode @LPS-176051, @LPS-178736', async ({
 		page,
 		visualizationModesPage,
 	}) => {
 		const SAMPLE_SCALAR_FIELD = 'id';
+		const RENDERER_COLUMN_INDEX = 4;
 
 		await test.step('Navigate to table visualization mode page', async () => {
 			await visualizationModesPage.goto({
@@ -731,7 +732,7 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			});
 		});
 
-		await test.step('Open field edition modal, check that name field is not editable @LPS-176051, @LPS-178736', async () => {
+		await test.step('Open field edition modal, check that name field is not editable', async () => {
 			await clickActionInRow({
 				actionName: 'Edit',
 				rowName: SAMPLE_SCALAR_FIELD,
@@ -751,7 +752,56 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 
 			await expect(nameInput).toBeDisabled();
 
-			await visualizationModesPage.cancelAddFieldsModal();
+			await saveFromModal({
+				page,
+			});
+		});
+
+		await test.step('Open field edition modal, check that the user can change the renderer', async () => {
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_FIELD)
+					.locator('td')
+					.nth(RENDERER_COLUMN_INDEX)
+			).toHaveText('Default');
+
+			await clickActionInRow({
+				actionName: 'Edit',
+				rowName: SAMPLE_SCALAR_FIELD,
+				visualizationModesPage,
+			});
+
+			const rendererButton = page.getByRole('button', {name: 'Default'});
+			await expect(rendererButton).toBeInViewport();
+
+			const rendererDropdownId = await rendererButton.evaluate((node) => {
+				return node.getAttribute('aria-controls');
+			});
+			await rendererButton.click();
+
+			await page.locator(`#${rendererDropdownId}`).waitFor();
+
+			const availbleRenderersCount = await page
+				.locator(`#${rendererDropdownId}`)
+				.getByRole('option')
+				.count();
+			await expect(availbleRenderersCount).toBeGreaterThanOrEqual(10);
+
+			await page
+				.locator(`#${rendererDropdownId}`)
+				.getByRole('option', {name: 'Boolean'})
+				.click();
+
+			await saveFromModal({
+				page,
+			});
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_FIELD)
+					.locator('td')
+					.nth(RENDERER_COLUMN_INDEX)
+			).toHaveText('Boolean');
 		});
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -706,6 +706,8 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 		visualizationModesPage,
 	}) => {
 		const SAMPLE_SCALAR_FIELD = 'id';
+		const SAMPLE_FIELD = 'name';
+		const LABEL_COLUMN_INDEX = 2;
 		const RENDERER_COLUMN_INDEX = 4;
 
 		await test.step('Navigate to table visualization mode page', async () => {
@@ -732,6 +734,85 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			});
 		});
 
+		await test.step('Check there is one field and is the one just added', async () => {
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_FIELD)
+					.locator('td')
+					.nth(LABEL_COLUMN_INDEX)
+			).toHaveText(SAMPLE_SCALAR_FIELD);
+
+			await visualizationModesPage.assertTableFieldRowCount(1);
+		});
+
+		await test.step('Add another field, save', async () => {
+			await visualizationModesPage.openAddFieldsModal();
+
+			await visualizationModesPage.selectField({
+				fieldName: SAMPLE_FIELD,
+			});
+
+			await saveFromModal({
+				page,
+			});
+		});
+
+		await test.step('Check there are two fields', async () => {
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_FIELD)
+					.locator('td')
+					.nth(LABEL_COLUMN_INDEX)
+			).toHaveText(SAMPLE_SCALAR_FIELD);
+
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_FIELD)
+					.locator('td')
+					.nth(LABEL_COLUMN_INDEX)
+			).toHaveText(SAMPLE_FIELD);
+
+			await visualizationModesPage.assertTableFieldRowCount(2);
+		});
+
+		await test.step('Delete field', async () => {
+			await clickActionInRow({
+				actionName: 'Delete',
+				rowName: SAMPLE_FIELD,
+				visualizationModesPage,
+			});
+
+			const deleteModal =
+				await visualizationModesPage.page.getByRole('dialog');
+
+			await expect(deleteModal).toContainText(
+				'Are you sure you want to delete this field? It will be removed immediately. Fragments using it will be affected. This action cannot be undone.'
+			);
+
+			await deleteModal.getByRole('button', {name: 'Delete'}).click();
+
+			const toastContainer = page.locator('.alert-container');
+
+			await expect(toastContainer.getByText('Success')).toBeInViewport();
+
+			await toastContainer
+				.getByRole('button', {
+					name: 'Close',
+				})
+				.click();
+		});
+
+		await test.step('Check that there is only one field', async () => {
+			await expect(
+				visualizationModesPage
+					.getRowByText(SAMPLE_SCALAR_FIELD)
+					.locator('td')
+					.nth(LABEL_COLUMN_INDEX)
+			).toHaveText(SAMPLE_SCALAR_FIELD);
+
+			await visualizationModesPage.assertTableFieldRowCount(1);
+		});
+
 		await test.step('Open field edition modal, check that name field is not editable', async () => {
 			await clickActionInRow({
 				actionName: 'Edit',
@@ -752,9 +833,7 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 
 			await expect(nameInput).toBeDisabled();
 
-			await saveFromModal({
-				page,
-			});
+			await visualizationModesPage.cancelAddFieldsModal();
 		});
 
 		await test.step('Open field edition modal, check that the user can change the renderer', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -700,4 +700,58 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			await visualizationModesPage.assertTableFieldRowCount(1);
 		});
 	});
+
+	test('Check field edition in table visualization mode', async ({
+		page,
+		visualizationModesPage,
+	}) => {
+		const SAMPLE_SCALAR_FIELD = 'id';
+
+		await test.step('Navigate to table visualization mode page', async () => {
+			await visualizationModesPage.goto({
+				dataSetLabel,
+			});
+
+			await visualizationModesPage.selectTab('Table');
+
+			await expect(
+				visualizationModesPage.page.getByPlaceholder('Search')
+			).toBeVisible();
+		});
+
+		await test.step('Add one field, save', async () => {
+			await visualizationModesPage.openAddFieldsModal();
+
+			await visualizationModesPage.selectField({
+				fieldName: SAMPLE_SCALAR_FIELD,
+			});
+
+			await saveFromModal({
+				page,
+			});
+		});
+
+		await test.step('Open field edition modal, check that name field is not editable @LPS-176051, @LPS-178736', async () => {
+			await clickActionInRow({
+				actionName: 'Edit',
+				rowName: SAMPLE_SCALAR_FIELD,
+				visualizationModesPage,
+			});
+
+			const editModal =
+				await visualizationModesPage.page.getByRole('dialog');
+
+			await expect(editModal.getByRole('heading')).toContainText(
+				`Edit ${SAMPLE_SCALAR_FIELD}`
+			);
+
+			const nameInput = visualizationModesPage.page.getByLabel('Name');
+
+			await expect(nameInput).toBeInViewport();
+
+			await expect(nameInput).toBeDisabled();
+
+			await visualizationModesPage.cancelAddFieldsModal();
+		});
+	});
 });

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -311,36 +311,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-179151. Confirm that the Checkbox in the Field edit modal is displayed."
-	@priority = 3
-	test CanAssertTheSortableCheckbox {
-		task ("And adds two or more fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And clicks on ellipsis button on one of these fields") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-		}
-
-		task ("And clicks on Edit option") {
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("Then Edit field modal is displayed") {
-			AssertVisible(
-				locator1 = "Portlet#MODAL_TITLE",
-				value1 = "Edit id");
-		}
-
-		task ("And contains Sortable checkbox") {
-			AssertElementPresent(
-				key_checkboxOption = "Sortable",
-				locator1 = "AppBuilder#CHECKBOX_OPTION_LABEL");
-		}
-	}
-
 	@description = "LPS-176516 Confirm that when adding a field with translation, and adding pt to the page URL, the values change according to the translation"
 	@priority = 3
 	test CanAssertTranslationIsWorking {
@@ -499,98 +469,6 @@ definition {
 
 		task ("Then Confirm that all fields are unchecked ") {
 			DataSetAdmin.assertFieldsNotChecked(key_fieldList = "renderer,rendererType");
-		}
-	}
-
-	@description = "LPS-179151. Confirm that the checkbox in the field edit modal is checked."
-	@priority = 4
-	test CanConfirmCheckedSortableCheckbox {
-		task ("And adds two or more fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And clicks on ellipsis button on one of these fields") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-		}
-
-		task ("And clicks on Edit option") {
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("Then Edit field modal is displayed") {
-			AssertVisible(
-				locator1 = "Portlet#MODAL_TITLE",
-				value1 = "Edit id");
-		}
-
-		task ("When the user unchecks and check on Sortable checkbox") {
-			Click(
-				key_checkboxOption = "Sortable",
-				locator1 = "AppBuilder#CHECKBOX_OPTION_LABEL");
-
-			Click(
-				key_checkboxOption = "Sortable",
-				locator1 = "AppBuilder#CHECKBOX_OPTION_LABEL");
-		}
-
-		task ("And clicks on Save button") {
-			Click(
-				key_text = "Save",
-				locator1 = "CP2ActivationKeys#KEY_DEACTIVATION_TERMS");
-		}
-
-		task ("Then the sortable field value is "yes" or "true"") {
-			AssertElementPresent(
-				chosenFilter = "true",
-				key_tableColumn = 1,
-				key_tableRow = 1,
-				locator1 = "DataSet#FILTER_TABLE_CELL");
-		}
-	}
-
-	@description = "LPS-179151. Confirm that the checkbox in the field edit modal is unchecked."
-	@priority = 4
-	test CanConfirmUncheckedSortableCheckbox {
-		task ("And adds two or more fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And clicks on ellipsis button on one of these fields") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-		}
-
-		task ("And clicks on Edit option") {
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("Then Edit field modal is displayed") {
-			AssertVisible(
-				locator1 = "Portlet#MODAL_TITLE",
-				value1 = "Edit id");
-		}
-
-		task ("When the user unchecks on Sortable checkbox") {
-			Click(
-				key_checkboxOption = "Sortable",
-				locator1 = "AppBuilder#CHECKBOX_OPTION_LABEL");
-		}
-
-		task ("And clicks on Save button") {
-			Click(
-				key_text = "Save",
-				locator1 = "CP2ActivationKeys#KEY_DEACTIVATION_TERMS");
-		}
-
-		task ("Then the sortable field value is "no" or "false"") {
-			AssertElementPresent(
-				chosenFilter = "false",
-				key_tableColumn = 1,
-				key_tableRow = 1,
-				locator1 = "DataSet#FILTER_TABLE_CELL");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -382,68 +382,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-179282. Confirm that the search bar returns works as expected"
-	@priority = 4
-	test CanSearchField {
-		property portal.upstream = "quarantine";
-
-		task ("And Clicking to Add a new field") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And type rendererType in the search bar and click enter") {
-			DataSetAdmin.searchFieldInModal(searchTerm = "rendererType");
-		}
-
-		task ("Then the corresponding option is the just displayed") {
-			AssertElementPresent(
-				key_name = "rendererType",
-				locator1 = "DataSet#FIELDS_ITEM");
-		}
-	}
-
-	@description = "LPS-185227. Confirm that the user can search a specific field when adding fields."
-	@priority = 4
-	test CanSearchFieldOnAddFieldsModal {
-		property portal.upstream = "quarantine";
-
-		task ("And clicks on Add Fields button") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And types 'label' on modal search bar") {
-			DataSetAdmin.searchFieldInModal(searchTerm = "label");
-		}
-
-		task ("Then 'label' field should appear on Add Fields modal") {
-			AssertElementPresent(
-				key_name = "label",
-				locator1 = "DataSet#FIELDS_ITEM");
-		}
-	}
-
-	@description = "LPS-185231. Confirm that the user can search a specific field on field's search bar."
-	@priority = 4
-	test CanSearchFieldOnFieldsSearchBar {
-		task ("And clicks on plus button/And checks id and label fields/And clicks on Save button") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And types id on Fields search bar") {
-			DataSetAdmin.searchField(searchTerm = "id");
-		}
-
-		task ("And clicks on search icon") {
-			Click(locator1 = "AppBuilder#SEARCH_BUTTON");
-		}
-
-		task ("Then only id field should appear on Fields page") {
-			DataSetAdmin.assertFieldsOnTable(
-				key_position = 1,
-				keyName = "id");
-		}
-	}
-
 	@description = "LPS-188333. Confirm that changes in the fields are not autosaved when edit and delete an entry"
 	@priority = 3
 	test FieldsChangesAreAutosaved {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -658,42 +658,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-185503. Confirm that fields are not updated when saving changes."
-	@priority = 5
-	test CanUpdateFieldsWhenSave {
-		property portal.acceptance = "true";
-
-		task ("And adds two or more fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("When the user selects the 'Plus' Button") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And uncheck a selected option") {
-			DataSetAdmin.uncheckFields(key_fieldList = "id");
-		}
-
-		task ("When the user clicks on the Save button") {
-			Click(
-				key_text = "Save",
-				locator1 = "CP2ActivationKeys#KEY_DEACTIVATION_TERMS");
-		}
-
-		task ("Then the Add field modal is closed") {
-			AssertElementNotPresent(
-				key_modalText = "Deleting a data set is an action that cannot be reversed. The content will be deleted and some data set fragments may not be displayed.",
-				locator1 = "DataSet#DELETE_DATA_SET_MODAL_BODY");
-		}
-
-		task ("And the changes are applied") {
-			DataSetAdmin.assertFieldsOnTable(
-				key_position = 1,
-				keyName = "label");
-		}
-	}
-
 	@description = "LPS-176051. Confirm that the user can view Edit icon modal"
 	@priority = 3
 	test CanViewEditModal {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -404,50 +404,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-178736. Confirm that the user can change the Cell Renderer type on Edit"
-	@priority = 5
-	test CanChangeCellRenderer {
-		property portal.acceptance = "true";
-
-		task ("And add an id Field") {
-			DataSetAdmin.addFields(key_fieldList = "id");
-		}
-
-		task ("Then assert the "Default" is present from the column Cell Renderer") {
-			AssertElementPresent(
-				key_tableColumn = "Renderer",
-				key_tableRow = "Default",
-				locator1 = "DataSet#FIELDS_TABLE_AND_ROW");
-		}
-
-		task ("When the user clicks on the edit option from the id Field") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("And change the Cell Renderer to "Label"") {
-			Click(
-				dropdownLabel = "Renderer",
-				locator1 = "ObjectField#ANY_DROPDOWN_LABEL");
-
-			MenuItem.click(menuItem = "Label");
-
-			Click(
-				key_text = "Save",
-				locator1 = "CP2ActivationKeys#KEY_DEACTIVATION_TERMS");
-		}
-
-		task ("Then assert the "Label" is present from the column Cell Renderer") {
-			AssertElementPresent(
-				key_tableColumn = "Renderer",
-				key_tableRow = "Label",
-				locator1 = "DataSet#FIELDS_TABLE_AND_ROW");
-		}
-	}
-
 	@description = "LPS-174141. Confirm that the user can check and uncheck all the fields"
 	@priority = 3
 	test CanCheckAndUncheckAllFields {
@@ -589,47 +545,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-176051. Blocked by :LPS-186987. Confirm that Cell Renderer option can be selected on Cell Renderer Field."
-	@ignore = "true"
-	@priority = 3
-	test CanSelectCellRendererOption {
-
-		// TODO LPS-185794 CanSelectCellRendererOption pending implementation
-
-	}
-
-	@description = "LPS-176051. Confirm that the user can select options of dropdown on Edit"
-	@priority = 5
-	test CanSelectDropdownOptions {
-		property portal.acceptance = "true";
-
-		task ("And add new fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And clicks on Edit option") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("When the user clicks on Cell Renderer field") {
-			Click(
-				dropdownLabel = "Renderer",
-				locator1 = "ObjectField#ANY_DROPDOWN_LABEL");
-		}
-
-		task ("Then a dropdown is displayed") {
-			AssertVisible(locator1 = "WorkflowAllItems#TRANSITION_DROPDOWN_KEBAB");
-		}
-
-		task ("And the options present in the dropdown can be selected") {
-			MenuItem.click(menuItem = "Date and Time");
-		}
-	}
-
 	@description = "LPS-179282. Confirm that the user can check and uncheck the fields"
 	@priority = 5
 	test CheckandUncheckFields {
@@ -712,24 +627,6 @@ definition {
 				key_tableColumn = 1,
 				key_tableRow = 1,
 				locator1 = "DataSet#FILTER_TABLE_CELL");
-		}
-	}
-
-	@description = "LPS-179151. Confirm that the Field Edit modal is displayed."
-	@priority = 3
-	test TheEditFieldModalIsDisplayed {
-		task ("And adds two or more fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And clicks on ellipsis button on one of these fields") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-		}
-
-		task ("Then a dropdown is displayed that contains Edit option") {
-			MenuItem.viewVisible(menuItem = "Edit");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -289,28 +289,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-185498. Confirm that when trying to delete field, modal appears."
-	@priority = 3
-	test CanAssertModalWhenDeleteField {
-		task ("And adds two or more fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("When the user selects the Delete option in the 3 dots menu") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-
-			ClickNoError(locator1 = "ObjectPortlet#DELETE_ENTRY_BUTTON");
-		}
-
-		task ("Then confirmation message is displayed") {
-			AssertElementPresent(
-				key_modalText = "Are you sure you want to delete this field? It will be removed immediately. Fragments using it will be affected. This action cannot be undone.",
-				locator1 = "DataSet#DELETE_DATA_SET_MODAL_BODY");
-		}
-	}
-
 	@description = "LPS-176516 Confirm that when adding a field with translation, and adding pt to the page URL, the values change according to the translation"
 	@priority = 3
 	test CanAssertTranslationIsWorking {
@@ -425,26 +403,6 @@ definition {
 
 		task ("Then Confirm that all fields are unchecked ") {
 			DataSetAdmin.assertFieldsNotChecked(key_fieldList = "renderer,rendererType");
-		}
-	}
-
-	@description = "LPS-185499. Confirm that field can be deleted."
-	@priority = 5
-	test CanDeleteField {
-		property portal.acceptance = "true";
-
-		task ("And adds 'id' field") {
-			DataSetAdmin.addFields(key_fieldList = "id");
-		}
-
-		task ("When the user selects the Delete option in the 3 dots menu / And the user confirms the deletion / Then the field is deleted") {
-			DataSetAdmin.deleteDataSetViewsFields(fieldName = "id");
-		}
-
-		task ("And assert the field is not present in the fields tab table") {
-			AssertElementPresent(
-				key_text = "Add Fields",
-				locator1 = "Button#ANY");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -527,34 +527,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-178736. Confirm that the Name field on Edit is not editable"
-	@priority = 4
-	test CannotEditNameFieldOnEdit {
-		task ("And add an id Field") {
-			DataSetAdmin.addFields(key_fieldList = "id");
-		}
-
-		task ("When the user clicks on the edit option from the id Field") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("Then the Edit Field modal is displayed") {
-			AssertElementPresent(
-				locator1 = "Portlet#MODAL_TITLE",
-				value1 = "Edit id");
-		}
-
-		task ("And asserts the name field is not editable") {
-			AssertElementPresent(
-				key_fieldLabel = "Name",
-				locator1 = "FormFields#FIELD_DISABLED");
-		}
-	}
-
 	@description = "LPS-179282. Confirm that the search bar returns works as expected"
 	@priority = 4
 	test CanSearchField {
@@ -655,46 +627,6 @@ definition {
 
 		task ("And the options present in the dropdown can be selected") {
 			MenuItem.click(menuItem = "Date and Time");
-		}
-	}
-
-	@description = "LPS-176051. Confirm that the user can view Edit icon modal"
-	@priority = 3
-	test CanViewEditModal {
-		task ("And add new fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("And clicks on Edit option") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-
-			MenuItem.click(menuItem = "Edit");
-		}
-
-		task ("Then the Edit field modal is displayed") {
-			AssertVisible(
-				locator1 = "Portlet#MODAL_TITLE",
-				value1 = "Edit id");
-		}
-	}
-
-	@description = "LPS-176051. Confirm that the user can view Edit icon of fields"
-	@priority = 3
-	test CanViewEditOption {
-		task ("And add new fields") {
-			DataSetAdmin.addFields(key_fieldList = "id,label");
-		}
-
-		task ("When the user clicks on 3 dots icon") {
-			Click(
-				key_fieldName = "id",
-				locator1 = "DataSet#VERTICAL_ELLIPSIS_BY_FIELDS_NAME");
-		}
-
-		task ("Then the Edit option appears") {
-			MenuItem.viewVisible(menuItem = "Edit");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewFields.testcase
@@ -382,65 +382,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-174141. Confirm that the user can check and uncheck all the fields"
-	@priority = 3
-	test CanCheckAndUncheckAllFields {
-		task ("And Clicking to Add a new field") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And select all the fields.") {
-			DataSetAdmin.checkFields(key_fieldList = "renderer,rendererType");
-		}
-
-		task ("Then Confirm all fields are checked ") {
-			DataSetAdmin.assertFieldsChecked(key_fieldList = "renderer,rendererType");
-		}
-
-		task ("When Uncheck all the fields.") {
-			DataSetAdmin.uncheckFields(key_fieldList = "renderer,rendererType");
-		}
-
-		task ("Then Confirm that all fields are unchecked ") {
-			DataSetAdmin.assertFieldsNotChecked(key_fieldList = "renderer,rendererType");
-		}
-	}
-
-	@description = "LPS-185228. Confirm that a field is not added after checking and unchecking it."
-	@priority = 5
-	test CannotAddFieldAfterUncheckingIt {
-		property portal.acceptance = "true";
-
-		task ("And clicks on plus button") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And checks id and label fields") {
-			DataSetAdmin.checkFields(key_fieldList = "id,label");
-		}
-
-		task ("And unchecks id field") {
-			DataSetAdmin.uncheckFields(key_fieldList = "id");
-		}
-
-		task ("And clicks on Save button") {
-			Button.clickSave();
-		}
-
-		task ("Then label field should appear on Visualization Modes tab page") {
-			DataSetAdmin.assertFieldsOnTable(
-				key_position = 1,
-				keyName = "label");
-		}
-
-		task ("And id should not appear on Visualization Modes tab page") {
-			AssertElementNotPresent(
-				key_position = 1,
-				keyName = "id",
-				locator1 = "DataSet#FIELDS_TABLE");
-		}
-	}
-
 	@description = "LPS-179282. Confirm that the search bar returns works as expected"
 	@priority = 4
 	test CanSearchField {
@@ -500,32 +441,6 @@ definition {
 			DataSetAdmin.assertFieldsOnTable(
 				key_position = 1,
 				keyName = "id");
-		}
-	}
-
-	@description = "LPS-179282. Confirm that the user can check and uncheck the fields"
-	@priority = 5
-	test CheckandUncheckFields {
-		property portal.acceptance = "true";
-
-		task ("And Clicking to Add a new field") {
-			LexiconEntry.gotoAdd();
-		}
-
-		task ("And Check three options (creator,id ,name)") {
-			DataSetAdmin.checkFields(key_fieldList = "creator,id,name");
-		}
-
-		task ("Then Confirm that the fields are checked ") {
-			DataSetAdmin.assertFieldsChecked(key_fieldList = "creator,id,name");
-		}
-
-		task ("When Check three options (Phone, User Account, and WebURL)") {
-			DataSetAdmin.uncheckFields(key_fieldList = "creator,id,name");
-		}
-
-		task ("Then Confirm that the fields are unchecked ") {
-			DataSetAdmin.assertFieldsNotChecked(key_fieldList = "creator,id,name");
 		}
 	}
 


### PR DESCRIPTION
## Task
[LPD-30051](https://liferay.atlassian.net/browse/LPD-30051)

## Removed tests (already covered)
- CanAssertTheSortableCheckbox
- CanConfirmCheckedSortableCheckbox
- CanConfirmUncheckedSortableCheckbox
- CannotAddFieldAfterUncheckingIt
- CanSearchField
- CanSearchFieldOnAddFieldsModal
- CanSearchFieldOnFieldsSearchBar
- CanUpdateFieldsWhenSave
- CanViewEditOption

## Removed tests (migrated)
- CanAssertModalWhenDeleteField
- CanChangeCellRenderer
- CanCheckAndUncheckAllFields
- CanDeleteField
- CannotEditNameFieldOnEdit
- CanSelectCellRendererOption
- CanSelectDropdownOptions
- CanViewEditModal
- CheckandUncheckFields
- TheEditFieldModalIsDisplayed

