### PR TITLE
LPD-36931 Create DSM action and sort object definitions from batch engine JSON

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
@@ -15,6 +15,219 @@
 	},
 	"items": [
 		{
+			"enableLocalization": true,
+			"externalReferenceCode": "L_DATA_SET_ACTION",
+			"label": {
+				"en_US": "Data Set Action"
+			},
+			"modifiable": true,
+			"name": "DataSetAction",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "CONFIRMATION_MESSAGE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Confirmation Message"
+					},
+					"localized": true,
+					"name": "confirmationMessage",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "CONFIRMATION_MESSAGE_TYPE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Confirmation Message Type"
+					},
+					"localized": false,
+					"name": "confirmationMessageType",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "ERROR_MESSAGE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Error Message"
+					},
+					"localized": true,
+					"name": "errorMessage",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "ICON",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Icon"
+					},
+					"localized": false,
+					"name": "icon",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "LABEL",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Label"
+					},
+					"localized": true,
+					"name": "label",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "METHOD",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Method"
+					},
+					"localized": false,
+					"name": "method",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "MODAL_SIZE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Modal Size"
+					},
+					"localized": false,
+					"name": "modalSize",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "PERMISSION_KEY",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Permission Key"
+					},
+					"localized": false,
+					"name": "permissionKey",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "SUCCESS_MESSAGE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Success Message"
+					},
+					"localized": true,
+					"name": "successMessage",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "TITLE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Title"
+					},
+					"localized": true,
+					"name": "title",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "TYPE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Type"
+					},
+					"localized": false,
+					"name": "type",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"externalReferenceCode": "URL",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "URL"
+					},
+					"localized": false,
+					"name": "url",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "Clob"
+				}
+			],
+			"panelCategoryKey": "",
+			"pluralLabel": {
+				"en_US": "Data Set Actions"
+			},
+			"portlet": false,
+			"scope": "company",
+			"status": {
+				"code": 0
+			},
+			"system": true
+		},
+		{
 			"externalReferenceCode": "L_DATA_SET_CARDS_SECTION",
 			"label": {
 				"en_US": "Data Set Cards Section"
@@ -529,6 +742,91 @@
 		},
 		{
 			"enableLocalization": true,
+			"externalReferenceCode": "L_DATA_SET_SORT",
+			"label": {
+				"en_US": "Data Set Sort"
+			},
+			"modifiable": true,
+			"name": "DataSetSort",
+			"objectFields": [
+				{
+					"DBType": "Boolean",
+					"businessType": "Boolean",
+					"externalReferenceCode": "DEFAULT",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Default"
+					},
+					"localized": false,
+					"name": "default",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "Boolean"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "FIELD_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Field Name"
+					},
+					"localized": false,
+					"name": "fieldName",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "LABEL",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Label"
+					},
+					"localized": true,
+					"name": "label",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "ORDER_TYPE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Order Type"
+					},
+					"localized": false,
+					"name": "orderType",
+					"required": true,
+					"state": false,
+					"system": true,
+					"type": "String"
+				}
+			],
+			"panelCategoryKey": "",
+			"pluralLabel": {
+				"en_US": "Data Set Sorts"
+			},
+			"portlet": false,
+			"scope": "company",
+			"status": {
+				"code": 0
+			},
+			"system": true
+		},
+		{
+			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_TABLE_SECTION",
 			"label": {
 				"en_US": "Data Set Table Section"
@@ -866,6 +1164,23 @@
 			"objectRelationships": [
 				{
 					"deletionType": "cascade",
+					"externalReferenceCode": "L_DATA_SET_TO_CREATION_DATA_SET_ACTIONS",
+					"label": {
+						"en_US": "Data Set to Creation Data Set Actions"
+					},
+					"name": "dataSetToCreationDataSetActions",
+					"objectDefinitionExternalReferenceCode1": "L_DATA_SET",
+					"objectDefinitionExternalReferenceCode2": "L_DATA_SET_ACTION",
+					"objectDefinitionName2": "DataSetAction",
+					"objectDefinitionSystem2": true,
+					"parameterObjectFieldId": 0,
+					"parameterObjectFieldName": "",
+					"reverse": false,
+					"system": true,
+					"type": "oneToMany"
+				},
+				{
+					"deletionType": "cascade",
 					"externalReferenceCode": "L_DATA_SET_TO_DATA_SET_CARDS_SECTIONS",
 					"label": {
 						"en_US": "Data Set to Data Set Cards Sections"
@@ -951,6 +1266,23 @@
 				},
 				{
 					"deletionType": "cascade",
+					"externalReferenceCode": "L_DATA_SET_TO_DATA_SET_SORTS",
+					"label": {
+						"en_US": "Data Set to Data Set Sorts"
+					},
+					"name": "dataSetToDataSetSorts",
+					"objectDefinitionExternalReferenceCode1": "L_DATA_SET",
+					"objectDefinitionExternalReferenceCode2": "L_DATA_SET_SORT",
+					"objectDefinitionName2": "DataSetSort",
+					"objectDefinitionSystem2": true,
+					"parameterObjectFieldId": 0,
+					"parameterObjectFieldName": "",
+					"reverse": false,
+					"system": true,
+					"type": "oneToMany"
+				},
+				{
+					"deletionType": "cascade",
 					"externalReferenceCode": "L_DATA_SET_TO_DATA_SET_TABLE_SECTIONS",
 					"label": {
 						"en_US": "Data Set to Data Set Table Sections"
@@ -959,6 +1291,23 @@
 					"objectDefinitionExternalReferenceCode1": "L_DATA_SET",
 					"objectDefinitionExternalReferenceCode2": "L_DATA_SET_TABLE_SECTION",
 					"objectDefinitionName2": "DataSetTableSection",
+					"objectDefinitionSystem2": true,
+					"parameterObjectFieldId": 0,
+					"parameterObjectFieldName": "",
+					"reverse": false,
+					"system": true,
+					"type": "oneToMany"
+				},
+				{
+					"deletionType": "cascade",
+					"externalReferenceCode": "L_DATA_SET_TO_ITEM_DATA_SET_ACTIONS",
+					"label": {
+						"en_US": "Data Set to Item Data Set Actions"
+					},
+					"name": "dataSetToItemDataSetActions",
+					"objectDefinitionExternalReferenceCode1": "L_DATA_SET",
+					"objectDefinitionExternalReferenceCode2": "L_DATA_SET_ACTION",
+					"objectDefinitionName2": "DataSetAction",
 					"objectDefinitionSystem2": true,
 					"parameterObjectFieldId": 0,
 					"parameterObjectFieldName": "",

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/util/ObjectDefinitionUtil.java
@@ -115,6 +115,8 @@ public class ObjectDefinitionUtil {
 		).put(
 			"DataSet", "/data-set-admin/data-sets"
 		).put(
+			"DataSetAction", "/data-set-admin/actions"
+		).put(
 			"DataSetCardsSection", "/data-set-admin/cards-sections"
 		).put(
 			"DataSetClientExtensionFilter",
@@ -125,6 +127,8 @@ public class ObjectDefinitionUtil {
 			"DataSetListSection", "/data-set-admin/list-sections"
 		).put(
 			"DataSetSelectionFilter", "/data-set-admin/selection-filters"
+		).put(
+			"DataSetSort", "/data-set-admin/sorts"
 		).put(
 			"DataSetTableSection", "/data-set-admin/table-sections"
 		).put(


### PR DESCRIPTION
### References

- Parent Story: [LPD-27261 Create Object Definitions from JSON batch engine instead of Java](https://issues.liferay.com/browse/LPD-27261)
- An alternative solution to https://github.com/liferay-frontend/liferay-portal/pull/4393
- A followup of https://github.com/liferay-frontend/liferay-portal/pull/4301 
- A part of https://github.com/liferay-frontend/liferay-portal/pull/4414
  - part 1: https://github.com/liferay-frontend/liferay-portal/pull/4419 
  - part 2: https://github.com/liferay-frontend/liferay-portal/pull/4421
  - part 3: https://github.com/liferay-frontend/liferay-portal/pull/4434

### What is the goal of this PR?

We are splitting up DSM object definitions from batch engine JSON. In this PR, we are setting last remaining objects, actions and sorts.

No need for peer review on this PR, but I will still run CI as a sanity check.