### PR TITLE
LPD-41258 Extract inline event handlers in <liferay-ui:search-container-row> and <liferay-ui:page-iterator>

### DIFF
--- a/portal-web/docroot/html/taglib/init.jsp
+++ b/portal-web/docroot/html/taglib/init.jsp
@@ -7,7 +7,8 @@
 
 <%@ include file="/html/common/init.jsp" %>
 
-<%@ page import="com.liferay.portal.kernel.servlet.MultiSessionErrors" %><%@
+<%@ page import="com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyHTMLRewriterUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.MultiSessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.DateFormatFactoryUtil" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %><%@
 page import="com.liferay.taglib.util.InlineUtil" %><%@

--- a/portal-web/docroot/html/taglib/ui/page_iterator/deprecated/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/deprecated/start.jsp
@@ -147,7 +147,7 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 		}
 		%>
 
-		<%= content %>
+		<%= ContentSecurityPolicyHTMLRewriterUtil.rewriteInlineEventHandlers(content, request, false) %>
 	</div>
 </c:if>
 
@@ -257,35 +257,43 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 		<ul class="lfr-pagination-buttons pagination">
 			<c:if test='<%= type.equals("approximate") || type.equals("more") || type.equals("regular") %>'>
 				<li class="<%= (cur != 1) ? "" : "disabled" %> first page-item">
-					<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, 1) : "" %>" tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
-						<%= PortalUtil.isRightToLeft(request) ? "&rarr;" : "&larr;" %> <liferay-ui:message key="first" />
-					</a>
+					<liferay-ui:csp>
+						<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, 1) : "" %>" tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
+							<%= PortalUtil.isRightToLeft(request) ? "&rarr;" : "&larr;" %> <liferay-ui:message key="first" />
+						</a>
+					</liferay-ui:csp>
 				</li>
 			</c:if>
 
 			<li class="<%= (cur != 1) ? "" : "disabled" %> page-item">
-				<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, cur - 1) : "" %>" tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
-					<liferay-ui:message key="previous" />
-				</a>
+				<liferay-ui:csp>
+					<a href="<%= (cur != 1) ? _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != 1) && forcePost) ? _getOnClick(namespace, curParam, cur - 1) : "" %>" tabIndex="<%= (cur != 1) ? "0" : "-1" %>" target="<%= target %>">
+						<liferay-ui:message key="previous" />
+					</a>
+				</liferay-ui:csp>
 			</li>
 			<li class="<%= (cur != pages) ? "" : "disabled" %> page-item">
-				<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>" tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
-					<c:choose>
-						<c:when test='<%= type.equals("approximate") || type.equals("more") %>'>
-							<liferay-ui:message key="more" />
-						</c:when>
-						<c:otherwise>
-							<liferay-ui:message key="next" />
-						</c:otherwise>
-					</c:choose>
-				</a>
+				<liferay-ui:csp>
+					<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, cur + 1) : "" %>" tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
+						<c:choose>
+							<c:when test='<%= type.equals("approximate") || type.equals("more") %>'>
+								<liferay-ui:message key="more" />
+							</c:when>
+							<c:otherwise>
+								<liferay-ui:message key="next" />
+							</c:otherwise>
+						</c:choose>
+					</a>
+				</liferay-ui:csp>
 			</li>
 
 			<c:if test='<%= type.equals("regular") %>'>
 				<li class="<%= (cur != pages) ? "" : "disabled" %> last page-item">
-					<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, pages) : "" %>" tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
-						<liferay-ui:message key="last" /> <%= PortalUtil.isRightToLeft(request) ? "&larr;" : "&rarr;" %>
-					</a>
+					<liferay-ui:csp>
+						<a href="<%= (cur != pages) ? _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) : "javascript:void(0);" %>" page-link onclick="<%= ((cur != pages) && forcePost) ? _getOnClick(namespace, curParam, pages) : "" %>" tabIndex="<%= (cur != pages) ? "0" : "-1" %>" target="<%= target %>">
+							<liferay-ui:message key="last" /> <%= PortalUtil.isRightToLeft(request) ? "&larr;" : "&rarr;" %>
+						</a>
+					</liferay-ui:csp>
 				</li>
 			</c:if>
 		</ul>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -201,30 +201,30 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 		<nav aria-label="<liferay-ui:message key="pagination" />">
 			<ul class="pagination">
 				<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
