### PR TITLE
LPD-41257 Extract inline event handlers in <liferay-ui:input-permissions>

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_permissions/page.jsp
@@ -84,39 +84,41 @@ String modelName = (String)request.getAttribute("liferay-ui:input-permissions:mo
 					</c:choose>
 				</label>
 
-				<select class="form-control" id="<%= uniqueNamespace %>inputPermissionsViewRole" name="<%= namespace %>inputPermissionsViewRole" onChange="<%= uniqueNamespace %>updatePermissionsView();">
+				<liferay-ui:csp>
+					<select class="form-control" id="<%= uniqueNamespace %>inputPermissionsViewRole" name="<%= namespace %>inputPermissionsViewRole" onChange="<%= uniqueNamespace %>updatePermissionsView();">
 
-					<%
-					String guestRoleLabel = LanguageUtil.format(request, "x-role", guestRole.getTitle(themeDisplay.getLocale()), false);
+						<%
+						String guestRoleLabel = LanguageUtil.format(request, "x-role", guestRole.getTitle(themeDisplay.getLocale()), false);
 
-					if (PropsValues.PERMISSIONS_CHECK_GUEST_ENABLED) {
-						guestRoleLabel = LanguageUtil.get(resourceBundle, "anyone") + StringPool.SPACE + StringPool.OPEN_PARENTHESIS + guestRoleLabel + StringPool.CLOSE_PARENTHESIS;
-					}
-					%>
+						if (PropsValues.PERMISSIONS_CHECK_GUEST_ENABLED) {
+							guestRoleLabel = LanguageUtil.get(resourceBundle, "anyone") + StringPool.SPACE + StringPool.OPEN_PARENTHESIS + guestRoleLabel + StringPool.CLOSE_PARENTHESIS;
+						}
+						%>
 
-					<option <%= inputPermissionsViewRole.equals(RoleConstants.GUEST) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.GUEST %>"><%= guestRoleLabel %></option>
+						<option <%= inputPermissionsViewRole.equals(RoleConstants.GUEST) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.GUEST %>"><%= guestRoleLabel %></option>
 
-					<c:if test="<%= hasViewDefaultGroupRolePermission %>">
-						<option <%= inputPermissionsViewRole.equals(defaultGroupRole.getName()) ? "selected=\"selected\"" : "" %> value="<%= defaultGroupRole.getName() %>">
-							<c:choose>
-								<c:when test="<%= defaultGroupRole.getName().equals(RoleConstants.ORGANIZATION_USER) %>">
-									<liferay-ui:message key="organization-members" />
-								</c:when>
-								<c:when test="<%= defaultGroupRole.getName().equals(RoleConstants.POWER_USER) %>">
-									<liferay-ui:message key="power-users" />
-								</c:when>
-								<c:when test="<%= defaultGroupRole.getName().equals(RoleConstants.SITE_MEMBER) %>">
-									<liferay-ui:message key="site-members" />
-								</c:when>
-								<c:otherwise>
-									<liferay-ui:message key="user" />
-								</c:otherwise>
-							</c:choose>
-						</option>
-					</c:if>
+						<c:if test="<%= hasViewDefaultGroupRolePermission %>">
+							<option <%= inputPermissionsViewRole.equals(defaultGroupRole.getName()) ? "selected=\"selected\"" : "" %> value="<%= defaultGroupRole.getName() %>">
+								<c:choose>
+									<c:when test="<%= defaultGroupRole.getName().equals(RoleConstants.ORGANIZATION_USER) %>">
+										<liferay-ui:message key="organization-members" />
+									</c:when>
+									<c:when test="<%= defaultGroupRole.getName().equals(RoleConstants.POWER_USER) %>">
+										<liferay-ui:message key="power-users" />
+									</c:when>
+									<c:when test="<%= defaultGroupRole.getName().equals(RoleConstants.SITE_MEMBER) %>">
+										<liferay-ui:message key="site-members" />
+									</c:when>
+									<c:otherwise>
+										<liferay-ui:message key="user" />
+									</c:otherwise>
+								</c:choose>
+							</option>
+						</c:if>
 
-					<option <%= inputPermissionsViewRole.equals(RoleConstants.OWNER) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.OWNER %>"><liferay-ui:message key="owner" /></option>
-				</select>
+						<option <%= inputPermissionsViewRole.equals(RoleConstants.OWNER) ? "selected=\"selected\"" : "" %> value="<%= RoleConstants.OWNER %>"><liferay-ui:message key="owner" /></option>
+					</select>
+				</liferay-ui:csp>
 			</p>
 		</c:if>
 


### PR DESCRIPTION
**QA analysis**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4557#issuecomment-2478744215
**Sign-off**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4557#pullrequestreview-2448327441

----

This is part of https://github.com/liferay-frontend/liferay-portal/pull/4466 (root PR for CSP inline event handlers).

It is in the high risk group, which is composed of infra stuff used pervasively that may break a lot of tests for different teams.

> ⚠️ Note that even though this PR may break tests it doesn't mean it breaks the product.
> Tests can break because:
>
> 1. A bug is introduced in the product, or
> 2. They rely on internals of the taglib changed in the PR

Since the taglib is used almost everywhere we don't have any specific CI test suite to run (we would need to run all of them to make sure). And since we run all tests suites every day on a batch schedule we will rely on that to detect big failures unless someone can find a better way (I'm open to suggestions).

In any case, I've tested one occurence of the tag by hand following the procedure described at https://liferay.atlassian.net/browse/LPD-41257?focusedCommentId=2788264 to make sure it's not very badly broken.