### PR TITLE
LPD-39724 Link View and Download permissions

### DIFF
--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -151,12 +151,36 @@ export class DocumentLibraryEditFilePage {
 		await this.goto(siteUrl);
 
 		await this.titleSelector.fill(title);
+
 		if (await this.permissionViewSelector.isVisible()) {
 			await this.permissionViewSelector.selectOption('Site Member');
 		}
 		else {
 			await this.page.getByRole('button', {name: 'Permissions'}).click();
 			await this.permissionViewSelector.selectOption('Site Member');
+		}
+
+		await this.publishButton.click();
+	}
+
+	async publishNewFileWithOwnerViewPermission(
+		title: string,
+		siteUrl?: Site['friendlyUrlPath']
+	) {
+		await this.goto(siteUrl);
+
+		await this.titleSelector.fill(title);
+
+		const permissionsRoleSelector = this.page.getByLabel(
+			'Viewable and Downloadable By'
+		);
+
+		if (await permissionsRoleSelector.isVisible()) {
+			await permissionsRoleSelector.selectOption('Owner');
+		}
+		else {
+			await this.page.getByRole('button', {name: 'Permissions'}).click();
+			await permissionsRoleSelector.selectOption('Owner');
 		}
 
 		await this.publishButton.click();

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryPage.ts
@@ -18,6 +18,7 @@ export class DocumentLibraryPage {
 	readonly optionsMenu: Locator;
 	readonly orderMenu: Locator;
 	readonly page: Page;
+	readonly permissionsFrameLocator: FrameLocator;
 	readonly searchButton: Locator;
 	readonly searchInput: Locator;
 
@@ -30,6 +31,9 @@ export class DocumentLibraryPage {
 			.getByLabel('Options');
 		this.orderMenu = page.getByLabel('Order');
 		this.page = page;
+		this.permissionsFrameLocator = page.frameLocator(
+			'iframe[title="Permissions"]'
+		);
 		this.searchButton = page.getByRole('button', {
 			name: 'Search for',
 		});
@@ -158,6 +162,19 @@ export class DocumentLibraryPage {
 		});
 	}
 
+	async goToFileEntryAction(action: string, entryTitle: string) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('menuitem', {
+				exact: true,
+				name: action,
+			}),
+			trigger: this.page
+				.locator(`.card-body:has-text('${entryTitle}')`)
+				.getByLabel('Actions'),
+		});
+	}
+
 	async openBulkEditCategoriesModal(titles: string[]) {
 		await this.selectFileEntries(titles);
 		await this.page.getByRole('button', {name: 'Edit Categories'}).click();
@@ -249,5 +266,33 @@ export class DocumentLibraryPage {
 		}
 
 		await fileEntryCheckbox.check();
+	}
+
+	async assertFileEntryPermissions(
+		permissions: {enabled: boolean; locator: string}[],
+		title: string
+	) {
+		await this.goToFileEntryAction('Permissions', title);
+
+		await this.permissionsFrameLocator
+			.locator(permissions[0].locator)
+			.waitFor();
+
+		for (const permission of permissions) {
+			const permissionCheckbox = this.permissionsFrameLocator.locator(
+				permission.locator
+			);
+
+			if (permission.enabled) {
+				await expect(permissionCheckbox).toBeChecked();
+			}
+			else {
+				await expect(permissionCheckbox).not.toBeChecked();
+			}
+		}
+
+		await this.permissionsFrameLocator
+			.getByRole('button', {name: 'Cancel'})
+			.click();
 	}
 }

