### PR TITLE
LPD-36619 - Autogenerate FDS cell class name and customize Minium FDS

### DIFF
--- a/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/css/minium/overrides/_data-set-display.scss
+++ b/modules/apps/commerce/commerce-theme-minium/commerce-theme-minium/src/css/minium/overrides/_data-set-display.scss
@@ -86,4 +86,35 @@
 	.table-style-stacked {
 		border: none;
 	}
+
+	/* ---------- Custom minium fds cell customization ---------- */
+
+	.dnd-table {
+		.dnd-td,
+		.dnd-th {
+			&.cell-externalReferenceCode {
+				min-width: 150px;
+			}
+
+			&.cell-promoPrice {
+				max-width: 132px;
+			}
+
+			&.cell-purchaseOrderNumber {
+				max-width: 175px;
+			}
+
+			&.cell-name {
+				min-width: 150px;
+			}
+
+			&.cell-shippedQuantity {
+				max-width: 150px;
+			}
+
+			&.cell-sku {
+				min-width: 100px;
+			}
+		}
+	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
@@ -34,6 +34,7 @@ import ViewsContext, {
 	IViewsContext,
 	TViewsContextDispatch,
 } from '../ViewsContext';
+import getCellColumnClassName from '../utils/getCellColumnClassName';
 
 // @ts-ignore
 
@@ -187,6 +188,7 @@ export function ClayTable({
 
 						return (
 							<Cell
+								className="cell-select-item"
 								key="select"
 								scope="col"
 								textValue={title}
@@ -222,6 +224,7 @@ export function ClayTable({
 
 					return (
 						<HeadCellResizer
+							className={getCellColumnClassName(field.fieldName)}
 							columnName={field.fieldName}
 							key={field.fieldName}
 							sortable={(field as any).sortable}
@@ -254,10 +257,15 @@ export function ClayTable({
 							key={id}
 						>
 							{(cell) => {
+								const cellColumnName = getCellColumnClassName(
+									cell.fieldName
+								);
+
 								switch (cell.fieldName) {
 									case 'actions': {
 										return (
 											<Cell
+												className="cell-select-item"
 												key={`${id}:actions`}
 												textValue={Liferay.Language.get(
 													'select-item'
@@ -285,6 +293,7 @@ export function ClayTable({
 									case 'select':
 										return (
 											<Cell
+												className="cell-select-item"
 												key={`${id}:select`}
 												textValue={Liferay.Language.get(
 													'select-item'
@@ -348,6 +357,7 @@ export function ClayTable({
 
 											return (
 												<Cell
+													className={cellColumnName}
 													key={`${id}:${cell.fieldName}`}
 												>
 													{InputRenderer ? (
@@ -391,6 +401,7 @@ export function ClayTable({
 
 										return (
 											<Cell
+												className={cellColumnName}
 												key={`${id}:${cell.fieldName}`}
 											>
 												<CellRenderer

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
@@ -11,11 +11,12 @@ import ViewsContext, {
 	IViewsContext,
 	TViewsContextDispatch,
 } from '../../ViewsContext';
+import getCellColumnClassName from '../../utils/getCellColumnClassName';
 
 // @ts-ignore
 
-import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
 import TableContext from './TableContext';
+import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
 
 const Cell = ({
 	children,
@@ -118,7 +119,11 @@ const Cell = ({
 
 	return (
 		<div
-			className={classNames(heading ? 'dnd-th' : 'dnd-td', className)}
+			className={classNames(
+				heading ? 'dnd-th' : 'dnd-td',
+				getCellColumnClassName(columnName),
+				className
+			)}
 			ref={cellRef}
 			style={{
 				width: width ?? defaultWidth,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
@@ -15,8 +15,8 @@ import getCellColumnClassName from '../../utils/getCellColumnClassName';
 
 // @ts-ignore
 
-import TableContext from './TableContext';
 import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
+import TableContext from './TableContext';
 
 const Cell = ({
 	children,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/dnd_table/Cell.tsx
@@ -17,8 +17,6 @@ import ViewsContext, {
 import {VIEWS_ACTION_TYPES} from '../../viewsReducer';
 import TableContext from './TableContext';
 
-const MINIMUM_COLUMN_WIDTH = 140;
-
 const Cell = ({
 	children,
 	className,
@@ -54,13 +52,6 @@ const Cell = ({
 	useEffect(() => {
 		if (columnName && heading && !isFixed && cellRef.current) {
 			const boundingClientRect = cellRef.current.getBoundingClientRect();
-
-			if (
-				columnName !== 'item-actions' &&
-				boundingClientRect.width < MINIMUM_COLUMN_WIDTH
-			) {
-				boundingClientRect.width = MINIMUM_COLUMN_WIDTH;
-			}
 
 			viewsDispatch({
 				type: VIEWS_ACTION_TYPES.UPDATE_FIELD,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/utils/getCellColumnClassName.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/utils/getCellColumnClassName.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function getCellColumnClassName(
+	columnName: string | Array<string>
+): string {
+	let className: string;
+
+	const languageIdentifierPosition = columnName.indexOf('LANG');
+
+	if (Array.isArray(columnName) && languageIdentifierPosition > 0) {
+		className = columnName.slice(0, languageIdentifierPosition)[0];
+	}
+	else if (Array.isArray(columnName)) {
+		className = columnName.join('-');
+	}
+	else {
+		className = columnName;
+	}
+
+	className = className.replace(/[\W]+/g, '-');
+
+	return `cell-${className}`;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/views/utils/getCellColumnClassName.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/views/utils/getCellColumnClassName.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import getCellColumnClassName from '../../../src/main/resources/META-INF/resources/views/utils/getCellColumnClassName';
+
+describe('getCellColumnClassName utility', () => {
+	it('returns a string composed by a prefix and the cell name when it receives a string', () => {
+		const given = 'name';
+		const expected = `cell-${given}`;
+
+		expect(getCellColumnClassName(given)).toEqual(expected);
+	});
+
+	it('returns a string composed by a prefix and the cell name when it receives an array of string plus "LANG"', () => {
+		const given = ['name', 'LANG'];
+		const expected = `cell-${given[0]}`;
+
+		expect(getCellColumnClassName(given)).toEqual(expected);
+	});
+
+	it('returns a string composed by a prefix and the cell name separated by hyphens when it receives an array of strings', () => {
+		const given = ['catalog', 'name'];
+		const expected = `cell-${given[0]}-${given[1]}`;
+
+		expect(getCellColumnClassName(given)).toEqual(expected);
+	});
+
+	it('returns a string composed by a prefix and the cell name, replacing non alphanumeric characters by hyphens', () => {
+		const given = ['catalog/name'];
+		const expected = `cell-catalog-name`;
+
+		expect(getCellColumnClassName(given)).toEqual(expected);
+	});
+});

--- a/modules/test/playwright/tests/frontend-data-set-web/styles.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/styles.spec.ts
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -10,6 +10,7 @@ import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest'
 import {commercePagesTest} from '../../fixtures/commercePagesTest';
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
+import getRandomString from '../../utils/getRandomString';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -18,6 +19,21 @@ const test = mergeTests(
 	dataApiHelpersTest,
 	loginTest()
 );
+
+let account;
+
+test.beforeEach(async ({apiHelpers}) => {
+	await test.step('Create account', async () => {
+		account = await apiHelpers.headlessAdminUser.postAccount({
+			name: getRandomString(),
+			type: 'business',
+		});
+	});
+});
+
+test.afterEach(async ({apiHelpers}) => {
+	await apiHelpers.headlessAdminUser.deleteAccount(account.id);
+});
 
 test('LPD-31378 Width of columns with very small header text is increased', async ({
 	apiHelpers,
@@ -36,30 +52,10 @@ test('LPD-31378 Width of columns with very small header text is increased', asyn
 		await applicationsMenuPage.goToSite('Minium');
 	});
 
-	await test.step('Create account', async () => {
-		const accountButton = page.getByRole('button', {
-			name: 'Select Account & Order',
-		});
-
-		await accountButton.waitFor({state: 'visible'});
-		await accountButton.click();
-
-		const newAccountButton = page.getByRole('button', {
-			name: 'Create New Account',
-		});
-
-		await newAccountButton.waitFor({state: 'visible'});
-		await newAccountButton.click();
-
-		const accountNameField = page.locator('input[name="accountName"]');
-
-		await accountNameField.waitFor({state: 'visible'});
-		await accountNameField.fill('test');
-
-		await page.getByRole('button', {exact: true, name: 'Create'}).click();
-	});
-
 	await test.step('Add transmission to shopping cart', async () => {
+		const accountNameField = page.getByText('There is no order selected.');
+		await accountNameField.waitFor({state: 'visible'});
+
 		const transmissionButton = page
 			.locator('#wwxc_column_2d_2_1_add_to_cart')
 			.getByRole('button', {name: 'Add to Cart'});
@@ -73,7 +69,7 @@ test('LPD-31378 Width of columns with very small header text is increased', asyn
 		await cartButton.click();
 	});
 
-	await test.step('Check SKU width length', async () => {
+	await test.step('Check Name and SKU headers width', async () => {
 		const viewDetailsButton = page.getByRole('button', {
 			name: 'View Details',
 		});
@@ -81,16 +77,17 @@ test('LPD-31378 Width of columns with very small header text is increased', asyn
 		await viewDetailsButton.waitFor({state: 'visible'});
 		await viewDetailsButton.click();
 
-		const skuTableHeader = page
-			.getByTestId('visualization-mode-table')
-			.getByText('SKU');
+		const nameTableHeader = page.locator('.dnd-th.cell-name');
+		await nameTableHeader.waitFor({state: 'visible'});
+		const nameTableHeaderBoundingBox = await nameTableHeader.boundingBox();
+		const nameTableHeaderWidth = nameTableHeaderBoundingBox.width;
 
-		await skuTableHeader.waitFor({state: 'visible'});
+		expect(nameTableHeaderWidth).toEqual(150);
 
+		const skuTableHeader = page.locator('.dnd-th.cell-sku');
 		const skuTableHeaderBoundingBox = await skuTableHeader.boundingBox();
-
 		const skuTableHeaderWidth = skuTableHeaderBoundingBox.width;
 
-		expect(skuTableHeaderWidth).toEqual(140);
+		expect(skuTableHeaderWidth).toEqual(100);
 	});
 });


### PR DESCRIPTION
## Goal
Provide a mechanism to identify cells, both for header and body, so it is possible to set the same width for all of them.
- followup of https://github.com/liferay-frontend/liferay-portal/pull/4422
- fix https://liferay.atlassian.net/browse/LPP-54602

## UI

### Before
![image](https://github.com/user-attachments/assets/dedac532-7fd6-4c54-87fd-4a5745dc5bb6)


### After
![image](https://github.com/user-attachments/assets/a8cd99d7-1a81-4947-8863-f85884d88a1e)
