### PR TITLE
LPD-35819 Accessibility issues in liferay-frontend:edit-form taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/edit_form/start.jsp
@@ -16,7 +16,7 @@ String fullName = namespace.concat(HtmlUtil.escapeAttribute(name));
 		<div class="sheet <%= fluid ? StringPool.BLANK : "sheet-lg" %>">
 	</c:if>
 
-		<div aria-orientation="vertical" class="panel-group panel-group-flush" role="tablist">
+		<div class="panel-group panel-group-flush">
 			<c:if test="<%= Validator.isNotNull(onSubmit) %>">
 				<div aria-label="<%= HtmlUtil.escape(Validator.isNotNull(title) ? title : portletDisplay.getTitle()) %>" class="input-container" role="group">
 			</c:if>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -47,7 +47,11 @@ else if (collapsible) {
 
 			<c:choose>
 				<c:when test="<%= collapsible %>">
-					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" id="<%= id %>Toggle">
+					<legend class="sr-only">
+						<%= header %>
+					</legend>
+
+					<a aria-controls="<%= id %>Content" aria-expanded="<%= !collapsed %>" class="collapse-icon <%= collapsed ? "collapsed" : StringPool.BLANK %> sheet-subtitle" data-toggle="liferay-collapse" href="#<%= id %>Content" role="button">
 						<span>
 							<%= header %>
 						</span>
@@ -71,5 +75,5 @@ else if (collapsible) {
 		</c:otherwise>
 	</c:choose>
 
-	<div aria-labelledby="<%= id %>Toggle" class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="tabpanel">
+	<div class="<%= !collapsed ? "show" : StringPool.BLANK %> <%= collapsible ? "panel-collapse collapse" : StringPool.BLANK %> <%= column ? "row" : StringPool.BLANK %>" id="<%= id %>Content" role="presentation">
 		<div class="<%= collapsible ? "panel-body" : StringPool.BLANK %>">

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -31,6 +31,7 @@ import {config as frontendDataSetWebConfig} from './tests/frontend-data-set-web/
 import {config as frontendEditorCKEditorSampleWebConfig} from './tests/frontend-editor-ckeditor-sample-web/config';
 import {config as frontendJsSpaWebConfig} from './tests/frontend-js-spa-web/config';
 import {config as frontendTaglibClayConfig} from './tests/frontend-taglib-clay/config';
+import {config as frontendTaglibConfig} from './tests/frontend-taglib/config';
 import {config as headlessBuilderImplConfig} from './tests/headless-builder-impl/config';
 import {config as headlessBuilderWebConfig} from './tests/headless-builder-web/config';
 import {config as itemSelectorTaglibConfig} from './tests/item-selector-taglib/config';
@@ -121,6 +122,7 @@ export default defineConfig({
 		frontendEditorCKEditorSampleWebConfig,
 		frontendJsSpaWebConfig,
 		frontendTaglibClayConfig,
+		frontendTaglibConfig,
 		headlessBuilderImplConfig,
 		headlessBuilderWebConfig,
 		itemSelectorTaglibConfig,

--- a/modules/test/playwright/tests/frontend-taglib/config.ts
+++ b/modules/test/playwright/tests/frontend-taglib/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'frontend-taglib',
+	testDir: 'tests/frontend-taglib',
+};

--- a/modules/test/playwright/tests/frontend-taglib/editFormTaglibRole.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/editFormTaglibRole.spec.ts
@@ -7,8 +7,8 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
-import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 import {loginTest} from '../../fixtures/loginTest';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -24,22 +24,19 @@ test('Form fields should not be wrapped in a tablist role @LPD-35819', async ({
 	site,
 }) => {
 	await test.step('Create a web content folder and access to edit it', async () => {
-		const webContentFolder = await apiHelpers.jsonWebServicesJournal.addFolder({
-			groupId: site.id,
-		});
+		const webContentFolder =
+			await apiHelpers.jsonWebServicesJournal.addFolder({
+				groupId: site.id,
+			});
 
 		await journalPage.goto(site.friendlyUrlPath);
 
-		//await page.locator('[data-title=`${webContentFolder.name}`]').getByLabel('More actions').click();
-		
 		await page
 			.locator(`.card-body:has-text('${webContentFolder.name}')`)
 			.getByLabel('More actions')
 			.click();
-		
-			await page.getByRole('menuitem', {name: 'Edit'}).click();
-	  
-		//await journalPage.goToJournalArticleAction('Edit', `${webContentFolder.name}`);
+
+		await page.getByRole('menuitem', {name: 'Edit'}).click();
 	});
 
 	await test.step('Edit Web Content Folder and check form', async () => {

--- a/modules/test/playwright/tests/frontend-taglib/editFormTaglibRole.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/editFormTaglibRole.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
+import {loginTest} from '../../fixtures/loginTest';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	journalPagesTest,
+	loginTest()
+);
+
+test('Form fields should not be wrapped in a tablist role @LPD-35819', async ({
+	apiHelpers,
+	journalPage,
+	page,
+	site,
+}) => {
+	await test.step('Create a web content folder and access to edit it', async () => {
+		const webContentFolder = await apiHelpers.jsonWebServicesJournal.addFolder({
+			groupId: site.id,
+		});
+
+		await journalPage.goto(site.friendlyUrlPath);
+
+		//await page.locator('[data-title=`${webContentFolder.name}`]').getByLabel('More actions').click();
+		
+		await page
+			.locator(`.card-body:has-text('${webContentFolder.name}')`)
+			.getByLabel('More actions')
+			.click();
+		
+			await page.getByRole('menuitem', {name: 'Edit'}).click();
+	  
+		//await journalPage.goToJournalArticleAction('Edit', `${webContentFolder.name}`);
+	});
+
+	await test.step('Edit Web Content Folder and check form', async () => {
+		const formFieldsContainer = page.locator(
+			'#_com_liferay_journal_web_portlet_JournalPortlet_fm .panel-group'
+		);
+
+		await expect(formFieldsContainer).not.toHaveRole('tablist');
+	});
+});

--- a/modules/test/playwright/tests/frontend-taglib/test.properties
+++ b/modules/test/playwright/tests/frontend-taglib/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=User Interface


### PR DESCRIPTION
Hi,

As it is explained along [LPP-55438](https://liferay.atlassian.net/browse/LPP-55438) we had to revert [LPS-167705](https://liferay.atlassian.net/browse/LPS-167705) in order to fix some accessibilities issues related to edit-form taglib.

To include a test for it, I had to create a new module, and I'm testing one of the functionalities that makes use of this taglib: editing a web content folder.

Thanks.

Regards.