### PR TITLE
LPD-37109 Prevent "Custom Javascript" injection from interfering with other injected JS in the page

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -60,6 +60,7 @@ import {config as portalSearchWebConfig} from './tests/portal-search-web/config'
 import {config as portalSecurityScriptManagementWebConfig} from './tests/portal-security-script-management-web/config';
 import {config as portalSecurityServiceAccessPolicyService} from './tests/portal-security-service-access-policy-service/config';
 import {config as portalToolsRestBuilderTestImpl} from './tests/portal-tools-rest-builder-test-impl/config';
+import {config as portalWebConfig} from './tests/portal-web/config';
 import {config as portalWorkflowKaleoDesignerWebConfig} from './tests/portal-workflow-kaleo-designer-web/config';
 import {config as portalWorkflowTaskWebConfig} from './tests/portal-workflow-task-web/config';
 import {config as portletConfigurationCssWebConfig} from './tests/portlet-configuration-css-web/config';
@@ -158,6 +159,7 @@ export default defineConfig({
 		portalSecurityScriptManagementWebConfig,
 		portalSecurityServiceAccessPolicyService,
 		portalToolsRestBuilderTestImpl,
+		portalWebConfig,
 		portalWorkflowKaleoDesignerWebConfig,
 		portalWorkflowTaskWebConfig,
 		portletConfigurationCssWebConfig,

--- a/modules/test/playwright/tests/portal-web/config.ts
+++ b/modules/test/playwright/tests/portal-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-web',
+	testDir: 'tests/portal-web',
+};

--- a/modules/test/playwright/tests/portal-web/html/common/themes/bottomJS.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/common/themes/bottomJS.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../fixtures/loginTest';
+import {masterPagesPagesTest} from '../../../../../fixtures/masterPagesPagesTest';
+import {pageEditorPagesTest} from '../../../../../fixtures/pageEditorPagesTest';
+import {pageSelectorPagesTest} from '../../../../../fixtures/pageSelectorPagesTest';
+import {pagesAdminPagesTest} from '../../../../../fixtures/pagesAdminPagesTest';
+import {systemSettingsPageTest} from '../../../../../fixtures/systemSettingsPageTest';
+import getRandomString from '../../../../../utils/getRandomString';
+import {waitForAlert} from '../../../../../utils/waitForAlert';
+
+const test = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	masterPagesPagesTest,
+	pageEditorPagesTest,
+	pageSelectorPagesTest,
+	pagesAdminPagesTest,
+	systemSettingsPageTest
+);
+
+test(
+	'Check JS injection works correctly',
+	{tag: '@LPD-37109'},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToSidebarTab('Page Design Options');
+
+		await page
+			.getByTitle('More Page Design Options', {exact: true})
+			.click();
+
+		await page.getByRole('tab', {name: 'JavaScript'}).click();
+
+		const sampleJS =
+			'window.onload=function(){console.log("customjssnippets")}';
+
+		await page.getByPlaceholder('JavaScript').fill(sampleJS);
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(page, 'Success:The page was updated successfully.');
+
+		await page.goto(
+			`/web${site.friendlyUrlPath}/${layout.friendlyUrlPath}`
+		);
+
+		const editButton = page.getByRole('link', {name: 'Edit'});
+
+		await editButton.waitFor({state: 'visible'});
+
+		await editButton.click();
+
+		const publishButton = page.getByRole('button', {name: 'Publish'});
+
+		await publishButton.waitFor({state: 'visible'});
+
+		await publishButton.click();
+
+		await waitForAlert(
+			page,
+			'Success:The page was published successfully.'
+		);
+
+		await page.reload();
+
+		await page.locator('#content').waitFor({state: 'visible'});
+
+		const jsSnippetIIFE = await page.evaluate((sampleJS) => {
+			let containsIIFEFunction = false;
+
+			const scriptElements = document.getElementsByTagName('script');
+
+			const injectedSampleJS = `(function(){${sampleJS}})`;
+
+			for (let i = 0; i < scriptElements.length; i++) {
+				const scriptText = scriptElements[i].textContent;
+
+				const oneLine = scriptText.replace(/\s+/g, '');
+
+				if (oneLine.includes(injectedSampleJS)) {
+					containsIIFEFunction = true;
+					break;
+				}
+			}
+
+			return containsIIFEFunction;
+		}, sampleJS);
+
+		expect(jsSnippetIIFE).toEqual(true);
+	}
+);

--- a/modules/test/playwright/tests/portal-web/test.properties
+++ b/modules/test/playwright/tests/portal-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+testray.main.component.name=Frontend JS API

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -199,7 +199,7 @@ if (layout != null) {
 	// ]]>
 </aui:script>
 
-<c:if test="<%= layout != null %>">
+<c:if test="<%= (layout != null) && !layout.isTypeControlPanel() %>">
 
 	<%-- User Inputted Layout and LayoutSet JavaScript --%>
 
@@ -219,17 +219,30 @@ if (layout != null) {
 	UnicodeProperties layoutSetSettingsUnicodeProperties = layoutSet.getSettingsProperties();
 
 	UnicodeProperties layoutTypeSettingsUnicodeProperties = layout.getTypeSettingsProperties();
+
+	List<String> snippets = new ArrayList<String>();
+
+	snippets.add(GetterUtil.getString(layoutSetSettingsUnicodeProperties.getProperty("javascript")));
+
+	snippets.add(GetterUtil.getString(masterLayoutTypeSettingsUnicodeProperties.getProperty("javascript")));
+
+	snippets.add(GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("javascript")));
+
+	for (String snippet : snippets) {
 	%>
 
-	<aui:script type="text/javascript">
-		// <![CDATA[
-			<c:if test="<%= !layout.isTypeControlPanel() %>">
-				<%= GetterUtil.getString(layoutSetSettingsUnicodeProperties.getProperty("javascript")) %>
+		<c:if test="<%= Validator.isNotNull(snippet) %>">
+			<aui:script type="text/javascript">
+				// <![CDATA[
+					(function() {
+						<%= snippet %>
+					})();
+				// ]]>
+			</aui:script>
+		</c:if>
 
-				<%= GetterUtil.getString(masterLayoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>
+	<%
+	}
+	%>
 
-				<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>
-			</c:if>
-		// ]]>
-	</aui:script>
 </c:if>


### PR DESCRIPTION
FWD: https://github.com/liferay-frontend/liferay-portal/pull/4437

Please let me know if there are any questions or comments about this.
Thank you!

> References:
>  *  [LPD-37109](https://liferay.atlassian.net/browse/LPD-37109)
>  * https://stackoverflow.com/questions/42036349/uncaught-typeerror-intermediate-value-is-not-a-function
> 
> In this PR we are IIFE'ing custom JS snippets added to the page. This way we prevent them to be interpreted in wrong ways.
> 
> ### Before
> ![image](https://github.com/user-attachments/assets/eb79ac76-b87c-4aef-97c9-28ed73a8aa3a)
> 
> Note I did not want to use `sandbox="true"` feature in aui:script because it adds 2 variables to the IIFE (see second red box in above screenshot), which sounds like a terrible idea as snippet is not expecting it.
> 
> ### After
> ![image](https://github.com/user-attachments/assets/81bccbe6-883b-47ee-b226-614dc14c0df4)
> 
