### PR TITLE
LPD-36188 Root PR

### DIFF
--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/page.jsp
@@ -79,8 +79,6 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 						boolean canSubscribe = !stagingGroupHelper.isLocalStagingGroup(siteGroup) && !stagingGroupHelper.isRemoteStagingGroup(siteGroup) && themeDisplay.isSignedIn() && discussionPermission.hasSubscribePermission(discussionRequestHelper.getPermissionChecker(), company.getCompanyId(), siteGroup.getGroupId(), discussionTaglibHelper.getClassName(), discussionTaglibHelper.getClassPK());
 
 						boolean subscribed = SubscriptionLocalServiceUtil.isSubscribed(company.getCompanyId(), user.getUserId(), discussionTaglibHelper.getSubscriptionClassName(), discussionTaglibHelper.getClassPK());
-
-						String subscriptionOnClick = randomNamespace + "subscribeToComments(" + !subscribed + ");";
 						%>
 
 						<clay:content-row
@@ -97,18 +95,29 @@ StagingGroupHelper stagingGroupHelper = StagingGroupHelperUtil.getStagingGroupHe
 
 							<clay:content-col>
 								<c:if test="<%= canSubscribe %>">
+
+									<%
+									String id = StringUtil.randomId();
+									%>
+
 									<c:choose>
 										<c:when test="<%= subscribed %>">
-											<button aria-label="<liferay-ui:message key="unsubscribe-from-comments" />" class="btn btn-outline-primary btn-sm" onclick="<%= subscriptionOnClick %>" type="button">
+											<button aria-label="<liferay-ui:message key="unsubscribe-from-comments" />" class="btn btn-outline-primary btn-sm" id="<%= id %>" type="button">
 												<liferay-ui:message key="unsubscribe" />
 											</button>
 										</c:when>
 										<c:otherwise>
-											<button aria-label="<liferay-ui:message key="subscribe-to-comments" />" class="btn btn-outline-primary btn-sm" onclick="<%= subscriptionOnClick %>" type="button">
+											<button aria-label="<liferay-ui:message key="subscribe-to-comments" />" class="btn btn-outline-primary btn-sm" id="<%= id %>" type="button">
 												<liferay-ui:message key="subscribe" />
 											</button>
 										</c:otherwise>
 									</c:choose>
+
+									<aui:script position="inline">
+										document.getElementById('<%= id %>').onclick = function () {
+											<%= randomNamespace %>subscribeToComments(<%= !subscribed %>);
+										};
+									</aui:script>
 								</c:if>
 							</clay:content-col>
 						</clay:content-row>

--- a/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
+++ b/modules/apps/comment/comment-taglib/src/main/resources/META-INF/resources/discussion/view_message_thread.jsp
@@ -210,9 +210,20 @@ Format dateTimeFormat = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 							<c:if test="<%= !discussion.isMaxCommentsLimitExceeded() %>">
 								<c:choose>
 									<c:when test="<%= commentTreeDisplayContext.isReplyButtonVisible() %>">
-										<button class="btn btn-outline-borderless btn-outline-secondary btn-sm" onclick="<%= randomNamespace %>showPostReplyEditor(<%= index %>);" type="button">
+
+										<%
+										String id = StringUtil.randomId();
+										%>
+
+										<button class="btn btn-outline-borderless btn-outline-secondary btn-sm" id="<%= id %>" type="button">
 											<liferay-ui:message key="reply" />
 										</button>
+
+										<aui:script position="inline">
+											document.getElementById('<%= id %>').onclick = function () {
+												<%= randomNamespace %>showPostReplyEditor(<%= index %>);
+											};
+										</aui:script>
 									</c:when>
 									<c:otherwise>
 										<a class="btn btn-outline-borderless btn-outline-secondary btn-sm" href="<%= themeDisplay.getURLSignIn() %>">

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/init.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/init.jsp
@@ -31,6 +31,7 @@ page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortletKeys" %><%@
+page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.workflow.WorkflowTask" %>
 

--- a/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
+++ b/modules/apps/commerce/commerce-frontend-taglib/src/main/resources/META-INF/resources/header/page.jsp
@@ -153,13 +153,23 @@ String myWorkflowTasksPortletNamespace = PortalUtil.getPortletNamespace(PortletK
 							<liferay-ui:message key="assigned-to" />:
 						</div>
 
-						<button aria-expanded="false" aria-haspopup="true" class="align-items-center btn btn-secondary d-flex dropdown-toggle header-assign-button justify-content-between" data-toggle="dropdown" onclick="<portlet:namespace />toggleDropdown();" type="button">
+						<%
+						String id = StringUtil.randomId();
+						%>
+
+						<button aria-expanded="false" aria-haspopup="true" class="align-items-center btn btn-secondary d-flex dropdown-toggle header-assign-button justify-content-between" data-toggle="dropdown" id="<%= id %>" type="button">
 							<liferay-ui:message key="<%= HtmlUtil.escape(assignee) %>" />
 
 							<clay:icon
 								symbol="caret-bottom"
 							/>
 						</button>
+
+						<aui:script position="inline">
+							document.getElementById('<%= id %>').onclick = function () {
+								<portlet:namespace />toggleDropdown();
+							};
+						</aui:script>
 
 						<div class="dropdown-menu dropdown-menu-right" id="<portlet:namespace />commerce-dropdown-assigned-to">
 							<c:if test="<%= !assignedToCurrentUser %>">

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/option_facets/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/option_facets/view.jsp
@@ -100,10 +100,17 @@ CPOptionsSearchFacetDisplayContext cpOptionsSearchFacetDisplayContext = (CPOptio
 												data-term-id="<%= HtmlUtil.escapeAttribute(termCollector.getTerm()) %>"
 												id="<portlet:namespace />term_<%= facet.getFieldName() + i %>"
 												name="<portlet:namespace />term_<%= facet.getFieldName() + i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 												type="checkbox"
 												<%= cpOptionsSearchFacetDisplayContext.isCPOptionValueSelected(companyId, facet.getFieldName(), termCollector.getTerm()) ? "checked" : "" %>
 											/>
+
+											<aui:script position="inline">
+												document.getElementById(
+													'<portlet:namespace />term_<%= facet.getFieldName() + i %>'
+												).onchange = function (event) {
+													Liferay.Search.FacetUtil.changeSelection(event);
+												};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= cpOptionsSearchFacetDisplayContext.isCPOptionValueSelected(companyId, facet.getFieldName(), termCollector.getTerm()) ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text"><%= HtmlUtil.escape(termCollector.getTerm()) %></span>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/price_range_facets/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/price_range_facets/view.jsp
@@ -89,10 +89,17 @@ CPPriceRangeFacetsDisplayContext cpPriceRangeFacetsDisplayContext = (CPPriceRang
 														data-term-id="<%= HtmlUtil.escapeAttribute(termCollector.getTerm()) %>"
 														id="<portlet:namespace />term_<%= facet.getFieldName() + i %>"
 														name="<portlet:namespace />term_<%= facet.getFieldName() + i %>"
-														onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 														type="checkbox"
 														<%= cpPriceRangeFacetsDisplayContext.isCPPriceRangeValueSelected(facet.getFieldName(), termCollector.getTerm()) ? "checked" : "" %>
 													/>
+
+													<aui:script position="inline">
+														document.getElementById(
+															'<portlet:namespace />term_<%= facet.getFieldName() + i %>'
+														).onchange = function (event) {
+															Liferay.Search.FacetUtil.changeSelection(event);
+														};
+													</aui:script>
 
 													<span class="custom-control-label term-name <%= cpPriceRangeFacetsDisplayContext.isCPPriceRangeValueSelected(facet.getFieldName(), termCollector.getTerm()) ? "facet-term-selected" : "facet-term-unselected" %>">
 														<span class="custom-control-label-text"><%= cpPriceRangeFacetsDisplayContext.getPriceRangeLabel(termCollector.getTerm()) %></span>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/specification_option_facets/view.jsp
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/META-INF/resources/specification_option_facets/view.jsp
@@ -105,9 +105,16 @@ CPSpecificationOptionFacetsDisplayContext cpSpecificationOptionFacetsDisplayCont
 																	data-term-id="<%= HtmlUtil.escapeAttribute(cpSpecificationOptionsSearchFacetTermDisplayContext.getDisplayName()) %>"
 																	id="<portlet:namespace />term_<%= parameterName + i %>"
 																	name="<portlet:namespace />term_<%= parameterName + i %>"
-																	onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 																	type="checkbox"
 																/>
+
+																<aui:script position="inline">
+																	document.getElementById(
+																		'<portlet:namespace />term_<%= parameterName + i %>'
+																	).onchange = function (event) {
+																		Liferay.Search.FacetUtil.changeSelection(event);
+																	};
+																</aui:script>
 
 																<span class="custom-control-label term-name <%= cpSpecificationOptionsSearchFacetTermDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 																	<span class="custom-control-label-text"><%= HtmlUtil.escape(cpSpecificationOptionsSearchFacetTermDisplayContext.getDisplayName()) %></span>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/option_facets/portlet_display_template_cloud.ftl
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/option_facets/portlet_display_template_cloud.ftl
@@ -24,14 +24,22 @@
 			<#if entries?has_content>
 				<#list entries as entry>
 					<span class="facet-value">
+						<#assign id = stringUtil.randomId() />
+
 						<button
 							class="btn btn-link btn-unstyled facet-term ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')} tag-popularity-${entry.getPopularity()} term-name"
 							data-term-id="${entry.getTerm()}"
+							id="${id}"
 							name="${name + entry?index}"
-							onClick="Liferay.Search.FacetUtil.changeSelection(event);"
 						>
 							${htmlUtil.escape(entry.getTerm())}
 						</button>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${id}').onclick = function() {
+								Liferay.Search.FacetUtil.changeSelection(event);
+							}
+						</@liferay_aui.script>
 					</span>
 				</#list>
 			</#if>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/option_facets/portlet_display_template_compact.ftl
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/option_facets/portlet_display_template_compact.ftl
@@ -24,11 +24,13 @@
 			<#if entries?has_content>
 				<#list entries as entry>
 					<li class="facet-value">
+						<#assign id = stringUtil.randomId() />
+
 						<button
 							class="btn btn-link btn-unstyled facet-term term-name ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')}"
 							data-term-id="${entry.getTerm()}"
 							name="${name + entry?index}"
-							onClick="Liferay.Search.FacetUtil.changeSelection(event);"
+							id="${id}"
 						>
 							${htmlUtil.escape(entry.getTerm())}
 								<#if showFrequencies>
@@ -37,6 +39,12 @@
 									</small>
 								</#if>
 						</button>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${id}').onclick = function() {
+								Liferay.Search.FacetUtil.changeSelection(event);
+							}
+						</@liferay_aui.script>
 					</li>
 				</#list>
 			</#if>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/option_facets/portlet_display_template_label.ftl
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/option_facets/portlet_display_template_label.ftl
@@ -23,11 +23,13 @@
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
+					<#assign id = stringUtil.randomId() />
+
 					<button
 						class="btn label label-lg facet-term term-name ${(entry.isSelected())?then('label-primary facet-term-selected', 'label-secondary facet-term-unselected')}"
 						data-term-id="${entry.getTerm()}"
+						id="${id}"
 						name="${name + entry?index}"
-						onClick="Liferay.Search.FacetUtil.changeSelection(event);"
 						type="button"
 					>
 						<span class="label-item label-item-expand">
@@ -37,6 +39,12 @@
 							</#if>
 						</span>
 					</button>
+
+					<@liferay_aui.script position="inline">
+						document.getElementById('${id}').onclick = function() {
+							Liferay.Search.FacetUtil.changeSelection(event);
+						}
+					</@liferay_aui.script>
 				</#list>
 			</div>
 		</#if>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/specification_option_facets/portlet_display_template_cloud.ftl
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/specification_option_facets/portlet_display_template_cloud.ftl
@@ -24,13 +24,21 @@
 			<#if entries?has_content>
 				<#list entries as entry>
 					<span class="facet-value">
+						<#assign id = stringUtil.randomId() />
+
 						<button
 							class="btn btn-link btn-unstyled facet-term ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')} tag-popularity-${entry.getPopularity()} term-name"
 							data-term-id="${entry.getDisplayName()}"
-							onClick="Liferay.Search.FacetUtil.changeSelection(event);"
+							id="${id}"
 						>
 							${htmlUtil.escape(entry.getDisplayName())}
 						</button>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${id}').onclick = function() {
+								Liferay.Search.FacetUtil.changeSelection(event);
+							}
+						</@liferay_aui.script>
 					</span>
 				</#list>
 			</#if>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/specification_option_facets/portlet_display_template_compact.ftl
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/specification_option_facets/portlet_display_template_compact.ftl
@@ -24,10 +24,12 @@
 			<#if entries?has_content>
 				<#list entries as entry>
 					<li class="facet-value">
