### PR TITLE
LPD-26285

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
@@ -1081,8 +1081,8 @@ class App extends EventEmitter {
 		event.capturedFormElement = form;
 		const buttonSelector =
 			'button:not([type]),button[type=submit],input[type=submit]';
-		if (document.activeElement.matches(buttonSelector)) {
-			event.capturedFormButtonElement = document.activeElement;
+		if (event.submitter.matches(buttonSelector)) {
+			event.capturedFormButtonElement = event.submitter;
 		}
 		else {
 			event.capturedFormButtonElement =

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
@@ -1081,8 +1081,11 @@ class App extends EventEmitter {
 		event.capturedFormElement = form;
 		const buttonSelector =
 			'button:not([type]),button[type=submit],input[type=submit]';
-		if (event.submitter.matches(buttonSelector)) {
-			event.capturedFormButtonElement = event.submitter;
+
+		const elementSubmitter = event.submitter ?? document.activeElement;
+
+		if (elementSubmitter.matches(buttonSelector)) {
+			event.capturedFormButtonElement = elementSubmitter;
 		}
 		else {
 			event.capturedFormButtonElement =

--- a/modules/test/playwright/tests/frontend-js-spa-web/safariSubmitButton.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/safariSubmitButton.spec.ts
@@ -104,5 +104,8 @@ test('@LPD-26285 Safari Submit Button', async ({
 		);
 
 		await expect(capturedFormButtonElement).toHaveText('Button B');
+
+		// Dispose context once it's no longer needed. 
+		await context.close();
 	});
 });

--- a/modules/test/playwright/tests/frontend-js-spa-web/safariSubmitButton.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/safariSubmitButton.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import {pageViewModePagesTest} from '../../fixtures/pageViewModePagesTest';
+import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
+import getRandomString from '../../utils/getRandomString';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
+
+export const test = mergeTests(
+	loginTest(),
+	apiHelpersTest,
+	isolatedSiteTest,
+	journalPagesTest,
+	pageEditorPagesTest,
+	productMenuPageTest,
+	pageViewModePagesTest
+);
+
+test('@LPD-26285 Safari Submit Button', async ({
+	apiHelpers,
+	journalEditArticlePage,
+	page,
+	site,
+	widgetPagePage,
+}) => {
+	const {devices, webkit} = require('playwright');
+	const safari = devices['Desktop Safari'];
+	const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+		groupId: site.id,
+		options: {
+			type: 'portlet',
+		},
+		title: getRandomString(),
+	});
+
+	await test.step('Check SPA is enabled', async () => {
+		await page.goto('/');
+
+		// @ts-ignore
+
+		const liferaySPAOutput = await page.evaluate(() => Liferay.SPA);
+
+		expect(liferaySPAOutput).not.toEqual(undefined);
+	});
+
+	await test.step('Add WCD and content with a form including two submit buttons', async () => {
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+		await widgetPagePage.addPortlet('Web Content Display');
+
+		await page
+			.locator(
+				'[id^="_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_"]'
+			)
+			.and(page.getByRole('button'))
+			.click();
+
+		await page.getByRole('menuitem', {name: 'Basic Web Content'}).click();
+
+		const title = getRandomString();
+
+		await journalEditArticlePage.fillTitle(title);
+
+		await page.getByLabel('Source', {exact: true}).click();
+
+		await page.locator('.CodeMirror-scroll').click();
+
+		const content =
+			'<form action="" method="post"><input type="submit" value="Button A" /> <input type="submit" value="Button B" /></form><p><span id="capturedFormButtonElement"></span></p><script>Liferay.once("beforeNavigate", function(){buttonValue = Liferay.SPA.__capturedFormButtonElement__.value});Liferay.once("endNavigate", function(){document.getElementById("capturedFormButtonElement").textContent = buttonValue;})</script>';
+
+		await page
+			.getByLabel('Content', {exact: true})
+			.getByRole('textbox')
+			.fill(content);
+
+		await journalEditArticlePage.publishButton.click();
+	});
+
+	await test.step('Set Safari as the browser and check submit buttons in form', async () => {
+		const browser = await webkit.launch();
+
+		const context = await browser.newContext({
+			...safari,
+		});
+
+		const incognitoPage = await context.newPage();
+
+		await incognitoPage.goto(
+			`/web${site.friendlyUrlPath}${layout.friendlyURL}`
+		);
+
+		await incognitoPage.getByRole('button', {name: 'Button B'}).click();
+
+		const capturedFormButtonElement = incognitoPage.locator(
+			'#capturedFormButtonElement'
+		);
+
+		await expect(capturedFormButtonElement).toHaveText('Button B');
+	});
+});

--- a/modules/test/playwright/tests/frontend-js-spa-web/safariSubmitButton.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/safariSubmitButton.spec.ts
@@ -105,7 +105,8 @@ test('@LPD-26285 Safari Submit Button', async ({
 
 		await expect(capturedFormButtonElement).toHaveText('Button B');
 
-		// Dispose context once it's no longer needed. 
+		// Dispose context once it's no longer needed.
+
 		await context.close();
 	});
 });


### PR DESCRIPTION
Hi,

The issue here is pretty easy to understand: Safari does not handled properly `document.activeElement`. So in case we had more than one submit button in a form we are always sending the first button as `capturedFormButtonElement`.

The solution itself is straightforward: change `document.activeElement` by `event.submitter`.

Testing this is not that easy, I decided to create a Basic Web Content including a form, two submit buttons and some javascript code to print which button was sent as `capturedFormButtonElement`. Then I had to change context to use Safari as the browser and check which button was pressed.

Please, let me know your thoughts and improvements.

Thanks a lot.