### PR TITLE
LPD-39339 Fix Header and adjust hide condition

### DIFF
--- a/modules/test/playwright/tests/portal-web/html/taglib/ui/bottom.spec.ts
+++ b/modules/test/playwright/tests/portal-web/html/taglib/ui/bottom.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../../../fixtures/loginTest';
+import getRandomString from '../../../../../utils/getRandomString';
+import {waitForAlert} from '../../../../../utils/waitForAlert';
+
+const test = mergeTests(loginTest());
+
+test(
+	'Check fixed permission header is visible',
+	{tag: ['@LPD-39339']},
+	async ({page}) => {
+		await page.goto('/');
+
+		const openProductButton = page.getByLabel('Open Product Menu');
+
+		if (await openProductButton.isVisible()) {
+			await openProductButton.click();
+		}
+
+		const contentAndDataTab = page.getByRole('menuitem', {
+			name: 'Content & Data',
+		});
+
+		await contentAndDataTab.waitFor({state: 'visible'});
+
+		await contentAndDataTab.click();
+
+		const webContentButton = page.getByRole('menuitem', {
+			name: 'Web Content',
+		});
+
+		await webContentButton.waitFor({state: 'visible'});
+
+		await webContentButton.click();
+
+		const newButton = page.getByRole('button', {name: 'New'});
+
+		await newButton.waitFor({state: 'visible'});
+
+		await newButton.click();
+
+		const basicWebContentButton = page.getByRole('menuitem', {
+			name: 'Basic Web Content',
+		});
+
+		await basicWebContentButton.waitFor({state: 'visible'});
+
+		await basicWebContentButton.click();
+
+		const currentLanguageButton = page.getByLabel(
+			'Select a language, current'
+		);
+
+		await currentLanguageButton.waitFor({state: 'visible'});
+
+		const webContentTitle = page.getByPlaceholder(
+			'Untitled Basic Web Content'
+		);
+
+		await webContentTitle.waitFor({state: 'visible'});
+
+		const randomTitle = getRandomString();
+
+		await webContentTitle.fill(randomTitle);
+
+		const publishButton = page.getByRole('button', {name: 'Publish'});
+
+		await publishButton.click();
+
+		await waitForAlert(
+			page,
+			`Success:${randomTitle} was created successfully.`
+		);
+
+		const webContentPage = page.getByRole('heading', {name: 'Web Content'});
+
+		await webContentPage.waitFor({state: 'visible'});
+
+		const editWebContentButton = page.locator(
+			`button[aria-label="Actions for ${randomTitle}"]`
+		);
+
+		await editWebContentButton.waitFor({state: 'visible'});
+
+		await editWebContentButton.click();
+
+		const permissionButton = page.getByRole('menuitem', {
+			name: 'Permissions',
+		});
+
+		await permissionButton.waitFor({state: 'visible'});
+
+		await permissionButton.click();
+
+		const permissionHeading = page.getByRole('heading', {
+			name: 'Permissions',
+		});
+
+		await permissionHeading.waitFor({state: 'visible'});
+
+		const fixedHeaderRow = page
+			.frameLocator('iframe[title="Permissions"]')
+			.locator(
+				'[id="_com_liferay_portlet_configuration_web_portlet_PortletConfigurationPortlet_rolesSearchContainerfixedHeader"]'
+			);
+
+		await expect(fixedHeaderRow).toHaveCSS('display', 'none');
+
+		await page
+			.frameLocator('iframe[title="Permissions"]')
+			.getByText('No roles were found. Role')
+			.click();
+
+		await page.keyboard.down('PageDown');
+
+		await expect(fixedHeaderRow).not.toHaveCSS('display', 'none');
+	}
+);

--- a/portal-web/docroot/html/taglib/ui/search_iterator/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/bottom.jspf
@@ -109,7 +109,10 @@
 
 						var fixedHeaderEventHandler = function(event) {
 							var scrollTop = verticalScrollingContainer.scrollTop;
-							var trDomRecTop = trDomRect.top;
+
+							var trDomRect = fixedHeader.previousElementSibling.getBoundingClientRect();
+
+							var trDomRecTop = (trDomRect.top + 80);
 
 							if (fixedHeader.classList.contains('hide') && (scrollTop >= trDomRecTop)) {
 								fixedHeader.classList.remove('hide');
@@ -136,14 +139,7 @@
 				}
 			}
 
-			if (inModal) {
-				Liferay.Util.getOpener().Liferay.on('modalIframeLoaded', function () {
-					initFixedHeaderSync();
-				});
-			}
-			else {
-				initFixedHeaderSync();
-			}
+			initFixedHeaderSync();
 		</c:if>
 
 		searchContainer.updateDataStore(<%= primaryKeysJSONArray.toString() %>);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-55772
https://liferay.atlassian.net/browse/LPD-39339

initFixedHeaderSync was not always being called on modalIframedLoaded, so I decided to always make sure it is being.
This resolves issues in MacOS browsers.

Another issue is when the modal is being loaded, if the user scrolls before everything is loaded, the fixedHeader would never be hidden.
BEFORE
[Screencast from 10-22-2024 01:04:16 PM.webm](https://github.com/user-attachments/assets/9b62b095-4365-45cb-b4f7-6efe1c0c9a60)


I had to get the fixedHeader boundingClientRect again and adjusted the top pixels a bit in order to have the desired look. I found adding 70 would yield the best result.
AFTER
[Screencast from 10-22-2024 01:14:13 PM.webm](https://github.com/user-attachments/assets/924ffe92-2b53-4ae5-8e54-80aa4ebcdf45)

Let me know if there are any questions or comments about this.
Thank you!
