### PR TITLE
LPD-37210 Remove FF for FDS URL resolver mechanism

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
@@ -15,7 +15,6 @@ import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -206,13 +205,11 @@ public class FDSAdminDisplayContext {
 	public JSONArray getRESTApplicationResolvedSchemasJSONArray() {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		if (FeatureFlagManagerUtil.isEnabled("LPD-25230")) {
-			List<FDSAPIURLResolver> fdsAPIURLResolvers =
-				_fdsAPIURLResolverRegistry.getFDSAPIURLResolvers();
+		List<FDSAPIURLResolver> fdsAPIURLResolvers =
+			_fdsAPIURLResolverRegistry.getFDSAPIURLResolvers();
 
-			for (FDSAPIURLResolver fdsAPIURLResolver : fdsAPIURLResolvers) {
-				jsonArray.put(fdsAPIURLResolver.getSchema());
-			}
+		for (FDSAPIURLResolver fdsAPIURLResolver : fdsAPIURLResolvers) {
+			jsonArray.put(fdsAPIURLResolver.getSchema());
 		}
 
 		return jsonArray;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/fragment/renderer/FDSAdminFragmentRenderer.java
@@ -1115,21 +1115,18 @@ public class FDSAdminFragmentRenderer implements FragmentRenderer {
 		String apiURL, String restApplication, String restSchema,
 		HttpServletRequest httpServletRequest) {
 
-		if (FeatureFlagManagerUtil.isEnabled("LPD-25230")) {
-			FDSAPIURLResolver fdsAPIURLResolver =
-				_fdsAPIURLResolverRegistry.getFDSAPIURLResolver(
-					restApplication, restSchema);
+		FDSAPIURLResolver fdsAPIURLResolver =
+			_fdsAPIURLResolverRegistry.getFDSAPIURLResolver(
+				restApplication, restSchema);
 
-			if (fdsAPIURLResolver != null) {
-				try {
-					return fdsAPIURLResolver.resolve(
-						apiURL, httpServletRequest);
-				}
-				catch (PortalException portalException) {
-					_log.error(portalException);
+		if (fdsAPIURLResolver != null) {
+			try {
+				return fdsAPIURLResolver.resolve(apiURL, httpServletRequest);
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException);
 
-					return apiURL;
-				}
+				return apiURL;
 			}
 		}
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -202,7 +202,7 @@ test('Create parameterized data set', async ({dataSetsPage, page}) => {
 
 test(
 	'Assert endpoint with resolved paramater is available as an option',
-	{tag: '@LPD-25230'},
+	{tag: '@LPD-31177'},
 	async ({dataSetsPage}) => {
 		const cartDataSetConfig = {
 			name: 'Carts',

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -16,7 +16,6 @@ export const test = mergeTests(
 	dataSetManagerApiHelpersTest,
 	dataSetsPageTest,
 	featureFlagsTest({
-		'LPD-25230': true,
 		'LPS-164563': true,
 	}),
 	loginTest(),


### PR DESCRIPTION
### References

- Parent Story: [LPD-37209 Remove dedicated FF](https://issues.liferay.com/browse/LPD-37209)

### What is the goal of this PR?

For a simple FF removal task, this was an odd one:
1. When we [created FF for resolver mechanism](https://github.com/liferay-frontend/liferay-portal/pull/4367), the name of the FF was wrong. We created it as `LPD-25230`, when it should have been `LPD-31177`, to match parent [epic](https://liferay.atlassian.net/browse/LPD-31177). cc @gianmarcobrunialti 
2. Few weeks later, we added [legitimate code](https://github.com/liferay-frontend/liferay-portal/pull/4428) for the `LPD-25230` epic under existing FF cc @thektan 

So, the situation before this PR is that `LPD-25230` FF covers two features. In this PR, we are cleaning this up by removing FF check of the resolver mechanism. We are leaving FF itself in, as it still covers the "additional params" feature. We're also fixing tag in resolver test to match the correct epic.

