### PR TITLE
LPD-35722 Required icons should be consistent

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -82,7 +82,12 @@ if (editorOptions != null) {
 		<liferay-ui:message key="<%= placeholder %>" />
 
 		<c:if test="<%= Boolean.parseBoolean(required) %>">
-			<clay:icon cssClass="reference-mark text-warning" symbol="asterisk" />
+			<clay:icon
+				cssClass="reference-mark text-warning"
+				symbol="asterisk"
+			/>
+
+			<span class="hide-accessible sr-only"><liferay-ui:message key="required" /></span>
 		</c:if>
 	</div>
 

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -82,7 +82,7 @@ if (editorOptions != null) {
 		<liferay-ui:message key="<%= placeholder %>" />
 
 		<c:if test="<%= Boolean.parseBoolean(required) %>">
-			<span class="text-warning">*</span>
+			<aui:icon cssClass="reference-mark text-warning" image="asterisk" markupView="lexicon" />
 		</c:if>
 	</div>
 

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -82,7 +82,7 @@ if (editorOptions != null) {
 		<liferay-ui:message key="<%= placeholder %>" />
 
 		<c:if test="<%= Boolean.parseBoolean(required) %>">
-			<aui:icon cssClass="reference-mark text-warning" image="asterisk" markupView="lexicon" />
+			<clay:icon cssClass="reference-mark text-warning" symbol="asterisk" />
 		</c:if>
 	</div>
 

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -8,6 +8,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -100,7 +100,11 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 			<liferay-ui:message key="<%= placeholder %>" />
 
 			<c:if test="<%= required %>">
-				<clay:icon cssClass="reference-mark text-warning" symbol="asterisk" />
+				<clay:icon
+					cssClass="reference-mark text-warning"
+					symbol="asterisk"
+				/>
+
 				<span class="hide-accessible sr-only"><liferay-ui:message key="required" /></span>
 			</c:if>
 		</label>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -100,7 +100,7 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 			<liferay-ui:message key="<%= placeholder %>" />
 
 			<c:if test="<%= required %>">
-				<span class="text-warning">*</span>
+				<aui:icon cssClass="reference-mark text-warning" image="asterisk" markupView="lexicon" />
 			</c:if>
 		</label>
 	</c:if>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditor.jsp
@@ -100,7 +100,8 @@ if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
 			<liferay-ui:message key="<%= placeholder %>" />
 
 			<c:if test="<%= required %>">
-				<aui:icon cssClass="reference-mark text-warning" image="asterisk" markupView="lexicon" />
+				<clay:icon cssClass="reference-mark text-warning" symbol="asterisk" />
+				<span class="hide-accessible sr-only"><liferay-ui:message key="required" /></span>
 			</c:if>
 		</label>
 	</c:if>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -10,6 +10,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@

--- a/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
+++ b/modules/test/playwright/tests/announcements-web/announcements-web.spec.ts
@@ -35,5 +35,9 @@ test('LPD-27067 Content field is required', async ({
 }) => {
 	await announcementsPage.goToCreateNewAnnouncement();
 
-	await expect(page.getByText('Content *')).toBeVisible();
+	const requiredField = page.locator(
+		'#_com_liferay_announcements_web_portlet_AnnouncementsAdminPortlet_contentEditorContainer svg.lexicon-icon-asterisk'
+	);
+
+	await expect(requiredField).toBeVisible();
 });


### PR DESCRIPTION
Hi,

The issue here is we were using the character * to say editor's content was required, opposite to what happens in any other required field in Liferay where they are marked with an SVG icon.

Fixing that broke that test, so I fixed it in such a way we can be sure the required mark is an SVG icon now.

I thought about creating apart a specific test for this case, but I realized it would be basically the same thing, going to a page with an editor and check for required mark, so we'd be duplicating the code.

Thanks.

Regards.