### PR TITLE
LPD-38101, LPD-38653, and LPD-38659

### DIFF
--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -58,6 +58,7 @@ import {config as portalSearchWebConfig} from './tests/portal-search-web/config'
 import {config as portalSecurityScriptManagementWebConfig} from './tests/portal-security-script-management-web/config';
 import {config as portalSecurityServiceAccessPolicyService} from './tests/portal-security-service-access-policy-service/config';
 import {config as portalToolsRestBuilderTestImpl} from './tests/portal-tools-rest-builder-test-impl/config';
+import {config as portalWebConfig} from './tests/portal-web/config';
 import {config as portalWorkflowKaleoDesignerWebConfig} from './tests/portal-workflow-kaleo-designer-web/config';
 import {config as portalWorkflowTaskWebConfig} from './tests/portal-workflow-task-web/config';
 import {config as portletConfigurationCssWebConfig} from './tests/portlet-configuration-css-web/config';
@@ -154,6 +155,7 @@ export default defineConfig({
 		portalSecurityScriptManagementWebConfig,
 		portalSecurityServiceAccessPolicyService,
 		portalToolsRestBuilderTestImpl,
+		portalWebConfig,
 		portalWorkflowKaleoDesignerWebConfig,
 		portalWorkflowTaskWebConfig,
 		portletConfigurationCssWebConfig,

--- a/modules/test/playwright/tests/portal-web/config.ts
+++ b/modules/test/playwright/tests/portal-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-web',
+	testDir: 'tests/portal-web',
+};

--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/pageIterator.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/pageIterator.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../../../fixtures/loginTest';
+
+const test = mergeTests(loginTest());
+
+test(
+	'Check various accessibility in pagination',
+	{tag: ['@LPD-38101', '@LPD-38653', '@LPD-38653']},
+	async ({page}) => {
+		await test.step('Use searchbar to go to search page', async () => {
+			await page.goto('/');
+
+			const searchBar = page.getByPlaceholder('Search...');
+
+			await searchBar.waitFor({state: 'visible'});
+
+			await searchBar.fill('png');
+
+			await searchBar.press('Enter');
+
+			await page
+				.getByRole('heading', {name: 'Search Results'})
+				.waitFor({state: 'visible'});
+		});
+
+		await test.step('Check pagination button is selected and contains option role', async () => {
+			await page.getByLabel('Items per Page').click();
+
+			const paginationFourSelection = page.getByRole('option', {
+				name: '4  Entries per Page',
+			});
+
+			await paginationFourSelection.click();
+
+			const pagination = page.getByLabel('Items per Page');
+
+			await pagination.waitFor({state: 'visible'});
+
+			const paginationLinkSelected = page.locator(
+				'a[aria-selected="true"][role="option"][id="4"]'
+			);
+
+			await expect(paginationLinkSelected).toBeHidden();
+		});
+
+		await test.step('Check pagination list has aria-labelledby', async () => {
+			const element = page.locator('.dropdown-menu.dropdown-menu-top');
+
+			await expect(element).toHaveAttribute('aria-labelledby');
+		});
+
+		await test.step('Check aria-label is being translated', async () => {
+			await page.goto('/es/search?q=png');
+
+			await page
+				.getByRole('heading', {name: 'Barra de búsqueda'})
+				.waitFor({state: 'visible'});
+
+			const paginationTranslated = page.getByLabel('Paginación');
+
+			await expect(paginationTranslated).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/portal-web/test.properties
+++ b/modules/test/playwright/tests/portal-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+testray.main.component.name=Frontend JS API

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -102,8 +102,8 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						String curDeltaURL = HttpComponentsUtil.setParameter(url + urlAnchor, namespace + deltaParam, curDelta);
 					%>
 
-						<li role="option">
-							<a class="dropdown-item <%= (delta == curDelta) ? "active" : "" %>" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" id="<%= String.valueOf(curDelta) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>">
+						<li role="presentation">
+							<a aria-selected="<%= (delta == curDelta) ? "true" : "false" %>" class="dropdown-item <%= (delta == curDelta) ? "active" : "" %>" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" id="<%= String.valueOf(curDelta) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>" role="option">
 								<%= String.valueOf(curDelta) %><span class="sr-only"><%= StringPool.NBSP %><liferay-ui:message key="entries-per-page" /></span>
 							</a>
 						</li>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -91,7 +91,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					<aui:icon image="caret-double-l" markupView="lexicon" />
 				</button>
 
-				<ul class="dropdown-menu dropdown-menu-top" id="<%= ariaPaginationPicker %>" role="listbox" tabindex="-1">
+				<ul aria-labelledby="<%= ariaPagination %>" class="dropdown-menu dropdown-menu-top" id="<%= ariaPaginationPicker %>" role="listbox" tabindex="-1">
 
 					<%
 					for (int curDelta : PropsValues.SEARCH_CONTAINER_PAGE_DELTA_VALUES) {

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -195,7 +195,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 			<liferay-ui:message arguments="<%= new Object[] {numberFormat.format(start + 1), numberFormat.format(end), numberFormat.format(total)} %>" key="showing-x-to-x-of-x-entries" />
 		</p>
 
-		<nav aria-label="pagination">
+		<nav aria-label="<liferay-ui:message key="pagination" />">
 			<ul class="pagination">
 				<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
 					<c:choose>


### PR DESCRIPTION
Three different LPD tickets that are related to page_iterator/start.jsp.

https://liferay.atlassian.net/browse/LPP-55999
https://liferay.atlassian.net/browse/LPD-38659

Needed to add `aria-labelledby` to the `ul`
4bdfedf322e83f89afc79a978fd2de7a26301c7f


https://liferay.atlassian.net/browse/LPP-56001
https://liferay.atlassian.net/browse/LPD-38653

Needed to change the role of `li` to `presentation`, added `aria-selected` attribute, and added `role="option"` to links.
85f8464accd333d0e4becf79b8b4c078cf02d1f5

https://liferay.atlassian.net/browse/LPP-56002
https://liferay.atlassian.net/browse/LPD-38101

The aria-label was not being translated. Added `liferay-ui:message` to change this
20c4c201ca34f8b4aa171f6c629cc3fe80109212



