### PR TITLE
LPD-37782 Editor config contributor client extensions are re-applied when creating new Rich Text repeatable fields

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/build.gradle
@@ -5,8 +5,12 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:client-extension:client-extension-api")
+	compileOnly project(":apps:client-extension:client-extension-type-api")
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/node-scripts.config.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/node-scripts.config.js
@@ -4,5 +4,6 @@
  */
 
 module.exports = {
+	main: 'src/main/resources/META-INF/resources/js/index.ts',
 	npmscripts: {},
 };

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
@@ -1,6 +1,9 @@
 {
 	"dependencies": {
+		"frontend-editor-ckeditor-web": "*",
+		"react": "16.12.0"
 	},
+	"main": "js/index.ts",
 	"name": "@liferay/frontend-editor-ckeditor-sample-web",
 	"private": true,
 	"scripts": {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/display/context/CKEditorSampleDisplayContext.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/display/context/CKEditorSampleDisplayContext.java
@@ -5,15 +5,58 @@
 
 package com.liferay.frontend.editor.ckeditor.sample.web.internal.display.context;
 
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.type.EditorConfigContributorCET;
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.List;
+
+import javax.portlet.RenderRequest;
 
 /**
  * @author Marko Cikos
  */
 public class CKEditorSampleDisplayContext {
+
+	public CKEditorSampleDisplayContext(
+		CETManager cetManager, RenderRequest renderRequest) {
+
+		_cetManager = cetManager;
+		_renderRequest = renderRequest;
+
+		_themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+	}
+
+	public JSONArray getEditorTransformerURLsJSONArray() throws Exception {
+		return JSONUtil.toJSONArray(
+			_cetManager.getCETs(
+				_themeDisplay.getCompanyId(), null,
+				ClientExtensionEntryConstants.TYPE_EDITOR_CONFIG_CONTRIBUTOR,
+				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null),
+			cet -> {
+				EditorConfigContributorCET editorConfigContributorCET =
+					(EditorConfigContributorCET)cet;
+
+				if (StringUtil.matches(
+						editorConfigContributorCET.getEditorConfigKeys(),
+						"sampleReactClassicEditor")) {
+
+					return editorConfigContributorCET.getURL();
+				}
+
+				return null;
+			});
+	}
 
 	public List<TabsItem> getTabsItems() {
 		if (_tabsItems != null) {
@@ -41,11 +84,19 @@ public class CKEditorSampleDisplayContext {
 				tabsItem.setLabel("Alloy");
 				tabsItem.setPanelId("alloy");
 			}
+		).add(
+			tabsItem -> {
+				tabsItem.setLabel("React");
+				tabsItem.setPanelId("react");
+			}
 		).build();
 
 		return _tabsItems;
 	}
 
+	private final CETManager _cetManager;
+	private final RenderRequest _renderRequest;
 	private List<TabsItem> _tabsItems;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/portlet/CKEditorSamplePortlet.java
@@ -5,6 +5,7 @@
 
 package com.liferay.frontend.editor.ckeditor.sample.web.internal.portlet;
 
+import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
 import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSampleWebKeys;
 import com.liferay.frontend.editor.ckeditor.sample.web.internal.display.context.CKEditorSampleDisplayContext;
@@ -18,6 +19,7 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Julien Castelain
@@ -52,9 +54,12 @@ public class CKEditorSamplePortlet extends MVCPortlet {
 
 		renderRequest.setAttribute(
 			CKEditorSampleWebKeys.CKEDITOR_SAMPLE_DISPLAY_CONTEXT,
-			new CKEditorSampleDisplayContext());
+			new CKEditorSampleDisplayContext(_cetManager, renderRequest));
 
 		super.doDispatch(renderRequest, renderResponse);
 	}
+
+	@Reference
+	private CETManager _cetManager;
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/init.jsp
@@ -9,12 +9,14 @@
 
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSampleWebKeys" %><%@
 page import="com.liferay.frontend.editor.ckeditor.sample.web.internal.display.context.CKEditorSampleDisplayContext" %><%@
 page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %>
 
 <%@ page import="java.util.List" %>
@@ -24,3 +26,7 @@ page import="com.liferay.portal.kernel.util.JavaConstants" %>
 <liferay-theme:defineObjects />
 
 <portlet:defineObjects />
+
+<%
+CKEditorSampleDisplayContext ckEditorSampleDisplayContext = (CKEditorSampleDisplayContext)request.getAttribute(CKEditorSampleWebKeys.CKEDITOR_SAMPLE_DISPLAY_CONTEXT);
+%>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/ReactClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/ReactClassicEditor.tsx
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {ClassicEditor} from 'frontend-editor-ckeditor-web';
+import React from 'react';
+
+const ReactClassicEditor = ({
+	editorTransformerURLs,
+	name,
+	title,
+}: {
+	editorTransformerURLs?: Array<string>;
+	name: string;
+	title?: string;
+}) => {
+	const config = {
+		editorTransformerURLs,
+		toolbar_simple: [
+			['Undo', 'Redo'],
+			['Bold', 'Italic', 'Underline'],
+		],
+	};
+
+	const beforeConfig = JSON.stringify(config);
+
+	return (
+		<>
+			<ClassicEditor
+				editorConfig={config}
+				name={name}
+				onReady={({editor}: {editor: any}) => {
+					const afterConfig = JSON.stringify(config);
+
+					editor.setData(
+						beforeConfig === afterConfig
+							? 'Editor configuration object was not mutated.'
+							: 'Editor configuration object must not be mutated!'
+					);
+				}}
+				title={title}
+			/>
+		</>
+	);
+};
+
+export default ReactClassicEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/index.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ReactClassicEditor from './ReactClassicEditor';
+
+export {ReactClassicEditor};

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/react.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/partials/react.jsp
@@ -1,0 +1,21 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<react:component
+	module="{ReactClassicEditor} from frontend-editor-ckeditor-sample-web"
+	props='<%=
+		HashMapBuilder.<String, Object>put(
+			"editorTransformerURLs", ckEditorSampleDisplayContext.getEditorTransformerURLsJSONArray()
+		).put(
+			"name", "sampleReactClassicEditor"
+		).put(
+			"title", "Classic Editor used from a React component"
+		).build()
+	%>'
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "b114870406575eea5781fa4aa0c49e2bdd4de37b",
+	"@generated": "ac07c7ba2a7e6993e1ffdd07fe0a595504925840",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-editor-ckeditor-web": [
+				"../../../../../../frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/index.d.ts"
+			]
 		},
 		"rootDir": "../../../../../../../..",
 		"skipLibCheck": true,
