### PR TITLE
LPD-28582 When a new default sorting is saved, set other previously set default sorting as false

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
@@ -242,6 +242,18 @@ public class FDSAdminDisplayContext {
 		return resourceURL.toString();
 	}
 
+	public String getSaveFDSSortURL() {
+		ResourceURL resourceURL =
+			(ResourceURL)PortalUtil.getControlPanelPortletURL(
+				_renderRequest, _themeDisplay.getScopeGroup(),
+				FDSAdminPortletKeys.FDS_ADMIN, 0, 0,
+				RenderRequest.RESOURCE_PHASE);
+
+		resourceURL.setResourceID("/frontend_data_set_admin/save_fds_sort");
+
+		return resourceURL.toString();
+	}
+
 	private final CETManager _cetManager;
 	private final ObjectDefinition _fdsEntryObjectDefinition;
 	private final ObjectDefinition _fdsViewObjectDefinition;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -1006,6 +1006,16 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
+				String label = (String)properties.get("label");
+
+				if (label.equals(StringPool.BLANK)) {
+					Map<String, String> labelI18n =
+						(Map<String, String>)properties.get("label_i18n");
+
+					label = labelI18n.get(
+						LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
+				}
+
 				if (FeatureFlagManagerUtil.isEnabled("LPD-19465")) {
 					return JSONUtil.put(
 						"active", properties.get("default")
@@ -1016,7 +1026,7 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					).put(
 						"key", properties.get("fieldName")
 					).put(
-						"label", properties.get("label")
+						"label", label
 					);
 				}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -879,8 +879,8 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 
 		DTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
-				false, null, null, null, null, LocaleUtil.getSiteDefault(),
-				null, null);
+				false, null, null, null, null,
+				LocaleUtil.getMostRelevantLocale(), null, null);
 
 		DefaultObjectEntryManager defaultObjectEntryManager =
 			DefaultObjectEntryManagerProvider.provide(
@@ -918,8 +918,8 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 
 		DTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
-				false, null, null, null, null, LocaleUtil.getSiteDefault(),
-				null, null);
+				false, null, null, null, null,
+				LocaleUtil.getMostRelevantLocale(), null, null);
 
 		DefaultObjectEntryManager defaultObjectEntryManager =
 			DefaultObjectEntryManagerProvider.provide(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/SaveFDSSortMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/SaveFDSSortMVCResourceCommand.java
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.admin.web.internal.portlet.action;
+
+import com.liferay.frontend.data.set.admin.web.internal.constants.FDSAdminPortletKeys;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.rest.dto.v1_0.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Kevin Tan
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + FDSAdminPortletKeys.FDS_ADMIN,
+		"mvc.command.name=/frontend_data_set_admin/save_fds_sort"
+	},
+	service = MVCResourceCommand.class
+)
+public class SaveFDSSortMVCResourceCommand
+	extends BaseTransactionalMVCResourceCommand {
+
+	@Override
+	protected void doTransactionalCommand(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		String dataSetId = ParamUtil.getString(resourceRequest, "dataSetId");
+		String externalReferenceCode = ParamUtil.getString(
+			resourceRequest, "externalReferenceCode");
+		String fieldName = ParamUtil.getString(resourceRequest, "fieldName");
+		String labelI18n = ParamUtil.getString(resourceRequest, "labelI18n");
+		String orderType = ParamUtil.getString(resourceRequest, "orderType");
+		boolean useAsDefaultSorting = GetterUtil.getBoolean(
+			ParamUtil.getString(resourceRequest, "useAsDefaultSorting"));
+
+		ObjectDefinition fdsViewObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				themeDisplay.getCompanyId(), "FDSView");
+
+		if (useAsDefaultSorting) {
+			Collection<ObjectEntry> fdsSortObjectEntries =
+				_getFDSSortObjectEntries(
+					fdsViewObjectDefinition, Long.valueOf(dataSetId));
+
+			for (ObjectEntry fdsSortObjectEntry : fdsSortObjectEntries) {
+				Map<String, Object> properties =
+					fdsSortObjectEntry.getProperties();
+
+				boolean defaultProperty = GetterUtil.getBoolean(
+					properties.get("default"));
+
+				if (defaultProperty) {
+					Map<String, Serializable> values = new HashMap<>();
+
+					for (Map.Entry<String, Object> entry :
+							properties.entrySet()) {
+
+						values.put(
+							entry.getKey(), (Serializable)entry.getValue());
+					}
+
+					values.put("default", false);
+
+					_objectEntryService.updateObjectEntry(
+						fdsSortObjectEntry.getId(), values,
+						new ServiceContext());
+				}
+			}
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				themeDisplay.getCompanyId(), "FDSSort");
+
+		Map<String, Serializable> labelI18nMap =
+			(Map<String, Serializable>)_jsonFactory.looseDeserialize(labelI18n);
+
+		_objectEntryService.addOrUpdateObjectEntry(
+			externalReferenceCode, 0, objectDefinition.getObjectDefinitionId(),
+			HashMapBuilder.<String, Serializable>put(
+				"default", useAsDefaultSorting
+			).put(
+				"fieldName", fieldName
+			).put(
+				"label_i18n", (Serializable)labelI18nMap
+			).put(
+				"orderType", orderType
+			).put(
+				"r_fdsViewFDSSortRelationship_c_fdsViewId", dataSetId
+			).build(),
+			new ServiceContext());
+
+		Collection<ObjectEntry> updatedFDSSortObjectEntries =
+			_getFDSSortObjectEntries(
+				fdsViewObjectDefinition, Long.valueOf(dataSetId));
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse, updatedFDSSortObjectEntries);
+	}
+
+	private Collection<ObjectEntry> _getFDSSortObjectEntries(
+			ObjectDefinition fdsViewObjectDefinition, Long objectEntryId)
+		throws Exception {
+
+		DTOConverterContext dtoConverterContext =
+			new DefaultDTOConverterContext(
+				false, null, null, null, null,
+				LocaleUtil.getMostRelevantLocale(), null, null);
+
+		DefaultObjectEntryManager defaultObjectEntryManager =
+			DefaultObjectEntryManagerProvider.provide(
+				_objectEntryManagerRegistry.getObjectEntryManager(
+					fdsViewObjectDefinition.getStorageType()));
+
+		Page<ObjectEntry> relatedObjectEntriesPage =
+			defaultObjectEntryManager.getObjectEntryRelatedObjectEntries(
+				dtoConverterContext, fdsViewObjectDefinition, objectEntryId,
+				"fdsViewFDSSortRelationship",
+				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+
+		return relatedObjectEntriesPage.getItems();
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryManagerRegistry _objectEntryManagerRegistry;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/data_set.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/data_set.jsp
@@ -34,6 +34,8 @@ renderResponse.setTitle(ParamUtil.getString(request, "dataSetLabel"));
 		).put(
 			"saveFDSFieldsURL", fdsAdminDisplayContext.getSaveFDSFieldsURL()
 		).put(
+			"saveFDSSortURL", fdsAdminDisplayContext.getSaveFDSSortURL()
+		).put(
 			"spritemap", themeDisplay.getPathThemeSpritemap()
 		).build()
 	%>'

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/fds_view.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/fds_view.jsp
@@ -34,6 +34,8 @@ renderResponse.setTitle(ParamUtil.getString(request, "fdsViewLabel"));
 		).put(
 			"saveFDSFieldsURL", fdsAdminDisplayContext.getSaveFDSFieldsURL()
 		).put(
+			"saveFDSSortURL", fdsAdminDisplayContext.getSaveFDSSortURL()
+		).put(
 			"spritemap", themeDisplay.getPathThemeSpritemap()
 		).build()
 	%>'

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
@@ -72,6 +72,7 @@ export interface IDataSetSectionProps {
 	onDataSetUpdate: (data: FDSViewType) => void;
 	restApplications: string[];
 	saveFDSFieldsURL: string;
+	saveFDSSortURL: string;
 	spritemap: string;
 }
 
