### PR TITLE
[dont merge yet] LPD-37109 Prevent "Custom Javascript" injection from interfering with other injected JS in the page

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -199,7 +199,7 @@ if (layout != null) {
 	// ]]>
 </aui:script>
 
-<c:if test="<%= layout != null %>">
+<c:if test="<%= (layout != null) && !layout.isTypeControlPanel() %>">
 
 	<%-- User Inputted Layout and LayoutSet JavaScript --%>
 
@@ -219,17 +219,30 @@ if (layout != null) {
 	UnicodeProperties layoutSetSettingsUnicodeProperties = layoutSet.getSettingsProperties();
 
 	UnicodeProperties layoutTypeSettingsUnicodeProperties = layout.getTypeSettingsProperties();
+
+	List<String> snippets = new ArrayList<String>();
+
+	snippets.add(GetterUtil.getString(layoutSetSettingsUnicodeProperties.getProperty("javascript")));
+
+	snippets.add(GetterUtil.getString(masterLayoutTypeSettingsUnicodeProperties.getProperty("javascript")));
+
+	snippets.add(GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("javascript")));
+
+	for (String snippet : snippets) {
 	%>
 
-	<aui:script type="text/javascript">
-		// <![CDATA[
-			<c:if test="<%= !layout.isTypeControlPanel() %>">
-				<%= GetterUtil.getString(layoutSetSettingsUnicodeProperties.getProperty("javascript")) %>
+		<c:if test="<%= Validator.isNotNull(snippet) %>">
+			<aui:script type="text/javascript">
+				// <![CDATA[
+					(function() {
+						<%= snippet %>
+					})();
+				// ]]>
+			</aui:script>
+		</c:if>
 
-				<%= GetterUtil.getString(masterLayoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>
+	<%
+	}
+	%>
 
-				<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>
-			</c:if>
-		// ]]>
-	</aui:script>
 </c:if>


### PR DESCRIPTION
References:
 *  [LPD-37109](https://liferay.atlassian.net/browse/LPD-37109)
 * https://stackoverflow.com/questions/42036349/uncaught-typeerror-intermediate-value-is-not-a-function

In this PR we are IIFE'ing custom JS snippets added to the page. This way we prevent them to be interpreted in wrong ways.

### Before
![image](https://github.com/user-attachments/assets/eb79ac76-b87c-4aef-97c9-28ed73a8aa3a)

Note I did not want to use `sandbox="true"` feature in aui:script because it adds 2 variables to the IIFE (see second red box in above screenshot), which sounds like a terrible idea as snippet is not expecting it.

### After
![image](https://github.com/user-attachments/assets/81bccbe6-883b-47ee-b226-614dc14c0df4)


DO NOT MERGE: this PR is to validate approach, tests are missing