-					<c:choose>
-						<c:when test="<%= cur > 1 %>">
-							<liferay-ui:csp>
+					<liferay-ui:csp>
+						<c:choose>
+							<c:when test="<%= cur > 1 %>">
 								<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
-							</liferay-ui:csp>
-						</c:when>
-						<c:otherwise>
-							<div class="page-link">
-						</c:otherwise>
-					</c:choose>
+							</c:when>
+							<c:otherwise>
+								<div class="page-link">
+							</c:otherwise>
+						</c:choose>
 
-						<liferay-ui:icon
-							icon='<%= PortalUtil.isRightToLeft(request) ? "angle-right" : "angle-left" %>'
-							markupView="lexicon"
-						/>
+							<liferay-ui:icon
+								icon='<%= PortalUtil.isRightToLeft(request) ? "angle-right" : "angle-left" %>'
+								markupView="lexicon"
+							/>
 
-					<c:choose>
-						<c:when test="<%= cur > 1 %>">
-							</a>
-						</c:when>
-						<c:otherwise>
-							</div>
-						</c:otherwise>
-					</c:choose>
+						<c:choose>
+							<c:when test="<%= cur > 1 %>">
+								</a>
+							</c:when>
+							<c:otherwise>
+								</div>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:csp>
 				</li>
 
 				<c:choose>
@@ -235,18 +235,18 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						%>
 
 							<li class="page-item <%= (i == cur) ? "active" : StringPool.BLANK %>">
-								<c:choose>
-									<c:when test="<%= i == cur %>">
-										<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" tabindex="0">
-									</c:when>
-									<c:otherwise>
-										<liferay-ui:csp>
+								<liferay-ui:csp>
+									<c:choose>
+										<c:when test="<%= i == cur %>">
+											<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" tabindex="0">
+										</c:when>
+										<c:otherwise>
 											<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
-										</liferay-ui:csp>
-									</c:otherwise>
-								</c:choose>
+										</c:otherwise>
+									</c:choose>
 
-								<span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+									<span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+								</liferay-ui:csp>
 							</li>
 
 						<%
@@ -453,30 +453,30 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				</c:choose>
 
 				<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
-					<c:choose>
-						<c:when test="<%= cur < pages %>">
-							<liferay-ui:csp>
+					<liferay-ui:csp>
+						<c:choose>
+							<c:when test="<%= cur < pages %>">
 								<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
-							</liferay-ui:csp>
-						</c:when>
-						<c:otherwise>
-							<div class="page-link">
-						</c:otherwise>
-					</c:choose>
+							</c:when>
+							<c:otherwise>
+								<div class="page-link">
+							</c:otherwise>
+						</c:choose>
 
-						<liferay-ui:icon
-							icon='<%= PortalUtil.isRightToLeft(request) ? "angle-left" : "angle-right" %>'
-							markupView="lexicon"
-						/>
+							<liferay-ui:icon
+								icon='<%= PortalUtil.isRightToLeft(request) ? "angle-left" : "angle-right" %>'
+								markupView="lexicon"
+							/>
 
-					<c:choose>
-						<c:when test="<%= cur < pages %>">
-							</a>
-						</c:when>
-						<c:otherwise>
-							</div>
-						</c:otherwise>
-					</c:choose>
+						<c:choose>
+							<c:when test="<%= cur < pages %>">
+								</a>
+							</c:when>
+							<c:otherwise>
+								</div>
+							</c:otherwise>
+						</c:choose>
+					</liferay-ui:csp>
 				</li>
 			</ul>
 		</nav>

--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -104,9 +104,11 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					%>
 
 						<li role="presentation">
