### PR TITLE
LPD-41259 Extract inline event handlers in <liferay-ui:tabs>

### DIFF
--- a/portal-web/docroot/html/taglib/ui/tabs/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/tabs/start.jsp
@@ -193,9 +193,11 @@ String type = GetterUtil.getString((String)request.getAttribute("liferay-ui:tabs
 	%>
 
 		<li class="nav-item" data-tab-name="<%= names[i] %>" id="<%= namespace %><%= param %><%= StringUtil.toCharCode(values[i]) %>TabsId" role="none">
-			<a class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" onClick="<%= Validator.isNotNull(curOnClick) ? curOnClick : StringPool.BLANK %>" role="tab">
-				<liferay-ui:message key="<%= HtmlUtil.escape(names[i]) %>" />
-			</a>
+			<liferay-ui:csp>
+				<a class="<%= linkCssClass %>" href="<%= Validator.isNotNull(curURL) ? HtmlUtil.escapeAttribute(curURL) : "javascript:void(0);" %>" onClick="<%= Validator.isNotNull(curOnClick) ? curOnClick : StringPool.BLANK %>" role="tab">
+					<liferay-ui:message key="<%= HtmlUtil.escape(names[i]) %>" />
+				</a>
+			</liferay-ui:csp>
 		</li>
 
 	<%


### PR DESCRIPTION
**QA analysis**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4554#issuecomment-2478695552
**Sign-off**: :green_circle: https://liferay.atlassian.net/browse/LPD-41259?focusedCommentId=2791818

----

This is part of https://github.com/liferay-frontend/liferay-portal/pull/4466 (root PR for CSP inline event handlers).

It is in the high risk group, which is composed of infra stuff used pervasively that may break a lot of tests for different teams.

> ⚠️ Note that even though this PR may break tests it doesn't mean it breaks the product.
> Tests can break because:
>
> 1. A bug is introduced in the product, or
> 2. They rely on internals of the taglib changed in the PR

Since the taglib is used almost everywhere we don't have any specific CI test suite to run (we would need to run all of them to make sure). And since we run all tests suites every day on a batch schedule we will rely on that to detect big failures unless someone can find a better way (I'm open to suggestions).

In any case, I've tested one occurence of the tag by hand following the procedure described at https://liferay.atlassian.net/browse/LPD-41259?focusedCommentId=2788214 to make sure it's not very badly broken.