### PR TITLE
LPD-32805 Bring back Filter By label

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/Configuration.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/Configuration.tsx
@@ -149,6 +149,8 @@ function Configuration({
 				})}
 			>
 				<label htmlFor={selectedFieldFormElementId}>
+					{Liferay.Language.get('filter-by')}
+
 					<RequiredMark />
 				</label>
 


### PR DESCRIPTION
When deleted FF for filters in DSM we accidentally removed a label in the UI. This makes some tests fail and the UX becomes very poor.

Reference: https://liferay.atlassian.net/browse/LPD-32805