-							<a aria-selected="<%= (delta == curDelta) ? "true" : "false" %>" class="dropdown-item <%= (delta == curDelta) ? "active" : "" %>" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" id="<%= String.valueOf(curDelta) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>" role="option">
-								<%= String.valueOf(curDelta) %><span class="sr-only"><%= StringPool.NBSP %><liferay-ui:message key="entries-per-page" /></span>
-							</a>
+							<liferay-ui:csp>
+								<a aria-selected="<%= (delta == curDelta) ? "true" : "false" %>" class="dropdown-item <%= (delta == curDelta) ? "active" : "" %>" href="<%= HtmlUtil.escapeHREF(curDeltaURL) %>" id="<%= String.valueOf(curDelta) %>" onClick="<%= forcePost ? _getOnClick(namespace, deltaParam, curDelta) : "" %>" role="option">
+									<%= String.valueOf(curDelta) %><span class="sr-only"><%= StringPool.NBSP %><liferay-ui:message key="entries-per-page" /></span>
+								</a>
+							</liferay-ui:csp>
 						</li>
 
 					<%
@@ -201,7 +203,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				<li class="page-item <%= (cur > 1) ? StringPool.BLANK : "disabled" %>">
 					<c:choose>
 						<c:when test="<%= cur > 1 %>">
-							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
+							<liferay-ui:csp>
+								<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur -1) : "" %>" title="<%= LanguageUtil.get(request, "previous-page") %>">
+							</liferay-ui:csp>
 						</c:when>
 						<c:otherwise>
 							<div class="page-link">
@@ -236,7 +240,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 										<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" tabindex="0">
 									</c:when>
 									<c:otherwise>
-										<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
+										<liferay-ui:csp>
+											<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>">
+										</liferay-ui:csp>
 									</c:otherwise>
 								</c:choose>
 
@@ -253,10 +259,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>2</a>
+							</liferay-ui:csp>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 3, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 3) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>3</a>
+							</liferay-ui:csp>
 						</li>
 						<li class="dropdown page-item">
 							<button aria-controls="dropdown-pages-1" aria-haspopup="true" class="dropdown-toggle page-link page-link" data-toggle="liferay-dropdown">
@@ -276,7 +286,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 									%>
 
 										<li>
-											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+											<liferay-ui:csp>
+												<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+											</liferay-ui:csp>
 										</li>
 
 									<%
@@ -287,12 +299,16 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							</div>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+							</liferay-ui:csp>
 						</li>
 					</c:when>
 					<c:when test="<%= cur == pages %>">
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+							</liferay-ui:csp>
 						</li>
 						<li class="dropdown page-item">
 							<button aria-controls="dropdown-pages-2" aria-haspopup="true" class="dropdown-toggle page-link" data-toggle="liferay-dropdown">
@@ -309,7 +325,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 									%>
 
 										<li>
-											<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+											<liferay-ui:csp>
+												<a class="dropdown-item" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+											</liferay-ui:csp>
 										</li>
 
 									<%
@@ -320,10 +338,14 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 							</div>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 2 %></a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 2, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 2) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 2 %></a>
+							</liferay-ui:csp>
 						</li>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages - 1 %></a>
+							</liferay-ui:csp>
 						</li>
 						<li class="active page-item">
 							<a aria-current="page" class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" tabindex="0"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
@@ -331,7 +353,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 					</c:when>
 					<c:otherwise>
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span>1</a>
+							</liferay-ui:csp>
 						</li>
 
 						<c:if test="<%= (cur - 3) > 1 %>">
@@ -351,7 +375,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						%>
 
 							<li class="<%= ((cur - 3) > 1) ? "" : "page-item" %>">
-								<a class="<%= ((cur - 3) > 1) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+								<liferay-ui:csp>
+									<a class="<%= ((cur - 3) > 1) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+								</liferay-ui:csp>
 							</li>
 
 						<%
@@ -366,7 +392,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 						<c:if test="<%= (cur - 1) > 1 %>">
 							<li class="page-item">
-								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur - 1 %></a>
+								<liferay-ui:csp>
+									<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur - 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur - 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur - 1 %></a>
+								</liferay-ui:csp>
 							</li>
 						</c:if>
 
