### PR TITLE
LPD-17128 Adapt ThemeCSS CX build process to account for caching

### DIFF
--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
@@ -2,7 +2,7 @@ assemble:
     - from: build/buildTheme/img
       into: static/img
 liferay-sample-theme-css-1:
-    clayURL: css/clay.css
-    mainURL: css/main.css
+    clayURL: css/clay.*.css
+    mainURL: css/main.*.css
     name: Liferay Sample Theme CSS 1
     type: themeCSS

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/client-extension.yaml
@@ -1,6 +1,6 @@
 assemble:
-    - from: build/buildTheme/img
-      into: static/img
+    - from: build/buildTheme/assets
+      into: static/assets
 liferay-sample-theme-css-1:
     clayURL: css/clay.*.css
     mainURL: css/main.*.css

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/package.json
@@ -2,10 +2,17 @@
 	"dependencies": {
 		"sassy-inputs": "1.0.6"
 	},
+	"devDependencies": {
+		"webpack": "5.90.1",
+		"webpack-cli": "5.1.4"
+	},
 	"liferayDesignPack": {
 		"baseTheme": "styled"
 	},
 	"main": "package.json",
 	"name": "@liferay/liferay-sample-theme-css-1",
+	"scripts": {
+		"build": "webpack"
+	},
 	"version": "0.0.0"
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
@@ -11,6 +11,19 @@ const webpack = require('webpack');
 const buildCSSDir = path.join(__dirname, 'build', 'buildTheme', 'css');
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 
+const includeReferencedAsset = (assetUrl) => {
+	const urlTokens = ['@base_url@', '@portal_ctx@', '@theme_image_path@']
+
+	if (!fs.existsSync(path.join(__dirname, 'src', 'css', assetUrl)) ||
+		assetUrl.startsWith("data:image") ||
+		urlTokens.some((token) => assetUrl.includes(token))) {
+
+		return false;
+	}
+
+	return true;
+}
+
 module.exports = {
 	context: buildCSSDir,
 	entry: {
@@ -28,8 +41,20 @@ module.exports = {
 					},
 					{
 						loader: "css-loader",
+						options: {
+							url: {
+								filter: includeReferencedAsset
+							}
+						}
 					}
 				]
+			},
+			{
+				generator: {
+					filename: '../assets/[name].[contenthash][ext]'
+				},
+				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
+				type: "asset/resource",
 			},
 		],
 	},

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-1/webpack.config.js
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+
+const buildCSSDir = path.join(__dirname, 'build', 'buildTheme', 'css');
+const DEVELOPMENT = process.env.NODE_ENV === 'development';
+
+module.exports = {
+	context: buildCSSDir,
+	entry: {
+		clay: './clay.css',
+		main: './main.css'
+	},
+	mode: DEVELOPMENT ? 'development' : 'production',
+	module: {
+		rules: [
+			{
+				test: /\.css$/i,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader,
+					},
+					{
+						loader: "css-loader",
+					}
+				]
+			},
+		],
+	},
+	optimization: {
+		minimize: !DEVELOPMENT,
+	},
+	output: {
+		clean: {
+			keep(asset) {
+				return !['main', 'clay'].some((file) => asset.includes(file));
+			}
+		},
+		path: buildCSSDir
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "[name].[contenthash].css"
+		}),
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1,
+		})
+	]
+};

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-2/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-2/client-extension.yaml
@@ -1,8 +1,8 @@
 assemble:
-    - from: build/buildTheme/img
-      into: static/img
+    - from: build/buildTheme/assets
+      into: static/assets
 liferay-sample-theme-css-2:
-    clayURL: css/clay.css
-    mainURL: css/main.css
+    clayURL: css/clay.*.css
+    mainURL: css/main.*.css
     name: Liferay Sample Theme CSS 2
     type: themeCSS

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-2/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-2/package.json
@@ -2,10 +2,17 @@
 	"dependencies": {
 		"sassy-inputs": "1.0.6"
 	},
+	"devDependencies": {
+		"webpack": "5.90.1",
+		"webpack-cli": "5.1.4"
+	},
 	"liferayDesignPack": {
 		"baseTheme": "unstyled"
 	},
 	"main": "package.json",
 	"name": "@liferay/liferay-sample-theme-css-2",