+						<#assign id = stringUtil.randomId() />
+
 						<button
 							class="btn btn-link btn-unstyled facet-term ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')} term-name"
 							data-term-id="${entry.getDisplayName()}"
-							onClick="Liferay.Search.FacetUtil.changeSelection(event);"
+							id="${id}"
 						>
 							${htmlUtil.escape(entry.getDisplayName())}
 
@@ -37,6 +39,12 @@
 								</small>
 							</#if>
 						</button>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${id}').onclick = function() {
+								Liferay.Search.FacetUtil.changeSelection(event);
+							}
+						</@liferay_aui.script>
 					</li>
 				</#list>
 			</#if>

--- a/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/specification_option_facets/portlet_display_template_label.ftl
+++ b/modules/apps/commerce/commerce-product-content-search-web/src/main/resources/com/liferay/commerce/product/content/search/web/internal/portlet/display/template/dependencies/specification_option_facets/portlet_display_template_label.ftl
@@ -23,10 +23,12 @@
 		<#if entries?has_content>
 			<div class="label-container">
 				<#list entries as entry>
+					<#assign id = stringUtil.randomId() />
+
 					<button
 						class="btn label label-lg facet-term term-name ${(entry.isSelected())?then('label-primary facet-term-selected', 'label-secondary facet-term-unselected')}"
 						data-term-id="${entry.getDisplayName()}"
-						onClick="Liferay.Search.FacetUtil.changeSelection(event);"
+						id="${id}"
 						type="button"
 					>
 						<span class="label-item label-item-expand">
@@ -37,6 +39,12 @@
 							</#if>
 						</span>
 					</button>
+
+					<@liferay_aui.script position="inline">
+						document.getElementById('${id}').onclick = function() {
+							Liferay.Search.FacetUtil.changeSelection(event);
+						}
+					</@liferay_aui.script>
 				</#list>
 			</div>
 		</#if>

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_value_rel.jspf
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/edit_cp_definition_option_value_rel.jspf
@@ -157,11 +157,17 @@ long cpDefinitionOptionValueRelId = cpDefinitionOptionValueRelDisplayContext.get
 				</div>
 
 				<div class="align-items-end col-auto d-flex">
-					<button class="btn btn-monospaced btn-secondary form-submitter" id="remove-sku-button" onclick="<portlet:namespace />removeSku();" type="button">
+					<button class="btn btn-monospaced btn-secondary form-submitter" id="remove-sku-button" type="button">
 						<clay:icon
 							symbol="trash"
 						/>
 					</button>
+
+					<aui:script position="inline">
+						document.getElementById('remove-sku-button').onclick = function () {
+							<portlet:namespace />removeSku();
+						};
+					</aui:script>
 				</div>
 			</div>
 		</div>

--- a/modules/apps/commerce/commerce-taglib/src/main/resources/META-INF/resources/tier_price/page.jsp
+++ b/modules/apps/commerce/commerce-taglib/src/main/resources/META-INF/resources/tier_price/page.jsp
@@ -33,6 +33,8 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 
 					<%
 					for (CommerceTierPriceEntry commerceTierPriceEntry : commerceTierPriceEntries) {
+						String id = StringUtil.randomId();
+
 						CommercePriceEntry commercePriceEntry = commerceTierPriceEntry.getCommercePriceEntry();
 
 						BigDecimal price = commercePriceEntry.getPrice();
@@ -62,13 +64,19 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 						BigDecimal savings = priceTotal.subtract(total);
 					%>
 
-						<tr class="multiples-row" onclick="<%= randomNamespace %>setQuantity('<%= minQuantity %>');">
+						<tr class="multiples-row" id="<%= id %>">
 							<td class="price-point-column"><%= minQuantity %></td>
 							<td class="msrp-column table-cell-expand"><%= commercePriceFormatter.format(commerceContext.getCommerceCurrency(), priceTotal, themeDisplay.getLocale()) %></td>
 							<td class="discount-column table-cell-expand"><%= commercePriceFormatter.format(discountPercent, themeDisplay.getLocale()) %> %</td>
 							<td class="savings-column table-cell-expand"><%= commercePriceFormatter.format(commerceContext.getCommerceCurrency(), savings, themeDisplay.getLocale()) %></td>
 							<td class="table-cell-expand total-column"><%= commercePriceFormatter.format(commerceContext.getCommerceCurrency(), total, themeDisplay.getLocale()) %></td>
 						</tr>
+
+						<aui:script position="inline">
+							document.getElementById('<%= id %>').onclick = function () {
+								<%= randomNamespace %>setQuantity('<%= minQuantity %>');
+							};
+						</aui:script>
 
 					<%
 					}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/TextHTMLDDMFormFieldValueRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/TextHTMLDDMFormFieldValueRenderer.java
@@ -9,6 +9,8 @@ import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.render.ValueAccessor;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -34,21 +36,31 @@ public class TextHTMLDDMFormFieldValueRenderer
 			public String get(DDMFormFieldValue ddmFormFieldValue) {
 				Value value = ddmFormFieldValue.getValue();
 
-				return StringUtil.replace(
-					_HTML,
-					new String[] {"[$DDM_FORM_FIELD_VALUE$]", "[$PREVIEW$]"},
-					new String[] {
-						HtmlUtil.escapeJS(value.getString(locale)),
-						LanguageUtil.get(locale, "preview")
-					});
+				StringBundler sb = new StringBundler(12);
+
+				sb.append("<a href=\"javascript:void(0);\" id=\"");
+
+				String id = StringUtil.randomId();
+
+				sb.append(id);
+
+				sb.append("\">(");
+				sb.append(LanguageUtil.get(locale, "preview"));
+				sb.append(")</a><script");
+				sb.append(
+					ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+						null));
+				sb.append(">document.getElementById('");
+				sb.append(id);
+				sb.append("').onclick=function() {Liferay.DDLUtil.");
+				sb.append("openPreviewDialog('");
+				sb.append(HtmlUtil.escapeJS(value.getString(locale)));
+				sb.append("');}</script>");
+
+				return sb.toString();
 			}
 
 		};
 	}
-
-	private static final String _HTML =
-		"<a href=\"javascript:void(0);\" onclick=\"Liferay.DDLUtil." +
-			"openPreviewDialog('[$DDM_FORM_FIELD_VALUE$]');\">([$PREVIEW$])" +
-				"</a>";
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/readonly/ddm-image.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/readonly/ddm-image.ftl
@@ -27,7 +27,13 @@
 	</#if>
 
 	<#if hasFieldValue>
-		[ <a href="javascript:void(0);" id="${portletNamespace}${namespacedFieldName}ToggleImage" onClick="${portletNamespace}${namespacedFieldName}ToggleImage();">${languageUtil.get(locale, "show")}</a> ]
+		[ <a href="javascript:void(0);" id="${portletNamespace}${namespacedFieldName}ToggleImage">${languageUtil.get(locale, "show")}</a> ]
+
+		<script ${nonceAttribute}>
+			document.getElementById('${portletNamespace}${namespacedFieldName}ToggleImage').onclick = function() {
+				${portletNamespace}${namespacedFieldName}ToggleImage();
+			};
+		</script>
 
 		<div class="hide wcm-image-preview" id="${portletNamespace}${namespacedFieldName}Container">
 			<#if validator.isNotNull(src)>

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/processes_list/export_layouts_processes.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export/processes_list/export_layouts_processes.jsp
@@ -145,9 +145,22 @@ PortletURL portletURL = exportLayoutsProcessesDisplayContext.getPortletURL();
 
 						<c:if test="<%= Validator.isNotNull(backgroundTask.getStatusMessage()) %>">
 							<span class="background-task-status-row">
-								<a class="details-link" href="javascript:void(0);" onclick="<portlet:namespace />viewBackgroundTaskDetails(<%= backgroundTask.getBackgroundTaskId() %>);">
+
+								<%
+								String id = StringUtil.randomId();
+								%>
+
+								<a class="details-link" href="javascript:void(0);" id="<%= id %>">
 									<liferay-ui:message key="see-more-details" />
 								</a>