@@ -376,7 +404,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 						<c:if test="<%= (cur + 1) < pages %>">
 							<li class="page-item">
-								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur + 1 %></a>
+								<liferay-ui:csp>
+									<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= cur + 1 %></a>
+								</liferay-ui:csp>
 							</li>
 						</c:if>
 
@@ -399,7 +429,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						%>
 
 							<li class="<%= ((cur + 3) < pages) ? "" : "page-item" %>">
-								<a class="<%= ((cur + 3) < pages) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+								<liferay-ui:csp>
+									<a class="<%= ((cur + 3) < pages) ? "dropdown-item" : "dropdown-item page-link" %>" href="<%= _getHREF(formName, namespace + curParam, i, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, i) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= i %></a>
+								</liferay-ui:csp>
 							</li>
 
 						<%
@@ -413,7 +445,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 						</c:if>
 
 						<li class="page-item">
-							<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+							<liferay-ui:csp>
+								<a class="page-link" href="<%= _getHREF(formName, namespace + curParam, pages, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, pages) : "" %>"><span class="sr-only"><liferay-ui:message key="page" /><%= StringPool.NBSP %></span><%= pages %></a>
+							</liferay-ui:csp>
 						</li>
 					</c:otherwise>
 				</c:choose>
@@ -421,7 +455,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 				<li class="page-item <%= (cur < pages) ? StringPool.BLANK : "disabled" %>">
 					<c:choose>
 						<c:when test="<%= cur < pages %>">
-							<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
+							<liferay-ui:csp>
+								<a class="lfr-portal-tooltip page-link" href="<%= _getHREF(formName, namespace + curParam, cur + 1, jsCall, url, urlAnchor) %>" onclick="<%= forcePost ? _getOnClick(namespace, curParam, cur + 1) : "" %>" title="<%= LanguageUtil.get(request, "next-page") %>">
+							</liferay-ui:csp>
 						</c:when>
 						<c:otherwise>
 							<div class="page-link">

--- a/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
+++ b/util-taglib/src/com/liferay/taglib/search/ButtonSearchEntry.java
@@ -7,6 +7,7 @@ package com.liferay.taglib.search;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyHTMLRewriterUtil;
 
 import java.io.Writer;
 
@@ -34,9 +35,11 @@ public class ButtonSearchEntry extends TextSearchEntry {
 		throws Exception {
 
 		writer.write(
-			StringBundler.concat(
-				"<input type=\"button\" value=\"", getName(), "\" onClick=\"",
-				getHref(), "\">"));
+			ContentSecurityPolicyHTMLRewriterUtil.rewriteInlineEventHandlers(
+				StringBundler.concat(
+					"<input type=\"button\" value=\"", getName(),
+					"\" onClick=\"", getHref(), "\">"),
+				httpServletRequest, false));
 	}
 
 }


### PR DESCRIPTION
**QA Passed**: https://github.com/liferay-frontend/liferay-portal/pull/4556#issuecomment-2478742203
**Review is disputed**: https://github.com/liferay-frontend/liferay-portal/pull/4556#pullrequestreview-2488831701

----

This is part of https://github.com/liferay-frontend/liferay-portal/pull/4466 (root PR for CSP inline event handlers).

It is in the high risk group, which is composed of infra stuff used pervasively that may break a lot of tests for different teams.

> ⚠️ Note that even though this PR may break tests it doesn't mean it breaks the product.
> Tests can break because:
>
> 1. A bug is introduced in the product, or
> 2. They rely on internals of the taglib changed in the PR

Since the taglib is used almost everywhere we don't have any specific CI test suite to run (we would need to run all of them to make sure). And since we run all tests suites every day on a batch schedule we will rely on that to detect big failures unless someone can find a better way (I'm open to suggestions).

In any case, I've tested one occurence of the tag by hand following the procedure described at https://liferay.atlassian.net/browse/LPD-41258?focusedCommentId=2788250 to make sure it's not very badly broken.