### PR TITLE
LPD-35816 - Apply DSM filters in the fragment using complex/composed field names

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -585,6 +585,13 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
+				String fieldName = StringUtil.replace(
+					String.valueOf(properties.get("fieldName")), "[]",
+					StringPool.FORWARD_SLASH);
+
+				fieldName = StringUtil.replace(fieldName, StringPool.PERIOD,
+					StringPool.FORWARD_SLASH);
+
 				String type = MapUtil.getString(properties, "type");
 
 				if (Objects.equals(type, "date") ||
@@ -606,7 +613,7 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 							FDSEntityFieldTypes.DATE :
 								FDSEntityFieldTypes.DATE_TIME
 					).put(
-						"id", properties.get("fieldName")
+						"id", fieldName
 					).put(
 						"label", _getValue("label", "fieldName", properties)
 					).put(
@@ -638,14 +645,25 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					).put(
 						"entityFieldType", FDSEntityFieldTypes.STRING
 					).put(
-						"id", properties.get("fieldName")
-					).put(
 						"label", _getValue("label", "fieldName", properties)
 					).put(
 						"multiple", properties.get("multiple")
 					).put(
 						"type", "selection"
 					);
+
+					if (Objects.equals(sourceType, "API_REST_APPLICATION")) {
+						selectionFilterJSONObject.put(
+							"id", fieldName
+						);
+					}
+					else {
+
+						selectionFilterJSONObject.put(
+							"id", fieldName.indexOf(StringPool.FORWARD_SLASH) > 0 ? fieldName.substring(0,
+								fieldName.lastIndexOf(StringPool.FORWARD_SLASH)) : fieldName
+						);
+					}
 
 					if (Validator.isNotNull(sourceType) &&
 						Objects.equals(sourceType, "API_REST_APPLICATION")) {
@@ -756,7 +774,7 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					).put(
 						"entityFieldType", FDSEntityFieldTypes.STRING
 					).put(
-						"id", properties.get("fieldName")
+						"id", fieldName
 					).put(
 						"label", _getValue("label", "fieldName", properties)
 					).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -587,11 +587,8 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 
 				String fieldName = String.valueOf(properties.get("fieldName"));
 
-				fieldName = StringUtil.replace(
-					fieldName, "[]", StringPool.FORWARD_SLASH);
-
-				fieldName = StringUtil.replace(
-					fieldName, CharPool.PERIOD, CharPool.FORWARD_SLASH);
+				fieldName = fieldName.replaceAll(
+					"(\\[\\]|\\.)", StringPool.FORWARD_SLASH);
 
 				String type = MapUtil.getString(properties, "type");
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -589,8 +589,8 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					String.valueOf(properties.get("fieldName")), "[]",
 					StringPool.FORWARD_SLASH);
 
-				fieldName = StringUtil.replace(fieldName, StringPool.PERIOD,
-					StringPool.FORWARD_SLASH);
+				fieldName = StringUtil.replace(
+					fieldName, StringPool.PERIOD, StringPool.FORWARD_SLASH);
 
 				String type = MapUtil.getString(properties, "type");
 
@@ -653,16 +653,16 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					);
 
 					if (Objects.equals(sourceType, "API_REST_APPLICATION")) {
-						selectionFilterJSONObject.put(
-							"id", fieldName
-						);
+						selectionFilterJSONObject.put("id", fieldName);
 					}
 					else {
-
 						selectionFilterJSONObject.put(
-							"id", fieldName.indexOf(StringPool.FORWARD_SLASH) > 0 ? fieldName.substring(0,
-								fieldName.lastIndexOf(StringPool.FORWARD_SLASH)) : fieldName
-						);
+							"id",
+							fieldName.indexOf(StringPool.FORWARD_SLASH) > 0 ?
+								fieldName.substring(
+									0,
+									fieldName.lastIndexOf(
+										StringPool.FORWARD_SLASH)) : fieldName);
 					}
 
 					if (Validator.isNotNull(sourceType) &&

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -585,12 +585,13 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 			(ObjectEntry objectEntry) -> {
 				Map<String, Object> properties = objectEntry.getProperties();
 
-				String fieldName = StringUtil.replace(
-					String.valueOf(properties.get("fieldName")), "[]",
-					StringPool.FORWARD_SLASH);
+				String fieldName = String.valueOf(properties.get("fieldName"));
 
 				fieldName = StringUtil.replace(
-					fieldName, StringPool.PERIOD, StringPool.FORWARD_SLASH);
+					fieldName, "[]", StringPool.FORWARD_SLASH);
+
+				fieldName = StringUtil.replace(
+					fieldName, CharPool.PERIOD, CharPool.FORWARD_SLASH);
 
 				String type = MapUtil.getString(properties, "type");
 
@@ -656,13 +657,17 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 						selectionFilterJSONObject.put("id", fieldName);
 					}
 					else {
-						selectionFilterJSONObject.put(
-							"id",
-							fieldName.indexOf(StringPool.FORWARD_SLASH) > 0 ?
-								fieldName.substring(
-									0,
-									fieldName.lastIndexOf(
-										StringPool.FORWARD_SLASH)) : fieldName);
+						Integer forwardSlashPositionInFieldName =
+							fieldName.indexOf(StringPool.FORWARD_SLASH);
+
+						if (forwardSlashPositionInFieldName > 0) {
+							fieldName = fieldName.substring(
+								0,
+								fieldName.lastIndexOf(
+									StringPool.FORWARD_SLASH));
+						}
+
+						selectionFilterJSONObject.put("id", fieldName);
 					}
 
 					if (Validator.isNotNull(sourceType) &&

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -570,6 +570,20 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 			});
 	}
 