+
+								<aui:script position="inline">
+									document.getElementById('<%= id %>').onclick = function () {
+										<portlet:namespace />viewBackgroundTaskDetails(
+											<%= backgroundTask.getBackgroundTaskId() %>
+										);
+									};
+								</aui:script>
 							</span>
 
 							<div class="background-task-status-message hide" id="<portlet:namespace />backgroundTaskStatusMessage<%= backgroundTask.getBackgroundTaskId() %>">

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_import_process.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/export_import_process.jsp
@@ -136,9 +136,22 @@ if (Validator.isNotNull(backURL)) {
 
 			<c:if test="<%= Validator.isNotNull(curBackgroundTask.getStatusMessage()) %>">
 				<div class="background-task-status-row h6">
-					<a class="details-link" href="javascript:void(0);" onclick="<portlet:namespace />viewBackgroundTaskDetails(<%= curBackgroundTask.getBackgroundTaskId() %>);">
+
+					<%
+					String id = StringUtil.randomId();
+					%>
+
+					<a class="details-link" href="javascript:void(0);" id="<%= id %>">
 						<liferay-ui:message key="see-more-details" />
 					</a>
+
+					<aui:script position="inline">
+						document.getElementById('<%= id %>').onclick = function () {
+							<portlet:namespace />viewBackgroundTaskDetails(
+								<%= curBackgroundTask.getBackgroundTaskId() %>
+							);
+						};
+					</aui:script>
 				</div>
 
 				<div class="background-task-status-message hide" id="<portlet:namespace />backgroundTaskStatusMessage<%= curBackgroundTask.getBackgroundTaskId() %>">

--- a/modules/apps/frontend-js/frontend-js-bundle-config-extender/src/main/java/com/liferay/frontend/js/bundle/config/extender/internal/JSBundleConfigServlet.java
+++ b/modules/apps/frontend-js/frontend-js-bundle-config-extender/src/main/java/com/liferay/frontend/js/bundle/config/extender/internal/JSBundleConfigServlet.java
@@ -82,7 +82,7 @@ public class JSBundleConfigServlet extends HttpServlet {
 			JSBundleConfigRegistryUtil.getJSConfigs();
 
 		if (!jsConfigs.isEmpty()) {
-			printWriter.print("(function(){");
+			printWriter.print("(function() {");
 
 			for (JSBundleConfigRegistryUtil.JSConfig jsConfig : jsConfigs) {
 				try {

--- a/modules/apps/frontend-js/frontend-js-minifier/src/test/java/com/liferay/frontend/js/minifier/internal/GoogleJavascriptMinifierTest.java
+++ b/modules/apps/frontend-js/frontend-js-minifier/src/test/java/com/liferay/frontend/js/minifier/internal/GoogleJavascriptMinifierTest.java
@@ -33,7 +33,7 @@ public class GoogleJavascriptMinifierTest {
 		GoogleJavaScriptMinifier googleJavaScriptMinifier =
 			new GoogleJavaScriptMinifier();
 
-		String code = "function(){ var invalidFunctionExpression; }";
+		String code = "function() { var invalidFunctionExpression; }";
 
 		try (LogCapture logCapture = LoggerTestUtil.configureJDKLogger(
 				GoogleJavaScriptMinifier.class.getName(), Level.SEVERE)) {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -7,7 +7,9 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.TagResourceBundleUtil;
 
@@ -139,9 +141,13 @@ public class AlertTag extends BaseContainerTag {
 				LanguageUtil.get(
 					TagResourceBundleUtil.getResourceBundle(pageContext),
 					"close"));
-			jspWriter.write("\" class=\"close\" onclick=\"");
-			jspWriter.write("event.target.closest('[role=alert]').remove()\"");
-			jspWriter.write(" type=\"button\">");
+			jspWriter.write("\" class=\"close\" id=\"");
+
+			String id = StringUtil.randomId();
+
+			jspWriter.write(id);
+
+			jspWriter.write("\" type=\"button\">");
 
 			IconTag iconTag = new IconTag();
 
@@ -149,7 +155,14 @@ public class AlertTag extends BaseContainerTag {
 
 			iconTag.doTag(pageContext);
 
-			jspWriter.write("</button>");
+			jspWriter.write("</button><script");
+			jspWriter.write(
+				ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+					getRequest()));
+			jspWriter.write(">document.getElementById('");
+			jspWriter.write(id);
+			jspWriter.write("').onclick=function(event) {event.target.");
+			jspWriter.write("closest('[role=alert]').remove()}</script>");
 		}
 
 		if (Validator.isNotNull(_variant) && _variant.equals("stripe")) {

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/proxy.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/proxy.jsp
@@ -14,7 +14,7 @@
 		<meta content="0" http-equiv="Expires" />
 	</head>
 
-	<body onLoad="setTimeout('document.fm.submit()', 100);">
+	<body>
 		<form action="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.src()) %>" method="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getFormMethod()) %>" name="fm">
 
 			<%
@@ -30,5 +30,11 @@
 			<input name="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.userNameField()) %>" type="hidden" value="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getUserName()) %>" />
 			<input name="<%= HtmlUtil.escapeAttribute(iFramePortletInstanceConfiguration.passwordField()) %>" type="hidden" value="<%= HtmlUtil.escapeAttribute(iFrameDisplayContext.getPassword()) %>" />
 		</form>
+
+		<aui:script position="inline">
+			window.body.onload = function () {
+				setTimeout('document.fm.submit()', 100);
+			};
+		</aui:script>
 	</body>
 </html>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/category/facet/view.jsp
@@ -103,9 +103,15 @@ CategoryFacetPortletInstanceConfiguration categoryFacetPortletInstanceConfigurat
 												disabled
 												id="<portlet:namespace />term_<%= i %>"
 												name="<portlet:namespace />term_<%= i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 												type="checkbox"
 											/>
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/custom/facet/view.jsp
@@ -92,7 +92,14 @@ CustomFacetPortletInstanceConfiguration customFacetPortletInstanceConfiguration 
 								<li class="facet-value">
 									<div class="custom-checkbox custom-control">
 										<label class="facet-checkbox-label" for="<portlet:namespace />term_<%= i %>">
-											<input class="custom-control-input facet-term" data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>" disabled id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" onChange="Liferay.Search.FacetUtil.changeSelection(event);" type="checkbox" <%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
+											<input class="custom-control-input facet-term" data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>" disabled id="<portlet:namespace />term_<%= i %>" name="<portlet:namespace />term_<%= i %>" type="checkbox" <%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %> />
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/folder/facet/view.jsp
@@ -102,9 +102,15 @@ FolderFacetPortletInstanceConfiguration folderFacetPortletInstanceConfiguration 
 												disabled
 												id="<portlet:namespace />term_<%= i %>"
 												name="<portlet:namespace />term_<%= i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 												type="checkbox" <%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 											/>
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/site/facet/view.jsp
@@ -102,10 +102,16 @@ SiteFacetPortletInstanceConfiguration siteFacetPortletInstanceConfiguration = sc
 												disabled
 												id="<portlet:namespace />term_<%= i %>"
 												name="<portlet:namespace />term_<%= i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 												type="checkbox"
 												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 											/>
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/tag/facet/view.jsp
@@ -103,9 +103,15 @@ TagFacetPortletInstanceConfiguration tagFacetPortletInstanceConfiguration = asse
 												disabled
 												id="<portlet:namespace />term_<%= i %>"
 												name="<portlet:namespace />term_<%= i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 												type="checkbox"
 											/>
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/view.jsp
@@ -102,10 +102,16 @@ TypeFacetPortletInstanceConfiguration typeFacetPortletInstanceConfiguration = as
 												disabled
 												id="<portlet:namespace />term_<%= i %>"
 												name="<portlet:namespace />term_<%= i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
 												type="checkbox"
 												<%= bucketDisplayContext.isSelected() ? "checked" : StringPool.BLANK %>
 											/>
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/user/facet/view.jsp
@@ -101,10 +101,17 @@ UserFacetPortletInstanceConfiguration userFacetPortletInstanceConfiguration = us
 												class="custom-control-input facet-term"
 												data-term-id="<%= HtmlUtil.escapeAttribute(bucketDisplayContext.getFilterValue()) %>"
 												disabled
-												id="<portlet:namespace />term_<%= i %>"name="<portlet:namespace />term_<%= i %>"
-												onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+												id="<portlet:namespace />term_<%= i %>"
+												name="<portlet:namespace />term_<%= i %>"
 												type="checkbox"
 											/>
+
+											<aui:script position="inline">
+												document.getElementById('<portlet:namespace />term_<%= i %>').onchange =
+													function (event) {
+														Liferay.Search.FacetUtil.changeSelection(event);
+													};
+											</aui:script>
 
 											<span class="custom-control-label term-name <%= bucketDisplayContext.isSelected() ? "facet-term-selected" : "facet-term-unselected" %>">
 												<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/view.jsp
@@ -33,12 +33,23 @@ pageContext.setAttribute("portletURL", portletURL);
 					<input class="form-control input-group-inset input-group-inset-after search-input search-portlet-keywords-input" id="<portlet:namespace />keywords" name="<portlet:namespace />keywords" placeholder="<%= LanguageUtil.get(request, "search") %>" type="text" value="<%= (searchDisplayContext.getKeywords() != null) ? HtmlUtil.escapeAttribute(searchDisplayContext.getKeywords()) : StringPool.BLANK %>" />
 
 					<div class="input-group-inset-item input-group-inset-item-after">
-						<button class="btn btn-light btn-unstyled" onclick="<portlet:namespace />search();" type="submit">
+
+						<%
+						String id = StringUtil.randomId();
+						%>
+
+						<button class="btn btn-light btn-unstyled" id="<%= id %>" type="submit">
 							<liferay-ui:icon
 								icon="search"
 								markupView="lexicon"
 							/>
 						</button>
+
+						<aui:script position="inline">
+							document.getElementById('<%= id %>').onclick = function () {
+								<portlet:namespace />search();
+							};
+						</aui:script>
 					</div>
 				</div>
 			</div>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -10,13 +10,15 @@
 >
 	<li class="treeview-item" role="none">
 		<#if name?has_content>
+			<#assign divRandomId = stringUtil.randomId() />
+
 			<div
 				aria-controls="${(termDisplayContexts?has_content)?then(namespace + 'treeItem' + id, '')}"
 				aria-expanded="true"
 				class="treeview-link ${cssClassTreeItem}"
 				data-target="#${namespace}treeItem${id}"
 				data-toggle="collapse"
-				onClick="${namespace}toggleTreeItem('${namespace}treeItem${id}');"
+				id="${divRandomId}"
 				onKeyPress="${namespace}toggleTreeItemKeypress(event);"
 				role="treeitem"
 				tabindex="${(termDisplayContexts?has_content)?then(0, -1)}"
@@ -101,6 +103,12 @@
 					</span>
 				</span>
 			</div>
+
+			<@liferay_aui.script position="inline">
+				document.getElementById('${divRandomId}').onclick = function() {
+					${namespace}toggleTreeItem('${namespace}treeItem${id}');
+				}
+			</@liferay_aui.script>
 		</#if>
 
 		<#if termDisplayContexts?has_content>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/category/facet/portlet/display/template/dependencies/portlet_display_template_vocabulary.ftl
@@ -51,14 +51,22 @@
 							<span class="autofit-col autofit-col-expand">
 								<div class="custom-checkbox custom-control">
 									<label>
+										<#assign inputRandomId = stringUtil.randomId() />
+
 										<input
 											${selected?then("checked", "")}
 											class="custom-control-input facet-term"
 											data-term-id=${id}
 											disabled
-											onChange="Liferay.Search.FacetUtil.changeSelection(event);"
+											id="${inputRandomId}"
 											type="checkbox"
 										/>
+
+										<@liferay_aui.script position="inline">
+											document.getElementById('${inputRandomId}').onchange = function() {
+												Liferay.Search.FacetUtil.changeSelection(event);
+											}
+										</@liferay_aui.script>
 
 										<span class="custom-control-label">
 											<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_checkbox.ftl
@@ -36,9 +36,14 @@
 									disabled
 									id="${namespace}${entry.getBucketText()}"
 									name="${namespace}${entry.getBucketText()}"
-									onChange='Liferay.Search.FacetUtil.changeSelection(event);'
 									type="checkbox"
 								/>
+
+								<@liferay_aui.script position="inline">
+									document.getElementById('${namespace}${entry.getBucketText()}').onchange = function() {
+										Liferay.Search.FacetUtil.changeSelection(event);
+									}
+								</@liferay_aui.script>
 
 								<span class="custom-control-label term-name ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')}">
 									<span class="custom-control-label-text">
@@ -71,9 +76,14 @@
 							disabled
 							id="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
 							name="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
-							onChange='Liferay.Search.FacetUtil.changeSelection(event);'
 							type="checkbox"
 						/>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onchange = function() {
+								Liferay.Search.FacetUtil.changeSelection(event);
+							}
+						</@liferay_aui.script>
 
 						<span class="custom-control-label term-name ${(customRangeBucketDisplayContext.isSelected())?then('facet-term-selected', 'facet-term-unselected')}">
 							<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/date/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -35,10 +35,15 @@
 									disabled
 									id="${namespace}${entry.getBucketText()}"
 									name="${namespace}${entry.getBucketText()}"
-									onChange='${"window.location.href = \"${entry.getFilterValue()}\";"}'
 									role="radio"
 									type="radio"
 								/>
+
+								<@liferay_aui.script position="inline">
+									document.getElementById('${namespace}${entry.getBucketText()}').onchange = function() {
+										window.location.href = "${entry.getFilterValue()}";
+									}
+								</@liferay_aui.script>
 
 								<span class="custom-control-label term-name ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')}">
 									<span class="custom-control-label-text">
@@ -68,10 +73,15 @@
 							disabled
 							id="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
 							name="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
-							onChange='${"window.location.href = \"${customRangeBucketDisplayContext.getFilterValue()}\";"}'
 							role="radio"
 							type="radio"
 						/>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onchange = function() {
+								window.location.href = "${customRangeBucketDisplayContext.getFilterValue()}";
+							}
+						</@liferay_aui.script>
 
 						<span class="custom-control-label term-name ${(customRangeBucketDisplayContext.isSelected())?then('facet-term-selected', 'facet-term-unselected')}">
 							<span class="custom-control-label-text">

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/com/liferay/portal/search/web/internal/modified/facet/portlet/display/template/dependencies/portlet_display_template_radio.ftl
@@ -35,10 +35,15 @@
 									disabled
 									id="${namespace}${entry.getBucketText()}"
 									name="${namespace}${entry.getBucketText()}"
-									onChange='${"window.location.href = \"${entry.getFilterValue()}\";"}'
 									role="radio"
 									type="radio"
 								/>
+
+								<@liferay_aui.script position="inline">
+									document.getElementById('${namespace}${entry.getBucketText()}').onchange = function() {
+										window.location.href = "${entry.getFilterValue()}";
+									}
+								</@liferay_aui.script>
 
 								<span class="custom-control-label term-name ${(entry.isSelected())?then('facet-term-selected', 'facet-term-unselected')}">
 									<span class="custom-control-label-text">
@@ -68,10 +73,15 @@
 							disabled
 							id="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
 							name="${namespace}${customRangeBucketDisplayContext.getBucketText()}"
-							onChange='${"window.location.href = \"${customRangeBucketDisplayContext.getFilterValue()}\";"}'
 							role="radio"
 							type="radio"
 						/>
+
+						<@liferay_aui.script position="inline">
+							document.getElementById('${namespace}${customRangeBucketDisplayContext.getBucketText()}').onchange = function() {
+								window.location.href = "${customRangeBucketDisplayContext.getFilterValue()}";
+							}
+						</@liferay_aui.script>
 
 						<span class="custom-control-label term-name ${(customRangeBucketDisplayContext.isSelected())?then('facet-term-selected', 'facet-term-unselected')}">
 							<span class="custom-control-label-text">

--- a/modules/apps/portal/portal-error-code/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/portal/portal-error-code/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.model.LayoutSet" %><%@
 page import="com.liferay.portal.kernel.servlet.HttpHeaders" %><%@

--- a/modules/apps/portal/portal-error-code/src/main/resources/META-INF/resources/dynamic_include/text_html.jsp
+++ b/modules/apps/portal/portal-error-code/src/main/resources/META-INF/resources/dynamic_include/text_html.jsp
@@ -55,7 +55,7 @@ String xRequestWith = request.getHeader(HttpHeaders.X_REQUESTED_WITH);
 				<meta content="1; url=<%= HtmlUtil.escapeAttribute(redirect) %>" http-equiv="refresh" />
 			</head>
 
-			<body onload="javascript:location.replace('<%= HtmlUtil.escapeJS(redirect) %>')">
+			<body>
 
 				<!--
 				The numbers below are used to fill up space so that this works properly in IE.
@@ -66,6 +66,12 @@ String xRequestWith = request.getHeader(HttpHeaders.X_REQUESTED_WITH);
 				12345678901234567890123456789012345678901234567890123456789012345678901234567890
 				12345678901234567890123456789012345678901234567890123456789012345678901234567890
 				-->
+
+				<aui:script position="inline">
+					window.body.onload = function () {
+						window.location.replace('<%= HtmlUtil.escapeJS(redirect) %>');
+					};
+				</aui:script>
 			</body>
 		</c:when>
 		<c:otherwise>

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/init.jsp
@@ -16,6 +16,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <%@ page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.HttpComponentsUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-sharing-web/src/main/resources/META-INF/resources/view.jsp
@@ -19,9 +19,19 @@ String widgetURL = ParamUtil.getString(request, "widgetURL");
 			<liferay-ui:message key="share-this-application-on-any-website" />
 		</p>
 
-		<textarea class="col-md-12 lfr-textarea" onClick="this.select();" rows="10">
+		<%
+		String id = StringUtil.randomId();
+		%>
+
+		<textarea class="col-md-12 lfr-textarea" id="<%= id %>" rows="10">
 			<iframe frameborder="0" height="100%" src="<%= HtmlUtil.escapeAttribute(widgetURL) %>" width="100%"></iframe>
 		</textarea>
+
+		<aui:script position="inline">
+			document.getElementById('<%= id %>').onclick = function () {
+				this.select();
+			};
+		</aui:script>
 	</c:when>
 	<c:when test="<%= Validator.isNotNull(netvibesURL) %>">
 		<p>

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_sharing.jsp
@@ -79,7 +79,14 @@ if (layout.isDraftLayout()) {
 						</liferay-util:buffer>
 
 						<aui:field-wrapper label="code">
-							<textarea aria-label="<%= LanguageUtil.get(request, "code") %>" class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" onClick="this.select();" readonly="true"><%= HtmlUtil.escape(textAreaContent) %></textarea>
+							<textarea aria-label="<%= LanguageUtil.get(request, "code") %>" class="field form-control lfr-textarea" id="<portlet:namespace />widgetScript" readonly="true"><%= HtmlUtil.escape(textAreaContent) %></textarea>
+
+							<aui:script position="inline">
+								document.getElementById('<portlet:namespace />widgetScript').onclick =
+									function () {
+										this.select();
+									};
+							</aui:script>
 						</aui:field-wrapper>
 
 						<aui:input inlineLabel="right" label='<%= LanguageUtil.format(request, "allow-users-to-add-x-to-any-website", HtmlUtil.escape(portletDisplay.getTitle()), false) %>' labelCssClass="simple-toggle-switch" name="widgetShowAddAppLink" type="toggle-switch" value='<%= GetterUtil.getBoolean(portletPreferences.getValue("lfrWidgetShowAddAppLink", null), PropsValues.THEME_PORTLET_SHARING_DEFAULT) %>' />

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/merge_layout_set_branch.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/merge_layout_set_branch.jsp
@@ -77,9 +77,17 @@ if (layoutSetBranches.contains(layoutSetBranch)) {
 					/>
 
 					<liferay-ui:search-container-column-text>
-						<a class="layout-set-branch" data-layoutSetBranchId="<%= curLayoutSetBranchId %>" data-layoutSetBranchMessage="<%= LanguageUtil.format(request, "are-you-sure-you-want-to-merge-changes-from-x", layoutSetBranchDisplayName, false) %>" data-layoutSetBranchName="<%= HtmlUtil.escapeAttribute(curLayoutSetBranch.getName()) %>" href="#" id="<portlet:namespace /><%= curLayoutSetBranchId %>" onClick="<portlet:namespace />selectLayoutSetBranch('<%= curLayoutSetBranchId %>');">
+						<a class="layout-set-branch" data-layoutSetBranchId="<%= curLayoutSetBranchId %>" data-layoutSetBranchMessage="<%= LanguageUtil.format(request, "are-you-sure-you-want-to-merge-changes-from-x", layoutSetBranchDisplayName, false) %>" data-layoutSetBranchName="<%= HtmlUtil.escapeAttribute(curLayoutSetBranch.getName()) %>" href="#" id="<portlet:namespace /><%= curLayoutSetBranchId %>">
 							<liferay-ui:message key="select" />
 						</a>
+
+						<aui:script position="inline">
+							document.getElementById(
+								'<portlet:namespace /><%= curLayoutSetBranchId %>'
+							).onclick = function () {
+								<portlet:namespace />selectLayoutSetBranch('<%= curLayoutSetBranchId %>');
+							};
+						</aui:script>
 					</liferay-ui:search-container-column-text>
 				</liferay-ui:search-container-row>
 

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -111,9 +111,23 @@ List<LayoutRevision> rootLayoutRevisions = LayoutRevisionLocalServiceUtil.getChi
 										<span class="current-version"><liferay-ui:message key="current-version" /></span>
 									</c:when>
 									<c:otherwise>
-										<a class="layout-revision selection-handle" data-layoutRevisionId="<%= curLayoutRevision.getLayoutRevisionId() %>" data-layoutSetBranchId="<%= curLayoutRevision.getLayoutSetBranchId() %>" href="javascript:void(0);" onclick="<portlet:namespace />selectRevision(<%= curLayoutRevision.getLayoutRevisionId() %>, <%= curLayoutRevision.getLayoutSetBranchId() %>);" title="<liferay-ui:message key="go-to-this-version" />">
+
+										<%
+										String id = StringUtil.randomId();
+										%>
+
+										<a class="layout-revision selection-handle" data-layoutRevisionId="<%= curLayoutRevision.getLayoutRevisionId() %>" data-layoutSetBranchId="<%= curLayoutRevision.getLayoutSetBranchId() %>" href="javascript:void(0);" id="<%= id %>" title="<liferay-ui:message key="go-to-this-version" />">
 											<%= curLayoutRevision.getLayoutRevisionId() %>
 										</a>
+
+										<aui:script position="inline">
+											document.getElementById('<%= id %>').onclick = function () {
+												<portlet:namespace />selectRevision(
+													<%= curLayoutRevision.getLayoutRevisionId() %>,
+													<%= curLayoutRevision.getLayoutSetBranchId() %>
+												);
+											};
+										</aui:script>
 									</c:otherwise>
 								</c:choose>
 							</liferay-ui:search-container-column-text>

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view.jsp
@@ -328,11 +328,19 @@ if (portletTitleBasedNavigation) {
 						).setParameter(
 							"title", originalPage.getTitle()
 						).buildPortletURL();
+
+						String id = StringUtil.randomId();
 						%>
 
-						<div class="page-redirect" onClick="location.href = '<%= originalViewPageURL.toString() %>';">
+						<div class="page-redirect" id="<%= id %>">
 							(<liferay-ui:message arguments="<%= originalPage.getTitle() %>" key="redirected-from-x" translateArguments="<%= false %>" />)
 						</div>
+
+						<aui:script position="inline">
+							document.getElementById('<%= id %>').onclick = function () {
+								location.href = '<%= originalViewPageURL.toString() %>';
+							};
+						</aui:script>
 					</c:if>
 
 					<c:if test="<%= !wikiPage.isHead() %>">

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_display/portlet_not_setup.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki_display/portlet_not_setup.jsp
@@ -12,7 +12,18 @@ renderRequest.setAttribute(WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE
 %>
 
 <div class="alert alert-info portlet-configuration">
-	<a href="<%= portletDisplay.getURLConfiguration() %>" onClick="<%= portletDisplay.getURLConfigurationJS() %>">
+
+	<%
+	String id = StringUtil.randomId();
+	%>
+
+	<a href="<%= portletDisplay.getURLConfiguration() %>" id="<%= id %>">
 		<liferay-ui:message key="please-configure-this-portlet-to-make-it-visible-to-all-users" />
 	</a>
+
+	<aui:script position="inline">
+		document.getElementById('<%= id %>').onclick = function () {
+			<%= portletDisplay.getURLConfigurationJS() %>;
+		};
+	</aui:script>
 </div>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal/saml_error.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal/saml_error.jsp
@@ -53,7 +53,19 @@ String samlSubjectScreenName = (String)request.getAttribute(SamlWebKeys.SAML_SUB
 				</aui:fieldset>
 			</c:when>
 			<c:otherwise>
-				<a onClick="this.closest('form').submit(); return false;"><liferay-ui:message arguments='<%= "<strong>" + HtmlUtil.escapeAttribute(samlSubjectScreenName) + "</strong>" %>' key="not-x" /></a>
+
+				<%
+				String id = StringUtil.randomId();
+				%>
+
+				<a id="<%= id %>"><liferay-ui:message arguments='<%= "<strong>" + HtmlUtil.escapeAttribute(samlSubjectScreenName) + "</strong>" %>' key="not-x" /></a>
+
+				<aui:script position="inline">
+					document.getElementById('<%= id %>').onclick = function () {
+						this.closest('form').submit();
+						return false;
+					};
+				</aui:script>
 			</c:otherwise>
 		</c:choose>
 	</aui:form>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -17,6 +17,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
+page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.saml.constants.SamlWebKeys" %>
 
 <liferay-frontend:defineObjects />

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RootCauseAnalysisToolBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/RootCauseAnalysisToolBuild.java
@@ -402,7 +402,7 @@ public class RootCauseAnalysisToolBuild extends DefaultTopLevelBuild {
 		StringBuilder sb = new StringBuilder();
 
 		sb.append("$(document).ready(function() {\n");
-		sb.append("$('[data-toggle=\"toggle\"]').change(function(){\n");
+		sb.append("$('[data-toggle=\"toggle\"]').change(function() {\n");
 		sb.append("$(this).parents().next('.hidden-row').toggle();\n");
 		sb.append("var label = $(this).parent('td').find('label');\n");
 		sb.append("var text = label.text();\n");

--- a/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/SafariWebDriverImpl.java
+++ b/modules/test/poshi/poshi-runner/src/main/java/com/liferay/poshi/runner/selenium/SafariWebDriverImpl.java
@@ -43,7 +43,7 @@ public class SafariWebDriverImpl extends BaseWebDriverImpl {
 
 			try {
 				javascriptExecutor.executeScript(
-					"confirm = function(){return true;};");
+					"confirm = function() {return true;};");
 
 				javaScriptClick(locator);
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
@@ -7,8 +7,10 @@ package com.liferay.portal.kernel.dao.search;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import javax.portlet.PortletResponse;
@@ -38,7 +40,7 @@ public class EmptyOnClickRowChecker extends RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(20);
+		StringBundler sb = new StringBundler(27);
 
 		sb.append("<div class=\"custom-checkbox custom-control\"><label>");
 		sb.append("<input ");
@@ -64,22 +66,34 @@ public class EmptyOnClickRowChecker extends RowChecker {
 			sb.append("disabled ");
 		}
 
-		sb.append("name=\"");
+		sb.append("id=\"");
+
+		String id = StringUtil.randomId();
+
+		sb.append(id);
+
+		sb.append("\" name=\"");
 		sb.append(name);
 		sb.append("\" title=\"");
 		sb.append(LanguageUtil.get(httpServletRequest.getLocale(), "select"));
 		sb.append("\" type=\"checkbox\" value=\"");
 		sb.append(HtmlUtil.escapeAttribute(value));
-		sb.append("\" ");
+		sb.append("\"><span class=\"custom-control-label\"></span></label>");
+		sb.append("</div>");
 
 		if (Validator.isNotNull(getAllRowIds())) {
+			sb.append("<script");
+			sb.append(
+				ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+					httpServletRequest));
+			sb.append(">document.getElementById('");
+			sb.append(id);
+			sb.append("').onclick=function() {");
 			sb.append(
 				getOnClick(
 					checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick));
+			sb.append("}</script>");
 		}
-
-		sb.append("><span class=\"custom-control-label\"></span></label>");
-		sb.append("</div>");
 
 		return sb.toString();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.dao.search;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -191,13 +192,33 @@ public class RowChecker {
 			return StringPool.BLANK;
 		}
 
-		return StringBundler.concat(
-			"<label><input name=\"", name, "\" title=\"",
-			LanguageUtil.get(getLocale(httpServletRequest), "select-all"),
-			"\" type=\"checkbox\" ", HtmlUtil.buildData(_data),
-			"onClick=\"Liferay.Util.checkAll(AUI().one(this).ancestor(",
-			"'.table'), ", checkBoxRowIds,
-			", this, 'tr:not(.d-none)');\"></label>");
+		StringBundler sb = new StringBundler(16);
+
+		sb.append("<label><input id=\"");
+
+		String id = StringUtil.randomId();
+
+		sb.append(id);
+
+		sb.append("\" name=\"");
+		sb.append(name);
+		sb.append("\" title=\"");
+		sb.append(
+			LanguageUtil.get(getLocale(httpServletRequest), "select-all"));
+		sb.append("\" type=\"checkbox\" ");
+		sb.append(HtmlUtil.buildData(_data));
+		sb.append("></label><script");
+		sb.append(
+			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+				httpServletRequest));
+		sb.append(">document.getElementById('");
+		sb.append(id);
+		sb.append("').onclick=function() {Liferay.Util.checkAll(AUI().");
+		sb.append("one(this).ancestor('.table'), ");
+		sb.append(checkBoxRowIds);
+		sb.append(", this, 'tr:not(.d-none)');}</script>");
+
+		return sb.toString();
 	}
 
 	protected Locale getLocale(HttpServletRequest httpServletRequest) {
@@ -237,11 +258,11 @@ public class RowChecker {
 		String checkBoxRowIds, String checkBoxAllRowIds,
 		String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(9);
+		StringBundler sb = new StringBundler(8);
 
-		sb.append("onClick=\"Liferay.Util.rowCheckerCheckAllBox(AUI().");
-		sb.append("one(this).ancestor('.table'), AUI().one(this).");
-		sb.append("ancestor('tr:not(.d-none)'), ");
+		sb.append("Liferay.Util.rowCheckerCheckAllBox(AUI().one(this).");
+		sb.append("ancestor('.table'), AUI().one(this).ancestor('tr:not(.");
+		sb.append("d-none)'), ");
 		sb.append(checkBoxRowIds);
 		sb.append(", ");
 		sb.append(checkBoxAllRowIds);
@@ -251,8 +272,6 @@ public class RowChecker {
 			sb.append(checkBoxPostOnClick);
 		}
 
-		sb.append("\"");
-
 		return sb.toString();
 	}
 
@@ -261,7 +280,7 @@ public class RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(17);
+		StringBundler sb = new StringBundler(24);
 
 		sb.append("<label><input ");
 
@@ -285,21 +304,33 @@ public class RowChecker {
 			sb.append("disabled ");
 		}
 
+		sb.append("\" id=\"");
+
+		String id = StringUtil.randomId();
+
+		sb.append(id);
+
 		sb.append("\" name=\"");
 		sb.append(name);
 		sb.append("\" title=\"");
 		sb.append(LanguageUtil.get(httpServletRequest.getLocale(), "select"));
 		sb.append("\" type=\"checkbox\" value=\"");
 		sb.append(HtmlUtil.escapeAttribute(value));
-		sb.append("\" ");
+		sb.append("\"></label>");
 
 		if (Validator.isNotNull(_allRowIds)) {
+			sb.append("<script");
+			sb.append(
+				ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+					httpServletRequest));
+			sb.append(">document.getElementById('");
+			sb.append(id);
+			sb.append("').onclick=function() {");
 			sb.append(
 				getOnClick(
 					checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick));
+			sb.append("}</script>");
 		}
-
-		sb.append("></label>");
 
 		return sb.toString();
 	}

--- a/portal-web/docroot/errors/code.jsp
+++ b/portal-web/docroot/errors/code.jsp
@@ -68,7 +68,7 @@ String xRequestWith = request.getHeader(HttpHeaders.X_REQUESTED_WITH);
 				<meta content="1; url=<%= HtmlUtil.escapeAttribute(redirect) %>" http-equiv="refresh" />
 			</head>
 
-			<body onload="javascript:location.replace('<%= HtmlUtil.escapeJS(redirect) %>');">
+			<body>
 
 				<!--
 				The numbers below are used to fill up space so that this works properly in IE.
@@ -79,6 +79,12 @@ String xRequestWith = request.getHeader(HttpHeaders.X_REQUESTED_WITH);
 				12345678901234567890123456789012345678901234567890123456789012345678901234567890
 				12345678901234567890123456789012345678901234567890123456789012345678901234567890
 				-->
+
+				<aui:script position="inline">
+					window.body.onload = function() {
+						window.location.replace('<%= HtmlUtil.escapeJS(redirect) %>');
+					}
+				</aui:script>
 			</body>
 		</html>
 	</c:when>

--- a/portal-web/docroot/errors/init.jsp
+++ b/portal-web/docroot/errors/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
-<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.portal.internal.errors.DynamicIncludeKeyUtil" %><%@

--- a/portal-web/docroot/html/portal/j_login.jsp
+++ b/portal-web/docroot/html/portal/j_login.jsp
@@ -46,7 +46,7 @@ if (PropsValues.PORTAL_JAAS_ENABLE && (jUserName != null)) {
 				<aui:link cssClass="lfr-css-file" href="<%= HtmlUtil.escapeAttribute(themeDisplay.getClayCSSURL()) %>" rel="stylesheet" type="text/css" />
 			</head>
 
-			<body onLoad="setTimeout('document.fm.submit()', 100);">
+			<body>
 				<center>
 					<table border="0" cellpadding="0" cellspacing="0" height="100%" width="600">
 						<tr>
@@ -67,6 +67,12 @@ if (PropsValues.PORTAL_JAAS_ENABLE && (jUserName != null)) {
 						</tr>
 					</table>
 				</center>
+
+				<aui:script position="inline">
+					window.body.onload = function() {
+						setTimeout('document.fm.submit()', 100);
+					}
+				</aui:script>
 			</body>
 		</html>
 
@@ -107,8 +113,12 @@ if (PropsValues.PORTAL_JAAS_ENABLE && (jUserName != null)) {
 				<meta content="0" http-equiv="Expires" />
 			</head>
 
-			<body onLoad="javascript:location.replace('<%= themeDisplay.getPathMain() %>')">
-
+			<body>
+				<aui:script position="inline">
+					window.body.onload = function() {
+						window.location.replace('<%= themeDisplay.getPathMain() %>');
+					}
+				</aui:script>
 			</body>
 		</html>
 	</c:otherwise>

--- a/portal-web/docroot/html/portal/license.jsp
+++ b/portal-web/docroot/html/portal/license.jsp
@@ -642,7 +642,7 @@ dateFormatDateTime.setTimeZone(timeZone);
 						<liferay-ui:message key="product" />
 					</td>
 					<td>
-						<select name="productEntryName" onChange="if (this.value == "basic-cluster") {document.getElementById("maxServers").style.display = "";} else {document.getElementById("maxServers").style.display = "none";}">
+						<select name="productEntryName">
 							<option value=""></option>
 
 							<%
@@ -670,6 +670,17 @@ dateFormatDateTime.setTimeZone(timeZone);
 							%>
 
 						</select>
+
+						<aui:script position="inline">
+							document.querySelector('[name="productEntryName"]').onchange = function() {
+								if (this.value == "basic-cluster") {
+									document.getElementById("maxServers").style.display = "";
+								}
+								else {
+									document.getElementById("maxServers").style.display = "none";
+								}
+							}
+						</aui:script>
 					</td>
 				</tr>
 				<tr id="maxServers" style="display: none;">

--- a/portal-web/docroot/html/portal/license.jsp
+++ b/portal-web/docroot/html/portal/license.jsp
@@ -717,7 +717,17 @@ dateFormatDateTime.setTimeZone(timeZone);
 			<c:when test="<%= orderProducts != null %>">
 				<input class="btn btn-secondary" type="submit" value="<liferay-ui:message key="register" />" />
 
-				<input onClick="location.href='<%= HtmlUtil.escapeJS(themeDisplay.getURLCurrent()) %>';" type="button" value="<liferay-ui:message key="cancel" />" />
+				<%
+				String id = StringUtil.randomId();
+				%>
+
+				<input id="<%= id %>" type="button" value="<liferay-ui:message key="cancel" />" />
+
+				<aui:script position="inline">
+					document.getElementById('<%= id %>').onclick = function() {
+						location.href='<%= HtmlUtil.escapeJS(themeDisplay.getURLCurrent()) %>';
+					}
+				</aui:script>
 			</c:when>
 			<c:otherwise>
 				<input class="btn btn-secondary" type="submit" value="<liferay-ui:message key="query" />" />

--- a/portal-web/docroot/html/portal/portlet_not_setup.jsp
+++ b/portal-web/docroot/html/portal/portlet_not_setup.jsp
@@ -14,7 +14,18 @@ renderRequest.setAttribute(WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE
 %>
 
 <div class="alert alert-info portlet-configuration">
-	<a href="<%= portletDisplay.getURLConfiguration() %>" onClick="<%= portletDisplay.getURLConfigurationJS() %>">
+
+	<%
+	String id = StringUtil.randomId();
+	%>
+
+	<a href="<%= portletDisplay.getURLConfiguration() %>" id="<%= id %>">
 		<liferay-ui:message key="please-configure-this-portlet-to-make-it-visible-to-all-users" />
 	</a>
+
+	<aui:script position="inline">
+		document.getElementById('<%= id %>').onclick = function() {
+			<%= portletDisplay.getURLConfigurationJS() %>
+		}
+	</aui:script>
 </div>

--- a/portal-web/docroot/html/portal/protected.jsp
+++ b/portal-web/docroot/html/portal/protected.jsp
@@ -35,7 +35,7 @@ response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 		<aui:link cssClass="lfr-css-file" href="<%= HtmlUtil.escapeAttribute(themeDisplay.getClayCSSURL()) %>" rel="stylesheet" type="text/css" />
 	</head>
 
-	<body onLoad="javascript:location.replace('<%= HtmlUtil.escapeJS(redirect) %>')">
+	<body>
 		<center>
 			<table border="0" cellpadding="0" cellspacing="0" height="100%" width="600">
 				<tr>
@@ -49,5 +49,11 @@ response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 				</tr>
 			</table>
 		</center>
+
+		<aui:script position="inline">
+			window.body.onload = function() {
+				window.location.replace('<%= HtmlUtil.escapeJS(redirect) %>');
+			}
+		</aui:script>
 	</body>
 </html>

--- a/portal-web/docroot/html/portal/touch_protected.jsp
+++ b/portal-web/docroot/html/portal/touch_protected.jsp
@@ -28,7 +28,7 @@ response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 		<aui:link cssClass="lfr-css-file" href="<%= HtmlUtil.escapeAttribute(themeDisplay.getClayCSSURL()) %>" rel="stylesheet" type="text/css" />
 	</head>
 
-	<body onLoad="javascript:location.replace('<%= redirect %>')">
+	<body>
 		<center>
 			<table border="0" cellpadding="0" cellspacing="0" height="100%" width="600">
 				<tr>
@@ -42,5 +42,11 @@ response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 				</tr>
 			</table>
 		</center>
+
+		<aui:script position="inline">
+			window.body.onload = function() {
+				window.location.replace('<%= redirect %>');
+			}
+		</aui:script>
 	</body>
 </html>

--- a/portal-web/docroot/html/taglib/aui/button/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/button/end.jsp
@@ -17,16 +17,19 @@
 			class="<%= AUIUtil.buildCss(AUIUtil.BUTTON_PREFIX, disabled, false, false, cssClass) %>"
 			href="<%= escapedHREF %>"
 			id="<%= id %>"
-
-			<c:if test="<%= Validator.isNotNull(onClick) %>">
-				onClick="<%= onClick %>"
-			</c:if>
-
 			role="button"
 
 			<%= AUIUtil.buildData(data) %>
 			<%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>
 		>
+
+		<c:if test="<%= Validator.isNotNull(onClick) %>">
+			<aui:script position="inline">
+				document.getElementById('<%= id %>').onclick = function() {
+					<%= onClick %>
+				}
+			</aui:script>
+		</c:if>
 	</c:when>
 	<c:otherwise>
 		<button
@@ -42,21 +45,32 @@
 				name="<%= namespace %><%= name %>"
 			</c:if>
 
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(onClick) %>">
-					onClick="<%= onClick %>"
-				</c:when>
-				<c:when test="<%= Validator.isNotNull(escapedHREF) %>">
-					data-href="<%= escapedHREF %>"
-					onClick="Liferay.Util.navigate(this.dataset.href)"
-				</c:when>
-			</c:choose>
+			<c:if test="<%= Validator.isNotNull(escapedHREF) %>">
+				data-href="<%= escapedHREF %>"
+			</c:if>
 
 			type="<%= type.equals("cancel") ? "button" : type %>"
 
 			<%= AUIUtil.buildData(data) %>
 			<%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>
 		>
+
+		<c:choose>
+			<c:when test="<%= Validator.isNotNull(onClick) %>">
+				<aui:script position="inline">
+					document.getElementById('<%= id %>').onclick = function() {
+						<%= onClick %>
+					}
+				</aui:script>
+			</c:when>
+			<c:when test="<%= Validator.isNotNull(escapedHREF) %>">
+				<aui:script position="inline">
+					document.getElementById('<%= id %>').onclick = function() {
+						Liferay.Util.navigate(this.dataset.href);
+					}
+				</aui:script>
+			</c:when>
+		</c:choose>
 	</c:otherwise>
 </c:choose>
 

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -146,12 +146,20 @@ boolean choiceField = checkboxField || radioField;
 				<span class="toggle-switch-check-bar">
 		</c:if>
 
-		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" onClick="<%= onClick %>" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="checkbox" <%= Validator.isNotNull(valueString) ? ("value=\"" + HtmlUtil.escapeAttribute(valueString)) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="checkbox" <%= Validator.isNotNull(valueString) ? ("value=\"" + HtmlUtil.escapeAttribute(valueString)) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
 
 		<c:if test="<%= Validator.isNotNull(onChange) %>">
 			<aui:script position="inline">
 				document.getElementById('<%= namespace + id %>').onchange = function() {
 					<%= onChange %>
+				}
+			</aui:script>
+		</c:if>
+
+		<c:if test="<%= Validator.isNotNull(onClick) %>">
+			<aui:script position="inline">
+				document.getElementById('<%= namespace + id %>').onclick = function() {
+					<%= onClick %>
 				}
 			</aui:script>
 		</c:if>
@@ -224,12 +232,20 @@ boolean choiceField = checkboxField || radioField;
 		}
 		%>
 
-		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="radio" value="<%= HtmlUtil.escapeAttribute(valueString) %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="radio" value="<%= HtmlUtil.escapeAttribute(valueString) %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
 
 		<c:if test="<%= Validator.isNotNull(onChange) %>">
 			<aui:script position="inline">
 				document.getElementById('<%= namespace + id %>').onchange = function() {
 					<%= onChange %>
+				}
+			</aui:script>
+		</c:if>
+
+		<c:if test="<%= Validator.isNotNull(onClick) %>">
+			<aui:script position="inline">
+				document.getElementById('<%= namespace + id %>').onclick = function() {
+					<%= onClick %>
 				}
 			</aui:script>
 		</c:if>
@@ -330,12 +346,20 @@ boolean choiceField = checkboxField || radioField;
 				String[] storedDimensions = resizable ? StringUtil.split(SessionClicks.get(request, _TEXTAREA_WIDTH_HEIGHT_PREFIX + namespace + id, StringPool.BLANK)) : StringPool.EMPTY_ARRAY;
 				%>
 
-				<textarea class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + (Validator.isBlank(fieldParam) ? name : fieldParam) %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= (storedDimensions.length > 1) ? "style=\"height: " + storedDimensions[0] + "; width: " + storedDimensions[1] + ";" + title + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> ><%= HtmlUtil.escape(valueString) %></textarea>
+				<textarea class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + (Validator.isBlank(fieldParam) ? name : fieldParam) %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= (storedDimensions.length > 1) ? "style=\"height: " + storedDimensions[0] + "; width: " + storedDimensions[1] + ";" + title + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> ><%= HtmlUtil.escape(valueString) %></textarea>
 
 				<c:if test="<%= Validator.isNotNull(onChange) %>">
 					<aui:script position="inline">
 						document.getElementById('<%= namespace + id %>').onchange = function() {
 							<%= onChange %>
+						}
+					</aui:script>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onClick) %>">
+					<aui:script position="inline">
+						document.getElementById('<%= namespace + id %>').onclick = function() {
+							<%= onClick %>
 						}
 					</aui:script>
 				</c:if>
@@ -369,12 +393,20 @@ boolean choiceField = checkboxField || radioField;
 				</c:if>
 			</c:when>
 			<c:otherwise>
-				<input <%= type.equals("image") ? "alt=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= (max != null) ? "max=\"" + max + "\"": StringPool.BLANK %> <%= (min != null) ? "min=\"" + min + "\"": StringPool.BLANK %> <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + name %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="<%= Validator.isNull(type) ? "text" : type %>" <%= !type.equals("image") ? "value=\"" + HtmlUtil.escapeAttribute(valueString) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+				<input <%= type.equals("image") ? "alt=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= (max != null) ? "max=\"" + max + "\"": StringPool.BLANK %> <%= (min != null) ? "min=\"" + min + "\"": StringPool.BLANK %> <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + name %>" <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="<%= Validator.isNull(type) ? "text" : type %>" <%= !type.equals("image") ? "value=\"" + HtmlUtil.escapeAttribute(valueString) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
 
 				<c:if test="<%= Validator.isNotNull(onChange) %>">
 					<aui:script position="inline">
 						document.getElementById('<%= namespace + id %>').onchange = function() {
 							<%= onChange %>
+						}
+					</aui:script>
+				</c:if>
+
+				<c:if test="<%= Validator.isNotNull(onClick) %>">
+					<aui:script position="inline">
+						document.getElementById('<%= namespace + id %>').onclick = function() {
+							<%= onClick %>
 						}
 					</aui:script>
 				</c:if>

--- a/portal-web/docroot/html/taglib/aui/input/page.jsp
+++ b/portal-web/docroot/html/taglib/aui/input/page.jsp
@@ -146,7 +146,15 @@ boolean choiceField = checkboxField || radioField;
 				<span class="toggle-switch-check-bar">
 		</c:if>
 
-		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> onClick="<%= onClick %>" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="checkbox" <%= Validator.isNotNull(valueString) ? ("value=\"" + HtmlUtil.escapeAttribute(valueString)) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" onClick="<%= onClick %>" <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="checkbox" <%= Validator.isNotNull(valueString) ? ("value=\"" + HtmlUtil.escapeAttribute(valueString)) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+
+		<c:if test="<%= Validator.isNotNull(onChange) %>">
+			<aui:script position="inline">
+				document.getElementById('<%= namespace + id %>').onchange = function() {
+					<%= onChange %>
+				}
+			</aui:script>
+		</c:if>
 
 		<c:if test='<%= type.equals("toggle-switch") %>'>
 
@@ -216,7 +224,15 @@ boolean choiceField = checkboxField || radioField;
 		}
 		%>
 
-		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="radio" value="<%= HtmlUtil.escapeAttribute(valueString) %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+		<input <%= checked ? "checked" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" name="<%= namespace + name %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="radio" value="<%= HtmlUtil.escapeAttribute(valueString) %>" <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+
+		<c:if test="<%= Validator.isNotNull(onChange) %>">
+			<aui:script position="inline">
+				document.getElementById('<%= namespace + id %>').onchange = function() {
+					<%= onChange %>
+				}
+			</aui:script>
+		</c:if>
 	</c:when>
 	<c:when test='<%= type.equals("resource") %>'>
 		<liferay-ui:input-resource
@@ -314,7 +330,15 @@ boolean choiceField = checkboxField || radioField;
 				String[] storedDimensions = resizable ? StringUtil.split(SessionClicks.get(request, _TEXTAREA_WIDTH_HEIGHT_PREFIX + namespace + id, StringPool.BLANK)) : StringPool.EMPTY_ARRAY;
 				%>
 
-				<textarea class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + (Validator.isBlank(fieldParam) ? name : fieldParam) %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= (storedDimensions.length > 1) ? "style=\"height: " + storedDimensions[0] + "; width: " + storedDimensions[1] + ";" + title + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>><%= HtmlUtil.escape(valueString) %></textarea>
+				<textarea class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + (Validator.isBlank(fieldParam) ? name : fieldParam) %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= (storedDimensions.length > 1) ? "style=\"height: " + storedDimensions[0] + "; width: " + storedDimensions[1] + ";" + title + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> ><%= HtmlUtil.escape(valueString) %></textarea>
+
+				<c:if test="<%= Validator.isNotNull(onChange) %>">
+					<aui:script position="inline">
+						document.getElementById('<%= namespace + id %>').onchange = function() {
+							<%= onChange %>
+						}
+					</aui:script>
+				</c:if>
 
 				<c:if test="<%= autoSize %>">
 					<aui:script sandbox="<%= true %>">
@@ -345,7 +369,15 @@ boolean choiceField = checkboxField || radioField;
 				</c:if>
 			</c:when>
 			<c:otherwise>
-				<input <%= type.equals("image") ? "alt=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= (max != null) ? "max=\"" + max + "\"": StringPool.BLANK %> <%= (min != null) ? "min=\"" + min + "\"": StringPool.BLANK %> <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="<%= Validator.isNull(type) ? "text" : type %>" <%= !type.equals("image") ? "value=\"" + HtmlUtil.escapeAttribute(valueString) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+				<input <%= type.equals("image") ? "alt=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> class="<%= fieldCssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= (max != null) ? "max=\"" + max + "\"": StringPool.BLANK %> <%= (min != null) ? "min=\"" + min + "\"": StringPool.BLANK %> <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + name %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(placeholder) ? "placeholder=\"" + LanguageUtil.get(resourceBundle, placeholder) + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="<%= Validator.isNull(type) ? "text" : type %>" <%= !type.equals("image") ? "value=\"" + HtmlUtil.escapeAttribute(valueString) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> />
+
+				<c:if test="<%= Validator.isNotNull(onChange) %>">
+					<aui:script position="inline">
+						document.getElementById('<%= namespace + id %>').onchange = function() {
+							<%= onChange %>
+						}
+					</aui:script>
+				</c:if>
 			</c:otherwise>
 		</c:choose>
 

--- a/portal-web/docroot/html/taglib/aui/select/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/select/end.jsp
@@ -34,7 +34,15 @@
 		</span>
 	</c:if>
 
-	<select class="<%= fieldCss %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + name %>" <%= Validator.isNotNull(onChange) ? "onChange=\"" + onChange + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
+	<select class="<%= fieldCss %>" <%= disabled ? "disabled" : StringPool.BLANK %> id="<%= namespace + id %>" <%= multiple ? "multiple" : StringPool.BLANK %> name="<%= namespace + name %>" <%= Validator.isNotNull(onClick) ? "onClick=\"" + onClick + "\"" : StringPool.BLANK %> <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> <%= AUIUtil.buildData(data) %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %>>
+		<c:if test="<%= Validator.isNotNull(onChange) %>">
+			<aui:script position="inline">
+				document.getElementById('<%= namespace + id %>').onchange = function() {
+					<%= onChange %>
+				}
+			</aui:script>
+		</c:if>
+
 		<c:if test="<%= showEmptyOption %>">
 			<aui:option value="<%= (Validator.isNotNull(listType) || numericValue) ? 0 : StringPool.BLANK %>" />
 		</c:if>

--- a/portal-web/docroot/html/taglib/init.jsp
+++ b/portal-web/docroot/html/taglib/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ include file="/html/common/init.jsp" %>
 
-<%@ page import="com.liferay.portal.kernel.servlet.MultiSessionErrors" %><%@
+<%@ page import="com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.MultiSessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %><%@
 page import="com.liferay.taglib.util.InlineUtil" %><%@

--- a/portal-web/docroot/html/taglib/ui/input_checkbox/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_checkbox/page.jsp
@@ -23,4 +23,10 @@ if (Validator.isNull(id)) {
 }
 %>
 
-<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> <%= value ? "checked" : "" %> class="<%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= HtmlUtil.escapeAttribute(id) %>" name="<%= namespace %><%= param %>" onClick="<%= onClick %>" type="checkbox" />
+<input <%= Validator.isNotNull(autoComplete) ? "autocomplete=\"" + autoComplete + "\"" : StringPool.BLANK %> <%= value ? "checked" : "" %> class="<%= cssClass %>" <%= disabled ? "disabled=\"disabled\"" : "" %> id="<%= HtmlUtil.escapeAttribute(id) %>" name="<%= namespace %><%= param %>" type="checkbox" />
+
+<aui:script position="inline">
+	document.getElementById('<%= HtmlUtil.escapeAttribute(id) %>').onclick = function() {
+		<%= onClick %>
+	}
+</aui:script>

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -119,9 +119,15 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 					}
 				</aui:script>
 
-				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm mt-3" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" onclick="<%= uniqueNamespace %>inputPermissionsToggle();" type="button">
+				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm mt-3" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" type="button">
 					<%= inputPermissionsShowOptions ? LanguageUtil.get(request, "hide-options") : LanguageUtil.get(request, "more-options") %>
 				</button>
+
+				<aui:script position="inline">
+					document.getElementById('<%= uniqueNamespace %>inputPermissionsOptionsButton').onclick = function() {
+						<%= uniqueNamespace %>inputPermissionsToggle();
+					}
+				</aui:script>
 
 				<span class="mt-3 <%= inputPermissionsShowOptions ? "hide" : "" %>" id="<%= uniqueNamespace %>inputPermissionsShowOptionsHelp">
 					<liferay-ui:icon-help message="input-permissions-more-options-help" />

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -79,7 +79,7 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 					<liferay-ui:message key="viewable-by" />
 				</label>
 
-				<select class="form-control" id="<%= uniqueNamespace %>inputPermissionsViewRole" name="<%= namespace %>inputPermissionsViewRole" onChange="<%= uniqueNamespace %>updatePermissionsView();">
+				<select class="form-control" id="<%= uniqueNamespace %>inputPermissionsViewRole" name="<%= namespace %>inputPermissionsViewRole">
 
 					<%
 					String guestRoleLabel = LanguageUtil.format(request, "x-role", guestRole.getTitle(themeDisplay.getLocale()), false);
@@ -112,6 +112,12 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 
 					<option <%= inputPermissionsViewRole.equals(RoleConstants.OWNER) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.OWNER %>"><liferay-ui:message key="owner" /></option>
 				</select>
+
+				<aui:script position="inline">
+					document.getElementById('<%= uniqueNamespace %>inputPermissionsViewRole').onchange = function() {
+						<%= uniqueNamespace %>updatePermissionsView();
+					}
+				</aui:script>
 
 				<button aria-controls="<%= uniqueNamespace %>inputPermissionsTable" aria-expanded="<%= inputPermissionsShowOptions %>" class="btn btn-secondary btn-sm mt-3" id="<%= uniqueNamespace %>inputPermissionsOptionsButton" onclick="<%= uniqueNamespace %>inputPermissionsToggle();" type="button">
 					<%= inputPermissionsShowOptions ? LanguageUtil.get(request, "hide-options") : LanguageUtil.get(request, "more-options") %>

--- a/portal-web/docroot/html/taglib/ui/input_resource/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_resource/page.jsp
@@ -11,16 +11,24 @@
 String id = GetterUtil.getString((String)request.getAttribute("liferay-ui:input-resource:id"));
 String title = (String)request.getAttribute("liferay-ui:input-resource:title");
 String url = (String)request.getAttribute("liferay-ui:input-resource:url");
+
+if (Validator.isNotNull(id)) {
+	id = namespace + id;
+}
+else {
+	id = StringUtil.randomId();
+}
 %>
 
-<input class="form-control lfr-input-resource <%= GetterUtil.getString((String)request.getAttribute("liferay-ui:input-resource:cssClass")) %>" <%= Validator.isNotNull(id) ? "id=\"" + namespace + id + "\"" : StringPool.BLANK %> onClick="this.select();" disabled <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="text" value="<%= HtmlUtil.escapeAttribute(url) %>" />
+<input class="form-control lfr-input-resource <%= GetterUtil.getString((String)request.getAttribute("liferay-ui:input-resource:cssClass")) %>" id="<%= id %>" disabled <%= Validator.isNotNull(title) ? "title=\"" + LanguageUtil.get(resourceBundle, title) + "\"" : StringPool.BLANK %> type="text" value="<%= HtmlUtil.escapeAttribute(url) %>" />
 
-<aui:script>
-	var inputField = document.getElementById('<portlet:namespace /><%= id %>');
+<aui:script position="inline">
+	var inputField = document.getElementById('<%= id %>');
 
 	inputField.addEventListener(
 		'click',
 		function () {
+			this.select();
 			this.setSelectionRange(0, 9999);
 		}
 	);

--- a/portal-web/docroot/html/taglib/ui/page_iterator/deprecated/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/deprecated/start.jsp
@@ -129,15 +129,25 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				else {
 					sb.append("<a class='journal-article-page-number' href='");
 					sb.append(_getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor));
+					sb.append("' id='");
 
-					if (forcePost) {
-						sb.append("' onClick='");
-						sb.append(_getOnClick(namespace, curParam, i));
-					}
+					String randomId = StringUtil.randomId();
+
+					sb.append(randomId);
 
 					sb.append("'>");
 					sb.append(i);
 					sb.append("</a>");
+
+					if (forcePost) {
+						sb.append("<script");
+						sb.append(ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(request));
+						sb.append(">document.getElementById('");
+						sb.append(randomId);
+						sb.append("').onclick = function() {");
+						sb.append(_getOnClick(namespace, curParam, i));
+						sb.append("};</script>");
+					}
 				}
 
 				sb.append("&nbsp;&nbsp;");
@@ -257,19 +267,50 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 		<ul class="lfr-pagination-buttons pagination">
 			<c:if test='<%= type.equals("approximate") || type.equals("more") || type.equals("regular") %>'>
 				<li class="<%= (cur != 1) ? "" : "disabled" %> first page-item">
-					<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, 1) : "" %>" tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
+
+					<%
+					String randomId = StringUtil.randomId();
+					%>
+
+					<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" id="<%= randomId %>" page-link tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
 						<%= PortalUtil.isRightToLeft(request) ? "&rarr;" : "&larr;" %> <liferay-ui:message key="first" />
 					</a>
+
+					<c:if test="<%= (cur != 1) && forcePost %>">
+						<aui:script position="inline">
+							document.getElementById('<%= randomId %>').onclick = function() {
+								<%= _getOnClick(namespace, curParam, 1) %>
+							}
+						</aui:script>
+					</c:if>
 				</li>
 			</c:if>
 
 			<li class="<%= (cur != 1) ? "" : "disabled" %> page-item">
-				<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, cur - 1) : "" %>" tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
+
+				<%
+				String randomId = StringUtil.randomId();
+				%>
+
+				<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" id="<%= randomId %>" page-link tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
 					<liferay-ui:message key="previous" />
 				</a>
+
+				<c:if test="<%= (cur != 1) && forcePost %>">
+					<aui:script position="inline">
+						document.getElementById('<%= randomId %>').onclick = function() {
+							<%= _getOnClick(namespace, curParam, cur - 1) %>
+						}
+					</aui:script>
+				</c:if>
 			</li>
 			<li class="<%= (cur != pages) ? "" : "disabled" %> page-item">
-				<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>" tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
+
+				<%
+				randomId = StringUtil.randomId();
+				%>
+
+				<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" id="<%= randomId %>" page-link tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
 					<c:choose>
 						<c:when test='<%= type.equals("approximate") || type.equals("more") %>'>
 							<liferay-ui:message key="more" />
@@ -279,13 +320,34 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</c:otherwise>
 					</c:choose>
 				</a>
+
+				<c:if test="<%= (cur != pages) && forcePost %>">
+					<aui:script position="inline">
+						document.getElementById('<%= randomId %>').onclick = function() {
+							<%= _getOnClick(namespace, curParam, cur + 1) %>
+						}
+					</aui:script>
+				</c:if>
 			</li>
 
 			<c:if test='<%= type.equals("regular") %>'>
 				<li class="<%= (cur != pages) ? "" : "disabled" %> last page-item">
-					<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, pages) : "" %>" tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
+
+					<%
+					randomId = StringUtil.randomId();
+					%>
+
+					<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) : "javascript:void(0);" %>" id="<%= randomId %>" page-link tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
 						<liferay-ui:message key="last" /> <%= PortalUtil.isRightToLeft(request) ? "&larr;" : "&rarr;" %>
 					</a>
+
+					<c:if test="<%= (cur != pages) && forcePost %>">
+						<aui:script position="inline">
+							document.getElementById('<%= randomId %>').onclick = function() {
+								<%= _getOnClick(namespace, curParam, pages) %>
+							}
+						</aui:script>
+					</c:if>
 				</li>
 			</c:if>
 		</ul>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -103,9 +103,17 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					%>
 
 						<li role="option">
-							<a class="dropdown-item <%= (delta == curDelta) ? "active" : "" %>" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" id="<%= String.valueOf(curDelta) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>">
+							<a class="dropdown-item <%= (delta == curDelta) ? "active" : "" %>" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" id="<%= String.valueOf(curDelta) %>">
 								<%= String.valueOf(curDelta) %><span class="sr-only"><%= StringPool.NBSP %><liferay-ui:message key="entries-per-page" /></span>
 							</a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= String.valueOf(curDelta) %>').onclick = function() {
+										<%= _getOnClick(namespace, deltaParam, curDelta) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 
 					<%
@@ -200,7 +208,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
 					<c:choose>
 						<c:when test="<%= cur > 1 %>">
-							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
+
+							<%
+							String randomId = StringUtil.randomId();
+							%>
+
+							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, cur -1) %>
+									}
+								</aui:script>
+							</c:if>
 						</c:when>
 						<c:otherwise>
 							<div class="page-link">