+	"scripts": {
+		"build": "webpack"
+	},
 	"version": "0.0.0"
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-2/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-2/webpack.config.js
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+
+const buildCSSDir = path.join(__dirname, 'build', 'buildTheme', 'css');
+const DEVELOPMENT = process.env.NODE_ENV === 'development';
+
+const includeReferencedAsset = (assetUrl) => {
+	const urlTokens = ['@base_url@', '@portal_ctx@', '@theme_image_path@']
+
+	if (!fs.existsSync(path.join(__dirname, 'src', 'css', assetUrl)) ||
+		assetUrl.startsWith("data:image") ||
+		urlTokens.some((token) => assetUrl.includes(token))) {
+
+		return false;
+	}
+
+	return true;
+}
+
+module.exports = {
+	context: buildCSSDir,
+	entry: {
+		clay: './clay.css',
+		main: './main.css'
+	},
+	mode: DEVELOPMENT ? 'development' : 'production',
+	module: {
+		rules: [
+			{
+				test: /\.css$/i,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader,
+					},
+					{
+						loader: "css-loader",
+						options: {
+							url: {
+								filter: includeReferencedAsset
+							}
+						}
+					}
+				]
+			},
+			{
+				generator: {
+					filename: '../assets/[name].[contenthash][ext]'
+				},
+				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
+				type: "asset/resource",
+			},
+		],
+	},
+	optimization: {
+		minimize: !DEVELOPMENT,
+	},
+	output: {
+		clean: {
+			keep(asset) {
+				return !['main', 'clay'].some((file) => asset.includes(file));
+			}
+		},
+		path: buildCSSDir
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "[name].[contenthash].css"
+		}),
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1,
+		})
+	]
+};

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-3/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-3/client-extension.yaml
@@ -1,9 +1,6 @@
-assemble:
-    - from: build/buildTheme/img
-      into: static/img
 liferay-sample-theme-css-3:
-    clayURL: css/clay.css
+    clayURL: css/clay.*.css
     frontendTokenDefinitionJSON: src/frontend-token-definition.json
-    mainURL: css/main.css
+    mainURL: css/main.*.css
     name: Liferay Sample Theme CSS 3
     type: themeCSS

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-3/package.json
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-3/package.json
@@ -1,0 +1,15 @@
+{
+	"devDependencies": {
+		"webpack": "5.90.1",
+		"webpack-cli": "5.1.4"
+	},
+	"liferayDesignPack": {
+		"baseTheme": "styled"
+	},
+	"main": "package.json",
+	"name": "@liferay/liferay-sample-theme-css-3",
+	"scripts": {
+		"build": "webpack"
+	},
+	"version": "0.0.0"
+}

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-3/webpack.config.js
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-theme-css-3/webpack.config.js
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const fs = require('fs');
+const path = require('path');
+const webpack = require('webpack');
+
+const buildCSSDir = path.join(__dirname, 'build', 'buildTheme', 'css');
+const DEVELOPMENT = process.env.NODE_ENV === 'development';
+
+const includeReferencedAsset = (assetUrl) => {
+	const urlTokens = ['@base_url@', '@portal_ctx@', '@theme_image_path@']
+
+	if (!fs.existsSync(path.join(__dirname, 'src', 'css', assetUrl)) ||
+		assetUrl.startsWith("data:image") ||
+		urlTokens.some((token) => assetUrl.includes(token))) {
+
+		return false;
+	}
+
+	return true;
+}
+
+module.exports = {
+	context: buildCSSDir,
+	entry: {
+		clay: './clay.css',
+		main: './main.css'
+	},
+	mode: DEVELOPMENT ? 'development' : 'production',
+	module: {
+		rules: [
+			{
+				test: /\.css$/i,
+				use: [
+					{
+						loader: MiniCssExtractPlugin.loader,
+					},
+					{
+						loader: "css-loader",
+						options: {
+							url: {
+								filter: includeReferencedAsset
+							}
+						}
+					}
+				]
+			},
+			{
+				generator: {
+					filename: '../assets/[name].[contenthash][ext]'
+				},
+				test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
+				type: "asset/resource",
+			},
+		],
+	},
+	optimization: {
+		minimize: !DEVELOPMENT,
+	},
+	output: {
+		clean: {
+			keep(asset) {
+				return !['main', 'clay'].some((file) => asset.includes(file));
+			}
+		},
+		path: buildCSSDir
+	},
+	plugins: [
+		new MiniCssExtractPlugin({
+			filename: "[name].[contenthash].css"
+		}),
+		new webpack.optimize.LimitChunkCountPlugin({
+			maxChunks: 1,
+		})
+	]
+};


### PR DESCRIPTION
This is the last state of the code, continues intiial effort from https://github.com/liferay-frontend/liferay-portal/pull/3980.

Basically we are adding some webpack configuration that handles hashing CSS resources and referenced resources as long as they belong to the project. This way new builds will be cachable forever as resource names will change.

@bryceosterhaus please take this as starting point. This gives some rebase conflicts on top of current master.