### PR TITLE
LPD-39350 Secure attribute is still present in cookie even in insecure contexts

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie/cookie.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie/cookie.js
@@ -19,6 +19,7 @@ const generateCookie = (name, value, options = {}) => {
 	for (const [key, value] of Object.entries(options)) {
 		if (key === 'secure') {
 			cookie += value ? '; secure' : '';
+			continue;
 		}
 
 		cookie += `; ${key}=${value}`;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie/cookie.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/cookie/cookie.js
@@ -17,12 +17,15 @@ const generateCookie = (name, value, options = {}) => {
 	}
 
 	for (const [key, value] of Object.entries(options)) {
-		if (key === 'secure') {
-			cookie += value ? '; secure' : '';
+		if (value === false) {
 			continue;
 		}
-
-		cookie += `; ${key}=${value}`;
+		else if (value === true) {
+			cookie += `; ${key}`;
+		}
+		else {
+			cookie += `; ${key}=${value}`;
+		}
 	}
 
 	return cookie;

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/cookie/cookie.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/cookie/cookie.js
@@ -174,6 +174,7 @@ describe('Liferay.Util.Cookie', () => {
 				Cookie.TYPES.NECESSARY,
 				{
 					'domain': domainValue,
+					'httponly': false,
 					'max-age': maxAgeValue,
 					'path': pathValue,
 					'samesite': samesiteValue,
@@ -184,6 +185,7 @@ describe('Liferay.Util.Cookie', () => {
 			expect(cookieSetterMock).toHaveBeenCalled();
 			expect(cookieValue).not.toBeUndefined();
 			expect(cookieValue.includes(`domain=${domainValue}`)).toBe(true);
+			expect(cookieValue.includes('httponly')).toBe(false);
 			expect(cookieValue.includes(`max-age=${maxAgeValue}`)).toBe(true);
 			expect(cookieValue.includes(`path=${pathValue}`)).toBe(true);
 			expect(cookieValue.includes('secure')).toBe(true);


### PR DESCRIPTION
Hi,

This is following [previous pull request](https://github.com/liferay-frontend/liferay-portal/pull/4484) sent by @istvansajtos.

Based on his solution and Marko's suggestion, we are just adding the attribute key for boolean cases when their value is `true`, and nothing at all when their value is `false`.

Thanks.

Regards.