@@ -235,7 +256,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 										<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" tabindex="0">
 									</c:when>
 									<c:otherwise>
-										<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
+
+										<%
+										String randomId = StringUtil.randomId();
+										%>
+
+										<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" id="<%= randomId %>">
+
+										<c:if test="<%= forcePost %>">
+											<aui:script position="inline">
+												document.getElementById('<%= randomId %>').onclick = function() {
+													<%= _getOnClick(namespace, curParam, i) %>
+												}
+											</aui:script>
+										</c:if>
 									</c:otherwise>
 								</c:choose>
 
@@ -252,10 +286,36 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
+
+							<%
+							String randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, 2) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
+
+							<%
+							randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, 3) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 						<li class="dropdown page-item">
 							<button aria-controls="dropdown-pages-1" aria-haspopup="true" class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown">
@@ -275,7 +335,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 									%>
 
 										<li>
-											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+											<%
+											randomId = StringUtil.randomId();
+											%>
+
+											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+											<c:if test="<%= forcePost %>">
+												<aui:script position="inline">
+													document.getElementById('<%= randomId %>').onclick = function() {
+														<%= _getOnClick(namespace, curParam, i) %>
+													}
+												</aui:script>
+											</c:if>
 										</li>
 
 									<%
@@ -286,12 +359,38 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							</div>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+
+							<%
+							randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, pages) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 					</c:when>
 					<c:when test="<%= cur == pages %>">
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+
+							<%
+							String randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, 1) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 						<li class="dropdown page-item">
 							<button aria-controls="dropdown-pages-2" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