@@ -84,6 +85,7 @@ const DataSet = ({
 	namespace,
 	restApplications,
 	saveFDSFieldsURL,
+	saveFDSSortURL,
 	spritemap,
 }: {
 	backURL: string;
@@ -94,6 +96,7 @@ const DataSet = ({
 	namespace: string;
 	restApplications: string[];
 	saveFDSFieldsURL: string;
+	saveFDSSortURL: string;
 	spritemap: string;
 }) => {
 	const [activeIndex, setActiveIndex] = useState(0);
@@ -178,6 +181,7 @@ const DataSet = ({
 						}}
 						restApplications={restApplications}
 						saveFDSFieldsURL={saveFDSFieldsURL}
+						saveFDSSortURL={saveFDSSortURL}
 						spritemap={spritemap}
 					/>
 				)

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -11,7 +11,7 @@ import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {InputLocalized} from 'frontend-js-components-web';
-import {fetch, openModal} from 'frontend-js-web';
+import {fetch, openModal, openToast, sub} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
@@ -101,15 +101,23 @@ const labelTextMatch = (item: IFDSSort) => {
 const AddFDSSortModalContent = ({
 	closeModal,
 	dataSet,
+	fdsSorts,
 	fields,
 	namespace,
 	onSave,
 }: {
 	closeModal: Function;
 	dataSet: IDataSet | FDSViewType;
+	fdsSorts: IFDSSort[];
 	fields: IField[];
 	namespace: string;
-	onSave: (newSort: IFDSSort) => void;
+	onSave: ({
+		newFDSSort,
+		previousDefaultFDSSort,
+	}: {
+		newFDSSort: IFDSSort;
+		previousDefaultFDSSort?: IFDSSort;
+	}) => void;
 }) => {
 	const [labelI18n, setLabelI18n] = useState<
 		Liferay.Language.LocalizedValue<string>
@@ -124,17 +132,9 @@ const AddFDSSortModalContent = ({
 	const handleSave = async () => {
 		setSaveButtonDisabled(true);
 
-		const field = fields.find(
-			(item: IField) => item.name === selectedFieldName
-		);
+		// Add new sorting.
 
-		if (!field) {
-			openDefaultFailureToast();
-
-			return;
-		}
-
-		const response = await fetch(API_URL.SORTS, {
+		const addFDSSortResponse = await fetch(API_URL.SORTS, {
 			body: JSON.stringify({
 				[OBJECT_RELATIONSHIP.DATA_SET_SORT_ID]: dataSet.id,
 				default: useAsDefaultSorting,
@@ -149,7 +149,7 @@ const AddFDSSortModalContent = ({
 			method: 'POST',
 		});
 
-		if (!response.ok) {
+		if (!addFDSSortResponse.ok) {
 			setSaveButtonDisabled(false);
 
 			openDefaultFailureToast();
@@ -157,11 +157,60 @@ const AddFDSSortModalContent = ({
 			return;
 		}
 
-		const responseJSON = await response.json();
+		const newFDSSort = await addFDSSortResponse.json();
 
-		openDefaultSuccessToast();
+		// If an existing default sorting exists, change its default to false.
 
-		onSave(responseJSON);
+		const defaultFDSSort = fdsSorts.find(
+			(fdsSort) => fdsSort.default
+		) as IFDSSort;
+
+		if (useAsDefaultSorting && defaultFDSSort) {
+			const updateDefaultFDSSortResponse = await fetch(
+				`${API_URL.SORTS}/by-external-reference-code/${defaultFDSSort.externalReferenceCode}`,
+				{
+					body: JSON.stringify({
+						default: false,
+					}),
+					headers: {
+						'Accept': 'application/json',
+						'Content-Type': 'application/json',
+					},
+					method: 'PATCH',
+				}
+			);
+
+			if (!updateDefaultFDSSortResponse.ok) {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'an-unexpected-error-occurred-and-the-existing-default-sorting-was-not-removed.please-edit-the-x-sorting-and-uncheck-the-default-option'
+						),
+						[
+							defaultFDSSort.label ||
+								defaultFDSSort.label_i18n[
+									Liferay.ThemeDisplay.getDefaultLanguageId()
+								] ||
+								'',
+						]
+					),
+					type: 'danger',
+				});
+			}
+
+			const previousDefaultFDSSort =
+				await updateDefaultFDSSortResponse.json();
+
+			onSave({newFDSSort, previousDefaultFDSSort});
+		}
+		else {
+			onSave({newFDSSort});
+		}
+
+		openToast({
+			message: Liferay.Language.get('sorting-was-successfully-added'),
+			type: 'success',
+		});
 
 		closeModal();
 	};
@@ -288,6 +337,7 @@ const AddFDSSortModalContent = ({
 interface IEditFDSSortModalContentProps {
 	closeModal: Function;
 	fdsSort: IFDSSort;
+	fdsSorts: IFDSSort[];
 	fields: IField[];
 	namespace: string;
 	onSave: Function;
@@ -296,6 +346,7 @@ interface IEditFDSSortModalContentProps {
 const EditFDSSortModalContent = ({
 	closeModal,
 	fdsSort,
+	fdsSorts,
 	fields,
 	namespace,
 	onSave,
@@ -317,7 +368,9 @@ const EditFDSSortModalContent = ({
 	const handleSave = async () => {
 		setSaveButtonDisabled(true);
 
-		const response = await fetch(
+		// Edit the sorting.
+
+		const editFDSSortResponse = await fetch(
 			`${API_URL.SORTS}/by-external-reference-code/${fdsSort.externalReferenceCode}`,
 			{
 				body: JSON.stringify({
@@ -334,7 +387,7 @@ const EditFDSSortModalContent = ({
 			}
 		);
 
-		if (!response.ok) {
+		if (!editFDSSortResponse.ok) {
 			setSaveButtonDisabled(false);
 
 			openDefaultFailureToast();
@@ -342,13 +395,62 @@ const EditFDSSortModalContent = ({
 			return;
 		}
 
-		const editedFDSSort = await response.json();
+		const editedFDSSort = await editFDSSortResponse.json();
+
+		// If an existing default sorting exists, change its default to false.
+
+		const defaultFDSSort = fdsSorts.find(
+			(fdsSort) => fdsSort.default
+		) as IFDSSort;
+
+		if (useAsDefaultSorting && defaultFDSSort) {
+			const updateDefaultFDSSortResponse = await fetch(
+				`${API_URL.SORTS}/by-external-reference-code/${defaultFDSSort.externalReferenceCode}`,
+				{
+					body: JSON.stringify({
+						default: false,
+					}),
+					headers: {
+						'Accept': 'application/json',
+						'Content-Type': 'application/json',
+					},
+					method: 'PATCH',
+				}
+			);
+
+			if (!updateDefaultFDSSortResponse.ok) {
+				openToast({
+					message: sub(
+						Liferay.Language.get(
+							'an-unexpected-error-occurred-and-the-existing-default-sorting-was-not-removed.please-edit-the-x-sorting-and-uncheck-the-default-option'
+						),
+						[
+							defaultFDSSort.label ||
+								defaultFDSSort.label_i18n[
+									Liferay.ThemeDisplay.getDefaultLanguageId()
+								] ||
+								'',
+						]
+					),
+					type: 'danger',
+				});
+			}
+
+			const previousDefaultFDSSort =
+				await updateDefaultFDSSortResponse.json();
+
+			onSave({editedFDSSort, previousDefaultFDSSort});
+		}
+		else {
+			onSave({editedFDSSort});
+		}
+
+		openToast({
+			message: Liferay.Language.get('sorting-was-successfully-edited'),
+			type: 'success',
+		});
 
 		closeModal();
-
-		openDefaultSuccessToast();
-
-		onSave({editedFDSSort});
 	};
 
 	const fdsSortLabelInput = `${namespace}fdsSortLabelInput`;
@@ -523,9 +625,32 @@ const Sorting = ({
 				<AddFDSSortModalContent
 					closeModal={closeModal}
 					dataSet={dataSet}
+					fdsSorts={fdsSorts}
 					fields={fields}
 					namespace={namespace}
-					onSave={(newSort) => setFDSSorts([...fdsSorts, newSort])}
+					onSave={({
+						newFDSSort,
+						previousDefaultFDSSort,
+					}: {
+						newFDSSort: IFDSSort;
+						previousDefaultFDSSort?: IFDSSort;
+					}) =>
+						setFDSSorts([
+							...(previousDefaultFDSSort
+								? fdsSorts?.map((fdsSort) => {
+										if (
+											fdsSort.id ===
+											previousDefaultFDSSort.id
+										) {
+											return previousDefaultFDSSort;
+										}
+
+										return fdsSort;
+									}) || []
+								: fdsSorts),
+							newFDSSort,
+						])
+					}
 				/>
 			),
 		});
@@ -585,13 +710,27 @@ const Sorting = ({
 				<EditFDSSortModalContent
 					closeModal={closeModal}
 					fdsSort={item}
+					fdsSorts={fdsSorts}
 					fields={fields}
 					namespace={namespace}
-					onSave={({editedFDSSort}: {editedFDSSort: IFDSSort}) => {
+					onSave={({
+						editedFDSSort,
+						previousDefaultFDSSort,
+					}: {
+						editedFDSSort: IFDSSort;
+						previousDefaultFDSSort?: IFDSSort;
+					}) => {
 						setFDSSorts(
 							fdsSorts?.map((fdsSort) => {
 								if (fdsSort.id === editedFDSSort.id) {
 									return editedFDSSort;
+								}
+
+								if (
+									previousDefaultFDSSort &&
+									fdsSort.id === previousDefaultFDSSort.id
+								) {
+									return previousDefaultFDSSort;
 								}
 
 								return fdsSort;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -450,7 +450,14 @@ const Sorting = ({
 	useEffect(() => {
 		const getFDSSort = async () => {
 			const response = await fetch(
-				`${API_URL.SORTS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_SORT_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_SORT}&sort=dateCreated:asc`
+				`${API_URL.SORTS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_SORT_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_SORT}&sort=dateCreated:asc`,
+				{
+					headers: {
+						'Accept': 'application/json',
+						'Accept-Language':
+							Liferay.ThemeDisplay.getBCP47LanguageId(),
+					},
+				}
 			);
 
 			const responseJSON = await response.json();

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -70,7 +70,7 @@ const DefaultComponent = ({item}: IContentRendererProps) => {
 const LabelComponent = ({item, query}: IContentRendererProps) => {
 	const label =
 		item.label ||
-		item.label_i18n[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
+		item.label_i18n?.[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
 		'';
 
 	const fuzzyMatch = fuzzy.match(query, label, FUZZY_OPTIONS);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -12,13 +12,18 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {InputLocalized} from 'frontend-js-components-web';
 import {fetch, openModal} from 'frontend-js-web';
+import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
 import {IDataSet} from '../../DataSets';
 import {FDSViewType} from '../../FDSViews';
 import OrderableTable from '../../components/OrderableTable';
 import RequiredMark from '../../components/RequiredMark';
-import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {
+	API_URL,
+	FUZZY_OPTIONS,
+	OBJECT_RELATIONSHIP,
+} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import sortItems from '../../utils/sortItems';
@@ -59,6 +64,37 @@ const DefaultComponent = ({item}: IContentRendererProps) => {
 				? Liferay.Language.get('yes')
 				: Liferay.Language.get('no')}
 		</ClayLabel>
+	);
+};
+
+const LabelComponent = ({item, query}: IContentRendererProps) => {
+	const label =
+		item.label ||
+		item.label_i18n[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
+		'';
+
+	const fuzzyMatch = fuzzy.match(query, label, FUZZY_OPTIONS);
+
+	return (
+		<span className="table-list-title">
+			{fuzzyMatch ? (
+				<span
+					dangerouslySetInnerHTML={{
+						__html: fuzzyMatch.rendered,
+					}}
+				/>
+			) : (
+				<span>{label}</span>
+			)}
+		</span>
+	);
+};
+
+const labelTextMatch = (item: IFDSSort) => {
+	return (
+		item.label ||
+		item.label_i18n[Liferay.ThemeDisplay.getDefaultLanguageId()] ||
+		''
 	);
 };
 
@@ -643,7 +679,10 @@ const Sorting = ({
 						]}
 						fields={[
 							{
-								headingTitle: true,
+								contentRenderer: {
+									component: LabelComponent,
+									textMatch: labelTextMatch,
+								},
 								label: Liferay.Language.get('label'),
 								name: 'label',
 							},

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -101,14 +101,13 @@ const labelTextMatch = (item: IFDSSort) => {
 const AddFDSSortModalContent = ({
 	closeModal,
 	dataSet,
-	fdsSorts,
 	fields,
 	namespace,
 	onSave,
+	saveFDSSortURL,
 }: {
 	closeModal: Function;
 	dataSet: IDataSet | FDSViewType;
-	fdsSorts: IFDSSort[];
 	fields: IField[];
 	namespace: string;
 	onSave: ({
@@ -118,6 +117,7 @@ const AddFDSSortModalContent = ({
 		newFDSSort: IFDSSort;
 		previousDefaultFDSSort?: IFDSSort;
 	}) => void;
+	saveFDSSortURL: string;
 }) => {
 	const [labelI18n, setLabelI18n] = useState<
 		Liferay.Language.LocalizedValue<string>
@@ -132,24 +132,23 @@ const AddFDSSortModalContent = ({
 	const handleSave = async () => {
 		setSaveButtonDisabled(true);
 
-		// Add new sorting.
+		const formData = new FormData();
 
-		const addFDSSortResponse = await fetch(API_URL.SORTS, {
-			body: JSON.stringify({
-				[OBJECT_RELATIONSHIP.DATA_SET_SORT_ID]: dataSet.id,
-				default: useAsDefaultSorting,
-				fieldName: selectedFieldName,
-				label_i18n: labelI18n,
-				orderType: selectedOrderType,
-			}),
-			headers: {
-				'Accept': 'application/json',
-				'Content-Type': 'application/json',
-			},
+		formData.append(`${namespace}dataSetId`, dataSet.id);
+		formData.append(
+			`${namespace}useAsDefaultSorting`,
+			String(useAsDefaultSorting)
+		);
+		formData.append(`${namespace}fieldName`, selectedFieldName);
+		formData.append(`${namespace}labelI18n`, JSON.stringify(labelI18n));
+		formData.append(`${namespace}orderType`, selectedOrderType);
+
+		const response = await fetch(saveFDSSortURL, {
+			body: formData,
 			method: 'POST',
 		});
 
-		if (!addFDSSortResponse.ok) {
+		if (!response.ok) {
 			setSaveButtonDisabled(false);
 
 			openDefaultFailureToast();
@@ -157,55 +156,9 @@ const AddFDSSortModalContent = ({
 			return;
 		}
 
-		const newFDSSort = await addFDSSortResponse.json();
+		const newFDSSort = await response.json();
 
-		// If an existing default sorting exists, change its default to false.
-
-		const defaultFDSSort = fdsSorts.find(
-			(fdsSort) => fdsSort.default
-		) as IFDSSort;
-
-		if (useAsDefaultSorting && defaultFDSSort) {
-			const updateDefaultFDSSortResponse = await fetch(
-				`${API_URL.SORTS}/by-external-reference-code/${defaultFDSSort.externalReferenceCode}`,
-				{
-					body: JSON.stringify({
-						default: false,
-					}),
-					headers: {
-						'Accept': 'application/json',
-						'Content-Type': 'application/json',
-					},
-					method: 'PATCH',
-				}
-			);
-
-			if (!updateDefaultFDSSortResponse.ok) {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'an-unexpected-error-occurred-and-the-existing-default-sorting-was-not-removed.please-edit-the-x-sorting-and-uncheck-the-default-option'
-						),
-						[
-							defaultFDSSort.label ||
-								defaultFDSSort.label_i18n[
-									Liferay.ThemeDisplay.getDefaultLanguageId()
-								] ||
-								'',
-						]
-					),
-					type: 'danger',
-				});
-			}
-
-			const previousDefaultFDSSort =
-				await updateDefaultFDSSortResponse.json();
-
-			onSave({newFDSSort, previousDefaultFDSSort});
-		}
-		else {
-			onSave({newFDSSort});
-		}
+		onSave({newFDSSort});
 
 		openToast({
 			message: Liferay.Language.get('sorting-was-successfully-added'),
@@ -336,20 +289,22 @@ const AddFDSSortModalContent = ({
 
 interface IEditFDSSortModalContentProps {
 	closeModal: Function;
+	dataSet: IDataSet | FDSViewType;
 	fdsSort: IFDSSort;
-	fdsSorts: IFDSSort[];
 	fields: IField[];
 	namespace: string;
 	onSave: Function;
+	saveFDSSortURL: string;
 }
 
 const EditFDSSortModalContent = ({
 	closeModal,
+	dataSet,
 	fdsSort,
-	fdsSorts,
 	fields,
 	namespace,
 	onSave,
+	saveFDSSortURL,
 }: IEditFDSSortModalContentProps) => {
 	const [labelI18n, setLabelI18n] = useState<
 		Liferay.Language.LocalizedValue<string>
@@ -368,26 +323,27 @@ const EditFDSSortModalContent = ({
 	const handleSave = async () => {
 		setSaveButtonDisabled(true);
 
-		// Edit the sorting.
+		const formData = new FormData();
 
-		const editFDSSortResponse = await fetch(
-			`${API_URL.SORTS}/by-external-reference-code/${fdsSort.externalReferenceCode}`,
-			{
-				body: JSON.stringify({
-					default: useAsDefaultSorting,
-					fieldName: selectedFieldName,
-					label_i18n: labelI18n,
-					orderType: selectedOrderType,
-				}),
-				headers: {
-					'Accept': 'application/json',
-					'Content-Type': 'application/json',
-				},
-				method: 'PATCH',
-			}
+		formData.append(`${namespace}dataSetId`, dataSet.id);
+		formData.append(
+			`${namespace}externalReferenceCode`,
+			fdsSort.externalReferenceCode
+		);
+		formData.append(`${namespace}fieldName`, selectedFieldName);
+		formData.append(`${namespace}labelI18n`, JSON.stringify(labelI18n));
+		formData.append(`${namespace}orderType`, selectedOrderType);
+		formData.append(
+			`${namespace}useAsDefaultSorting`,
+			String(useAsDefaultSorting)
 		);
 
-		if (!editFDSSortResponse.ok) {
+		const response = await fetch(saveFDSSortURL, {
+			body: formData,
+			method: 'POST',
+		});
+
+		if (!response.ok) {
 			setSaveButtonDisabled(false);
 
 			openDefaultFailureToast();
@@ -395,55 +351,9 @@ const EditFDSSortModalContent = ({
 			return;
 		}
 
-		const editedFDSSort = await editFDSSortResponse.json();
+		const newFDSSort = await response.json();
 
-		// If an existing default sorting exists, change its default to false.
-
-		const defaultFDSSort = fdsSorts.find(
-			(fdsSort) => fdsSort.default
-		) as IFDSSort;
-
-		if (useAsDefaultSorting && defaultFDSSort) {
-			const updateDefaultFDSSortResponse = await fetch(
-				`${API_URL.SORTS}/by-external-reference-code/${defaultFDSSort.externalReferenceCode}`,
-				{
-					body: JSON.stringify({
-						default: false,
-					}),
-					headers: {
-						'Accept': 'application/json',
-						'Content-Type': 'application/json',
-					},
-					method: 'PATCH',
-				}
-			);
-
-			if (!updateDefaultFDSSortResponse.ok) {
-				openToast({
-					message: sub(
-						Liferay.Language.get(
-							'an-unexpected-error-occurred-and-the-existing-default-sorting-was-not-removed.please-edit-the-x-sorting-and-uncheck-the-default-option'
-						),
-						[
-							defaultFDSSort.label ||
-								defaultFDSSort.label_i18n[
-									Liferay.ThemeDisplay.getDefaultLanguageId()
-								] ||
-								'',
-						]
-					),
-					type: 'danger',
-				});
-			}
-
-			const previousDefaultFDSSort =
-				await updateDefaultFDSSortResponse.json();
-
-			onSave({editedFDSSort, previousDefaultFDSSort});
-		}
-		else {
-			onSave({editedFDSSort});
-		}
+		onSave({newFDSSort});
 
 		openToast({
 			message: Liferay.Language.get('sorting-was-successfully-edited'),
@@ -580,6 +490,7 @@ const Sorting = ({
 	dataSet,
 	fieldTreeItems,
 	namespace,
+	saveFDSSortURL,
 }: IDataSetSectionProps) => {
 	const fields = fieldTreeItems.filter((field) => field.sortable);
 	const [fdsSorts, setFDSSorts] = useState<Array<IFDSSort>>([]);
@@ -625,7 +536,6 @@ const Sorting = ({
 				<AddFDSSortModalContent
 					closeModal={closeModal}
 					dataSet={dataSet}
-					fdsSorts={fdsSorts}
 					fields={fields}
 					namespace={namespace}
 					onSave={({
@@ -651,6 +561,7 @@ const Sorting = ({
 							newFDSSort,
 						])
 					}
+					saveFDSSortURL={saveFDSSortURL}
 				/>
 			),
 		});
@@ -709,8 +620,8 @@ const Sorting = ({
 			contentComponent: ({closeModal}: {closeModal: Function}) => (
 				<EditFDSSortModalContent
 					closeModal={closeModal}
+					dataSet={dataSet}
 					fdsSort={item}
-					fdsSorts={fdsSorts}
 					fields={fields}
 					namespace={namespace}
 					onSave={({
@@ -737,6 +648,7 @@ const Sorting = ({
 							}) || []
 						);
 					}}
+					saveFDSSortURL={saveFDSSortURL}
 				/>
 			),
 		});

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/sorting/Sorting.tsx
@@ -11,9 +11,9 @@ import ClayLayout from '@clayui/layout';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal from '@clayui/modal';
 import {InputLocalized} from 'frontend-js-components-web';
-import {fetch, openModal, openToast, sub} from 'frontend-js-web';
+import {fetch, openModal} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {IDataSet} from '../../DataSets';
 import {FDSViewType} from '../../FDSViews';
@@ -110,13 +110,7 @@ const AddFDSSortModalContent = ({
 	dataSet: IDataSet | FDSViewType;
 	fields: IField[];
 	namespace: string;
-	onSave: ({
-		newFDSSort,
-		previousDefaultFDSSort,
-	}: {
-		newFDSSort: IFDSSort;
-		previousDefaultFDSSort?: IFDSSort;
-	}) => void;
+	onSave: Function;
 	saveFDSSortURL: string;
 }) => {
 	const [labelI18n, setLabelI18n] = useState<
@@ -160,10 +154,7 @@ const AddFDSSortModalContent = ({
 
 		onSave({newFDSSort});
 
-		openToast({
-			message: Liferay.Language.get('sorting-was-successfully-added'),
-			type: 'success',
-		});
+		openDefaultSuccessToast();
 
 		closeModal();
 	};
@@ -287,16 +278,6 @@ const AddFDSSortModalContent = ({
 	);
 };
 
-interface IEditFDSSortModalContentProps {
-	closeModal: Function;
-	dataSet: IDataSet | FDSViewType;
-	fdsSort: IFDSSort;
-	fields: IField[];
-	namespace: string;
-	onSave: Function;
-	saveFDSSortURL: string;
-}
-
 const EditFDSSortModalContent = ({
 	closeModal,
 	dataSet,
@@ -305,7 +286,15 @@ const EditFDSSortModalContent = ({
 	namespace,
 	onSave,
 	saveFDSSortURL,
-}: IEditFDSSortModalContentProps) => {
+}: {
+	closeModal: Function;
+	dataSet: IDataSet | FDSViewType;
+	fdsSort: IFDSSort;
+	fields: IField[];
+	namespace: string;
+	onSave: Function;
+	saveFDSSortURL: string;
+}) => {
 	const [labelI18n, setLabelI18n] = useState<
 		Liferay.Language.LocalizedValue<string>
 	>(fdsSort.label_i18n);
@@ -355,10 +344,7 @@ const EditFDSSortModalContent = ({
 
 		onSave({newFDSSort});
 
-		openToast({
-			message: Liferay.Language.get('sorting-was-successfully-edited'),
-			type: 'success',
-		});
+		openDefaultSuccessToast();
 
 		closeModal();
 	};
@@ -496,39 +482,41 @@ const Sorting = ({
 	const [fdsSorts, setFDSSorts] = useState<Array<IFDSSort>>([]);
 	const [loading, setLoading] = useState(true);
 
-	useEffect(() => {
-		const getFDSSort = async () => {
-			const response = await fetch(
-				`${API_URL.SORTS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_SORT_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_SORT}&sort=dateCreated:asc`,
-				{
-					headers: {
-						'Accept': 'application/json',
-						'Accept-Language':
-							Liferay.ThemeDisplay.getBCP47LanguageId(),
-					},
-				}
-			);
+	const fetchFDSSorts = useCallback(async () => {
+		setLoading(true);
 
-			const responseJSON = await response.json();
+		const response = await fetch(
+			`${API_URL.SORTS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_SORT_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_SORT}&sort=dateCreated:asc`,
+			{
+				headers: {
+					'Accept': 'application/json',
+					'Accept-Language':
+						Liferay.ThemeDisplay.getBCP47LanguageId(),
+				},
+			}
+		);
 
-			const storedFDSSorts: IFDSSort[] = responseJSON.items;
+		const responseJSON = await response.json();
 
-			setFDSSorts(
-				sortItems(
-					storedFDSSorts,
+		const storedFDSSorts: IFDSSort[] = responseJSON.items;
 
-					// @ts-ignore
+		setFDSSorts(
+			sortItems(
+				storedFDSSorts,
 
-					storedFDSSorts?.[0]?.[OBJECT_RELATIONSHIP.DATA_SET_SORT]
-						?.fdsSortsOrder as string
-				) as IFDSSort[]
-			);
+				// @ts-ignore
 
-			setLoading(false);
-		};
+				storedFDSSorts?.[0]?.[OBJECT_RELATIONSHIP.DATA_SET_SORT]
+					?.fdsSortsOrder as string
+			) as IFDSSort[]
+		);
 
-		getFDSSort();
+		setLoading(false);
 	}, [dataSet]);
+
+	useEffect(() => {
+		fetchFDSSorts();
+	}, [fetchFDSSorts]);
 
 	const handleCreation = () =>
 		openModal({
@@ -538,29 +526,9 @@ const Sorting = ({
 					dataSet={dataSet}
 					fields={fields}
 					namespace={namespace}
-					onSave={({
-						newFDSSort,
-						previousDefaultFDSSort,
-					}: {
-						newFDSSort: IFDSSort;
-						previousDefaultFDSSort?: IFDSSort;
-					}) =>
-						setFDSSorts([
-							...(previousDefaultFDSSort
-								? fdsSorts?.map((fdsSort) => {
-										if (
-											fdsSort.id ===
-											previousDefaultFDSSort.id
-										) {
-											return previousDefaultFDSSort;
-										}
-
-										return fdsSort;
-									}) || []
-								: fdsSorts),
-							newFDSSort,
-						])
-					}
+					onSave={() => {
+						fetchFDSSorts();
+					}}
 					saveFDSSortURL={saveFDSSortURL}
 				/>
 			),
@@ -624,29 +592,8 @@ const Sorting = ({
 					fdsSort={item}
 					fields={fields}
 					namespace={namespace}
-					onSave={({
-						editedFDSSort,
-						previousDefaultFDSSort,
-					}: {
-						editedFDSSort: IFDSSort;
-						previousDefaultFDSSort?: IFDSSort;
-					}) => {
-						setFDSSorts(
-							fdsSorts?.map((fdsSort) => {
-								if (fdsSort.id === editedFDSSort.id) {
-									return editedFDSSort;
-								}
-
-								if (
-									previousDefaultFDSSort &&
-									fdsSort.id === previousDefaultFDSSort.id
-								) {
-									return previousDefaultFDSSort;
-								}
-
-								return fdsSort;
-							}) || []
-						);
+					onSave={() => {
+						fetchFDSSorts();
 					}}
 					saveFDSSortURL={saveFDSSortURL}
 				/>

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/helpers/DataSetManagerApiHelpers.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/helpers/DataSetManagerApiHelpers.ts
@@ -316,7 +316,6 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 			[SORT_DATA_SET_RELATIONSHIP]: dataSetERC,
 			default: defaultValue,
 			fieldName,
-			label: label_i18n[Object.keys(label_i18n)[0]],
 			label_i18n,
 			orderType,
 		};

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
@@ -241,6 +241,51 @@ test.describe('Sorting in Data Set Manager', () => {
 		});
 	});
 
+	test('Unmark default sorting when a new one is marked and saved @LPD-25392', async ({
+		page,
+		sortingPage,
+	}) => {
+		await test.step('Navigate to Sorting section', async () => {
+			await sortingPage.goto({
+				dataSetLabel,
+			});
+		});
+
+		await test.step('Create new sorting Date Modified as default', async () => {
+			await sortingPage.openAddSortingModal();
+
+			await page.getByLabel('Label').fill('Date Modified');
+			await page.getByLabel('Sort By').selectOption('dateModified');
+			await page.getByLabel('Use as Default Sorting').check();
+
+			await saveFromModal({page});
+		});
+
+		await test.step('Create new sorting Date Created as default', async () => {
+			await sortingPage.openAddSortingModal();
+
+			await page.getByLabel('Label').fill('Date Created');
+			await page.getByLabel('Sort By').selectOption('dateCreated');
+			await page.getByLabel('Use as Default Sorting').check();
+
+			await saveFromModal({page});
+		});
+
+		await test.step('Check that Date Created is marked as default and Date Modified is not', async () => {
+			await expect(
+				page
+					.getByRole('row', {name: 'Date Created'})
+					.getByRole('cell', {name: 'Yes'})
+			).toBeVisible();
+
+			await expect(
+				page
+					.getByRole('row', {name: 'Date Modified'})
+					.getByRole('cell', {name: 'No'})
+			).toBeVisible();
+		});
+	});
+
 	test('Sorting label in the table is not blank after changing default site language @LPD-25464', async ({
 		page,
 		sortingPage,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
@@ -42,17 +42,16 @@ test.afterEach(async ({dataSetManagerApiHelpers}) => {
 });
 
 test.describe('Sorting in Data Set Manager', () => {
-	test.beforeEach(async ({sortingPage}) => {
+	test('Save and cancel buttons are not present @LPD-9468', async ({
+		page,
+		sortingPage,
+	}) => {
 		await test.step('Navigate to Sorting section', async () => {
 			await sortingPage.goto({
 				dataSetLabel,
 			});
 		});
-	});
 
-	test('Save and cancel buttons are not present @LPD-9468', async ({
-		page,
-	}) => {
 		await test.step('Check that save and cancel buttons are not present', async () => {
 			await expect(
 				page.getByRole('button', {name: 'Save'})
@@ -140,6 +139,12 @@ test.describe('Sorting in Data Set Manager', () => {
 		page,
 		sortingPage,
 	}) => {
+		await test.step('Navigate to Sorting section', async () => {
+			await sortingPage.goto({
+				dataSetLabel,
+			});
+		});
+
 		await test.step('Open new sort modal', async () => {
 			await sortingPage.openAddSortingModal();
 		});
@@ -157,6 +162,12 @@ test.describe('Sorting in Data Set Manager', () => {
 		page,
 		sortingPage,
 	}) => {
+		await test.step('Navigate to Sorting section', async () => {
+			await sortingPage.goto({
+				dataSetLabel,
+			});
+		});
+
 		await test.step('Open new sort modal', async () => {
 			await sortingPage.openAddSortingModal();
 		});
@@ -228,6 +239,109 @@ test.describe('Sorting in Data Set Manager', () => {
 				page.getByText('Date Created').first()
 			).not.toBeVisible();
 		});
+	});
+
+	test('Sorting label in the table is not blank after changing default site language @LPD-25464', async ({
+		page,
+		sortingPage,
+	}) => {
+		let spanishLanguage = false;
+
+		try {
+			await test.step('Navigate to Instance Settings Localization', async () => {
+				await page
+					.getByLabel('Open Applications MenuCtrl+Alt+A')
+					.click();
+
+				await page.getByRole('tab', {name: 'Control Panel'}).click();
+
+				await page
+					.getByRole('menuitem', {name: 'Instance Settings'})
+					.click();
+
+				await page.getByRole('link', {name: 'Localization'}).click();
+			});
+
+			await test.step('Change default site language to Spanish', async () => {
+				await page.getByLabel('Default Language').selectOption('es_ES');
+
+				await page.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					page.getByText(
+						'Success:Your request completed successfully.'
+					)
+				).toBeVisible();
+
+				spanishLanguage = true;
+
+				// Reload page for language changes to take affect.
+				// Otherwise the Label language selector will still default to
+				// en_US.
+
+				await page.reload();
+			});
+
+			await test.step('Navigate to Sorting section', async () => {
+				await sortingPage.goto({
+					dataSetLabel,
+				});
+			});
+
+			await test.step('Open new sort modal', async () => {
+				await sortingPage.openAddSortingModal();
+			});
+
+			await test.step('Input values', async () => {
+				await page.getByLabel('Label').fill('Nombre');
+				await page.getByLabel('Sort By').selectOption('name');
+			});
+
+			await test.step('Save changes', async () => {
+				await saveFromModal({
+					page,
+				});
+			});
+
+			await test.step('Label in the table is not blank', async () => {
+				await expect(page.getByText('Nombre').first()).toBeVisible();
+			});
+		}
+		finally {
+			if (spanishLanguage) {
+				await test.step('Navigate to Instance Settings Localization', async () => {
+					await page
+						.getByLabel('Open Applications MenuCtrl+Alt+A')
+						.click();
+
+					await page
+						.getByRole('tab', {name: 'Control Panel'})
+						.click();
+
+					await page
+						.getByRole('menuitem', {name: 'Instance Settings'})
+						.click();
+
+					await page
+						.getByRole('link', {name: 'Localization'})
+						.click();
+				});
+
+				await test.step('Change default site language back to English', async () => {
+					await page
+						.getByLabel('Default Language')
+						.selectOption('en_US');
+
+					await page.getByRole('button', {name: 'Save'}).click();
+
+					await expect(
+						page.getByText(
+							'Success:Your request completed successfully.'
+						)
+					).toBeVisible();
+				});
+			}
+		}
 	});
 });
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
@@ -222,7 +222,15 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 			});
 
 			await test.step('Change user account default language to Spanish', async () => {
-				await accountSettingsPage.goToAccountSettings();
+
+				// This method should be used, but since it uses it a different
+				// configured `testIdAttribute`, a locator has to be used.
+				//
+				// await accountSettingsPage.goToAccountSettings();
+
+				await page.locator('[data-qa-id="userPersonalMenu"]').click();
+
+				await accountSettingsPage.accountSettingsMenuItem.click();
 
 				await page.getByLabel('Language').selectOption('es_ES');
 
@@ -257,7 +265,9 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 		finally {
 			if (spanishLanguage) {
 				await test.step('Change user account default language back to English', async () => {
-					await page.getByTestId('userPersonalMenu').click();
+					await page
+						.locator('[data-qa-id="userPersonalMenu"]')
+						.click(); // This is using `locator` instead of `getByTestId` because of the difference in `testIdAttribute` names.
 
 					await page
 						.getByRole('menuitem', {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
@@ -5,6 +5,7 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {accountSettingsPagesTest} from '../../../../fixtures/accountSettingsPagesTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
@@ -13,6 +14,7 @@ import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelp
 import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 
 export const test = mergeTests(
+	accountSettingsPagesTest,
 	dataSetManagerApiHelpersTest,
 	featureFlagsTest({
 		'LPD-19465': true,
@@ -163,5 +165,117 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 
 			expect(firstNameTextAscending < lastNameTextAscending).toBeTruthy();
 		});
+	});
+
+	test('When the current page language is changed, the current translation is used and fallbacks to the site default language @LPD-25464', async ({
+		accountSettingsPage,
+		dataSetManagerApiHelpers,
+		fdsFragmentPage,
+		layout,
+		page,
+	}) => {
+		let spanishLanguage = false;
+
+		try {
+			await test.step('Create sorting', async () => {
+				await dataSetManagerApiHelpers.createDataSetSort({
+					dataSetERC,
+					defaultValue: true,
+					fieldName: 'id',
+					label_i18n: {en_US: 'ID'},
+					orderType: 'asc',
+				});
+
+				await dataSetManagerApiHelpers.createDataSetSort({
+					dataSetERC,
+					defaultValue: false,
+					fieldName: 'name',
+					label_i18n: {en_US: 'Name', es_ES: 'Nombre'},
+				});
+			});
+
+			await test.step('Add fields, so data is displayed', async () => {
+				await dataSetManagerApiHelpers.createDataSetField({
+					dataSetERC,
+					label_i18n: {
+						en_US: 'ID',
+					},
+					name: 'id',
+					sortable: true,
+					type: 'string',
+				});
+
+				await dataSetManagerApiHelpers.createDataSetField({
+					dataSetERC,
+					label_i18n: {en_US: 'Name'},
+					name: 'name',
+					sortable: true,
+					type: 'string',
+				});
+			});
+
+			await test.step('Configure Data Set fragment', async () => {
+				await fdsFragmentPage.configureDataSetFragment({
+					dataSetLabel,
+					layout,
+				});
+			});
+
+			await test.step('Change user account default language to Spanish', async () => {
+				await accountSettingsPage.goToAccountSettings();
+
+				await page.getByLabel('Language').selectOption('es_ES');
+
+				await page.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					page.getByText('Éxito:Su petición ha terminado con éxito.')
+				).toBeVisible();
+
+				spanishLanguage = true;
+			});
+
+			await test.step('Go to Data Set fragment page', async () => {
+				await fdsFragmentPage.goToPage({layout});
+
+				await page
+					.locator('.data-set-content-wrapper')
+					.waitFor({state: 'visible'});
+			});
+
+			await test.step('Check that the correct translations are displayed in the dropdown', async () => {
+				await page.getByRole('button', {name: 'Pedido'}).click();
+
+				await expect(
+					page.getByRole('menuitem', {name: 'ID'})
+				).toBeVisible();
+				await expect(
+					page.getByRole('menuitem', {name: 'Nombre'})
+				).toBeVisible();
+			});
+		}
+		finally {
+			if (spanishLanguage) {
+				await test.step('Change user account default language back to English', async () => {
+					await page.getByTestId('userPersonalMenu').click();
+
+					await page
+						.getByRole('menuitem', {
+							name: 'Mi cuenta',
+						})
+						.click();
+
+					await page.getByLabel('Lenguaje').selectOption('en_US');
+
+					await page.getByRole('button', {name: 'Guardar'}).click();
+
+					await expect(
+						page.getByText(
+							'Success:Your request completed successfully.'
+						)
+					).toBeVisible();
+				});
+			}
+		}
 	});
 });


### PR DESCRIPTION
**Bug Ticket:** https://liferay.atlassian.net/browse/LPD-25464
+
**Story:** https://liferay.atlassian.net/browse/LPD-25392
**Subtask:** https://liferay.atlassian.net/browse/LPD-28582

---

**Notes:**
- Sending with https://liferay.atlassian.net/browse/LPD-25464 to avoid any conflicts.
- Creates an `MVCResourceCommand` to batch multiple updates if a previous default needs to be set to false
- When adding or editing a sorting, the entire sorting table refetches the data, which means there will be a loading spinner before the table is displayed again to refresh any `default` value changes.

## Demo 

https://github.com/user-attachments/assets/cec9d310-1ed5-4376-ba2b-d88799489b30
