### PR TITLE
LPD-33533 Control bulk actions and its management bar in full via propTransfomer v2

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -158,6 +158,14 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		return _style;
 	}
 
+	public boolean isShowBulkActionsManagementBar() {
+		return _showBulkActionsManagementBar;
+	}
+
+	public boolean isShowBulkActionsManagementBarActions() {
+		return _showBulkActionsManagementBarActions;
+	}
+
 	public boolean isShowManagementBar() {
 		return _showManagementBar;
 	}
@@ -233,6 +241,19 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_selectionType = selectionType;
 	}
 
+	public void setShowBulkActionsManagementBar(
+		boolean showBulkActionsManagementBar) {
+
+		_showBulkActionsManagementBar = showBulkActionsManagementBar;
+	}
+
+	public void setShowBulkActionsManagementBarActions(
+		boolean showBulkActionsManagementBarActions) {
+
+		_showBulkActionsManagementBarActions =
+			showBulkActionsManagementBarActions;
+	}
+
 	public void setShowManagementBar(boolean showManagementBar) {
 		_showManagementBar = showManagementBar;
 	}
@@ -271,6 +292,8 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_nestedItemsReferenceKey = null;
 		_selectedItemsKey = null;
 		_selectionType = null;
+		_showBulkActionsManagementBar = true;
+		_showBulkActionsManagementBarActions = true;
 		_showManagementBar = true;
 		_showPagination = true;
 		_showSearch = true;
@@ -316,6 +339,11 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 				"selectedItemsKey", _toNullOrObject(_selectedItemsKey)
 			).put(
 				"selectionType", _toNullOrObject(_selectionType)
+			).put(
+				"showBulkActionsManagementBar", _showBulkActionsManagementBar
+			).put(
+				"showBulkActionsManagementBarActions",
+				_showBulkActionsManagementBarActions
 			).put(
 				"showManagementBar", _showManagementBar
 			).put(
@@ -378,6 +406,8 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 	private String _nestedItemsReferenceKey;
 	private String _selectedItemsKey;
 	private String _selectionType;
+	private boolean _showBulkActionsManagementBar = true;
+	private boolean _showBulkActionsManagementBarActions = true;
 	private boolean _showManagementBar = true;
 	private boolean _showPagination = true;
 	private boolean _showSearch = true;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -125,6 +125,14 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		return _customViewsEnabled;
 	}
 
+	public boolean isShowBulkActionsManagementBar() {
+		return _showBulkActionsManagementBar;
+	}
+
+	public boolean isShowBulkActionsManagementBarActions() {
+		return _showBulkActionsManagementBarActions;
+	}
+
 	public boolean isShowManagementBar() {
 		return _showManagementBar;
 	}
@@ -206,6 +214,19 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_selectionType = selectionType;
 	}
 
+	public void setShowBulkActionsManagementBar(
+		boolean showBulkActionsManagementBar) {
+
+		_showBulkActionsManagementBar = showBulkActionsManagementBar;
+	}
+
+	public void setShowBulkActionsManagementBarActions(
+		boolean showBulkActionsManagementBarActions) {
+
+		_showBulkActionsManagementBarActions =
+			showBulkActionsManagementBarActions;
+	}
+
 	public void setShowManagementBar(boolean showManagementBar) {
 		_showManagementBar = showManagementBar;
 	}
@@ -246,6 +267,8 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_nestedItemsReferenceKey = null;
 		_selectedItemsKey = null;
 		_selectionType = null;
+		_showBulkActionsManagementBar = true;
+		_showBulkActionsManagementBarActions = true;
 		_showManagementBar = true;
 		_showPagination = true;
 		_showSearch = true;