@@ -308,7 +407,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 									%>
 
 										<li>
-											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+											<%
+											randomId = StringUtil.randomId();
+											%>
+
+											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+											<c:if test="<%= forcePost %>">
+												<aui:script position="inline">
+													document.getElementById('<%= randomId %>').onclick = function() {
+														<%= _getOnClick(namespace, curParam, i) %>
+													}
+												</aui:script>
+											</c:if>
 										</li>
 
 									<%
@@ -319,10 +431,36 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							</div>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 2 %></a>
+
+							<%
+							randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 2 %></a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, pages - 2) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
+
+							<%
+							randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, pages - 1) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 						<li class="active page-item">
 							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
@@ -330,7 +468,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					</c:when>
 					<c:otherwise>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+
+							<%
+							String randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, 1) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 
 						<c:if test="<%= (cur - 3) > 1 %>">
@@ -350,7 +501,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						%>
 
 							<li class="<%= ((cur - 3) > 1) ? "" : "page-item" %>">
-								<a class="<%= ((cur - 3) > 1) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+								<%
+								randomId = StringUtil.randomId();
+								%>
+
+								<a class="<%= ((cur - 3) > 1) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+								<c:if test="<%= forcePost %>">
+									<aui:script position="inline">
+										document.getElementById('<%= randomId %>').onclick = function() {
+											<%= _getOnClick(namespace, curParam, i) %>
+										}
+									</aui:script>
+								</c:if>
 							</li>
 
 						<%
