### PR TITLE
LPD-34946 Update liferay-ckeditor to 4.21.0-liferay.4 in frontend-js-dependencies-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
@@ -16,7 +16,7 @@
 		"html-to-image": "1.11.11",
 		"image-promise": "5.0.1",
 		"jspdf": "2.5.1",
-		"liferay-ckeditor": "4.21.0-liferay.3",
+		"liferay-ckeditor": "4.21.0-liferay.4",
 		"lodash.groupby": "4.6.0",
 		"lodash.isequal": "4.5.0",
 		"moment": "2.29.4",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11170,11 +11170,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-liferay-ckeditor@4.21.0-liferay.3:
-  version "4.21.0-liferay.3"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.21.0-liferay.3.tgz#522e4d4e5c3965bdb10dc1cc4434cd34243573eb"
-  integrity sha512-WFET4jRWCL46mF6jOXG1HMH7N74feYaJP5fx69WftS8AF8rD1IWdbwgSlUatGFZA/3l4YBpKDbu3ZkVv0ax1Zg==
-
 liferay-ckeditor@4.21.0-liferay.4:
   version "4.21.0-liferay.4"
   resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.21.0-liferay.4.tgz#d9067b1ae4bd3825b9d0ad743223de2a18fb880d"
@@ -15388,7 +15383,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15431,6 +15426,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15506,7 +15510,7 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15540,6 +15544,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"


### PR DESCRIPTION
Additional commit needed.
https://liferay.atlassian.net/browse/LPD-35291
https://github.com/liferay-frontend/liferay-portal/pull/4398

We need to update ckeditor in fronend-js-dependencies-web as well.
I tested and found it contains all the fixes in the latest version after this change.

Please let me know if there are any questions or comments about this.
Thank you!