### PR TITLE
LPD-26897 Data Set Selector in fragment doesn't keep the selected data set

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/item/selector/FDSAdminItemSelector.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/item/selector/FDSAdminItemSelector.tsx
@@ -35,11 +35,31 @@ const FDSAdminItemSelector = ({
 	classNameId,
 	namespace,
 }: {
-	className: String;
-	classNameId: String;
-	namespace: String;
+	className: string;
+	classNameId: string;
+	namespace: string;
 }) => {
-	const [selectedItem, setSelectedItem] = useState<ISelectedItem>();
+	const getSelectedData = () => {
+		const dataset = (window.frameElement as HTMLElement)?.dataset;
+
+		const externalReferenceCode = dataset.selecteditemsercs;
+		const id = dataset.selecteditemsids;
+		const label = dataset.selecteditemslabels;
+
+		if (!externalReferenceCode || !id || !label) {
+			return null;
+		}
+
+		return {
+			externalReferenceCode,
+			id,
+			label,
+		};
+	};
+
+	const [selectedItem, setSelectedItem] = useState<ISelectedItem | null>(
+		getSelectedData()
+	);
 
 	return (
 		<div className="fds-admin-item-selector">
@@ -60,7 +80,8 @@ const FDSAdminItemSelector = ({
 							label: selectedItems[0].label,
 						});
 					}}