@@ -365,7 +529,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 						<c:if test="<%= (cur - 1) > 1 %>">
 							<li class="page-item">
-								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur - 1 %></a>
+
+								<%
+								randomId = StringUtil.randomId();
+								%>
+
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur - 1 %></a>
+
+								<c:if test="<%= forcePost %>">
+									<aui:script position="inline">
+										document.getElementById('<%= randomId %>').onclick = function() {
+											<%= _getOnClick(namespace, curParam, cur - 1) %>
+										}
+									</aui:script>
+								</c:if>
 							</li>
 						</c:if>
 
@@ -375,7 +552,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 						<c:if test="<%= (cur + 1) < pages %>">
 							<li class="page-item">
-								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur + 1 %></a>
+
+								<%
+								randomId = StringUtil.randomId();
+								%>
+
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur + 1 %></a>
+
+								<c:if test="<%= forcePost %>">
+									<aui:script position="inline">
+										document.getElementById('<%= randomId %>').onclick = function() {
+											<%= _getOnClick(namespace, curParam, cur + 1) %>
+										}
+									</aui:script>
+								</c:if>
 							</li>
 						</c:if>
 
@@ -398,7 +588,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						%>
 
 							<li class="<%= ((cur + 3) < pages) ? "" : "page-item" %>">
