### PR TITLE
LPD-32489 Add PUT method to `Async` actions in DSM

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/Actions.tsx
@@ -318,7 +318,12 @@ const Actions = ({dataSet, namespace, spritemap}: IDataSetSectionProps) => {
 						</ClayTabs>
 
 						<ClayTabs.Content active={activeTab} fade>
-							<ClayTabs.TabPane className="item-actions-tab-pane">
+							<ClayTabs.TabPane
+								aria-label={Liferay.Language.get(
+									'item-actions'
+								)}
+								className="item-actions-tab-pane"
+							>
 								<ActionList
 									actions={actions}
 									createAction={createAction}
@@ -334,7 +339,12 @@ const Actions = ({dataSet, namespace, spritemap}: IDataSetSectionProps) => {
 								/>
 							</ClayTabs.TabPane>
 
-							<ClayTabs.TabPane className="creation-actions-tab-pane">
+							<ClayTabs.TabPane
+								aria-label={Liferay.Language.get(
+									'creation-actions'
+								)}
+								className="creation-actions-tab-pane"
+							>
 								<ActionList
 									actions={actions}
 									createAction={createAction}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/Actions.tsx
@@ -10,7 +10,11 @@ import ClayTabs from '@clayui/tabs';
 import {fetch, openModal} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {
+	API_URL,
+	DEFAULT_FETCH_HEADERS,
+	OBJECT_RELATIONSHIP,
+} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {IDataSetSectionProps} from '../DataSet';
@@ -145,7 +149,9 @@ const Actions = ({dataSet, namespace, spritemap}: IDataSetSectionProps) => {
 			setActiveSection(SECTIONS.CREATION_ACTIONS);
 		}
 
-		const response = await fetch(url);
+		const response = await fetch(url, {
+			headers: DEFAULT_FETCH_HEADERS,
+		});
 
 		if (!response.ok) {
 			setLoading(false);
@@ -198,6 +204,7 @@ const Actions = ({dataSet, namespace, spritemap}: IDataSetSectionProps) => {
 						processClose();
 
 						fetch(item.actions.delete.href, {
+							headers: DEFAULT_FETCH_HEADERS,
 							method: item.actions.delete.method,
 						})
 							.then(() => {
@@ -244,10 +251,7 @@ const Actions = ({dataSet, namespace, spritemap}: IDataSetSectionProps) => {
 				body: JSON.stringify({
 					[actionTypeOrder]: order,
 				}),
-				headers: {
-					'Accept': 'application/json',
-					'Content-Type': 'application/json',
-				},
+				headers: DEFAULT_FETCH_HEADERS,
 				method: 'PATCH',
 			}
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/components/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/components/ActionForm.tsx
@@ -24,22 +24,13 @@ import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 import {IAction} from '../Actions';
 
-const ACTION_METHOD = {
-	DELETE: 'DELETE',
-	GET: 'GET',
-	PATCH: 'PATCH',
-	POST: 'POST',
-};
-
-const ACTION_METHODS = () => {
-	const methods = [];
-
-	for (const method in ACTION_METHOD) {
-		methods.push({label: method, value: method});
-	}
-
-	return methods;
-};
+enum EActionMethod {
+	DELETE = 'DELETE',
+	GET = 'GET',
+	PATCH = 'PATCH',
+	POST = 'POST',
+	PUT = 'PUT',
+}
 
 const ACTION_TYPE = {
 	ASYNC: 'async',
@@ -180,7 +171,7 @@ const ActionForm = ({
 
 		setActionData({
 			...actionData,
-			method: type === ACTION_TYPE.ASYNC ? ACTION_METHOD.DELETE : '',
+			method: type === ACTION_TYPE.ASYNC ? EActionMethod.DELETE : '',
 			modalSize: type === ACTION_TYPE.MODAL ? MODAL_SIZES[0].value : '',
 			type,
 		});
@@ -581,7 +572,12 @@ const ActionForm = ({
 												method: event.target.value,
 											})
 										}
-										options={ACTION_METHODS()}
+										options={Object.values(
+											EActionMethod
+										).map((method) => ({
+											label: method,
+											value: method,
+										}))}
 										placeholder={Liferay.Language.get(
 											'please-select-an-option'
 										)}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/components/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/components/ActionForm.tsx
@@ -19,7 +19,11 @@ import {FDSViewType} from '../../../FDSViews';
 import RequiredMark from '../../../components/RequiredMark';
 import Search from '../../../components/Search';
 import ValidationFeedback from '../../../components/ValidationFeedback';
-import {API_URL, OBJECT_RELATIONSHIP} from '../../../utils/constants';
+import {
+	API_URL,
+	DEFAULT_FETCH_HEADERS,
+	OBJECT_RELATIONSHIP,
+} from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 import {IAction} from '../Actions';
@@ -234,10 +238,7 @@ const ActionForm = ({
 
 		const response = await fetch(apiURL, {
 			body: JSON.stringify(body),
-			headers: {
-				'Accept': 'application/json',
-				'Content-Type': 'application/json',
-			},
+			headers: DEFAULT_FETCH_HEADERS,
 			method: fetchMethod,
 		});
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/creationActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/creationActions.spec.ts
@@ -12,6 +12,7 @@ import getRandomString from '../../../../utils/getRandomString';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import clickRowAction from '../../utils/clickRowAction';
 import getRowByText from '../../utils/getRowByText';
+import getSelectOptionLabels from '../../utils/getSelectOptionLabels';
 import {actionsPageTest} from './fixtures/actionsPageTest';
 import {dataSetManagerSetupTest} from './fixtures/dataSetManagerSetupTest';
 
@@ -63,6 +64,40 @@ test(
 			await expect(actionsPage.noActionsWereCreatedMessage).toContainText(
 				'No actions were created.'
 			);
+		});
+	}
+);
+
+test(
+	'Assert available selection options in creation action form',
+	{tag: '@LPD-11245'},
+	async ({actionsPage}) => {
+		await test.step('Go to creation actions tab', async () => {
+			await actionsPage.gotoCreationActionsTab({dataSetLabel});
+		});
+
+		await test.step('Open new item actions form', async () => {
+			await actionsPage.newCreationActionPlusButton.click();
+
+			await expect(
+				actionsPage.page.getByText('Display Options')
+			).toBeInViewport();
+		});
+
+		await test.step('Asset action type options', async () => {
+			expect(
+				await getSelectOptionLabels(actionsPage.actionForm.typeSelect)
+			).toEqual(['Link', 'Modal', 'Side Panel']);
+		});
+
+		await test.step('Asset variant options for `Modal` action type', async () => {
+			await actionsPage.actionForm.typeSelect.selectOption('Modal');
+
+			expect(
+				await getSelectOptionLabels(
+					actionsPage.actionForm.variantSelect
+				)
+			).toEqual(['Full Screen', 'Large', 'Small']);
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/itemActions.spec.ts
@@ -11,6 +11,7 @@ import getRandomString from '../../../../utils/getRandomString';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import clickRowAction from '../../utils/clickRowAction';
 import getRowByText from '../../utils/getRowByText';
+import getSelectOptionLabels from '../../utils/getSelectOptionLabels';
 import {ItemActionTypes} from '../../utils/types';
 import {actionsPageTest} from './fixtures/actionsPageTest';
 import {dataSetManagerSetupTest} from './fixtures/dataSetManagerSetupTest';
@@ -57,6 +58,56 @@ test(
 			await expect(actionsPage.noActionsWereCreatedMessage).toContainText(
 				'No actions were created.'
 			);
+		});
+	}
+);
+
+test(
+	'Assert available selection options in item action form',
+	{tag: '@LPD-11300'},
+	async ({actionsPage}) => {
+		await test.step('Go to item actions tab', async () => {
+			await actionsPage.gotoItemActionsTab({dataSetLabel});
+		});
+
+		await test.step('Open new item actions form', async () => {
+			await actionsPage.newItemActionPlusButton.click();
+
+			await expect(
+				actionsPage.page.getByText('Display Options')
+			).toBeInViewport();
+		});
+
+		await test.step('Asset action type options', async () => {
+			expect(
+				await getSelectOptionLabels(actionsPage.actionForm.typeSelect)
+			).toEqual(['Async', 'Headless', 'Link', 'Modal', 'Side Panel']);
+		});
+
+		await test.step('Asset confirmation message type options', async () => {
+			expect(
+				await getSelectOptionLabels(
+					actionsPage.actionForm.confirmationMessageTypeSelect
+				)
+			).toEqual(['Info', 'Secondary', 'Success', 'Danger', 'Warning']);
+		});
+
+		await test.step('Asset method options for `Async` action type', async () => {
+			await actionsPage.actionForm.typeSelect.selectOption('Async');
+
+			expect(
+				await getSelectOptionLabels(actionsPage.actionForm.methodSelect)
+			).toEqual(['DELETE', 'GET', 'PATCH', 'POST', 'PUT']);
+		});
+
+		await test.step('Asset variant options for `Modal` action type', async () => {
+			await actionsPage.actionForm.typeSelect.selectOption('Modal');
+
+			expect(
+				await getSelectOptionLabels(
+					actionsPage.actionForm.variantSelect
+				)
+			).toEqual(['Full Screen', 'Large', 'Small']);
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/utils/getSelectOptionLabels.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/utils/getSelectOptionLabels.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator} from '@playwright/test';
+
+export default async function getSelectOptionLabels(
+	select: Locator
+): Promise<Array<string>> {
+	return await select.evaluate((element: HTMLSelectElement) =>
+		Array.from(element.options).map((options) => options.label)
+	);
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -241,63 +241,6 @@ definition {
 		}
 	}
 
-	@description = "LPS-192956 When the user clicks on the Variant field, a dropdown with the options “Full Screen”, “Large” and “Small” is displayed"
-	@priority = 5
-	test AllVariantOptionArePresentInItemAction {
-		property portal.acceptance = "true";
-
-		task ("Given a new data set entry") {
-			DataSetAdmin.goToDataSetAdminPage();
-
-			DataSetAdmin.createDataSetEntryViaAPI(
-				dataSetName = "Country",
-				restApplication = "/headless-admin-address/v1.0",
-				restEndpoint = "/v1.0/countries",
-				restSchema = "Country");
-		}
-
-		task ("And a new view") {
-			DataSetAdmin.createFDSViewViaAPI(
-				dataSetName = "Country",
-				dataSetViewDescription = "FDSViewDescription",
-				key_dataSetViewNameList = "View Test");
-		}
-
-		task ("When the user goes to the view created") {
-			DataSetAdmin.goToSpecificViewPage(
-				dataSetName = "Country",
-				key_viewName = "View Test");
-		}
-
-		task ("When the user goes to the Action tab.") {
-			DataSetAdmin.goToTab(tabName = "Actions");
-		}
-
-		task ("And chooses the Modal option on Type field") {
-			LexiconEntry.gotoAdd();
-
-			Select(
-				key_fieldLabel = "Type",
-				locator1 = "Select#GENERIC_SELECT_FIELD",
-				value1 = "Modal");
-		}
-
-		task ("And clicks on Variant field") {
-			Click(
-				key_fieldLabel = "Variant",
-				locator1 = "Select#GENERIC_SELECT_FIELD");
-		}
-
-		task ("Then the options Full Screen, Large and Small are displayed in the dropdown") {
-			for (var assertFields : list "Full Screen,Large,Small") {
-				AssertElementPresent(
-					key_fieldLabel = "Variant",
-					locator1 = "Select#GENERIC_SELECT_FIELD",
-					value1 = ${assertFields});
-			}
-		}
-	}
-
 	@description = "LPS-192956 Confirm that all the values set in the creation for all the fields are still present when the Edit modal is opened"
 	@priority = 4
 	test AssertAllFieldsArePresentWhenEditAModalActionOnItemAction {
@@ -373,59 +316,6 @@ definition {
 				key_fieldName = "Add the title of the modal.",
 				locator1 = "DataSet#PRESELECT_VALUE_INPUT",
 				value1 = "Edit item Action");
-		}
-	}
-
-	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
-	@priority = 3
-	test AssertAllMethodOptionsArePresentOnItemAction {
-		task ("When clicks on New Action button") {
-			Click(
-				key_text = "New Item Action",
-				locator1 = "Button#ANY_SECONDARY");
-		}
-
-		task ("When the user selects the Async option in Type field") {
-			Select(
-				key_fieldLabel = "Type",
-				locator1 = "Select#GENERIC_SELECT_FIELD",
-				value1 = "Async");
-		}
-
-		task ("And fills URL field") {
-			Type(
-				key_fieldId = "URL",
-				locator1 = "TextArea#ANY_ID",
-				value1 = "wwww.liferay.com");
-		}
-
-		task ("Then Confirm that the DELETE option is selected by default.") {
-			AssertElementPresent(
-				key_fieldLabel = "Method",
-				locator1 = "Select#GENERIC_SELECT_FIELD",
-				value1 = "DELETE");
-		}
-
-		task ("When the user selects the Method option") {
-			Select(
-				key_fieldLabel = "Method",
-				locator1 = "Select#GENERIC_SELECT_FIELD",
-				value1 = "DELETE");
-		}
-
-		task ("Then The options GET, POST, PATCH, DELETE are present in the Method dropdown") {
-			for (var assertFields : list "GET,POST,PATCH,DELETE") {
-				AssertElementPresent(
-					key_fieldLabel = "Method",
-					locator1 = "Select#GENERIC_SELECT_FIELD",
-					value1 = ${assertFields});
-			}
-		}
-
-		task ("And confirm that it is not possible to save the action") {
-			AssertVisible(
-				key_title = "New Item Action",
-				locator1 = "Header#H2_TITLE");
 		}
 	}
 


### PR DESCRIPTION
### References

- Parent Story: [LPD-29358 [DataSetViewActions.testcase] Delete poshi](https://issues.liferay.com/browse/LPD-29358)
- Requires PR to be merged: https://github.com/liferay-frontend/liferay-portal/pull/4343

### What is the goal of this PR?

A small change in DSM, adding an option in select, bit of improvement. Further migration of action tests.

:warning: I'm opening this as a draft, as it requires https://github.com/liferay-frontend/liferay-portal/pull/4343 to be merged

### What does it look like?

![image](https://github.com/user-attachments/assets/8a78fd60-cc16-4100-ae84-6c3626dffb1a)

![image](https://github.com/user-attachments/assets/b2df0a8d-aa74-4441-b963-dd83284a5b7d)
