### PR TITLE
LPD-38501 - Adjust editFormrTaglibRole test

### DIFF
--- a/modules/test/playwright/tests/frontend-taglib/editFormTaglibRole.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/editFormTaglibRole.spec.ts
@@ -31,6 +31,8 @@ test('Form fields should not be wrapped in a tablist role @LPD-35819', async ({
 
 		await journalPage.goto(site.friendlyUrlPath);
 
+		await journalPage.changeView('cards');
+
 		await page
 			.locator(`.card-body:has-text('${webContentFolder.name}')`)
 			.getByLabel('More actions')


### PR DESCRIPTION
Fix https://liferay.atlassian.net/browse/LPD-38501

Test assumes that default visualization is cards but locally it seems to be list.

![Screenshot from 2024-10-08 13-49-23](https://github.com/user-attachments/assets/2e4a77b4-4087-4c0b-8814-356eae4a2e25)