--- a/modules/test/playwright/tests/document-library-web/dmPermissions.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmPermissions.spec.ts
@@ -9,6 +9,7 @@ import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixt
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
+import getRandomString from '../../utils/getRandomString';
 
 const test = mergeTests(
 	documentLibraryPagesTest,
@@ -33,5 +34,30 @@ test(
 		await expect(
 			page.getByRole('cell', {exact: true, name: 'Role'})
 		).toBeVisible();
+	}
+);
+
+test(
+	'View and Download permissions are linked in DM',
+	{tag: '@LPD-39724'},
+	async ({documentLibraryEditFilePage, documentLibraryPage, site}) => {
+		const title = getRandomString();
+
+		await documentLibraryEditFilePage.publishNewFileWithOwnerViewPermission(
+			title,
+			site.friendlyUrlPath
+		);
+
+		await documentLibraryPage.assertFileEntryPermissions(
+			[
+				{enabled: false, locator: '#guest_ACTION_DOWNLOAD'},
+				{enabled: false, locator: '#guest_ACTION_VIEW'},
+				{enabled: false, locator: '#site-member_ACTION_DOWNLOAD'},
+				{enabled: false, locator: '#site-member_ACTION_VIEW'},
+				{enabled: true, locator: '#owner_ACTION_DOWNLOAD'},
+				{enabled: true, locator: '#owner_ACTION_VIEW'},
+			],
+			title
+		);
 	}
 );

--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -207,6 +207,11 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 
 					<%= uniqueNamespace %>doUpdateViewValue('<%= uniqueNamespace %>guestPermissions_VIEW', checkGuestViewPermissions);
 					<%= uniqueNamespace %>doUpdateViewValue('<%= uniqueNamespace %>groupPermissions_VIEW', checkGroupViewPermissions);
+
+					<c:if test='<%= supportedActions.contains(ActionKeys.DOWNLOAD) && FeatureFlagManagerUtil.isEnabled("LPD-19787") %>'>
+						<%= uniqueNamespace %>doUpdateViewValue('<%= uniqueNamespace %>guestPermissions_DOWNLOAD', checkGuestViewPermissions);
+						<%= uniqueNamespace %>doUpdateViewValue('<%= uniqueNamespace %>groupPermissions_DOWNLOAD', checkGroupViewPermissions);
+					</c:if>
 				}
 			}
 


### PR DESCRIPTION
### Link View and Download permissions
[Link to ticket](https://liferay.atlassian.net/browse/LPD-39724) 

As described in the task, we want that the Download permission behaves as the View permissions while creating a new file entry. 

- When the user changes the selector to “Viewable By → Site Members” the Download permissions checkbox for Guest should initially be unchecked
- When the user changes the selector to “Viewable By → Owner” the Download permissions checkboxes for both Guest and Site Member should initially be unchecked

###  How do I fix it
This is currently how it works for View permission, so I just added the condition to do the same for the Download permission if it exists (it is only present in DM)

This solution have been agreed with @dsanz. There are [customers](https://liferay.atlassian.net/browse/LPD-35510?focusedCommentId=2775431) expecting a backport/hotfix for this, so we wanted to keep as easy as possible to facilitate it. 

###  How can you test it
You can create a new file entry in DM, or just run `npm run playwright -- test -g 'LPD-39724' --reporter list`

```
npm run playwright -- test -g 'LPD-39724' --reporter list --repeat-each=5

> @liferay/playwright@1.0.0 playwright
> playwright "test" "-g" "LPD-39724" "--reporter" "list" "--repeat-each=5"


Running 5 tests using 1 worker

  ✓  1 [document-library-web] › document-library-web/dmPermissions.spec.ts:40:1 › View and Download permissions are linked in DM (24.4s)
  ✓  2 [document-library-web] › document-library-web/dmPermissions.spec.ts:40:1 › View and Download permissions are linked in DM (18.0s)
  ✓  3 [document-library-web] › document-library-web/dmPermissions.spec.ts:40:1 › View and Download permissions are linked in DM (17.1s)
  ✓  4 [document-library-web] › document-library-web/dmPermissions.spec.ts:40:1 › View and Download permissions are linked in DM (17.3s)
  ✓  5 [document-library-web] › document-library-web/dmPermissions.spec.ts:40:1 › View and Download permissions are linked in DM (17.3s)

  5 passed (1.9m)
```


