### PR TITLE
LPD-32037 - Add accept-language headers to DSM & FDS requests

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/DataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/DataSets.tsx
@@ -193,11 +193,9 @@ const NewDataSetModalContent = ({
 			return;
 		}
 
-		const response = await fetch(`/o${restApplication}/openapi.json`,
-			{
-				headers: DEFAULT_FETCH_HEADERS
-			}
-		);
+		const response = await fetch(`/o${restApplication}/openapi.json`, {
+			headers: DEFAULT_FETCH_HEADERS,
+		});
 
 		if (!response.ok) {
 			openDefaultFailureToast();

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/DataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/DataSets.tsx
@@ -22,6 +22,7 @@ import RESTSchemaDropdownMenu from './components/rest/RESTSchemaDropdownMenu';
 import {
 	ALLOWED_ENDPOINTS_PARAMETERS,
 	API_URL,
+	DEFAULT_FETCH_HEADERS,
 	FDS_DEFAULT_PROPS,
 } from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
@@ -145,10 +146,7 @@ const NewDataSetModalContent = ({
 
 		const response = await fetch(API_URL.DATA_SETS, {
 			body: JSON.stringify(body),
-			headers: {
-				'Accept': 'application/json',
-				'Content-Type': 'application/json',
-			},
+			headers: DEFAULT_FETCH_HEADERS,
 			method: 'POST',
 		});
 
@@ -195,7 +193,11 @@ const NewDataSetModalContent = ({
 			return;
 		}
 
-		const response = await fetch(`/o${restApplication}/openapi.json`);
+		const response = await fetch(`/o${restApplication}/openapi.json`,
+			{
+				headers: DEFAULT_FETCH_HEADERS
+			}
+		);
 
 		if (!response.ok) {
 			openDefaultFailureToast();
@@ -601,6 +603,7 @@ const DataSets = ({
 						processClose();
 
 						fetch(itemData.actions.delete.href, {
+							headers: DEFAULT_FETCH_HEADERS,
 							method: itemData.actions.delete.method,
 						})
 							.then(() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -24,6 +24,7 @@ import RESTSchemaDropdownMenu from './components/rest/RESTSchemaDropdownMenu';
 import {
 	ALLOWED_ENDPOINTS_PARAMETERS,
 	API_URL,
+	DEFAULT_FETCH_HEADERS,
 	FDS_DEFAULT_PROPS,
 	OBJECT_RELATIONSHIP,
 } from './utils/constants';
@@ -153,10 +154,7 @@ const AddFDSEntryModalContent = ({
 
 		const response = await fetch(API_URL.FDS_ENTRIES, {
 			body: JSON.stringify(body),
-			headers: {
-				'Accept': 'application/json',
-				'Content-Type': 'application/json',
-			},
+			headers: DEFAULT_FETCH_HEADERS,
 			method: 'POST',
 		});
 
@@ -203,7 +201,11 @@ const AddFDSEntryModalContent = ({
 			return;
 		}
 
-		const response = await fetch(`/o${restApplication}/openapi.json`);
+		const response = await fetch(`/o${restApplication}/openapi.json`,
+			{
+				headers: DEFAULT_FETCH_HEADERS
+			}
+		);
 
 		if (!response.ok) {
 			openDefaultFailureToast();
@@ -608,6 +610,7 @@ const FDSEntries = ({
 						processClose();
 
 						fetch(itemData.actions.delete.href, {
+							headers: DEFAULT_FETCH_HEADERS,
 							method: itemData.actions.delete.method,
 						})
 							.then(() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/FDSEntries.tsx
@@ -201,11 +201,9 @@ const AddFDSEntryModalContent = ({
 			return;
 		}
 
-		const response = await fetch(`/o${restApplication}/openapi.json`,
-			{
-				headers: DEFAULT_FETCH_HEADERS
-			}
-		);
+		const response = await fetch(`/o${restApplication}/openapi.json`, {
+			headers: DEFAULT_FETCH_HEADERS,
+		});
 
 		if (!response.ok) {
 			openDefaultFailureToast();

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/FDSViews.tsx
@@ -19,6 +19,7 @@ import {FDSEntryType} from './FDSEntries';
 import RequiredMark from './components/RequiredMark';
 import {
 	API_URL,
+	DEFAULT_FETCH_HEADERS,
 	FDS_DEFAULT_PROPS,
 	OBJECT_RELATIONSHIP,
 } from './utils/constants';
@@ -72,10 +73,7 @@ const AddFDSViewModalContent = ({
 
 		const response = await fetch(API_URL.DATA_SETS, {
 			body: JSON.stringify(body),
-			headers: {
-				'Accept': 'application/json',
-				'Content-Type': 'application/json',
-			},
+			headers: DEFAULT_FETCH_HEADERS,
 			method: 'POST',
 		});
 
@@ -248,6 +246,7 @@ const FDSViews = ({
 						processClose();
 
 						fetch(`${API_URL.DATA_SETS}/${itemData.id}`, {
+							headers: DEFAULT_FETCH_HEADERS,
 							method: 'DELETE',
 						})
 							.then(() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
@@ -12,7 +12,7 @@ import React, {useEffect, useState} from 'react';
 
 import {IDataSet} from '../DataSets';
 import {FDSViewType} from '../FDSViews';
-import {API_URL, OBJECT_RELATIONSHIP} from '../utils/constants';
+import {API_URL, DEFAULT_FETCH_HEADERS, OBJECT_RELATIONSHIP} from '../utils/constants';
 import getFields from '../utils/getFields';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import {IFieldTreeItem} from '../utils/types';
@@ -107,9 +107,7 @@ const DataSet = ({
 				: `${API_URL.DATA_SETS}/${fdsViewId}?nestedFields=${OBJECT_RELATIONSHIP.FDS_ENTRY_FDS_VIEW}`;
 
 			const response = await fetch(url, {
-				headers: {
-					Accept: 'application/json',
-				},
+				headers: DEFAULT_FETCH_HEADERS,
 			});
 
 			const responseJSON = await response.json();

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
@@ -12,7 +12,11 @@ import React, {useEffect, useState} from 'react';
 
 import {IDataSet} from '../DataSets';
 import {FDSViewType} from '../FDSViews';
-import {API_URL, DEFAULT_FETCH_HEADERS, OBJECT_RELATIONSHIP} from '../utils/constants';
+import {
+	API_URL,
+	DEFAULT_FETCH_HEADERS,
+	OBJECT_RELATIONSHIP,
+} from '../utils/constants';
 import getFields from '../utils/getFields';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import {IFieldTreeItem} from '../utils/types';

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
@@ -15,7 +15,7 @@ import React, {useRef, useState} from 'react';
 import {IDataSet} from '../../DataSets';
 import {FDSViewType} from '../../FDSViews';
 import RequiredMark from '../../components/RequiredMark';
-import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {API_URL, DEFAULT_FETCH_HEADERS, OBJECT_RELATIONSHIP} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {IDataSetSectionProps} from '../DataSet';
@@ -41,10 +41,7 @@ const Details = ({
 			`${API_URL.DATA_SETS}/by-external-reference-code/${dataSet.externalReferenceCode}`,
 			{
 				body: JSON.stringify(body),
-				headers: {
-					'Accept': 'application/json',
-					'Content-Type': 'application/json',
-				},
+				headers: DEFAULT_FETCH_HEADERS,
 				method: 'PATCH',
 			}
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
@@ -15,7 +15,11 @@ import React, {useRef, useState} from 'react';
 import {IDataSet} from '../../DataSets';
 import {FDSViewType} from '../../FDSViews';
 import RequiredMark from '../../components/RequiredMark';
-import {API_URL, DEFAULT_FETCH_HEADERS, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {
+	API_URL,
+	DEFAULT_FETCH_HEADERS,
+	OBJECT_RELATIONSHIP,
+} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {IDataSetSectionProps} from '../DataSet';

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -10,7 +10,11 @@ import {fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import OrderableTable from '../../components/OrderableTable';
-import {API_URL, DEFAULT_FETCH_HEADERS, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {
+	API_URL,
+	DEFAULT_FETCH_HEADERS,
+	OBJECT_RELATIONSHIP,
+} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {
@@ -169,10 +173,11 @@ function Filters({
 					dataSet.id
 				}?nestedFields=${Object.values(FILTER_TYPES)
 					.map((filter) => filter.fdsViewRelationship)
-					.join(',')}`
-			, {
-				headers: DEFAULT_FETCH_HEADERS
-			});
+					.join(',')}`,
+				{
+					headers: DEFAULT_FETCH_HEADERS,
+				}
+			);
 
 			const responseJSON = await response.json();
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -10,7 +10,7 @@ import {fetch, openModal, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
 import OrderableTable from '../../components/OrderableTable';
-import {API_URL, OBJECT_RELATIONSHIP} from '../../utils/constants';
+import {API_URL, DEFAULT_FETCH_HEADERS, OBJECT_RELATIONSHIP} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {
@@ -112,10 +112,7 @@ function AddFDSFilterModalContent({
 
 		const response = await fetch(url, {
 			body: JSON.stringify(formData),
-			headers: {
-				'Accept': 'application/json',
-				'Content-Type': 'application/json',
-			},
+			headers: DEFAULT_FETCH_HEADERS,
 			method,
 		});
 
@@ -173,7 +170,9 @@ function Filters({
 				}?nestedFields=${Object.values(FILTER_TYPES)
 					.map((filter) => filter.fdsViewRelationship)
 					.join(',')}`
-			);
+			, {
+				headers: DEFAULT_FETCH_HEADERS
+			});
 
 			const responseJSON = await response.json();
 
@@ -225,10 +224,7 @@ function Filters({
 				body: JSON.stringify({
 					fdsFiltersOrder,
 				}),
-				headers: {
-					'Accept': 'application/json',
-					'Content-Type': 'application/json',
-				},
+				headers: DEFAULT_FETCH_HEADERS,
 				method: 'PATCH',
 			}
 		);
@@ -377,6 +373,7 @@ function Filters({
 						}/${item.id}`;
 
 						fetch(url, {
+							headers: DEFAULT_FETCH_HEADERS,
 							method: 'DELETE',
 						})
 							.then(() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/pagination/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/pagination/Pagination.tsx
@@ -11,7 +11,7 @@ import {fetch, navigate} from 'frontend-js-web';
 import React, {useRef, useState} from 'react';
 
 import RequiredMark from '../../components/RequiredMark';
-import {API_URL} from '../../utils/constants';
+import {API_URL, DEFAULT_FETCH_HEADERS} from '../../utils/constants';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {IDataSetSectionProps} from '../DataSet';
@@ -108,10 +108,7 @@ function Pagination({
 			`${API_URL.DATA_SETS}/by-external-reference-code/${dataSet.externalReferenceCode}`,
 			{
 				body: JSON.stringify(body),
-				headers: {
-					'Accept': 'application/json',
-					'Content-Type': 'application/json',
-				},
+				headers: DEFAULT_FETCH_HEADERS,
 				method: 'PATCH',
 			}
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/settings/Settings.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/settings/Settings.tsx
@@ -55,7 +55,7 @@ const Settings = ({
 		const response = await fetch(
 			`${API_URL.DATA_SETS}/by-external-reference-code/${dataSet.externalReferenceCode}?fields=${fields}&nestedFields=${fields}`,
 			{
-				headers: DEFAULT_FETCH_HEADERS
+				headers: DEFAULT_FETCH_HEADERS,
 			}
 		);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/settings/Settings.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/settings/Settings.tsx
@@ -15,6 +15,7 @@ import React, {useEffect, useState} from 'react';
 
 import {
 	API_URL,
+	DEFAULT_FETCH_HEADERS,
 	DEFAULT_VISUALIZATION_MODES,
 	OBJECT_RELATIONSHIP,
 } from '../../utils/constants';
@@ -52,7 +53,10 @@ const Settings = ({
 		].join(',');
 
 		const response = await fetch(
-			`${API_URL.DATA_SETS}/by-external-reference-code/${dataSet.externalReferenceCode}?fields=${fields}&nestedFields=${fields}`
+			`${API_URL.DATA_SETS}/by-external-reference-code/${dataSet.externalReferenceCode}?fields=${fields}&nestedFields=${fields}`,
+			{
+				headers: DEFAULT_FETCH_HEADERS
+			}
 		);
 
 		if (!response.ok) {
@@ -119,10 +123,7 @@ const Settings = ({
 			`${API_URL.DATA_SETS}/by-external-reference-code/${dataSet.externalReferenceCode}`,
 			{
 				body: JSON.stringify(body),
-				headers: {
-					'Accept': 'application/json',
-					'Content-Type': 'application/json',
-				},
+				headers: DEFAULT_FETCH_HEADERS,
 				method: 'PATCH',
 			}
 		);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
@@ -16,7 +16,7 @@ export default async function getAllPicklists(
 	const response = await fetch(
 		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=100&page=${page}`,
 		{
-			headers: DEFAULT_FETCH_HEADERS
+			headers: DEFAULT_FETCH_HEADERS,
 		}
 	);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
@@ -5,6 +5,7 @@
 
 import {fetch} from 'frontend-js-web';
 
+import {DEFAULT_FETCH_HEADERS} from './constants';
 import openDefaultFailureToast from './openDefaultFailureToast';
 import {IPickList} from './types';
 
@@ -13,7 +14,10 @@ export default async function getAllPicklists(
 	items: IPickList[] = []
 ) {
 	const response = await fetch(
-		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=100&page=${page}`
+		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=100&page=${page}`,
+		{
+			headers: DEFAULT_FETCH_HEADERS
+		}
 	);
 
 	if (!response.ok) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/constants.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/constants.ts
@@ -2,7 +2,11 @@
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
-
+export const DEFAULT_FETCH_HEADERS = {
+	'Accept': 'application/json',
+	'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+	'Content-Type': 'application/json',
+};
 export const FDS_ARRAY_FIELD_NAME_DELIMITER: string = '[]';
 export const FDS_ARRAY_FIELD_NAME_PARENT_SUFFIX: string = `${FDS_ARRAY_FIELD_NAME_DELIMITER}*`;
 export const FDS_NESTED_FIELD_NAME_DELIMITER: string = '.';

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -7,6 +7,7 @@ import {fetch} from 'frontend-js-web';
 
 import getValueFromItem from './getValueFromItem';
 import createOdataFilter from './odata';
+import {DEFAULT_FETCH_HEADERS} from '../constants';
 
 export function getData(apiURL, query) {
 	const url = new URL(apiURL);
@@ -16,6 +17,7 @@ export function getData(apiURL, query) {
 	}
 
 	return fetch(url, {
+		headers: DEFAULT_FETCH_HEADERS,
 		method: 'GET',
 	}).then((data) => data.json());
 }
@@ -155,11 +157,7 @@ export async function loadData(
 	}
 
 	const response = await fetch(url, {
-		headers: {
-			'Accept': 'application/json',
-			'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
-			'Content-Type': 'application/json',
-		},
+		headers: DEFAULT_FETCH_HEADERS,
 		method: 'GET',
 	});
 	const responseJSON = await response.json();

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -5,9 +5,9 @@
 
 import {fetch} from 'frontend-js-web';
 
+import {DEFAULT_FETCH_HEADERS} from '../constants';
 import getValueFromItem from './getValueFromItem';
 import createOdataFilter from './odata';
-import {DEFAULT_FETCH_HEADERS} from '../constants';
 
 export function getData(apiURL, query) {
 	const url = new URL(apiURL);


### PR DESCRIPTION
## Task
[LPD-32037] / (https://liferay.atlassian.net/browse/LPD-32037)

## Issue
Apply headers after Headless changes in https://liferay.atlassian.net/browse/LPD-19654
We are adding `accept-language` headers to ensure we get the correct localized values. We've already covered in PW tests in [DSM Visualization Modes](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts#L889)