+	private String _getFilterId(String sourceType, String fieldName) {
+		if (!Objects.equals(sourceType, "API_REST_APPLICATION")) {
+			Integer forwardSlashPositionInFieldName = fieldName.indexOf(
+				StringPool.FORWARD_SLASH);
+
+			if (forwardSlashPositionInFieldName > 0) {
+				fieldName = fieldName.substring(
+					0, fieldName.lastIndexOf(StringPool.FORWARD_SLASH));
+			}
+		}
+
+		return fieldName;
+	}
+
 	private JSONArray _getFiltersJSONArray(
 			ObjectDefinition fdsViewObjectDefinition,
 			ObjectEntry fdsViewObjectEntry,
@@ -643,29 +657,14 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 					).put(
 						"entityFieldType", FDSEntityFieldTypes.STRING
 					).put(
+						"id", _getFilterId(sourceType, fieldName)
+					).put(
 						"label", _getValue("label", "fieldName", properties)
 					).put(
 						"multiple", properties.get("multiple")
 					).put(
 						"type", "selection"
 					);
-
-					if (Objects.equals(sourceType, "API_REST_APPLICATION")) {
-						selectionFilterJSONObject.put("id", fieldName);
-					}
-					else {
-						Integer forwardSlashPositionInFieldName =
-							fieldName.indexOf(StringPool.FORWARD_SLASH);
-
-						if (forwardSlashPositionInFieldName > 0) {
-							fieldName = fieldName.substring(
-								0,
-								fieldName.lastIndexOf(
-									StringPool.FORWARD_SLASH));
-						}
-
-						selectionFilterJSONObject.put("id", fieldName);
-					}
 
 					if (Validator.isNotNull(sourceType) &&
 						Objects.equals(sourceType, "API_REST_APPLICATION")) {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -19,6 +19,7 @@ const picklistDefaultOptionLabel = 'Default';
 
 const apiHeadlessName = 'FieldType';
 const apiHeadlessURL = `c/${apiHeadlessName.toLocaleLowerCase()}s`;
+const dataSetERCs: string[] = [];
 let dataSetERC: string;
 let dataSetLabel: string;
 let objectDefinition: any;
@@ -43,6 +44,8 @@ test.beforeEach(
 		dataSetERC = getRandomString();
 		dataSetLabel = getRandomString();
 		picklistName = getRandomString();
+
+		dataSetERCs.push(dataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			erc: dataSetERC,
@@ -125,7 +128,13 @@ test.beforeEach(
 
 test.afterEach(
 	async ({apiHelpers, dataSetManagerApiHelpers, picklistApiHelpers}) => {
-		await dataSetManagerApiHelpers.deleteDataSet({erc: dataSetERC});
+		for (const DATA_SET_ERC of dataSetERCs) {
+			await dataSetManagerApiHelpers.deleteDataSet({
+				erc: DATA_SET_ERC,
+			});
+		}
+
+		dataSetERCs.length = 0;
 
 		await picklistApiHelpers.deletePicklist(picklistName);
 
@@ -727,3 +736,108 @@ test('Selection filter of type "API REST Application" is displayed in fragment @
 		).toBeVisible();
 	});
 });
+
+test(
+	'Selection filter of type "API REST Application" with a composed field name is displayed in the fragment',
+	{tag: '@25905'},
+	async ({dataSetManagerApiHelpers, fdsFragmentPage, layout}) => {
+		const filterLabel = getRandomString();
+		const customDataSetLabel = getRandomString();
+		const customDataSetERC = getRandomString();
+		dataSetERCs.push(customDataSetERC);
+
+		await test.step('Create custom data set of Data Sets', async () => {
+			await dataSetManagerApiHelpers.createDataSet({
+				erc: customDataSetERC,
+				label: customDataSetLabel,
+				restApplication: '/data-set-manager/data-sets',
+				restSchema: 'FDSView',
+			});
+		});
+
+		await test.step('Add some card sections', async () => {
+			await dataSetManagerApiHelpers.createDataSetCardsSection({
+				dataSetERC: customDataSetERC,
+				fieldName: 'label',
+				name: 'title',
+			});
+		});
+
+		await test.step('Create a new "API Rest Application" selection filter for card fields', async () => {
+			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+				dataSetERC: customDataSetERC,
+				fieldName: 'fdsViewFDSCardsSectionRelationship[]fieldName',
+				itemKey: 'fieldName',
+				itemLabel: 'fieldName',
+				label_i18n: {en_US: filterLabel},
+				multiple: true,
+				source: `/o/data-set-manager/cards-sections/`,
+				sourceType: 'API_REST_APPLICATION',
+			});
+		});
+
+		await test.step('Configure Data Set fragment', async () => {
+			await fdsFragmentPage.configureDataSetFragment({
+				dataSetLabel: customDataSetLabel,
+				layout,
+			});
+		});
+
+		await test.step('Check current items in the Frontend Data Set', async () => {
+			await fdsFragmentPage.fdsPaginationResults.scrollIntoViewIfNeeded();
+
+			await expect(
+				fdsFragmentPage.fdsPaginationResults.getByText(
+					'Showing 1 to 2 of 2 entries.'
+				)
+			).toBeVisible();
+		});
+
+		await test.step('Select filter', async () => {
+			await fdsFragmentPage.selectFilter(filterLabel);
+		});
+
+		await test.step('Configure and apply filter', async () => {
+			await expect(
+				fdsFragmentPage.fdsFilterItem.getByRole('checkbox', {
+					name: 'label',
+				})
+			).toBeVisible();
+
+			await fdsFragmentPage.fdsFilterItem
+				.getByRole('checkbox', {name: 'label'})
+				.check();
+			await fdsFragmentPage.fdsFilterItem
+				.getByRole('button', {name: 'Add filter'})
+				.click();
+
+			// Close filter
+
+			await fdsFragmentPage.page.keyboard.press('Escape');
+		});
+
+		await test.step('Check that the filter works', async () => {
+			await fdsFragmentPage.fdsFilterResumeButton.waitFor({
+				state: 'visible',
+			});
+
+			await expect(
+				fdsFragmentPage.page.getByRole('button', {
+					name: `${filterLabel}: label`,
+				})
+			).toBeVisible();
+
+			await fdsFragmentPage.page.locator('.card').first().waitFor();
+
+			const firstCard = fdsFragmentPage.page.locator('.card').first();
+
+			await expect(firstCard.locator('.card-title')).toContainText(
+				customDataSetLabel
+			);
+
+			await expect(
+				fdsFragmentPage.page.getByText('Showing 1 to 1 of 1 entries.')
+			).toBeVisible();
+		});
+	}
+);


### PR DESCRIPTION
## Story / Task
[LPD-26998](https://liferay.atlassian.net/browse/LPD-26998) / [LPD-35816](https://liferay.atlassian.net/browse/LPD-35816)

> [!NOTE]  
> The creation of filters using the TreeView selection (complex/composed/nested fields) needs the activation of the `LPD-25905` FF

## Goal
This task is a follow up of [LPD-26397](https://liferay.atlassian.net/browse/LPD-26397), where the user can select field names from a treeview. In this case, we need to parse the field names and transform them to provide an oData compliant expression to the filter.

## Limitations

> [!WARNING] 
> We can only ensure that filters will work with Object generated endpoints. `api-headless-*` will need a case by case review.

> [!CAUTION]  
> Filters cannot be used with translatable object fields. Using a filter with this type of object fields will throw a 500 Internal Server Error. There is a [bug](https://liferay.atlassian.net/browse/LPD-36054) open for it.

## UI
https://github.com/user-attachments/assets/c9b92854-f2f0-4b88-bc75-7c08e8d5f89d

