### PR TITLE
LPD-38760 Editor in blogs cannot display image added via item selector URL

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -25,8 +25,8 @@
 			max-width: 100%;
 		}
 
-		img[data-cke-saved-src]:not([data-fileentryid]) {
-			visibility: hidden;
+		img[data-cke-saved-src^='data:image']:not([data-fileentryid]) {
+			display: none;
 		}
 
 		.cover-image-container {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -362,8 +362,16 @@
 
 				const TPL_PROGRESS_BAR = '<div class="progressbar"></div>';
 
+				const ckeditorImage = document.querySelector(
+					'img[data-cke-saved-src^="data:image"]:not([data-fileentryid])'
+				);
+
 				const _onUploadError = () => {
 					const image = this._tempImage;
+
+					if (ckeditorImage) {
+						ckeditorImage.remove();
+					}
 
 					if (image) {
 						image.parentElement.remove();
@@ -390,6 +398,10 @@
 
 					if (data.success) {
 						const image = this._tempImage;
+
+						if (ckeditorImage) {
+							ckeditorImage.remove();
+						}
 
 						if (image) {
 							image.removeAttribute(ATTR_DATA_RANDOM_ID);
@@ -419,14 +431,6 @@
 								fileEntryId: data.file.fileEntryId,
 								uploadImageReturnType: '',
 							});
-
-							const ckeditorImage = document.querySelector(
-								'img[data-cke-saved-src^="data:image"]:not([data-fileentryid])'
-							);
-
-							if (ckeditorImage) {
-								ckeditorImage.remove();
-							}
 
 							const fragment =
 								CKEDITOR.htmlParser.fragment.fromHtml(

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/addimages/plugin.js
@@ -421,7 +421,7 @@
 							});
 
 							const ckeditorImage = document.querySelector(
-								'[data-cke-saved-src]'
+								'img[data-cke-saved-src^="data:image"]:not([data-fileentryid])'
 							);
 
 							if (ckeditorImage) {


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-38760

Currently, when an image is added via a URL in the blog editor, it fails to display correctly in edit mode. Additionally, inserting a new image after a URL-based one either hides or removes the previous image, complicating content editing and causing the DOM to retain unnecessary elements, thus increasing page weight.

# How am I fixing it? (Temporary but Impactful)

This fix adjusts selectors to target elements with inline src data, ensuring that hidden images are removed in case of an error. This approach closely follows the original fix that introduced this behavior but adds specificity to avoid redundant image accumulation. While this is a temporary solution, it significantly reduces the problem.

>[!WARNING] 
> Limitation: This fix does not cover cases where inline data (e.g., base64) is used directly in the src attribute.

# How can you verify that it works?

Run the POSHI test `ItemSelector#CanAddBlogsImageViaURL`

## Before the PR
![image](https://github.com/user-attachments/assets/c84c7439-77e3-436b-a5e3-79ec8021de56)

## After the PR
![image](https://github.com/user-attachments/assets/004ed941-f649-4846-8584-e45e19e2e5f9)


# Alternative Approach (Long-Term Solution)

A more robust, permanent solution would be to prevent CKEditor from automatically inserting images through the addImages plugin. This approach fixes the root cause by controlling image insertions during pasting events. 

However, I lack the expertise to effectively configure this behavior, and attempting such changes could lead to complex compatibility issues. 

## Issues with the Alternative Solution:

Disabling the automatic paste functionality might inadvertently disrupt modules like Knowledge Base and Web Content..., where the paste is working on **CKEditor default paste**.

Currently, while the addImages plugin is technically initiated, it does not actively perform any actions in these other modules. This suggests that while the plugin is present, it remains inactive and works over **CKEditor default paste** (base64 inline images).

**Configurations**: This plugin was added in the following configurations:
   - `BaseAlloyEditorConfigContributor.java`
   - `CKEditorConfigContributor.java`
   - `LayoutTranslateEditorConfigContributor.java`
   - DDM Configurations

---

>[!NOTE]
> **CSS File**: I try to move the blog CSS to the editor CSS so that it’s closer to the plugin code and deploys at once. However, this could potentially cause some issues in other modules, where CKEditor images are used without the plugin.