### PR TITLE
LPD-38546 - Make test fail if no CX is available

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -1390,6 +1390,11 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 				hasText: 'Liferay Sample Frontend Data Set Cell Renderer',
 			});
 
+			test.fail(
+				await cellRendererOption.isHidden(),
+				'No Cell Renderer available. Possibly due to a missing CX'
+			);
+
 			await expect(cellRendererOption).toBeInViewport();
 
 			const cellRendererOptionLabel =

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/clientExtensionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/clientExtensionFilters.spec.ts
@@ -85,6 +85,11 @@ test('Deployed client extension filter is available in fragment @LPS-190457', as
 
 	const filterButton = page.locator('.filters-dropdown').getByText('Filter');
 
+	test.fail(
+		await filterButton.isHidden(),
+		'No filter button available. Possible due to missing CX'
+	);
+
 	await expect(filterButton).toBeInViewport();
 
 	await clickAndExpectToBeVisible({


### PR DESCRIPTION
Check `test.fail()` usage to bypass tests that can not be completed due to lack of a CX.

Using [`test.fail()`](https://playwright.dev/docs/api/class-test#test-fail) we could annotate test as "failing" at runtime:

The test will throw the error if the CX is not deployed, but marked as Passed:
## CX cell renderer (w/ failure)
![cx_cell_renderer_pass_with_failure](https://github.com/user-attachments/assets/1e5717a5-ae90-4b56-9f78-1913e99b9d42)

## CX cell renderer (w/ success)
![cx_cell_renderer_pass_without_failure](https://github.com/user-attachments/assets/c9989e8e-a82b-4f28-af47-f020715bcc31)

## CX Filter (w/ failure)
![cx_fds_filter_pass_with_failure](https://github.com/user-attachments/assets/40255873-2231-4497-829b-4822c72531cb)

## CX Filter (w/ success)
![cx_fds_filter_pass_without_failure](https://github.com/user-attachments/assets/a9b6b22d-8e48-4876-bc4a-85263daecf3b)