-					selectedItemsKey="id"
+					selectedItems={[selectedItem?.externalReferenceCode]}
+					selectedItemsKey="externalReferenceCode"
 					selectionType="single"
 					views={views}
 				/>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -22,7 +22,6 @@ export declare function FrontendDataSet({
 	formName,
 	header,
 	id,
-	initialSelectedItemsValues,
 	inlineAddingSettings,
 	inlineEditingSettings,
 	items,
@@ -36,6 +35,7 @@ export declare function FrontendDataSet({
 	overrideEmptyResultView,
 	pagination,
 	portletId,
+	selectedItems,
 	selectedItemsKey,
 	selectionType,
 	showManagementBar,
@@ -180,7 +180,6 @@ export interface IFrontendDataSetProps {
 		title?: string;
 	};
 	id: string;
-	initialSelectedItemsValues?: any[];
 	inlineAddingSettings?: {
 		apiURL: string;
 		defaultBodyContent: object;
@@ -201,6 +200,7 @@ export interface IFrontendDataSetProps {
 		initialPageNumber?: number;
 	};
 	portletId?: string;
+	selectedItems?: any[];
 	selectedItemsKey?: string;
 	selectionType?: 'single' | 'multiple';
 	showManagementBar?: boolean;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -509,6 +509,42 @@ const openSelectionModal = ({
 		}
 	};
 
+	const iframeProps = {};
+
+	if (selectedData) {
+		const ercs = [];
+		const ids = [];
+		const labels = [];
+
+		selectedData.forEach((item) => {
+			const {externalReferenceCode, id, label} = item;
+
+			if (externalReferenceCode) {
+				ercs.push(externalReferenceCode);
+			}
+
+			if (id) {
+				ids.push(id);
+			}
+
+			if (label) {
+				labels.push(label);
+			}
+		});
+
+		if (ercs.length) {
+			iframeProps['data-selecteditemsercs'] = ercs.join(',');
+		}
+
+		if (ids.length) {
+			iframeProps['data-selecteditemsids'] = ids.join(',');
+		}
+
+		if (labels.length) {
+			iframeProps['data-selecteditemslabels'] = labels.join(',');
+		}
+	}
+
 	openModal({
 		buttons: multiple
 			? [
@@ -527,6 +563,7 @@ const openSelectionModal = ({
 		height,
 		id: id || selectEventName,
 		iframeBodyCssClass,
+		iframeProps,
 		onClose: () => {
 			eventHandlers.forEach((eventHandler) => {
 				eventHandler.detach();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ItemSelector.js
@@ -62,6 +62,7 @@ export default function ItemSelector({
 			eventName: eventName || `${config.portletNamespace}selectInfoItem`,
 			itemSelectorURL: itemSelectorURL || config.infoItemSelectorURL,
 			modalProps,
+			selectedItem,
 			transformValueCallback,
 		});
 	}, [
@@ -70,6 +71,7 @@ export default function ItemSelector({
 		modalProps,
 		onItemSelect,
 		onBeforeItemSelect,
+		selectedItem,
 		transformValueCallback,
 	]);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openItemSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/openItemSelector.js
@@ -11,6 +11,7 @@ export function openItemSelector({
 	itemSelectorURL,
 	destroyedCallback = null,
 	modalProps = {},
+	selectedItem,
 	transformValueCallback,
 }) {
 	openSelectionModal({
@@ -50,6 +51,13 @@ export function openItemSelector({
 			infoItem = callback(infoItem);
 		},
 		selectEventName: eventName,
+		selectedData: selectedItem && [
+			{
+				externalReferenceCode: selectedItem.externalReferenceCode,
+				id: selectedItem.classPK,
+				label: selectedItem.title,
+			},
+		],
 		title: Liferay.Language.get('select'),
 		url: itemSelectorURL,
 		...modalProps,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/openItemSelector.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/common/openItemSelector.test.js
@@ -12,6 +12,7 @@ jest.mock('frontend-js-web');
 const openModal = ({
 	callback = () => {},
 	destroyedCallback = null,
+	selectedItem,
 	transformValueCallback = (item) => item,
 }) => {
 	openItemSelector({
@@ -19,6 +20,7 @@ const openModal = ({
 		destroyedCallback,
 		eventName: '',
 		itemSelectorURL: '',
+		selectedItem,
 		transformValueCallback,
 	});
 
@@ -107,5 +109,40 @@ describe('openItemSelector', () => {
 		onSelect({'item-1': {name: 'Item 1'}});
 
 		expect(callback).toHaveBeenCalledWith({name: 'Item 1'});
+	});
+
+	it('passes selected item information to the selection modal', () => {
+		const selectedItem = {
+			classPK: '12345',
+			externalReferenceCode: 'abcd-efgh',
+			title: 'My Item',
+		};
+
+		openModal({
+			selectedItem,
+		});
+
+		expect(openSelectionModal).toHaveBeenCalledWith(
+			expect.objectContaining({
+				selectedData: [
+					{
+						externalReferenceCode:
+							selectedItem.externalReferenceCode,
+						id: selectedItem.classPK,
+						label: selectedItem.title,
+					},
+				],
+			})
+		);
+	});
+
+	it('omits selectedData prop if no items are selected', () => {
+		openModal({});
+
+		expect(openSelectionModal).toHaveBeenCalledWith(
+			expect.not.objectContaining({
+				selectedData: expect.anything(),
+			})
+		);
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -9,6 +9,7 @@ import {apiHelpersTest} from '../../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../../utils/getRandomString';
 
 // Structured Content utilities
@@ -29,13 +30,11 @@ export const test = mergeTests(
 	fdsFragmentPageTest
 );
 
-const dataSetERCs = [];
-let article;
-let dataSetERC;
-let dataSetLabel;
-let siteId;
-let structuredContentId;
-let structuredContentTitle;
+const dataSetERCs: string[] = [];
+let article: any;
+let siteId: string;
+let structuredContentId: number;
+let structuredContentTitle: string;
 
 const adminUserDataSetConfig = {
 	erc: getRandomString(),
@@ -61,18 +60,6 @@ const taxonomyVocabularyDataSetConfig = {
 	restSchema: 'TaxonomyVocabulary',
 };
 
-test.beforeEach(async ({dataSetManagerApiHelpers}) => {
-	dataSetERC = getRandomString();
-	dataSetLabel = getRandomString();
-
-	dataSetERCs.push(dataSetERC);
-
-	await dataSetManagerApiHelpers.createDataSet({
-		erc: dataSetERC,
-		label: dataSetLabel,
-	});
-});
-
 test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers}) => {
 	for (const DATA_SET_ERC of dataSetERCs) {
 		await dataSetManagerApiHelpers.deleteDataSet({
@@ -93,46 +80,95 @@ test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers}) => {
 });
 
 test(
-	'Data Set can be added to the fragment and the fragment can be removed',
+	'Assing a data set to the "Data Set" fragment, change and delete assignment',
 	{
 		tag: '@LPS-172403',
 	},
 	async ({dataSetManagerApiHelpers, fdsFragmentPage, layout, page}) => {
-		await test.step('Add fields, so data is displayed', async () => {
-			await dataSetManagerApiHelpers.createDataSetField({
-				dataSetERC,
-				label_i18n: {
-					en_US: 'ID',
-				},
-				name: 'id',
-				sortable: true,
-				type: 'string',
+		const dataSetERC1 = getRandomString();
+		const dataSetERC2 = getRandomString();
+		const dataSetLabel1 = getRandomString();
+		const dataSetLabel2 = getRandomString();
+
+		dataSetERCs.push(dataSetERC1);
+		dataSetERCs.push(dataSetERC2);
+
+		await test.step('Create data sets', async () => {
+			await dataSetManagerApiHelpers.createDataSet({
+				erc: dataSetERC1,
+				label: dataSetLabel1,
 			});
 
+			await dataSetManagerApiHelpers.createDataSet({
+				erc: dataSetERC2,
+				label: dataSetLabel2,
+			});
+		});
+
+		await test.step('Create sample data for data sets', async () => {
 			await dataSetManagerApiHelpers.createDataSetField({
-				dataSetERC,
+				dataSetERC: dataSetERC1,
 				label_i18n: {en_US: 'Name'},
 				name: 'name',
-				sortable: true,
-				type: 'string',
+			});
+
+			await dataSetManagerApiHelpers.createDataSetField({
+				dataSetERC: dataSetERC2,
+				label_i18n: {en_US: 'ID'},
+				name: 'id',
+			});
+
+			await dataSetManagerApiHelpers.createDataSetField({
+				dataSetERC: dataSetERC2,
+				label_i18n: {en_US: 'Name'},
+				name: 'name',
 			});
 		});
 
-		await test.step('Configure Data Set fragment', async () => {
-			await fdsFragmentPage.configureDataSetFragment({
-				dataSetLabel,
-				layout,
-			});
+		await test.step('Go to page configuration, add "Data Set" fragment', async () => {
+			await fdsFragmentPage.addDataSetFragment(layout);
 		});
 
-		await test.step('Assert that the Data Set is available on the page', async () => {
+		await test.step('Assign first data set to fragment', async () => {
+			await fdsFragmentPage.selectDataSetButton.click();
+
+			await fdsFragmentPage.selectDataSet(dataSetLabel1);
+		});
+
+		await test.step('Change assigment to second data set', async () => {
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {
+					name: 'Select Data Set View...',
+				}),
+				trigger: fdsFragmentPage.changeDataSetButton,
+			});
+
+			const selectionListContainer =
+				fdsFragmentPage.selectDataSetModalFrame.locator(
+					'.fds-admin-item-selector'
+				);
+
+			await expect(selectionListContainer).toBeVisible();
+
+			await expect(
+				selectionListContainer
+					.locator('.selectable.list-group-item')
+					.filter({
+						has: page.getByText(dataSetLabel1, {exact: true}),
+					})
+					.getByRole('radio')
+			).toBeChecked();
+
+			await fdsFragmentPage.selectDataSet(dataSetLabel2);
+		});
+
+		await test.step('Assert that the data set is available on the page', async () => {
 			await fdsFragmentPage.fdsTableWrapper.waitFor({
 				state: 'visible',
 			});
 
-			await expect(
-				await fdsFragmentPage.fdsTableWrapper
-			).toBeInViewport();
+			await expect(fdsFragmentPage.fdsTableWrapper).toBeInViewport();
 
 			expect(
 				await page
@@ -143,11 +179,21 @@ test(
 			).toEqual(['ID', 'Name', '']);
 		});
 
-		await test.step('Remove Data Set Fragment from the page', async () => {
-			await fdsFragmentPage.editPage({layout});
+		await test.step('Unassign data set', async () => {
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {
+					name: 'Remove Data Set View',
+				}),
+				trigger: page.getByRole('button', {
+					name: 'View Data Set View Options',
+				}),
+			});
 
-			await fdsFragmentPage.fdsTableWrapper.click();
+			await expect(fdsFragmentPage.selectedDataSetInput).toHaveValue('');
+		});
 
+		await test.step('Remove "Data Set" fragment from the page', async () => {
 			const dataSetFragmentOptionsButton = page
 				.locator('.page-editor__topper__item.tbar-item')
 				.getByLabel('Options');
@@ -167,7 +213,7 @@ test(
 				.click();
 		});
 
-		await test.step('Assert that the Data Set Fragment is not available on the page', async () => {
+		await test.step('Assert that "Data Set" fragment is not available on the page', async () => {
 			await expect(
 				page.getByText('Place fragments or widgets here.')
 			).toBeInViewport();
@@ -179,19 +225,16 @@ test(
 	}
 );
 
-test('Data Set selection modal shows a "No results found" message when there are no Data Sets created', async ({
-	dataSetManagerApiHelpers,
+test('Data set selection modal shows a "No results found" message when there are no data sets created', async ({
 	fdsFragmentPage,
 	layout,
 }) => {
-	test.step('Remove Data Set', async () => {
-		await dataSetManagerApiHelpers.deleteDataSet({erc: dataSetERC});
+	await test.step('Go to page configuration, add "Data Set" fragment', async () => {
+		await fdsFragmentPage.addDataSetFragment(layout);
 	});
 
-	await test.step('Configure Data Set fragment', async () => {
-		await fdsFragmentPage.configureEmptyDataSetFragment({
-			layout,
-		});
+	await test.step('Open data set selection modal', async () => {
+		await fdsFragmentPage.selectDataSetButton.click();
 	});
 
 	test.step('Assert that there are no Data Sets available to select', async () => {
@@ -204,7 +247,7 @@ test('Data Set selection modal shows a "No results found" message when there are
 });
 
 test(
-	'Data Set can use different sources of data: StructuredContentSchema, UserSchema, TaxonomyVocabularySchema',
+	'"Data Set" fragment can display different sources of data: StructuredContentSchema, UserSchema, TaxonomyVocabularySchema',
 	{
 		tag: ['@LPS-172403', '@LPS-190724'],
 	},
@@ -220,7 +263,7 @@ test(
 		structuredContentId = await getBasicWebContentStructureId(apiHelpers);
 
 		siteId = await page.evaluate(() => {
-			return Liferay.ThemeDisplay.getSiteGroupId();
+			return String(Liferay.ThemeDisplay.getSiteGroupId());
 		});
 
 		await test.step('Create a Structured Content Schema Data Set and add fields', async () => {
@@ -333,9 +376,7 @@ test(
 				state: 'visible',
 			});
 
-			await expect(
-				await fdsFragmentPage.fdsTableWrapper
-			).toBeInViewport();
+			await expect(fdsFragmentPage.fdsTableWrapper).toBeInViewport();
 
 			expect(
 				await page
@@ -348,14 +389,14 @@ test(
 			expect(
 				await page
 					.locator('.dnd-tbody > .dnd-tr')
-					.first()
 					.locator('.dnd-td')
 					.allInnerTexts()
-			).toEqual([
-				structuredContentTitle,
-				structuredContentDescription,
-				'',
-			]);
+			).toEqual(
+				expect.arrayContaining([
+					structuredContentTitle,
+					structuredContentDescription,
+				])
+			);
 		});
 
 		await test.step('Confirm that we can change the Data Set and display the Roles Data Set', async () => {
@@ -405,9 +446,7 @@ test(
 				state: 'visible',
 			});
 
-			await expect(
-				await fdsFragmentPage.fdsTableWrapper
-			).toBeInViewport();
+			await expect(fdsFragmentPage.fdsTableWrapper).toBeInViewport();
 
 			expect(
 				await page

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/pages/FDSFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/pages/FDSFragmentPage.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page, expect} from '@playwright/test';
+import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {ApiHelpers} from '../../../../../helpers/ApiHelpers';
 import {DEFAULT_LABEL} from '../../../utils/constants';
@@ -11,6 +11,7 @@ import {VisualizationMode} from '../../../utils/types';
 
 export class FDSFragmentPage {
 	readonly apiHelpers: ApiHelpers;
+	readonly changeDataSetButton: Locator;
 	readonly creationMenuButton: Locator;
 	readonly editPageButton: Locator;
 	readonly emptyStateTitle: Locator;
@@ -29,9 +30,15 @@ export class FDSFragmentPage {
 	readonly loadingIndicator: Locator;
 	readonly page: Page;
 	readonly publishPageButton: Locator;
+	readonly selectDataSetModalFrame: FrameLocator;
+	readonly selectDataSetButton: Locator;
+	readonly selectedDataSetInput: Locator;
 
 	constructor(page: Page) {
 		this.apiHelpers = new ApiHelpers(page);
+		this.changeDataSetButton = page.getByRole('button', {
+			name: 'Change Data Set View',
+		});
 		this.creationMenuButton = page.getByRole('button', {name: 'New'});
 		this.emptyStateTitle = page.getByText('No Results Found');
 		this.fdsActiveViewSelector = page.getByLabel('Show View Options');
@@ -63,10 +70,41 @@ export class FDSFragmentPage {
 		this.publishPageButton = page.getByRole('button', {
 			name: 'Publish',
 		});
+		this.selectDataSetModalFrame = page.frameLocator(
+			'iframe[title="Select"]'
+		);
+		this.selectDataSetButton = page.getByRole('button', {
+			name: 'Select Data Set View',
+		});
+		this.selectedDataSetInput = page
+			.getByLabel('Configuration Panel')
+			.getByLabel('Data Set View', {exact: true});
 	}
 
 	async goto() {
 		await this.page.goto('/');
+	}
+
+	async selectDataSet(label: string) {
+		await this.page.getByRole('dialog').isVisible();
+
+		await this.page.getByRole('heading', {name: 'Select'}).isVisible();
+
+		await this.selectDataSetModalFrame
+			.locator('.fds-admin-item-selector')
+			.waitFor({state: 'visible'});
+
+		await this.selectDataSetModalFrame
+			.locator('li')
+			.filter({hasText: label})
+			.first()
+			.click();
+
+		await this.selectDataSetModalFrame
+			.getByRole('button', {name: 'Save'})
+			.click();
+
+		await expect(this.selectedDataSetInput).toHaveValue(label);
 	}
 
 	async selectFilter(filterLabel) {
@@ -105,30 +143,11 @@ export class FDSFragmentPage {
 		dataSetLabel?: string;
 		layout: Layout;
 	}) {
-		await this.setupPageAndFragment(layout);
+		await this.addDataSetFragment(layout);
 
-		await this.page
-			.frameLocator('iframe[title="Select"]')
-			.locator('.fds-admin-item-selector')
-			.waitFor({state: 'visible'});
+		await this.selectDataSetButton.click();
 
-		await this.page
-			.frameLocator('iframe[title="Select"]')
-			.locator('li')
-			.filter({hasText: dataSetLabel})
-			.first()
-			.click();
-
-		await this.page
-			.frameLocator('iframe[title="Select"]')
-			.getByRole('button', {name: 'Save'})
-			.click();
-
-		const selectedDataSetViewInput = this.page
-			.getByLabel('Configuration Panel')
-			.getByLabel('Data Set View', {exact: true});
-
-		await expect(selectedDataSetViewInput).toHaveValue(dataSetLabel);
+		await this.selectDataSet(dataSetLabel);
 
 		await this.publishPage();
 
@@ -140,10 +159,9 @@ export class FDSFragmentPage {
 	}
 
 	async configureEmptyDataSetFragment({layout}: {layout: Layout}) {
-		await this.setupPageAndFragment(layout);
+		await this.addDataSetFragment(layout);
 
-		await this.page
-			.frameLocator('iframe[title="Select"]')
+		await this.selectDataSetModalFrame
 			.locator('.c-empty-state-title')
 			.waitFor({state: 'visible'});
 	}
@@ -166,7 +184,7 @@ export class FDSFragmentPage {
 		await this.fragmentWidgetSearchInput.fill(itemName);
 	}
 
-	async setupPageAndFragment(layout: Layout) {
+	async addDataSetFragment(layout: Layout) {
 		await this.editPage({layout});
 
 		await this.searchFragmentOrWidget('Data Set');
@@ -187,13 +205,5 @@ export class FDSFragmentPage {
 		await expect(fragmentSelectionArea).toBeVisible();
 
 		await fragmentSelectionArea.click();
-
-		await this.page
-			.getByRole('button', {name: 'Select Data Set View'})
-			.click();
-
-		await this.page.getByRole('dialog').isVisible();
-
-		await this.page.getByRole('heading', {name: 'Select'}).isVisible();
 	}
 }


### PR DESCRIPTION
### References

- JIRA: [LPD-26897 Data Set Selector in fragment doesn't keep the selected data set](https://issues.liferay.com/browse/LPD-26897)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/4362

### What is the goal of this PR

We're adding missing capability to selection modal that enables working with selection data to implementations other than search container. We're then applying this to item selector of Data Set fragment.

Few technical notes in comments.

### What does it look like?

https://github.com/user-attachments/assets/ef96cea0-2a14-43e0-a51a-3be21f081f4f

![image](https://github.com/user-attachments/assets/c9cc3407-aba4-4299-9b51-2f0668e8064e)

### Steps to reproduce