@@ -29,5 +32,8 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/tsconfig.json"
+		}
 	]
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -8,8 +8,6 @@
 <%@ include file="/init.jsp" %>
 
 <%
-CKEditorSampleDisplayContext ckEditorSampleDisplayContext = (CKEditorSampleDisplayContext)request.getAttribute(CKEditorSampleWebKeys.CKEDITOR_SAMPLE_DISPLAY_CONTEXT);
-
 List<TabsItem> tabsItems = ckEditorSampleDisplayContext.getTabsItems();
 %>
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/editor/ClassicEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/editor/ClassicEditor.js
@@ -18,6 +18,7 @@ const ClassicEditor = forwardRef(
 			editorConfig,
 			initialToolbarSet = 'simple',
 			name,
+			onReady = () => {},
 			title,
 			...otherProps
 		},
@@ -80,6 +81,8 @@ const ClassicEditor = forwardRef(
 						editor.setData(contents, {
 							callback: () => {
 								editor.resetUndo();
+
+								onReady({editor});
 							},
 							noSnapshot: true,
 						});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/index.d.ts
@@ -15,6 +15,7 @@ export function ClassicEditor({
 	contents,
 	editorConfig,
 	onChange,
+	onReady,
 	ref,
 }: IClassicEditorProps): JSX.Element;
 
@@ -34,6 +35,7 @@ interface IClassicEditorProps {
 	initialToolbarSet?: string;
 	name: string;
 	onChange: (content: string) => void;
+	onReady: ({editor}: {editor: any}) => void;
 	ref: React.RefObject<IEditor>;
 	title?: string;
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/client_extensions/loadEditorClientExtensions.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/utils/client_extensions/loadEditorClientExtensions.ts
@@ -24,7 +24,7 @@ export default function loadEditorClientExtensions({
 				})
 			),
 			onLoad: (bindingContexts) => {
-				let transformedConfig = config;
+				let transformedConfig = JSON.parse(JSON.stringify(config));
 
 				bindingContexts.forEach(
 					({binding: editorTransformer, error}) => {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/env/client-extensions.list
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/env/client-extensions.list
@@ -1,0 +1,1 @@
+liferay-sample-editor-config-contributor

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/fixtures/ckeditorSamplePageTest.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/fixtures/ckeditorSamplePageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {CKEditorSamplePage} from '../pages/CKEditorSamplePage';
+
+const ckeditorSamplePageTest = test.extend<{
+	ckeditorSamplePage: CKEditorSamplePage;
+}>({
+	ckeditorSamplePage: async ({page}, use) => {
+		await use(new CKEditorSamplePage(page));
+	},
+});
+
+export {ckeditorSamplePageTest};

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/pages/CKEditorSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/pages/CKEditorSamplePage.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
+import {liferayConfig} from '../../../liferay.config';
+import getRandomString from '../../../utils/getRandomString';
+import getPageDefinition from '../../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../../layout-content-page-editor-web/utils/getWidgetDefinition';
+
+export class CKEditorSamplePage {
+	readonly apiHelpers: ApiHelpers;
+	readonly page: Page;
+
+	constructor(page: Page) {
+		this.apiHelpers = new ApiHelpers(page);
+		this.page = page;
+	}
+
+	async createAndGotoSitePage({site}: {site: Site}) {
+		const widgetDefinition = getWidgetDefinition({
+			id: getRandomString(),
+			widgetName:
+				'com_liferay_editor_ckeditor_sample_web_internal_portlet_CKEditorSamplePortlet',
+		});
+
+		const title = getRandomString();
+
+		await this.apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title,
+		});
+
+		await this.page.goto(
+			`${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}/${title}`
+		);
+	}
+}

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/react.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {ckeditorSamplePageTest} from './fixtures/ckeditorSamplePageTest';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	ckeditorSamplePageTest
+);
+
+test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
+	await ckeditorSamplePage.createAndGotoSitePage({site});
+
+	const reactTab = page.getByRole('tab', {
+		name: 'React',
+	});
+
+	await reactTab.click();
+
+	expect(
+		page.getByText('Classic Editor used from a React component')
+	).toBeVisible();
+});
+
+test(
+	'Editor configuration object must not be mutated',
+	{tag: '@LPD-37782'},
+	async ({page}) => {
+		const iframe = page.frameLocator(
+			'iframe[title$="sampleReactClassicEditor"]'
+		);
+
+		expect(
+			iframe.getByText('Editor configuration object was not mutated.')
+		).toBeVisible();
+	}
+);

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/client-extension.yaml
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-editor-config-contributor/client-extension.yaml
@@ -7,6 +7,7 @@ liferay-sample-editor-config-contributor:
         - sampleAlloyEditor
         - sampleClassicEditor
         - sampleLegacyEditor
+        - sampleReactClassicEditor
     name: Liferay Sample Editor Config Contributor
     type: editorConfigContributor
     url: index.js


### PR DESCRIPTION
### References

- JIRA: [Editor config contributor client extensions are re-applied when creating new Rich Text repeatable fields](https://issues.liferay.com/browse/LPD-37782)
- Related to https://github.com/liferay-frontend/liferay-portal/pull/4430

### What is the goal of this PR?

A bugfix. Technical note inline.

### What does it look like?
Note - two `AI Creator` buttons in expected behavior. One is added by product, one by CX. The bug was that their number grew to 3, 4, 5 etc.


https://github.com/user-attachments/assets/fe145d35-36e0-480f-b1e6-c21b75a06951




See behavior before PR and steps to reproduce in JIRA.