@@ -295,6 +318,11 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 				"selectedItemsKey", _validateDataAttribute(_selectedItemsKey)
 			).put(
 				"selectionType", _validateDataAttribute(_selectionType)
+			).put(
+				"showBulkActionsManagementBar", _showBulkActionsManagementBar
+			).put(
+				"showBulkActionsManagementBarActions",
+				_showBulkActionsManagementBarActions
 			).put(
 				"showManagementBar", _showManagementBar
 			).put(
@@ -365,6 +393,8 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private String _nestedItemsReferenceKey;
 	private String _selectedItemsKey;
 	private String _selectionType;
+	private boolean _showBulkActionsManagementBar = true;
+	private boolean _showBulkActionsManagementBarActions = true;
 	private boolean _showManagementBar = true;
 	private boolean _showPagination = true;
 	private boolean _showSearch = true;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -139,6 +139,16 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>showBulkActionsManagementBar</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>showBulkActionsManagementBarActions</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>showManagementBar</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -293,6 +303,16 @@
 		</attribute>
 		<attribute>
 			<name>selectionType</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>showBulkActionsManagementBar</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>showBulkActionsManagementBarActions</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -74,6 +74,7 @@ const FrontendDataSet = ({
 	nestedItemsReferenceKey,
 	onActionDropdownItemClick,
 	onBulkActionItemClick,
+	onItemSelected,
 	onSelect,
 	overrideEmptyResultView,
 	pagination,
@@ -81,6 +82,8 @@ const FrontendDataSet = ({
 	selectedItems: initialSelectedItemsValues,
 	selectedItemsKey,
 	selectionType,
+	showBulkActionsManagementBar,
+	showBulkActionsManagementBarActions,
 	showManagementBar,
 	showPagination,
 	showSearch,
@@ -431,9 +434,11 @@ const FrontendDataSet = ({
 				}
 			});
 
+			onItemSelected(newSelectedItems);
+
 			return newSelectedItems;
 		});
-	}, [selectedItemsValue, items, selectedItemsKey]);
+	}, [selectedItemsValue, items, onItemSelected, selectedItemsKey]);
 
 	useEffect(() => {
 		if (View || !contentRendererModuleURL) {
@@ -897,6 +902,8 @@ const FrontendDataSet = ({
 				selectedItemsKey,
 				selectedItemsValue,
 				selectionType,
+				showBulkActionsManagementBar,
+				showBulkActionsManagementBarActions,
 				sidePanelId: dataSetSupportSidePanelId,
 				sorts,
 				style,
@@ -967,8 +974,11 @@ FrontendDataSet.defaultProps = {
 	inlineEditingSettings: null,
 	items: null,
 	itemsActions: null,
+	onItemSelected: () => {},
 	selectedItemsKey: 'id',
 	selectionType: 'multiple',
+	showBulkActionsManagementBar: true,
+	showBulkActionsManagementBarActions: true,
 	showManagementBar: true,
 	showPagination: true,
 	showSearch: true,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -74,8 +74,8 @@ const FrontendDataSet = ({
 	nestedItemsReferenceKey,
 	onActionDropdownItemClick,
 	onBulkActionItemClick,
-	onItemSelected,
 	onSelect,
+	onSelectedItemsChange,
 	overrideEmptyResultView,
 	pagination,
 	portletId,
@@ -434,11 +434,11 @@ const FrontendDataSet = ({
 				}
 			});
 
-			onItemSelected(newSelectedItems);
+			onSelectedItemsChange(newSelectedItems);
 
 			return newSelectedItems;
 		});
-	}, [selectedItemsValue, items, onItemSelected, selectedItemsKey]);
+	}, [selectedItemsValue, items, onSelectedItemsChange, selectedItemsKey]);
 
 	useEffect(() => {
 		if (View || !contentRendererModuleURL) {
@@ -974,7 +974,7 @@ FrontendDataSet.defaultProps = {
 	inlineEditingSettings: null,
 	items: null,
 	itemsActions: null,
-	onItemSelected: () => {},
+	onSelectedItemsChange: () => {},
 	selectedItemsKey: 'id',
 	selectionType: 'multiple',
 	showBulkActionsManagementBar: true,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -36,9 +36,12 @@ function BulkActions({
 	selectedItemsValue,
 	total,
 }) {
-	const {actionParameterName, onBulkActionItemClick} = useContext(
-		FrontendDataSetContext
-	);
+	const {
+		actionParameterName,
+		onBulkActionItemClick,
+		showBulkActionsManagementBar,
+		showBulkActionsManagementBarActions,
+	} = useContext(FrontendDataSetContext);
 
 	const [currentSidePanelActionPayload, setCurrentSidePanelActionPayload] =
 		useState(null);
@@ -75,7 +78,10 @@ function BulkActions({
 		else if (onBulkActionItemClick) {
 			onBulkActionItemClick({
 				action: actionDefinition,
+				formId,
+				formName,
 				loadData,
+				namespace,
 				selectedData: {
 					items: selectedItems,
 					keyValues: selectedItemsValue,
@@ -129,7 +135,7 @@ function BulkActions({
 		[selectedItemsValue]
 	);
 
-	return selectedItemsValue.length ? (
+	return showBulkActionsManagementBar && selectedItemsValue.length ? (
 		<FrontendDataSetContext.Consumer>
 			{({formId, formName, loadData, namespace, sidePanelId}) => (
 				<nav className="management-bar management-bar-primary navbar navbar-expand-md pb-2 pt-2 subnav-tbar">
@@ -164,30 +170,34 @@ function BulkActions({
 							</li>
 						</ul>
 
-						<div className="bulk-actions">
-							{bulkActions.map((actionDefinition, i) => (
-								<button
-									className={classNames(
-										'btn btn-monospaced btn-link',
-										i > 0 && 'ml-1'
-									)}
-									key={actionDefinition.label}
-									onClick={() =>
-										handleActionClick(
-											actionDefinition,
-											formId,
-											formName,
-											loadData,
-											namespace,
-											sidePanelId
-										)
-									}
-									type="button"
-								>
-									<ClayIcon symbol={actionDefinition.icon} />
-								</button>
-							))}
-						</div>
+						{showBulkActionsManagementBarActions ? (
+							<div className="bulk-actions">
+								{bulkActions.map((actionDefinition, i) => (
+									<button
+										className={classNames(
+											'btn btn-monospaced btn-link',
+											i > 0 && 'ml-1'
+										)}
+										key={actionDefinition.label}
+										onClick={() =>
+											handleActionClick(
+												actionDefinition,
+												formId,
+												formName,
+												loadData,
+												namespace,
+												sidePanelId
+											)
+										}
+										type="button"
+									>
+										<ClayIcon
+											symbol={actionDefinition.icon}
+										/>
+									</button>
+								))}
+							</div>
+						) : null}
 					</div>
 				</nav>
 			)}


### PR DESCRIPTION
### References

- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/4370

### What is the goal of this PR?

After some conversations and analysis, we concluded:
- The solutions in previous iteration was good. Only naming of the new prop was misleading, as it is not a handler of a select event. It is a handler of selection change event. Selection can be changed on a select event, but it can also be changed when set items changes (on pagination, filtering etc.)
- The overall implementation of selection in FDS can be improved, task for it: https://liferay.atlassian.net/browse/LPD-37358