-								<a class="<%= ((cur + 3) < pages) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+								<%
+								randomId = StringUtil.randomId();
+								%>
+
+								<a class="<%= ((cur + 3) < pages) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+
+								<c:if test="<%= forcePost %>">
+									<aui:script position="inline">
+										document.getElementById('<%= randomId %>').onclick = function() {
+											<%= _getOnClick(namespace, curParam, i) %>
+										}
+									</aui:script>
+								</c:if>
 							</li>
 
 						<%
@@ -412,7 +615,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</c:if>
 
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+
+							<%
+							randomId = StringUtil.randomId();
+							%>
+
+							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" id="<%= randomId %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, pages) %>
+									}
+								</aui:script>
+							</c:if>
 						</li>
 					</c:otherwise>
 				</c:choose>
@@ -420,7 +636,20 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
 					<c:choose>
 						<c:when test="<%= cur < pages %>">
-							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
+
+							<%
+							String randomId = StringUtil.randomId();
+							%>
+
+							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" id="<%= randomId %>" title="<%= LanguageUtil.get(request, "next-page") %>">
+
+							<c:if test="<%= forcePost %>">
+								<aui:script position="inline">
+									document.getElementById('<%= randomId %>').onclick = function() {
+										<%= _getOnClick(namespace, curParam, cur + 1) %>
+									}
+								</aui:script>
+							</c:if>
 						</c:when>
 						<c:otherwise>
 							<div class="page-link">

