### PR TITLE
LPD-37756 FDS is not applying user timezone when rendering dates

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/view/table/PendingCommerceOrderTableFDSView.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/view/table/PendingCommerceOrderTableFDSView.java
@@ -8,10 +8,12 @@ package com.liferay.commerce.order.content.web.internal.frontend.data.set.view.t
 import com.liferay.commerce.order.content.web.internal.constants.CommerceOrderFDSNames;
 import com.liferay.frontend.data.set.view.FDSView;
 import com.liferay.frontend.data.set.view.table.BaseTableFDSView;
+import com.liferay.frontend.data.set.view.table.DateTimeFDSTableSchemaField;
 import com.liferay.frontend.data.set.view.table.FDSTableSchema;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilder;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
 import com.liferay.frontend.data.set.view.table.StringFDSTableSchemaField;
+import com.liferay.portal.kernel.json.JSONUtil;
 
 import java.util.Locale;
 
@@ -45,8 +47,7 @@ public class PendingCommerceOrderTableFDSView extends BaseTableFDSView {
 		).add(
 			"purchaseOrderNumber", "purchase-order-number"
 		).add(
-			"date", "create-date",
-			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
+			_addDateFDSTableSchemaField()
 		).add(
 			_addAccountNameStringFDSTableSchemaField()
 		).add(
@@ -73,6 +74,22 @@ public class PendingCommerceOrderTableFDSView extends BaseTableFDSView {
 		stringFDSTableSchemaField.setTruncate(true);
 
 		return stringFDSTableSchemaField;
+	}
+
+	private DateTimeFDSTableSchemaField _addDateFDSTableSchemaField() {
+		DateTimeFDSTableSchemaField dateFDSTableSchemaField =
+			new DateTimeFDSTableSchemaField();
+
+		dateFDSTableSchemaField.setFieldName(
+			"date"
+		).setLabel(
+			"create-date"
+		);
+
+		dateFDSTableSchemaField.setFormat(
+			JSONUtil.put("convertToUserTimeZone", true));
+
+		return dateFDSTableSchemaField;
 	}
 
 	@Reference

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -598,7 +598,7 @@ const FrontendDataSet = ({
 							Liferay.Language.get('sorry,-no-results-were-found')
 						}
 						imgSrc={
-							themeDisplay.getPathThemeImages() +
+							Liferay.ThemeDisplay.getPathThemeImages() +
 							(emptyState?.image ?? '/states/search_state.svg')
 						}
 						title={

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateRenderer.js
@@ -27,7 +27,7 @@ function DateRenderer({options, value}) {
 		}
 	}
 
-	const locale = themeDisplay.getBCP47LanguageId();
+	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
 
 	const dateOptions = {
 		day: options?.format?.day || 'numeric',

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateRenderer.js
@@ -32,7 +32,8 @@ function DateRenderer({options, value}) {
 	const dateOptions = {
 		day: options?.format?.day || 'numeric',
 		month: options?.format?.month || 'short',
-		timeZone: options?.format?.timeZone || 'UTC',
+		timeZone:
+			options?.format?.timeZone || Liferay.ThemeDisplay.getTimeZone(),
 		year: options?.format?.year || 'numeric',
 	};
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
@@ -21,7 +21,10 @@ function DateTimeRenderer({options, value}) {
 		year: options?.format?.year || 'numeric',
 	};
 
-	if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{3}Z$/.test(value)) {
+	if (
+		!dateOptions.timeZone &&
+		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2,3}Z$/.test(value)
+	) {
 		dateOptions.timeZone = Liferay.ThemeDisplay.getTimeZone();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
@@ -10,7 +10,7 @@ function DateTimeRenderer({options, value}) {
 		return null;
 	}
 
-	const locale = themeDisplay.getBCP47LanguageId();
+	const locale = Liferay.ThemeDisplay.getBCP47LanguageId();
 	const dateOptions = {
 		day: options?.format?.day || 'numeric',
 		hour: options?.format?.hour || 'numeric',

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
@@ -10,15 +10,21 @@ function DateTimeRenderer({options, value}) {
 		return null;
 	}
 
-	const locale = themeDisplay.getLanguageId().replaceAll('_', '-');
-	const dateOptions = options?.format || {
-		day: 'numeric',
-		hour: 'numeric',
-		minute: 'numeric',
-		month: 'short',
-		second: 'numeric',
-		year: 'numeric',
+	const locale = themeDisplay.getBCP47LanguageId();
+	const dateOptions = {
+		day: options?.format?.day || 'numeric',
+		hour: options?.format?.hour || 'numeric',
+		minute: options?.format?.minute || 'numeric',
+		month: options?.format?.month || 'short',
+		second: options?.format?.second || 'numeric',
+		timeZone: options?.format?.timeZone,
+		year: options?.format?.year || 'numeric',
 	};
+
+	if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{3}Z$/.test(value)) {
+		dateOptions.timeZone = Liferay.ThemeDisplay.getTimeZone();
+	}
+
 	const formattedDate = new Intl.DateTimeFormat(locale, dateOptions).format(
 		new Date(value)
 	);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/DateTimeRenderer.js
@@ -22,7 +22,7 @@ function DateTimeRenderer({options, value}) {
 	};
 
 	if (
-		!dateOptions.timeZone &&
+		options?.format?.convertToUserTimeZone &&
 		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2,3}Z$/.test(value)
 	) {
 		dateOptions.timeZone = Liferay.ThemeDisplay.getTimeZone();

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/index.js
@@ -117,7 +117,9 @@ export async function loadData(
 	additionalAPIURLParameters
 ) {
 	const fullUrl = apiURL.startsWith('/')
-		? themeDisplay.getPortalURL() + themeDisplay.getPathContext() + apiURL
+		? Liferay.ThemeDisplay.getPortalURL() +
+			Liferay.ThemeDisplay.getPathContext() +
+			apiURL
 		: apiURL;
 
 	const url = new URL(fullUrl);
@@ -137,8 +139,8 @@ export async function loadData(
 		);
 	}
 
-	if (themeDisplay.isImpersonated()) {
-		url.searchParams.append('doAsUserId', themeDisplay.getUserId());
+	if (Liferay.ThemeDisplay.isImpersonated()) {
+		url.searchParams.append('doAsUserId', Liferay.ThemeDisplay.getUserId());
 	}
 
 	url.searchParams.append('page', page);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/saveViewSettings.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/saveViewSettings.js
@@ -14,8 +14,8 @@ export function saveViewSettings({appURL, id, portletId, settings}) {
 
 	const url = new URL(`${appURL}/data-set/${id}/save-active-view-settings`);
 
-	url.searchParams.append('groupId', themeDisplay.getScopeGroupId());
-	url.searchParams.append('plid', themeDisplay.getPlid());
+	url.searchParams.append('groupId', Liferay.ThemeDisplay.getScopeGroupId());
+	url.searchParams.append('plid', Liferay.ThemeDisplay.getPlid());
 	url.searchParams.append('portletId', portletId);
 
 	return fetch(url, {

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -306,6 +306,9 @@
 			getSiteGroupId: function() {
 				return '<%= themeDisplay.getSiteGroupId() %>';
 			},
+			getTimeZone: function() {
+				return '<%= Validator.isNotNull(themeDisplay.getTimeZone()) ? themeDisplay.getTimeZone().getID() : TimeZone.getDefault().getID() %>';
+			},
 			getURLControlPanel: function() {
 				return '<%= themeDisplay.getURLControlPanel() %>';
 			},


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-37756

In this PR, though filed as a bug, we are enhancing the FDS ability to render dates converted to the current user time zone. In doing so, we first check date is in ISO 8601 format and comes in UTC which is a reasonable expectation when fetching data from Liferay APIs

To test this:

- Create a minium site
- Browse products, watch modified date
- Go to user Account Settings | Preferences | Display Setting
- Change timezone to a different value
- Repeat step 2 and assert the difference 