### PR TITLE
LPD-35757 Prevent InstanceScoped JS Client Extension from being applied at any other scope

### DIFF
--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -5,7 +5,9 @@
 
 package com.liferay.client.extension.type.item.selector.web.internal.item.selector;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.item.selector.CETItemSelectorReturnType;
 import com.liferay.client.extension.type.item.selector.criterion.CETItemSelectorCriterion;
 import com.liferay.client.extension.type.manager.CETManager;
@@ -18,6 +20,10 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.vulcan.pagination.Pagination;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -67,11 +73,29 @@ public class CETItemSelectorViewDescriptor
 				JavaConstants.JAVAX_PORTLET_REQUEST),
 			_portletURL, null, "there-are-no-items-to-display");
 
-		searchContainer.setResultsAndTotal(
-			_cetManager.getCETs(
-				themeDisplay.getCompanyId(), null,
+		List<CET> cets = _cetManager.getCETs(
+			themeDisplay.getCompanyId(), null,
+			_cetItemSelectorCriterion.getType(),
+			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+
+		if (Objects.equals(
 				_cetItemSelectorCriterion.getType(),
-				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null));
+				ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
+
+			List<CET> filteredCETs = new ArrayList<>();
+
+			for (CET cet : cets) {
+				GlobalJSCET globalJSCET = (GlobalJSCET)cet;
+
+				if (!Objects.equals(globalJSCET.getScope(), "instance")) {
+					filteredCETs.add(cet);
+				}
+			}
+
+			cets = filteredCETs;
+		}
+
+		searchContainer.setResultsAndTotal(cets);
 
 		return searchContainer;
 	}

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/test/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptorTest.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/test/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptorTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.type.item.selector.web.internal.item.selector;
+
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalJSCET;
+import com.liferay.client.extension.type.item.selector.criterion.CETItemSelectorCriterion;
+import com.liferay.client.extension.type.manager.CETManager;
+import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Thiago Buarque
+ */
+public class CETItemSelectorViewDescriptorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_cetManager = Mockito.mock(CETManager.class);
+
+		_cetItemSelectorCriterion = Mockito.mock(
+			CETItemSelectorCriterion.class);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, Mockito.mock(ThemeDisplay.class));
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_REQUEST,
+			new MockLiferayResourceRequest());
+
+		_cetItemSelectorViewDescriptor = new CETItemSelectorViewDescriptor(
+			_cetManager, _cetItemSelectorCriterion, mockHttpServletRequest,
+			new MockLiferayPortletURL());
+	}
+
+	@Test
+	public void testGetSearchContainer() throws PortalException {
+		Mockito.when(
+			_cetItemSelectorCriterion.getType()
+		).thenReturn(
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS
+		);
+
+		GlobalJSCET globalJSCET1 = Mockito.mock(GlobalJSCET.class);
+
+		Mockito.when(
+			globalJSCET1.getScope()
+		).thenReturn(
+			"instance"
+		);
+
+		GlobalJSCET globalJSCET2 = Mockito.mock(GlobalJSCET.class);
+
+		Mockito.when(
+			globalJSCET2.getScope()
+		).thenReturn(
+			""
+		);
+
+		Mockito.when(
+			_cetManager.getCETs(
+				Mockito.anyLong(), Mockito.any(),
+				Mockito.eq(ClientExtensionEntryConstants.TYPE_GLOBAL_JS),
+				Mockito.any(), Mockito.any())
+		).thenReturn(
+			Arrays.asList(globalJSCET1, globalJSCET2)
+		);
+
+		SearchContainer<CET> searchContainer =
+			_cetItemSelectorViewDescriptor.getSearchContainer();
+
+		List<CET> results = searchContainer.getResults();
+
+		Assert.assertEquals(results.toString(), 1, results.size());
+
+		GlobalJSCET globalJSCET3 = (GlobalJSCET)results.get(0);
+
+		Assert.assertEquals("", globalJSCET3.getScope());
+	}
+
+	private static CETItemSelectorCriterion _cetItemSelectorCriterion;
+	private static CETItemSelectorViewDescriptor _cetItemSelectorViewDescriptor;
+	private static CETManager _cetManager;
+
+}


### PR DESCRIPTION
# Context
We now have a way to inject a globalJS CET into all pages of a instance. See https://liferay.atlassian.net/browse/LPD-33747 for more info

Original PR: https://github.com/liferay-platform-experience/liferay-portal/pull/706

## Original description for this PR

Task: https://liferay.atlassian.net/browse/LPD-35757
Story: https://liferay.atlassian.net/browse/LPD-35637

## Motivation
There is no benefit of allowing a JS client extension, that is applied to the entire instance, to be applied to the page level. 

## Goal
Hide instance scoped cxs when a user is selecting a globalJS cx to a page.

### Steps to reproduce

1. Deploy a globalJS client extension with instance scope. You can deploy the one in the sample workspace
2. Go to `Site builder > pages > configuration > JavaScript > in page head` and assert that the client extension is not listed there.
3. Enable the feature flag LPD-30371
4. Repeat step 2