### PR TITLE
LPD-31008 Fix change the source of a selection filter on edit

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -468,6 +468,7 @@ function Body({
 								aria-label={Liferay.Language.get(
 									'choose-an-option'
 								)}
+								disabled={!!filter}
 								id={sourceOptionFormElementId}
 								name={sourceOptionFormElementId}
 								onChange={(event) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -18,6 +18,7 @@ import React, {useEffect, useState} from 'react';
 
 import CheckboxMultiSelect from '../../../../components/CheckboxMultiSelect';
 import RequiredMark from '../../../../components/RequiredMark';
+import getAPISourceItems from '../../../../utils/getAPISourceItems';
 import getAllPicklists from '../../../../utils/getAllPicklists';
 import {
 	ESelectionFilterSourceType,
@@ -30,7 +31,6 @@ import Configuration from '../Configuration';
 import Footer from '../Footer';
 import ApiRestApplication from './source_type/ApiRestApplication';
 import ObjectPicklist from './source_type/ObjectPicklist';
-import getAPISourceItems from '../../../../utils/getAPISourceItems';
 
 function Header() {
 	return <>{Liferay.Language.get('new-selection-filter')}</>;
@@ -289,8 +289,11 @@ function Body({
 		}
 
 		const selectionFilter = filter as ISelectionFilter;
-		
-		if (selectionFilter.sourceType === ESelectionFilterSourceType.API_HEADLESS) {
+
+		if (
+			selectionFilter.sourceType ===
+			ESelectionFilterSourceType.API_HEADLESS
+		) {
 			const selectionFilter = filter as ISelectionFilter;
 
 			setSelectedRESTApplication(selectionFilter.restApplication);
@@ -308,8 +311,7 @@ function Body({
 				selectedItemKey: selectionFilter.itemKey,
 				selectedItemLabel: selectionFilter.itemLabel,
 				source: selectionFilter.source,
-			})
-			.then((sourceItems) => {
+			}).then((sourceItems) => {
 				const filterPreselectedValues = JSON.parse(
 					selectionFilter.preselectedValues || '[]'
 				);
@@ -322,7 +324,7 @@ function Body({
 								filterValue.value === item.value
 						)
 				);
-				
+
 				setPreselectedValues(validSavedPreselectedValues);
 				setIncludeMode(
 					validSavedPreselectedValues?.length
@@ -331,8 +333,9 @@ function Body({
 							: 'exclude'
 						: 'include'
 				);
-			})	
+			});
 		}
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -342,37 +345,42 @@ function Body({
 		}
 
 		const selectionFilter = filter as ISelectionFilter;
-		
-		if( selectionFilter.sourceType === ESelectionFilterSourceType.PICKLIST ) {
+
+		if (
+			selectionFilter.sourceType === ESelectionFilterSourceType.PICKLIST
+		) {
 			getAllPicklists().then((items) => {
-				if (items.length === 0) {
+				if (!items.length) {
 					setNoPicklistsAvailableValidationError(true);
-				} else {
+				}
+				else {
 					setNoPicklistsAvailableValidationError(false);
 					setSourceType(selectionFilter.sourceType);
-		
+
 					const picklist = items.find(
 						(item) =>
 							String(item.externalReferenceCode) ===
 							selectionFilter?.source
 					);
-		
+
 					if (picklist) {
 						setSource(picklist);
 
 						let validSavedPreselectedValues: any[] = [];
 
-						validSavedPreselectedValues = picklist.listTypeEntries.filter((item) =>
-							JSON.parse(selectionFilter.preselectedValues || '[]')
-								.includes(item.externalReferenceCode)
-						);
+						validSavedPreselectedValues =
+							picklist.listTypeEntries.filter((item) =>
+								JSON.parse(
+									selectionFilter.preselectedValues || '[]'
+								).includes(item.externalReferenceCode)
+							);
 
-						const sourceItems = picklist.listTypeEntries
-							.map((item) => 
-								({
-									label: item.name, 
-									value: item.externalReferenceCode
-								}));
+						const sourceItems = picklist.listTypeEntries.map(
+							(item) => ({
+								label: item.name,
+								value: item.externalReferenceCode,
+							})
+						);
 
 						setFilteredSourceItems(sourceItems);
 						setPreselectedValues(validSavedPreselectedValues);
@@ -387,6 +395,7 @@ function Body({
 				}
 			});
 		}
+
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
@@ -467,12 +476,20 @@ function Body({
 
 									setSourceType(newSourceType);
 
-									if( newSourceType === ESelectionFilterSourceType.PICKLIST ) {
+									if (
+										newSourceType ===
+										ESelectionFilterSourceType.PICKLIST
+									) {
 										getAllPicklists().then((items) => {
-											if (items.length === 0) {
-												setNoPicklistsAvailableValidationError(true);
-											} else {
-												setNoPicklistsAvailableValidationError(false);
+											if (!items.length) {
+												setNoPicklistsAvailableValidationError(
+													true
+												);
+											}
+											else {
+												setNoPicklistsAvailableValidationError(
+													false
+												);
 											}
 										});
 									}
@@ -531,16 +548,15 @@ function Body({
 								<ObjectPicklist
 									filter={filter}
 									namespace={namespace}
-									onChange={({
-										picklist,
-										sourceItems
-										}) => {
-											setSource(picklist);
-											setSourceValidationError(false);
-											setFilteredSourceItems(sourceItems);
-											setPreselectedValues([]);
+									onChange={({picklist, sourceItems}) => {
+										setSource(picklist);
+										setSourceValidationError(false);
+										setFilteredSourceItems(sourceItems);
+										setPreselectedValues([]);
 									}}
-									preselectedValueInput={preselectedValueInput}
+									preselectedValueInput={
+										preselectedValueInput
+									}
 									sourceValidationError={
 										sourceValidationError
 									}
@@ -672,7 +688,6 @@ function Body({
 												sourceType ===
 												ESelectionFilterSourceType.PICKLIST
 											) {
-												
 												valueItem = {
 													label: item.name,
 													value: String(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/SelectionFilter.tsx
@@ -14,7 +14,6 @@ import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
-import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
 import CheckboxMultiSelect from '../../../../components/CheckboxMultiSelect';
@@ -31,6 +30,7 @@ import Configuration from '../Configuration';
 import Footer from '../Footer';
 import ApiRestApplication from './source_type/ApiRestApplication';
 import ObjectPicklist from './source_type/ObjectPicklist';
+import getAPISourceItems from '../../../../utils/getAPISourceItems';
 
 function Header() {
 	return <>{Liferay.Language.get('new-selection-filter')}</>;
@@ -67,6 +67,10 @@ function Body({
 		useState<boolean>(false);
 
 	const [
+		noPicklistsAvailableValidationError,
+		setNoPicklistsAvailableValidationError,
+	] = useState(false);
+	const [
 		requiredRESTApplicationValidationError,
 		setRequiredRESTApplicationValidationError,
 	] = useState(false);
@@ -86,7 +90,6 @@ function Body({
 	const [multiple, setMultiple] = useState<boolean>(
 		(filter as ISelectionFilter)?.multiple ?? true
 	);
-	const [picklists, setPicklists] = useState<IPickList[]>([]);
 	const [preselectedValues, setPreselectedValues] = useState<any[]>([]);
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
 		fields.find((item) => item.name === filter?.fieldName)
@@ -281,113 +284,113 @@ function Body({
 	}
 
 	useEffect(() => {
-		if (
-			(filter as ISelectionFilter)?.sourceType ===
-			ESelectionFilterSourceType.PICKLIST
-		) {
-			getAllPicklists().then((items) => {
-				setPicklists(items);
-
-				const picklist = items.find(
-					(item) =>
-						String(item.externalReferenceCode) ===
-						(filter as any)?.source
-				);
-
-				if (picklist) {
-					setSource(picklist);
-				}
-			});
+		if (!filter) {
+			return;
 		}
-	}, [filter]);
 
-	useEffect(() => {
-		if (filter) {
+		const selectionFilter = filter as ISelectionFilter;
+		
+		if (selectionFilter.sourceType === ESelectionFilterSourceType.API_HEADLESS) {
 			const selectionFilter = filter as ISelectionFilter;
 
-			if (
-				selectionFilter.sourceType ===
-				ESelectionFilterSourceType.API_HEADLESS
-			) {
-				setSelectedRESTApplication(selectionFilter.restApplication);
-				setSelectedRESTSchema(selectionFilter.restSchema);
-				setSelectedRESTEndpoint(selectionFilter.restEndpoint);
+			setSelectedRESTApplication(selectionFilter.restApplication);
+			setSelectedRESTSchema(selectionFilter.restSchema);
+			setSelectedRESTEndpoint(selectionFilter.restEndpoint);
 
-				setSelectedItemKey(selectionFilter.itemKey);
-				setSelectedItemLabel(selectionFilter.itemLabel);
+			setSelectedItemKey(selectionFilter.itemKey);
+			setSelectedItemLabel(selectionFilter.itemLabel);
 
-				setSource(selectionFilter.source);
-			}
-		}
-	}, [filter]);
-
-	useEffect(() => {
-		if (filter) {
-			const selectionFilter = filter as ISelectionFilter;
+			setSource(selectionFilter.source);
 			setSourceType(selectionFilter.sourceType);
 
-			let validSavedPreselectedValues: any[] = [];
-
-			if (
-				source &&
-				sourceType === ESelectionFilterSourceType.API_HEADLESS
-			) {
+			getAPISourceItems({
+				preselectedValueInput: '',
+				selectedItemKey: selectionFilter.itemKey,
+				selectedItemLabel: selectionFilter.itemLabel,
+				source: selectionFilter.source,
+			})
+			.then((sourceItems) => {
 				const filterPreselectedValues = JSON.parse(
-					(filter as ISelectionFilter).preselectedValues || '[]'
+					selectionFilter.preselectedValues || '[]'
 				);
+				let validSavedPreselectedValues: any[] = [];
 
-				validSavedPreselectedValues = filteredSourceItems.filter(
-					(item) =>
+				validSavedPreselectedValues = sourceItems.filter(
+					(item: {label: string; value: string}) =>
 						filterPreselectedValues.find(
 							(filterValue: {label: string; value: string}) =>
 								filterValue.value === item.value
 						)
 				);
-			}
-
-			if (source && sourceType === ESelectionFilterSourceType.PICKLIST) {
-				validSavedPreselectedValues = (
-					source as IPickList
-				).listTypeEntries.filter((item) =>
-					JSON.parse(
-						(filter as ISelectionFilter).preselectedValues || '[]'
-					).includes(item.externalReferenceCode)
+				
+				setPreselectedValues(validSavedPreselectedValues);
+				setIncludeMode(
+					validSavedPreselectedValues?.length
+						? filter && selectionFilter.include
+							? 'include'
+							: 'exclude'
+						: 'include'
 				);
-			}
-
-			setPreselectedValues(validSavedPreselectedValues);
-
-			setIncludeMode(
-				validSavedPreselectedValues?.length
-					? filter && (filter as ISelectionFilter).include
-						? 'include'
-						: 'exclude'
-					: 'include'
-			);
+			})	
 		}
-	}, [filter, filteredSourceItems, source, sourceType]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	useEffect(() => {
-		if (sourceType === ESelectionFilterSourceType.PICKLIST) {
-			setFilteredSourceItems(
-				!source
-					? []
-					: (source as IPickList).listTypeEntries
-							.filter((item) =>
-								fuzzy.match(preselectedValueInput, item.name)
-							)
-							.map((item) => ({
-								label: item.name,
-								value: String(item.externalReferenceCode),
-							}))
-			);
+		if (!filter) {
+			return;
 		}
-	}, [preselectedValueInput, source, sourceType]);
 
-	if (
-		sourceType === ESelectionFilterSourceType.API_HEADLESS &&
-		!picklists.length
-	) {
+		const selectionFilter = filter as ISelectionFilter;
+		
+		if( selectionFilter.sourceType === ESelectionFilterSourceType.PICKLIST ) {
+			getAllPicklists().then((items) => {
+				if (items.length === 0) {
+					setNoPicklistsAvailableValidationError(true);
+				} else {
+					setNoPicklistsAvailableValidationError(false);
+					setSourceType(selectionFilter.sourceType);
+		
+					const picklist = items.find(
+						(item) =>
+							String(item.externalReferenceCode) ===
+							selectionFilter?.source
+					);
+		
+					if (picklist) {
+						setSource(picklist);
+
+						let validSavedPreselectedValues: any[] = [];
+
+						validSavedPreselectedValues = picklist.listTypeEntries.filter((item) =>
+							JSON.parse(selectionFilter.preselectedValues || '[]')
+								.includes(item.externalReferenceCode)
+						);
+
+						const sourceItems = picklist.listTypeEntries
+							.map((item) => 
+								({
+									label: item.name, 
+									value: item.externalReferenceCode
+								}));
+
+						setFilteredSourceItems(sourceItems);
+						setPreselectedValues(validSavedPreselectedValues);
+						setIncludeMode(
+							validSavedPreselectedValues?.length
+								? filter && selectionFilter.include
+									? 'include'
+									: 'exclude'
+								: 'include'
+						);
+					}
+				}
+			});
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	if (noPicklistsAvailableValidationError) {
 		return (
 			<ClayAlert displayType="info" title="Info">
 				{Liferay.Language.get(
@@ -463,6 +466,17 @@ function Body({
 										.value as ESelectionFilterSourceType;
 
 									setSourceType(newSourceType);
+
+									if( newSourceType === ESelectionFilterSourceType.PICKLIST ) {
+										getAllPicklists().then((items) => {
+											if (items.length === 0) {
+												setNoPicklistsAvailableValidationError(true);
+											} else {
+												setNoPicklistsAvailableValidationError(false);
+											}
+										});
+									}
+
 									setSourceTypeValidationError(false);
 
 									setSource(undefined);
@@ -517,10 +531,16 @@ function Body({
 								<ObjectPicklist
 									filter={filter}
 									namespace={namespace}
-									onChange={(item: IPickList) => {
-										setSource(item);
-										setSourceValidationError(false);
+									onChange={({
+										picklist,
+										sourceItems
+										}) => {
+											setSource(picklist);
+											setSourceValidationError(false);
+											setFilteredSourceItems(sourceItems);
+											setPreselectedValues([]);
 									}}
+									preselectedValueInput={preselectedValueInput}
 									sourceValidationError={
 										sourceValidationError
 									}
@@ -652,6 +672,7 @@ function Body({
 												sourceType ===
 												ESelectionFilterSourceType.PICKLIST
 											) {
+												
 												valueItem = {
 													label: item.name,
 													value: String(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
@@ -9,7 +9,6 @@ import ClayForm from '@clayui/form';
 import {TItem} from '@clayui/form/lib/SelectBox';
 import classNames from 'classnames';
 import {fetch} from 'frontend-js-web';
-import getAPISourceItems from '../../../../../utils/getAPISourceItems';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
@@ -23,6 +22,7 @@ import {
 	ALLOWED_ENDPOINTS_PARAMETERS,
 	FUZZY_OPTIONS,
 } from '../../../../../utils/constants';
+import getAPISourceItems from '../../../../../utils/getAPISourceItems';
 import getFields, {
 	ISchemas,
 	getValidFields,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ApiRestApplication.tsx
@@ -9,6 +9,7 @@ import ClayForm from '@clayui/form';
 import {TItem} from '@clayui/form/lib/SelectBox';
 import classNames from 'classnames';
 import {fetch} from 'frontend-js-web';
+import getAPISourceItems from '../../../../../utils/getAPISourceItems';
 import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
@@ -106,55 +107,6 @@ function ApiRestApplication({
 
 		return true;
 	};
-
-	async function getSourceItems({
-		preselectedValueInput,
-		selectedItemKey,
-		selectedItemLabel,
-		source,
-	}: {
-		preselectedValueInput: string;
-		selectedItemKey: string;
-		selectedItemLabel: string;
-		source: string | null;
-	}) {
-		const isValidSource =
-			source && !(source as string).match(/\{[A-Za-z0-9]+\}/g);
-
-		if (!isValidSource || !selectedItemKey || !selectedItemLabel) {
-			return [];
-		}
-
-		const sourceItems = await fetch(source as string)
-			.then((response) => {
-				if (!response.ok) {
-					return [];
-				}
-
-				const responseJSON = response.json();
-
-				return responseJSON;
-			})
-			.then((apiValues) => {
-				return !apiValues?.items?.length
-					? []
-					: apiValues.items
-							.filter((item: any) => {
-								return fuzzy.match(
-									preselectedValueInput,
-									String(item[selectedItemLabel])
-								);
-							})
-							.map((item: any) => {
-								return {
-									label: String(item[selectedItemLabel]),
-									value: String(item[selectedItemKey]),
-								};
-							});
-			});
-
-		return sourceItems;
-	}
 
 	const getRESTSchemas = async (restApplication: string) => {
 		if (!restApplication) {
@@ -568,7 +520,7 @@ function ApiRestApplication({
 				}
 			})
 			.then(() =>
-				getSourceItems({
+				getAPISourceItems({
 					preselectedValueInput,
 					selectedItemKey: filter.itemKey,
 					selectedItemLabel: filter.itemLabel,
@@ -720,7 +672,7 @@ function ApiRestApplication({
 										let currentSourceItems: TItem[] =
 											sourceItems;
 
-										getSourceItems({
+										getAPISourceItems({
 											preselectedValueInput,
 											selectedItemKey: itemKey,
 											selectedItemLabel,
@@ -791,7 +743,7 @@ function ApiRestApplication({
 										let currentSourceItems: TItem[] =
 											sourceItems;
 
-										getSourceItems({
+										getAPISourceItems({
 											preselectedValueInput,
 											selectedItemKey,
 											selectedItemLabel: itemLabel,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
@@ -5,15 +5,15 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayForm, {ClaySelectWithOption} from '@clayui/form';
+import {TItem} from '@clayui/form/lib/SelectBox';
 import classNames from 'classnames';
+import fuzzy from 'fuzzy';
 import React, {useEffect, useState} from 'react';
 
 import RequiredMark from '../../../../../components/RequiredMark';
 import ValidationFeedback from '../../../../../components/ValidationFeedback';
 import getAllPicklists from '../../../../../utils/getAllPicklists';
-import fuzzy from 'fuzzy';
 import {IFilter, IPickList} from '../../../../../utils/types';
-import {TItem} from '@clayui/form/lib/SelectBox';
 
 interface IObjectPicklistProps {
 	filter?: IFilter;
@@ -90,24 +90,30 @@ function ObjectPicklist({
 										event.target.value
 								);
 
-								if(picklist) {
+								if (picklist) {
 									setSelectedPicklist(picklist);
 
-									const sourceItems =
-										!picklist
-											? []
-											: (picklist as IPickList).listTypeEntries
-													.filter((item) =>
-														fuzzy.match(preselectedValueInput, item.name)
+									const sourceItems = !picklist
+										? []
+										: (
+												picklist as IPickList
+											).listTypeEntries
+												.filter((item) =>
+													fuzzy.match(
+														preselectedValueInput,
+														item.name
 													)
-													.map((item) => ({
-														label: item.name,
-														value: String(item.externalReferenceCode),
-													}));
+												)
+												.map((item) => ({
+													label: item.name,
+													value: String(
+														item.externalReferenceCode
+													),
+												}));
 
 									onChange({
-										picklist, 
-										sourceItems
+										picklist,
+										sourceItems,
 									});
 								}
 							}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/modals/selection_filter/source_type/ObjectPicklist.tsx
@@ -11,12 +11,21 @@ import React, {useEffect, useState} from 'react';
 import RequiredMark from '../../../../../components/RequiredMark';
 import ValidationFeedback from '../../../../../components/ValidationFeedback';
 import getAllPicklists from '../../../../../utils/getAllPicklists';
+import fuzzy from 'fuzzy';
 import {IFilter, IPickList} from '../../../../../utils/types';
+import {TItem} from '@clayui/form/lib/SelectBox';
 
 interface IObjectPicklistProps {
 	filter?: IFilter;
 	namespace: string;
-	onChange: Function;
+	onChange: ({
+		picklist,
+		sourceItems,
+	}: {
+		picklist: IPickList;
+		sourceItems: TItem[];
+	}) => void;
+	preselectedValueInput: string;
 	sourceValidationError: boolean;
 }
 
@@ -24,6 +33,7 @@ function ObjectPicklist({
 	filter,
 	namespace,
 	onChange,
+	preselectedValueInput,
 	sourceValidationError,
 }: IObjectPicklistProps) {
 	const [picklists, setPicklists] = useState<IPickList[]>();
@@ -79,8 +89,27 @@ function ObjectPicklist({
 										String(item.externalReferenceCode) ===
 										event.target.value
 								);
-								setSelectedPicklist(picklist);
-								onChange(picklist);
+
+								if(picklist) {
+									setSelectedPicklist(picklist);
+
+									const sourceItems =
+										!picklist
+											? []
+											: (picklist as IPickList).listTypeEntries
+													.filter((item) =>
+														fuzzy.match(preselectedValueInput, item.name)
+													)
+													.map((item) => ({
+														label: item.name,
+														value: String(item.externalReferenceCode),
+													}));
+
+									onChange({
+										picklist, 
+										sourceItems
+									});
+								}
 							}}
 							options={[
 								{

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAPISourceItems.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAPISourceItems.ts
@@ -2,54 +2,55 @@
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
+
 import {fetch} from 'frontend-js-web';
 import fuzzy from 'fuzzy';
 
 export default async function getAPISourceItems({
-    preselectedValueInput,
-    selectedItemKey,
-    selectedItemLabel,
-    source,
+	preselectedValueInput,
+	selectedItemKey,
+	selectedItemLabel,
+	source,
 }: {
-    preselectedValueInput: string;
-    selectedItemKey: string;
-    selectedItemLabel: string;
-    source: string | null;
+	preselectedValueInput: string;
+	selectedItemKey: string;
+	selectedItemLabel: string;
+	source: string | null;
 }) {
-    const isValidSource =
-        source && !(source as string).match(/\{[A-Za-z0-9]+\}/g);
+	const isValidSource =
+		source && !(source as string).match(/\{[A-Za-z0-9]+\}/g);
 
-    if (!isValidSource || !selectedItemKey || !selectedItemLabel) {
-        return [];
-    }
+	if (!isValidSource || !selectedItemKey || !selectedItemLabel) {
+		return [];
+	}
 
-    const sourceItems = await fetch(source as string)
-        .then((response) => {
-            if (!response.ok) {
-                return [];
-            }
+	const sourceItems = await fetch(source as string)
+		.then((response) => {
+			if (!response.ok) {
+				return [];
+			}
 
-            const responseJSON = response.json();
+			const responseJSON = response.json();
 
-            return responseJSON;
-        })
-        .then((apiValues) => {
-            return !apiValues.items.length
-                ? []
-                : apiValues.items
-                        .filter((item: any) => {
-                            return fuzzy.match(
-                                preselectedValueInput,
-                                String(item[selectedItemLabel])
-                            );
-                        })
-                        .map((item: any) => {
-                            return {
-                                label: String(item[selectedItemLabel]),
-                                value: String(item[selectedItemKey]),
-                            };
-                        });
-        });
+			return responseJSON;
+		})
+		.then((apiValues) => {
+			return !apiValues.items.length
+				? []
+				: apiValues.items
+						.filter((item: any) => {
+							return fuzzy.match(
+								preselectedValueInput,
+								String(item[selectedItemLabel])
+							);
+						})
+						.map((item: any) => {
+							return {
+								label: String(item[selectedItemLabel]),
+								value: String(item[selectedItemKey]),
+							};
+						});
+		});
 
-    return sourceItems;
+	return sourceItems;
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAPISourceItems.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAPISourceItems.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+import {fetch} from 'frontend-js-web';
+import fuzzy from 'fuzzy';
+
+export default async function getAPISourceItems({
+    preselectedValueInput,
+    selectedItemKey,
+    selectedItemLabel,
+    source,
+}: {
+    preselectedValueInput: string;
+    selectedItemKey: string;
+    selectedItemLabel: string;
+    source: string | null;
+}) {
+    const isValidSource =
+        source && !(source as string).match(/\{[A-Za-z0-9]+\}/g);
+
+    if (!isValidSource || !selectedItemKey || !selectedItemLabel) {
+        return [];
+    }
+
+    const sourceItems = await fetch(source as string)
+        .then((response) => {
+            if (!response.ok) {
+                return [];
+            }
+
+            const responseJSON = response.json();
+
+            return responseJSON;
+        })
+        .then((apiValues) => {
+            return !apiValues.items.length
+                ? []
+                : apiValues.items
+                        .filter((item: any) => {
+                            return fuzzy.match(
+                                preselectedValueInput,
+                                String(item[selectedItemLabel])
+                            );
+                        })
+                        .map((item: any) => {
+                            return {
+                                label: String(item[selectedItemLabel]),
+                                value: String(item[selectedItemKey]),
+                            };
+                        });
+        });
+
+    return sourceItems;
+}


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-31008

This PR fixes the issue where the filter type could not be changed in selection filters.

- The initial data loading from filter while editing had been move to a dependency-free useEffect (one for each source type for the sake of clarity)
- API headless values loading feature is present in ApiRestApplication.tsx and SelectionFilter.tsx, so fetching function had been moved to /js/utils/getAPISourceItems.ts