### PR TITLE
LPD-34521 Review tests in client-extension-web

### DIFF
--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -64,7 +64,7 @@ export class PageEditorPage {
 		await this.page.goto('/');
 
 		await this.page.goto(
-			`/web${siteUrl || '/guest'}${layout.friendlyUrlPath}?p_l_mode=edit${doAsUserId ? '&doAsUserId=' + doAsUserId : ''}`
+			`/web${siteUrl || '/guest'}${layout.friendlyUrlPath || layout.friendlyURL}?p_l_mode=edit${doAsUserId ? '&doAsUserId=' + doAsUserId : ''}`
 		);
 	}
 

--- a/modules/test/playwright/tests/client-extension-web/customElement.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/customElement.spec.ts
@@ -64,6 +64,10 @@ for (const sample of SAMPLES) {
 		await test.step(`${sample.name} is visible and configured from Workspace`, async () => {
 			await clientExtensionsPage.goto();
 
+			await page.getByPlaceholder('Search').fill(sample.name);
+
+			await page.getByRole('button', {name: 'Search'}).click();
+
 			await clientExtensionsPage.assertName(sample.name);
 
 			await clientExtensionsPage.assertIsConfiguredFrom(

--- a/modules/test/playwright/tests/client-extension-web/jsImportMapsEntry.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/jsImportMapsEntry.spec.ts
@@ -15,13 +15,13 @@ const SAMPLES = [
 		bareSpecifier: 'jquery',
 		erc: 'LXC:liferay-sample-js-import-maps-entry',
 		name: 'Liferay Sample JS Import Maps Entry',
-		url: '/o/liferay-sample-js-import-maps-entry/jquery.db7c7063a8b5d1298dbc.js',
+		url: '/o/liferay-sample-js-import-maps-entry/jquery.62d686ddc1e428e249ff.js',
 	},
 	{
 		bareSpecifier: 'my-utils',
 		erc: 'LXC:liferay-sample-etc-frontend-js-import-maps-entry',
 		name: 'Liferay Sample Etc Frontend JS Import Maps Entry',
-		url: '/o/liferay-sample-etc-frontend/my-utils.2db3acbc64ea700ac5b4.js',
+		url: '/o/liferay-sample-etc-frontend/my-utils.41642c66e4920076a271.js',
 	},
 ];
 

--- a/modules/test/playwright/tests/client-extension-web/themeSpritemap.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/themeSpritemap.spec.ts
@@ -23,7 +23,7 @@ const SAMPLES = [
 	{
 		erc: 'LXC:liferay-sample-theme-spritemap-2',
 		name: 'Liferay Sample Theme Spritemap 2',
-		url: '/o/liferay-sample-theme-spritemap-2/spritemap.60a35738d5217bbca1ba8470eba2fd8440ab368d.svg',
+		url: '/o/liferay-sample-theme-spritemap-2/spritemap.87f79d7e10ac5f96ecc168234ba026ccf2ecf451.svg',
 	},
 ];
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34521

Fixes frontend-infra-owned tests in `client-extension-web`.

- Slightly unsure how acceptable this change is f694a3a5c73a3899a3242c85ce6823a0fd6e98a8, but it seemed like `layout.friendlyUrlPath` wasn't defined when the layout was created with [`apiHelpers.jsonWebServicesLayout.addLayout`](https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/fixtures/isolatedLayoutTest.ts#L69-L76).
  - For example, `layout.friendlyUrlPath` is created when it's created with a site using [`apiHelpers.headlessDelivery.createSitePage`](https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/tests/frontend-data-set-web/clayTable.spec.ts#L37-L47).
  - I also found places where the URL path was being created with `layout.friendlyURL` instead of `layout.friendlyUrlPath` as well https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/tests/layout-admin-web/pageConfiguration.spec.ts#L97