--- a/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/quick_access/page.jsp
@@ -43,16 +43,22 @@ String randomNamespace = StringUtil.randomId() + StringPool.UNDERLINE;
 							<li>
 								<c:choose>
 									<c:when test="<%= Validator.isNull(quickAccessEntry.getURL()) %>">
-										<button class="<%= linkClass %> btn btn-link btn-unstyled text-nowrap" id="<%= randomNamespace + quickAccessEntry.getId() %>" onclick="<%= quickAccessEntry.getOnClick() %>">
+										<button class="<%= linkClass %> btn btn-link btn-unstyled text-nowrap" id="<%= randomNamespace + quickAccessEntry.getId() %>">
 											<%= quickAccessEntry.getContent() %>
 										</button>
 									</c:when>
 									<c:otherwise>
-										<a class="<%= linkClass %>" href="<%= quickAccessEntry.getURL() %>" id="<%= randomNamespace + quickAccessEntry.getId() %>" onclick="<%= quickAccessEntry.getOnClick() %>">
+										<a class="<%= linkClass %>" href="<%= quickAccessEntry.getURL() %>" id="<%= randomNamespace + quickAccessEntry.getId() %>">
 											<%= quickAccessEntry.getContent() %>
 										</a>
 									</c:otherwise>
 								</c:choose>
+
+								<aui:script position="inline">
+									document.getElementById('<%= randomNamespace + quickAccessEntry.getId() %>').onclick = function() {
+										<%= quickAccessEntry.getOnClick() %>
+									}
+								</aui:script>
 							</li>
 
 						<%

--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -193,9 +193,22 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs
 	%>
 
 		<li class="nav-item" data-tab-name="<%= names[i] %>" id="<%= namespace %><%= param %><%= StringUtil.toCharCode(values[i]) %>TabsId" role="none">
-			<a class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" onClick="<%= Validator.isNotNull(curOnClick) ? curOnClick : StringPool.BLANK %>" role="tab">
+
+			<%
+			String id = StringUtil.randomId();
+			%>
+
+			<a class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" id="<%= id %>" role="tab">
 				<liferay-ui:message key="<%= HtmlUtil.escape(names[i]) %>" />
 			</a>
+
+			<c:if test="<%= Validator.isNotNull(curOnClick) %>">
+				<aui:script position="inline">
+					document.getElementById('<%= id %>').onclick = function() {
+						<%= curOnClick %>
+					}
+				</aui:script>
+			</c:if>
 		</li>
 
 	<%

--- a/portal-web/docroot/index.jsp
+++ b/portal-web/docroot/index.jsp
@@ -64,7 +64,11 @@ response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
 		<meta content="1; url=<%= HtmlUtil.escapeAttribute(redirect) %>" http-equiv="refresh" />
 	</head>
 
-	<body onload="javascript:location.replace('<%= HtmlUtil.escapeJS(redirect) %>')">
-
+	<body>
+		<aui:script position="inline">
+			window.body.onload = function() {
+				window.location.replace('<%= HtmlUtil.escapeJS(redirect) %>');
+			}
+		</aui:script>
 	</body>
 </html>

--- a/portal-web/docroot/init.jsp
+++ b/portal-web/docroot/init.jsp
@@ -5,6 +5,8 @@
  */
 --%>
 
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %>
+
 <%@ page import="com.liferay.petra.string.CharPool" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.events.ServicePreAction" %><%@

--- a/util-taglib/src/com/liferay/taglib/aui/ATag.java
+++ b/util-taglib/src/com/liferay/taglib/aui/ATag.java
@@ -6,11 +6,13 @@
 package com.liferay.taglib.aui;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.aui.base.BaseATag;
@@ -34,6 +36,13 @@ import javax.servlet.jsp.JspWriter;
  */
 @Deprecated
 public class ATag extends BaseATag {
+
+	@Override
+	protected void cleanUp() {
+		super.cleanUp();
+
+		_randomId = StringUtil.randomId();
+	}
 
 	@Override
 	protected int processEndTag() throws Exception {
@@ -76,6 +85,30 @@ public class ATag extends BaseATag {
 			jspWriter.write("</span>");
 		}
 
+		String onClick = getOnClick();
+
+		if (Validator.isNotNull(onClick)) {
+			jspWriter.write("<script");
+			jspWriter.write(
+				ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+					getRequest()));
+			jspWriter.write(">document.getElementById('");
+
+			String id = getId();
+
+			if (Validator.isNotNull(id)) {
+				jspWriter.write(_getNamespace());
+				jspWriter.write(id);
+			}
+			else {
+				jspWriter.write(_randomId);
+			}
+
+			jspWriter.write("').onclick=function() {");
+			jspWriter.write(onClick);
+			jspWriter.write("}</script>");
+		}
+
 		return EVAL_PAGE;
 	}
 
@@ -92,7 +125,6 @@ public class ATag extends BaseATag {
 		String iconCssClass = getIconCssClass();
 		String label = getLabel();
 		String lang = getLang();
-		String onClick = getOnClick();
 		String title = getTitle();
 
 		if (Validator.isNotNull(href)) {
@@ -132,16 +164,15 @@ public class ATag extends BaseATag {
 			jspWriter.write(id);
 			jspWriter.write("\" ");
 		}
+		else {
+			jspWriter.write("id=\"");
+			jspWriter.write(_randomId);
+			jspWriter.write("\" ");
+		}
 
 		if (Validator.isNotNull(lang)) {
 			jspWriter.write("lang=\"");
 			jspWriter.write(lang);
-			jspWriter.write("\" ");
-		}
-
-		if (Validator.isNotNull(onClick)) {
-			jspWriter.write("onClick=\"");
-			jspWriter.write(HtmlUtil.escapeAttribute(onClick));
 			jspWriter.write("\" ");
 		}
 
@@ -224,5 +255,7 @@ public class ATag extends BaseATag {
 			jspWriter.write(dynamicAttributesString);
 		}
 	}
+
+	private String _randomId = StringUtil.randomId();
 
 }

--- a/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
+++ b/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
@@ -5,8 +5,9 @@
 
 package com.liferay.taglib.search;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.Writer;
 
@@ -33,10 +34,21 @@ public class ButtonSearchEntry extends TextSearchEntry {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
+		String id = StringUtil.randomId();
+
+		writer.write("<input id=\"");
+		writer.write(id);
+		writer.write("\" type=\"button\" value=\"");
+		writer.write(getName());
+		writer.write("\"><script");
 		writer.write(
-			StringBundler.concat(
-				"<input type=\"button\" value=\"", getName(), "\" onClick=\"",
-				getHref(), "\">"));
+			ContentSecurityPolicyNonceProviderUtil.getNonce(
+				httpServletRequest));
+		writer.write(">document.getElementById('");
+		writer.write(id);
+		writer.write("').onclick=function() {");
+		writer.write(getHref());
+		writer.write("}</script>");
 	}
 
 }

--- a/util-taglib/src/com/liferay/taglib/util/PositionTagSupport.java
+++ b/util-taglib/src/com/liferay/taglib/util/PositionTagSupport.java
@@ -69,26 +69,32 @@ public class PositionTagSupport extends BaseBodyTagSupport implements BodyTag {
 				(ThemeDisplay)httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
 
-			if (themeDisplay.isIsolated() ||
-				themeDisplay.isLifecycleResource() ||
-				themeDisplay.isStateExclusive()) {
-
+			if (themeDisplay == null) {
 				position = _POSITION_INLINE;
 			}
 			else {
-				position = _POSITION_AUTO;
-			}
+				if (themeDisplay.isIsolated() ||
+					themeDisplay.isLifecycleResource() ||
+					themeDisplay.isStateExclusive()) {
 
-			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+					position = _POSITION_INLINE;
+				}
+				else {
+					position = _POSITION_AUTO;
+				}
 
-			String portletId = portletDisplay.getId();
+				PortletDisplay portletDisplay =
+					themeDisplay.getPortletDisplay();
 
-			if (Validator.isNotNull(portletId) &&
-				themeDisplay.isPortletEmbedded(
-					themeDisplay.getScopeGroupId(), themeDisplay.getLayout(),
-					portletId)) {
+				String portletId = portletDisplay.getId();
 
-				position = _POSITION_INLINE;
+				if (Validator.isNotNull(portletId) &&
+					themeDisplay.isPortletEmbedded(
+						themeDisplay.getScopeGroupId(),
+						themeDisplay.getLayout(), portletId)) {
+
+					position = _POSITION_INLINE;
+				}
 			}
 		}
 


### PR DESCRIPTION
This draft PR contains all commits for [LPD-36188](https://liferay.atlassian.net/browse/LPD-36188).

We are tracking the progress of teams' sub-PRs at [LPD-36186](https://liferay.atlassian.net/browse/LPD-36186).

The "Welcome Pack" (in Technical Draft format) for teams' sub-PRs is at this [confluence doc](https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3245277533/LPD-36188+-+Allow+using+directive+script-src-attr+none+by+removing+inline+handlers).

I will split it in parts based on ownership and will send sub-PRs accordingly for CI testing.

This PR reflects the real time status of LPD-36188 using emojis, like this:

- :see_no_evil: Infrastructure commits that cannot really be tested directly (because they affect the majority of the portal)
- :ok_hand: Commits for which we know what test suite to run (based on heuristics, see below)
- :link: Commits for which we know which team we should send the PR to (based on heuristics, see below)
- :question: Commits for which we don't yet know the team or the test suite
- :checkered_flag:  Commit that has already been submitted in a sub-PR

**How to determine test suite and team for a given commit:**
1. Determine the "app" to which the commit belongs (eg: `modules/apps/wiki`).
2. Perform a `git log` on that app directory.
3. Find a meaningful LPD and based on the user and the PR, determine:
    1. The `liferay-portal` fork for the app (eg: `https://github.com/liferay-content-management`)
    2. The typical test suite used by that team (eg: `ci:test:content-management`)

**List of teams affected by this PR and their ongoing sub-PRs:**
1. ~https://github.com/liferay-appsec/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4468~ (SENT :white_check_mark:) 
2. ~https://github.com/liferay-commerce/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4471~ (SENT :white_check_mark:) 
3. ~https://github.com/liferay-content-management/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4473~ (SENT :white_check_mark:)
4. ~https://github.com/liferay-forms/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4474~ (SENT :white_check_mark:)
5. ~https://github.com/liferay-frontend/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4475~ (MERGED :white_check_mark:)
6. ~https://github.com/liferay-headless/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4476~ (SENT :white_check_mark:)
7. ~https://github.com/liferay-search/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4477~ (SENT :white_check_mark:)
8. ~https://github.com/liferay-content-management/liferay-portal :point_right: https://github.com/liferay-frontend/liferay-portal/pull/4479~ (SENT :white_check_mark:)

**Confluence doc to attach to each team PR explaining what's going on:** 
https://liferay.atlassian.net/wiki/spaces/ENGFRONTENDINFRA/pages/3245277533/LPD-36188+-+Allow+using+directive+script-src-attr+none+by+removing+inline+handlers

**Rest of :see_no_evil: commits:**

I've analyzed where each commit subject is used and have come to these conclusions:

```
=== Used pervasively:
- RowChecker
- <aui:a>
- <aui:button>
- <aui:input>
	- <liferay-ui:input-resource> (bc it is only used in <aui:input>)
	- <liferay-ui:input-checkbox> (bc it is mainly used in <aui:input>)
- <aui:select>
- <clay:alert>
- <liferay-ui:input-permissions>
- <liferay-ui:search-container-row>
	- <liferay-ui:page-iterator> (bc it is mainly used in <liferay-ui:search-paginator>)
- <liferay-ui:tabs>

=== Not used at all:
- <liferay-ui:quick-access>
```

So I will create 9 :see_no_evil: (high risk) PRs and one more with `<liferay-ui:quick-access>` that I will send ASAP since it is not expected to break anything.

**Back to square one (Oct 10th):**

Since [duplicated code has been found in revisions](https://github.com/brianchandotcom/liferay-portal/pull/155357#issuecomment-2423742140) we are going to change the approach of this PR and try to use `<aui:..>` tags instead of raw HTML to hide the id computation and attachment inside their implementation.

We will find a better way to do all this under [LPD-39791](https://liferay.atlassian.net/browse/LPD-39791), then undo everything and redo it with the new approach.

