### PR TITLE
LPD-29981 Remove duplicate escape usage

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -594,7 +594,7 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 										for (String curDefaultValue : (String[])defaultValue) {
 										%>
 
-											<aui:option label="<%= HtmlUtil.escape(curDefaultValue) %>" selected="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, HtmlUtil.escape(curDefaultValue)) %>" value="<%= HtmlUtil.escape(curDefaultValue) %>" />
+											<aui:option label="<%= curDefaultValue %>" selected="<%= (curValue.length > 0) && ArrayUtil.contains(curValue, HtmlUtil.escape(curDefaultValue)) %>" value="<%= HtmlUtil.escape(curDefaultValue) %>" />
 
 										<%
 										}

--- a/modules/test/playwright/tests/users-admin-web/usersAndOrganizations.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/usersAndOrganizations.spec.ts
@@ -411,3 +411,66 @@ test('LPD-33048 Last login visibility', async ({usersAndOrganizationsPage}) => {
 		usersAndOrganizationsPage.tableOrderLastLoginDateItem
 	).toBeVisible();
 });
+
+test('LPD-29981 Check custom field is escaped', async ({
+	page,
+	usersAndOrganizationsPage,
+}) => {
+	await page.goto('/');
+
+	await usersAndOrganizationsPage.goToUsers();
+	await usersAndOrganizationsPage.openOptionsMenu();
+
+	await usersAndOrganizationsPage.manageCustomFieldsOptionsMenuItem.click();
+
+	await page.getByRole('link', {name: 'Add Custom Field'}).click();
+
+	const dropdownOptionButton = page.getByRole('link', {
+		name: 'Dropdown Option',
+	});
+
+	await dropdownOptionButton.waitFor({state: 'visible'});
+	await dropdownOptionButton.click();
+
+	const customFieldLabel = page.getByLabel('Field Name Required');
+
+	await customFieldLabel.waitFor({state: 'visible'});
+	await customFieldLabel.click();
+	await customFieldLabel.fill('fieldTest');
+
+	const customFieldValue = page.getByLabel('Values Required Enter one');
+
+	await customFieldValue.waitFor({state: 'visible'});
+	await customFieldValue.click();
+	await customFieldValue.fill('a & b');
+
+	const saveButton = page.getByRole('button', {
+		name: 'Save',
+	});
+
+	await saveButton.waitFor({state: 'visible'});
+	await saveButton.click();
+
+	await expect(
+		page.getByText('Success:Your request completed successfully.')
+	).toBeVisible();
+
+	await usersAndOrganizationsPage.goToUsers();
+	await (await usersAndOrganizationsPage.usersTableRowLink('test')).click();
+
+	const customFieldDropDownLabel = page.getByLabel('Fieldtest', {
+		exact: true,
+	});
+
+	await customFieldDropDownLabel.waitFor({state: 'visible'});
+
+	const customFieldDropDownOptions = await page.evaluate(() => {
+		const selection = document.querySelector('[title="field-test"]');
+
+		// @ts-ignore
+
+		return [...selection.options].some((option) => option.text === 'a & b');
+	});
+
+	expect(customFieldDropDownOptions).toBeTruthy();
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-29981
https://liferay.atlassian.net/browse/LPD-29981

The label was being escaped twice and resulting in incorrect labels. 

The double escape was introduced in https://liferay.atlassian.net/browse/LPS-185312 with this commit https://github.com/liferay-frontend/liferay-portal/pull/3578/files adding the escape to true.

I looked for aui:option with HtmlUtil.escape for the label and removed it so it would not get escaped twice.

For a case like this where it hits a lot of different components, how do we want to make the playwright test?
Should FEI be the ones making this change in the first place or should each team be responsible for their own tests?

Thank you for the help!