### PR TITLE
LPD-37270 Provide help to add manual fields in a Data Set

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/components/AddCustomFieldModalContent.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/components/AddCustomFieldModalContent.tsx
@@ -5,6 +5,7 @@
 
 import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
 import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
 import React, {useState} from 'react';
@@ -44,10 +45,19 @@ const AddCustomFieldModalContent = ({
 						{Liferay.Language.get('field-name')}
 
 						<RequiredMark />
+
+						<span
+							className="label-icon lfr-portal-tooltip ml-2"
+							title={Liferay.Language.get(
+								'you-can-add-a-field-that-is-in-the-API-response-but-not-declared-in-the-schema'
+							)}
+						>
+							<ClayIcon symbol="question-circle-full" />
+						</span>
 					</label>
 
 					<ClayInput
-						id=""
+						id={`${namespace}FieldNameInput`}
 						onChange={(event) => {
 							setRequiredFieldNameValidationError(false);
 							setFieldName(event.target.value);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
@@ -116,10 +116,19 @@ const NewFieldModalContent = ({
 						{Liferay.Language.get('field-name')}
 
 						<RequiredMark />
+
+						<span
+							className="label-icon lfr-portal-tooltip ml-2"
+							title={Liferay.Language.get(
+								'you-can-add-a-field-that-is-in-the-API-response-but-not-declared-in-the-schema'
+							)}
+						>
+							<ClayIcon symbol="question-circle-full" />
+						</span>
 					</label>
 
 					<ClayInput
-						id=""
+						id={`${namespace}FieldNameInput`}
 						onChange={(event) => {
 							setRequiredFieldNameValidationError(false);
 							setFieldName(event.target.value);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
@@ -33,15 +33,13 @@ import {
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
 import {IDataSetSectionProps} from '../../DataSet';
+import AddCustomFieldModalContent from '../components/AddCustomFieldModalContent';
 
 import '../../../../css/TableVisualizationMode.scss';
 
 import ClayAlert from '@clayui/alert';
 import ClayIcon from '@clayui/icon';
-import classNames from 'classnames';
 
-import RequiredMark from '../../../components/RequiredMark';
-import ValidationFeedback from '../../../components/ValidationFeedback';
 import sortItems from '../../../utils/sortItems';
 import {
 	EFieldType,
@@ -83,98 +81,6 @@ const getRendererLabel = ({
 
 		return rendererName;
 	}
-};
-
-const NewFieldModalContent = ({
-	closeModal,
-	namespace,
-	onSaveButtonClick,
-}: {
-	closeModal: Function;
-	namespace: string;
-	onSaveButtonClick: Function;
-}) => {
-	const [fieldName, setFieldName] = useState<string>();
-	const [
-		requiredFieldNameValidationError,
-		setRequiredFieldNameValidationError,
-	] = useState<boolean>(false);
-
-	return (
-		<>
-			<ClayModal.Header>
-				{Liferay.Language.get('add-field-manually')}
-			</ClayModal.Header>
-
-			<ClayModal.Body>
-				<ClayForm.Group
-					className={classNames({
-						'has-error': requiredFieldNameValidationError,
-					})}
-				>
-					<label htmlFor={`${namespace}FieldNameInput`}>
-						{Liferay.Language.get('field-name')}
-
-						<RequiredMark />
-
-						<span
-							className="label-icon lfr-portal-tooltip ml-2"
-							title={Liferay.Language.get(
-								'you-can-add-a-field-that-is-in-the-API-response-but-not-declared-in-the-schema'
-							)}
-						>
-							<ClayIcon symbol="question-circle-full" />
-						</span>
-					</label>
-
-					<ClayInput
-						id={`${namespace}FieldNameInput`}
-						onChange={(event) => {
-							setRequiredFieldNameValidationError(false);
-							setFieldName(event.target.value);
-						}}
-						placeholder={Liferay.Language.get('type-field-here')}
-						type="text"
-					/>
-
-					{requiredFieldNameValidationError && (
-						<ValidationFeedback
-							message={Liferay.Language.get(
-								'alert-you-must-enter-a-field-name'
-							)}
-						/>
-					)}
-				</ClayForm.Group>
-			</ClayModal.Body>
-			<ClayModal.Footer
-				last={
-					<ClayButton.Group spaced>
-						<ClayButton
-							displayType="secondary"
-							onClick={() => closeModal()}
-						>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
-
-						<ClayButton
-							onClick={() => {
-								if (!fieldName) {
-									setRequiredFieldNameValidationError(true);
-								}
-								else {
-									onSaveButtonClick({
-										fieldName,
-									});
-								}
-							}}
-						>
-							{Liferay.Language.get('add')}
-						</ClayButton>
-					</ClayButton.Group>
-				}
-			/>
-		</>
-	);
 };
 
 interface IRendererLabelCellRendererComponentProps {
@@ -695,15 +601,13 @@ function Table(props: IDataSetSectionProps & {title?: string}) {
 	const onCreationFieldButtonClick = () => {
 		openModal({
 			contentComponent: ({closeModal}: {closeModal: Function}) => (
-				<NewFieldModalContent
+				<AddCustomFieldModalContent
 					{...props}
 					closeModal={closeModal}
-					onSaveButtonClick={({fieldName}: {fieldName: string}) => {
+					onSaveButtonClick={({name}: {name: string}) => {
 						saveDataSetTableColumns({
 							closeModal,
-							fields: [
-								{name: fieldName, sortable: true},
-							] as IField[],
+							fields: [{name, sortable: true}] as IField[],
 						});
 					}}
 				/>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -22239,6 +22239,7 @@ you-are-viewing-an-archived-version-of-this-page=You are viewing an archived ver
 you-are-x=You are {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate.
 you-can-add-a-comment-to-continue-the-existing-thread=You can add a comment to continue the existing thread.
+you-can-add-a-field-that-is-in-the-API-response-but-not-declared-in-the-schema=You can add a field that is in the API response but not declared in the Schema.
 you-can-add-as-many-as-x-favorites-in-your-quick-menu=You can add as many as {0} favorites in your quick menu.
 you-can-add-your-own-css-and-include-variables-to-use-existing-tokens=You can add your own CSS and include variables to use existing tokens. This CSS is appended to the current styles.
 you-can-also-add-a-rule-for-more-accurate-results=You can also add a rule for more accurate results.

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/visualizationModes.spec.ts
@@ -157,11 +157,35 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 
 			await visualizationModesPage.addCustomFieldInput.waitFor();
 
-			await visualizationModesPage.addCustomFieldInput.fill(fieldName);
+			await test.step('Check helper tooltip', async () => {
+				const parent = page
+					.locator('.form-group')
+					.filter({has: visualizationModesPage.addCustomFieldInput});
 
-			await saveFromModal({
-				page,
-				saveText: 'Add',
+				const tooltipTrigger = parent.locator(
+					'.lexicon-icon-question-circle-full'
+				);
+
+				await expect(tooltipTrigger).toBeVisible();
+
+				await tooltipTrigger.hover();
+
+				await expect(
+					page.getByTitle(
+						'You can add a field that is in the API response but not declared in the Schema.'
+					)
+				).toBeVisible();
+			});
+
+			await test.step('Add manual field', async () => {
+				await visualizationModesPage.addCustomFieldInput.fill(
+					fieldName
+				);
+
+				await saveFromModal({
+					page,
+					saveText: 'Add',
+				});
 			});
 
 			const assignedFieldLocator =
@@ -310,11 +334,35 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 
 			await visualizationModesPage.addCustomFieldInput.waitFor();
 
-			await visualizationModesPage.addCustomFieldInput.fill(fieldName);
+			await test.step('Check helper tooltip', async () => {
+				const parent = page
+					.locator('.form-group')
+					.filter({has: visualizationModesPage.addCustomFieldInput});
 
-			await saveFromModal({
-				page,
-				saveText: 'Add',
+				const tooltipTrigger = parent.locator(
+					'.lexicon-icon-question-circle-full'
+				);
+
+				await expect(tooltipTrigger).toBeVisible();
+
+				await tooltipTrigger.hover();
+
+				await expect(
+					page.getByTitle(
+						'You can add a field that is in the API response but not declared in the Schema.'
+					)
+				).toBeVisible();
+			});
+
+			await test.step('Add manual field', async () => {
+				await visualizationModesPage.addCustomFieldInput.fill(
+					fieldName
+				);
+
+				await saveFromModal({
+					page,
+					saveText: 'Add',
+				});
 			});
 
 			const assignedFieldLocator =


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-37270

<h1>Provide help to add manual fields in a Data Set</h1>

The goal of this PR is to add a tooltip on Add Manual Field modal in DSM visualization modes, so the user can get an explanation about what manual fields are.

![image](https://github.com/user-attachments/assets/35e7082a-e5b5-4720-b1b8-195a91b62d19)
