### PR TITLE
LPD-34714 Add aria-label attribute for ClassicEditor component

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -40,6 +40,10 @@
 	"jest": {
 		"setupFiles": [
 			"<rootDir>/jest-setup.config.js"
+		],
+		"testMatch": [
+			"<rootDir>/test/**/*.js",
+			"<rootDir>/test/**/*.spec.js"
 		]
 	},
 	"main": "index.ts",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -44,6 +44,7 @@ const RichText = ({
 	editorConfig,
 	fieldName,
 	id,
+	label,
 	locale,
 	name,
 	localizedObjectField,
@@ -229,6 +230,7 @@ const RichText = ({
 			{...otherProps}
 			fieldName={fieldName}
 			id={id}
+			label={label}
 			name={name}
 			readOnly={readOnly}
 			style={readOnly ? {pointerEvents: 'none'} : null}
@@ -237,6 +239,7 @@ const RichText = ({
 			<ClayInput.Group>
 				<ClayInput.GroupItem>
 					<ClassicEditor
+						ariaLabel={label}
 						ariaRequired={otherProps.required}
 						className="w-100"
 						contents={

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/RichText/RichText.spec.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/RichText/RichText.spec.js
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import RichText from '../../../src/main/resources/META-INF/resources/RichText/RichText.es';
+
+describe('RichText component', () => {
+	it('has aria-label attribute when it is rendered', () => {
+		const {getByRole} = render(
+			<RichText label="RichText Label" name="RichTextName" />
+		);
+
+		const richTextElement = getByRole('textbox');
+
+		expect(richTextElement).toHaveAttribute('aria-label', 'RichText Label');
+	});
+});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/editor/ClassicEditor.js
@@ -11,6 +11,7 @@ import BaseEditor from './BaseEditor';
 const ClassicEditor = forwardRef(
 	(
 		{
+			ariaLabel,
 			ariaRequired,
 			className,
 			contents,
@@ -23,7 +24,12 @@ const ClassicEditor = forwardRef(
 		ref
 	) => {
 		return (
-			<div className={className} id={`${name}Container`} role="textbox">
+			<div
+				aria-label={ariaLabel}
+				className={className}
+				id={`${name}Container`}
+				role="textbox"
+			>
 				{title && (
 					<label className="control-label" htmlFor={name}>
 						{title}


### PR DESCRIPTION
Related Issue: https://liferay.atlassian.net/browse/LPD-34714

Hello reviewer! This PR solves an accessibility problem that we have in our DDM Rich Text component mentioned above, as Rich Text uses Ckeditor I made a change to it by adding the `aria-label` attribute to the `div` that surrounds the BasicEditor in the `ClassicEditor` component as pointed out by axe DevTools. Please let me know your thoughts on this fix :smile: 

![RichTextAccessibilityIssue](https://github.com/user-attachments/assets/523ba8fc-16e5-42e3-a64b-5fb8f5ec2ee9)
