### PR TITLE
LPD-41466 Create playwright tests for "View" and "Permissions" permissions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
@@ -684,7 +684,7 @@ const CustomDataSets = ({
 						href: permissionsURL,
 						icon: 'password-policies',
 						label: Liferay.Language.get('permissions'),
-						target: 'modal',
+						target: 'modal-permissions',
 					},
 					{
 						separator: true,

--- a/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
@@ -154,6 +154,12 @@ export class HeadlessAdminUserApiHelper {
 		);
 	}
 
+	async deleteRole(roleId: number) {
+		return this.apiHelpers.delete(
+			`${this.apiHelpers.baseUrl}${this.basePath}/roles/${roleId}`
+		);
+	}
+
 	async deleteUserAccount(userAccountId: number) {
 		return this.apiHelpers.delete(
 			`${this.apiHelpers.baseUrl}${this.basePath}/user-accounts/${userAccountId}`

--- a/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/ApplicationsMenuPage.ts
@@ -247,8 +247,8 @@ export class ApplicationsMenuPage {
 		await this.announcementsItem.click();
 	}
 
-	async goToDataSetManager() {
-		await this.goToControlPanel();
+	async goToDataSetManager(checkTabVisibility = true) {
+		await this.goToControlPanel(checkTabVisibility);
 		await this.dataSetManagerMenuItem.click();
 	}
 
@@ -430,8 +430,8 @@ export class ApplicationsMenuPage {
 		await this.page.getByRole('link', {exact: true, name}).click();
 	}
 
-	async goToControlPanel() {
-		await this.goto();
+	async goToControlPanel(checkTabVisibility = true) {
+		await this.goto(checkTabVisibility);
 		await this.controlPanelButton.click();
 	}
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -951,13 +951,25 @@ test('A user with "View" and "Permissions" permission', async ({
 
 	await test.step('Open Permissions modal', async () => {
 		await page.getByRole('menuitem', {name: 'Permissions'}).click();
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Permissions"]')
+				.locator('#guest_ACTION_VIEW')
+		).not.toBeChecked();
 	});
 
 	await test.step('Enable "View" permission for "User" role', async () => {
 		await page
 			.frameLocator('iframe[title="Permissions"]')
-			.locator('#user_ACTION_VIEW')
+			.locator('#guest_ACTION_VIEW')
 			.setChecked(true);
+
+		await expect(
+			page
+				.frameLocator('iframe[title="Permissions"]')
+				.locator('#guest_ACTION_VIEW')
+		).toBeChecked();
 	});
 
 	await test.step('Save Permissions modal', async () => {
@@ -965,6 +977,8 @@ test('A user with "View" and "Permissions" permission', async ({
 			.frameLocator('iframe[title="Permissions"]')
 			.getByRole('button', {name: 'Save'})
 			.click();
+
+		await waitForAlert(page.frameLocator('iframe[title="Permissions"]'));
 	});
 
 	await test.step('Click "Cancel" in the Permissions modal', async () => {
@@ -973,6 +987,7 @@ test('A user with "View" and "Permissions" permission', async ({
 			.getByRole('button', {name: 'Cancel'})
 			.click();
 	});
+
 	await test.step('Check that the Permissions modal is closed', async () => {
 		await expect(
 			page.getByRole('heading', {name: 'Permissions'})
@@ -1000,7 +1015,7 @@ test('A user with "View" and "Permissions" permission', async ({
 		await expect(
 			page
 				.frameLocator('iframe[title="Permissions"]')
-				.locator('#user_ACTION_VIEW')
+				.locator('#guest_ACTION_VIEW')
 		).toBeChecked();
 	});
 });

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -930,7 +930,7 @@ test('A user with "Delete" permission', async ({
 }) => {
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
-		dataSetERCs.push(blogPostDataSetERC);
+		createdDataSetERCs.push(blogPostDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...blogPostsDataSetConfig,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -843,7 +843,7 @@ test('A user with only "View" permission', async ({
 	});
 
 	await test.step('Go to Data Sets', async () => {
-		await dataSetsPage.goto();
+		await dataSetsPage.goto({checkTabVisibility: false});
 	});
 
 	await test.step('Open actions dropdown', async () => {
@@ -886,7 +886,7 @@ test('A user without "View" permission on Data Set items', async ({
 	});
 
 	await test.step('Go to Data Sets', async () => {
-		await dataSetsPage.goto();
+		await dataSetsPage.goto({checkTabVisibility: false});
 	});
 
 	await test.step('Assert that no data sets appear on the table', async () => {
@@ -923,7 +923,7 @@ dataSetsTabsTest(
 		});
 
 		await test.step('Navigate to System Data Sets tab', async () => {
-			await dataSetsPage.goto('System Data Sets');
+			await dataSetsPage.goto({dataSetsType: 'System Data Sets'});
 
 			await expect(
 				dataSetsPage.dataSetsEmptyState.locator('.c-empty-state-title')

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -919,6 +919,66 @@ test(
 	}
 );
 
+test('A user with "Delete" permission', async ({
+	apiHelpers,
+	dataSetManagerApiHelpers,
+	dataSetsPage,
+	page,
+	roleDefinePermissionsPage,
+	rolePage,
+	rolesPage,
+}) => {
+	await test.step('Create a data set', async () => {
+		const blogPostDataSetERC = getRandomString();
+		dataSetERCs.push(blogPostDataSetERC);
+
+		await dataSetManagerApiHelpers.createDataSet({
+			...blogPostsDataSetConfig,
+			erc: blogPostDataSetERC,
+			label: blogPostsDataSetConfig.name,
+		});
+	});
+
+	await test.step('Setup user role and login as user', async () => {
+		await setupUserRoleAndLoginAsUser({
+			apiHelpers,
+			dataSetResourcePermissions: [
+				{
+					actions: ['Delete'],
+					name: 'Data Set',
+				},
+			],
+			page,
+			roleDefinePermissionsPage,
+			rolePage,
+			rolesPage,
+		});
+	});
+
+	await test.step('Go to Data Sets', async () => {
+		await dataSetsPage.goto({checkTabVisibility: false});
+	});
+
+	await test.step('Open actions dropdown', async () => {
+		const dataSetRows = await page
+			.locator('.data-set-content-wrapper .dnd-tbody .dnd-tr')
+			.filter({
+				hasText: blogPostsDataSetConfig.name,
+			});
+
+		await dataSetRows
+			.first()
+			.getByRole('button', {name: 'Actions'})
+			.click();
+	});
+
+	await test.step('Check that "Delete" is visible', async () => {
+		await expect(
+			page.getByRole('menuitem', {name: 'Delete'})
+		).toBeVisible();
+	});
+});
+
 test('A user with "View" and "Permissions" permission', async ({
 	apiHelpers,
 	dataSetManagerApiHelpers,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -3,22 +3,35 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, mergeTests} from '@playwright/test';
+import {Page, expect, mergeTests} from '@playwright/test';
 
+import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {rolesPagesTest} from '../../../../fixtures/rolesPagesTest';
+import {DataApiHelpers} from '../../../../helpers/ApiHelpers';
+import {RoleDefinePermissionsPage} from '../../../../pages/roles-admin-web/RoleDefinePermissionsPage';
+import {RolePage} from '../../../../pages/roles-admin-web/RolePage';
+import {RolesPage} from '../../../../pages/roles-admin-web/RolesPage';
 import getRandomString from '../../../../utils/getRandomString';
+import performLogin, {
+	performLogout,
+	userData,
+} from '../../../../utils/performLogin';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import {API_ENDPOINT_PATH} from '../../utils/constants';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
 
 export const test = mergeTests(
+	dataApiHelpersTest,
 	dataSetManagerApiHelpersTest,
 	dataSetsPageTest,
 	featureFlagsTest({
 		'LPD-37531': false,
 		'LPS-164563': true,
 	}),
+	rolesPagesTest,
 	loginTest()
 );
 
@@ -147,6 +160,131 @@ async function assertTableRowsCount(page, rowsCount) {
 		const rows = await page.locator('.dnd-table > .dnd-tbody > .dnd-tr');
 
 		expect(rows).toHaveCount(rowsCount);
+	});
+}
+
+async function setupUserRoleAndLoginAsUser({
+	apiHelpers,
+	dataSetResourcePermissions,
+	page,
+	roleDefinePermissionsPage,
+	rolePage,
+	rolesPage,
+}: {
+	apiHelpers: DataApiHelpers;
+	dataSetResourcePermissions?: {
+		actions: string[];
+		name: string;
+	}[];
+	page: Page;
+	roleDefinePermissionsPage: RoleDefinePermissionsPage;
+	rolePage: RolePage;
+	rolesPage: RolesPage;
+}) {
+	const roleName = `ds_user_${getRandomString()}`;
+
+	let dataSetUserRole;
+	let userAccount: TUserAccount;
+
+	await test.step('Create Data Set user role', async () => {
+		const companyId = await page.evaluate(() => {
+			return Liferay.ThemeDisplay.getCompanyId();
+		});
+
+		dataSetUserRole = await apiHelpers.headlessAdminUser.postRole({
+			name: roleName,
+			rolePermissions: [
+				{
+					actionIds: ['VIEW_CONTROL_PANEL'],
+					primaryKey: companyId,
+					resourceName: '90',
+					scope: 1,
+				},
+				{
+					actionIds: ['ACCESS_IN_CONTROL_PANEL', 'VIEW'],
+					primaryKey: companyId,
+					resourceName:
+						'com_liferay_frontend_data_set_admin_web_internal_portlet_FDSAdminPortlet',
+					scope: 1,
+				},
+			],
+			roleType: 'regular',
+		});
+	});
+
+	await test.step('Create a new user', async () => {
+		userAccount = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[userAccount.alternateName] = {
+			name: userAccount.givenName,
+			password: 'test',
+			surname: userAccount.familyName,
+		};
+	});
+
+	await test.step('Assign new role to user', async () => {
+		await apiHelpers.headlessAdminUser.postRoleUserAccountAssociation(
+			dataSetUserRole.id,
+			Number(userAccount.id)
+		);
+
+		apiHelpers.data.push({
+			id: `${dataSetUserRole.id}_${userAccount.id}`,
+			type: 'roleUserAccountAssociation',
+		});
+	});
+
+	// Enable Data Set roles through the UI since the Data Set Object created
+	// is given a random resource name (For example: com.liferay.object.model.ObjectDefinition#E0X3).
+
+	if (dataSetResourcePermissions) {
+		await test.step('Go to roles admin page', async () => {
+			await rolesPage.goto();
+		});
+
+		await test.step('Navigate to role edit page', async () => {
+			await page.getByRole('link', {exact: true, name: roleName}).click();
+		});
+
+		await test.step('Navigate to "Define Permissions" > "Data Set" section', async () => {
+			await rolePage.definePermissionsLink.click();
+			await roleDefinePermissionsPage.searchInput.click();
+			await roleDefinePermissionsPage.searchInput.fill('Data Set');
+
+			await page
+				.getByRole('menuitem', {exact: true, name: 'Data Set'})
+				.click();
+		});
+
+		for (const dataSetResourcePermission of dataSetResourcePermissions) {
+			await test.step('Enable role checkboxes', async () => {
+				const dataSetRolesTable = page
+					.locator('.sheet-tertiary-title')
+					.getByText(dataSetResourcePermission.name, {exact: true})
+					.locator('~ .lfr-search-container');
+
+				for (const action of dataSetResourcePermission.actions) {
+					await dataSetRolesTable
+						.getByRole('row', {name: action})
+						.getByRole('checkbox')
+						.setChecked(true);
+				}
+			});
+		}
+
+		await test.step('Save roles', async () => {
+			await page.getByRole('button', {name: 'Save'}).click();
+
+			await waitForAlert(
+				page,
+				'Success:The role permissions were updated.'
+			);
+		});
+	}
+
+	await test.step('Do login with the new user', async () => {
+		await performLogout(page);
+		await performLogin(page, userAccount.alternateName);
 	});
 }
 
@@ -726,13 +864,14 @@ test(
 );
 
 test('A user with "View" and "Permissions" permission', async ({
+	apiHelpers,
 	dataSetManagerApiHelpers,
 	dataSetsPage,
 	page,
+	roleDefinePermissionsPage,
+	rolePage,
+	rolesPage,
 }) => {
-
-	// @TODO Create user with "Permissions" permission and login as that user.
-
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
 		dataSetERCs.push(blogPostDataSetERC);
@@ -744,8 +883,24 @@ test('A user with "View" and "Permissions" permission', async ({
 		});
 	});
 
+	await test.step('Setup user role and login as user', async () => {
+		await setupUserRoleAndLoginAsUser({
+			apiHelpers,
+			dataSetResourcePermissions: [
+				{
+					actions: ['Permissions', 'View'],
+					name: 'Data Set',
+				},
+			],
+			page,
+			roleDefinePermissionsPage,
+			rolePage,
+			rolesPage,
+		});
+	});
+
 	await test.step('Go to Data Sets', async () => {
-		await dataSetsPage.goto();
+		await dataSetsPage.goto({checkTabVisibility: false});
 	});
 
 	await test.step('Open actions dropdown', async () => {
@@ -824,13 +979,14 @@ test('A user with "View" and "Permissions" permission', async ({
 });
 
 test('A user with only "View" permission', async ({
+	apiHelpers,
 	dataSetManagerApiHelpers,
 	dataSetsPage,
 	page,
+	roleDefinePermissionsPage,
+	rolePage,
+	rolesPage,
 }) => {
-
-	// @TODO Create user with only "View" permission and login as that user.
-
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
 		dataSetERCs.push(blogPostDataSetERC);
@@ -839,6 +995,22 @@ test('A user with only "View" permission', async ({
 			...blogPostsDataSetConfig,
 			erc: blogPostDataSetERC,
 			label: blogPostsDataSetConfig.name,
+		});
+	});
+
+	await test.step('Setup user role and login as user', async () => {
+		await setupUserRoleAndLoginAsUser({
+			apiHelpers,
+			dataSetResourcePermissions: [
+				{
+					actions: ['View'],
+					name: 'Data Set',
+				},
+			],
+			page,
+			roleDefinePermissionsPage,
+			rolePage,
+			rolesPage,
 		});
 	});
 
@@ -867,13 +1039,14 @@ test('A user with only "View" permission', async ({
 });
 
 test('A user without "View" permission on Data Set items', async ({
+	apiHelpers,
 	dataSetManagerApiHelpers,
 	dataSetsPage,
 	page,
+	roleDefinePermissionsPage,
+	rolePage,
+	rolesPage,
 }) => {
-
-	// @TODO Create user without "View" permission and login as that user.
-
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
 		dataSetERCs.push(blogPostDataSetERC);
@@ -882,6 +1055,16 @@ test('A user without "View" permission on Data Set items', async ({
 			...blogPostsDataSetConfig,
 			erc: blogPostDataSetERC,
 			label: blogPostsDataSetConfig.name,
+		});
+	});
+
+	await test.step('Setup user role and login as user', async () => {
+		await setupUserRoleAndLoginAsUser({
+			apiHelpers,
+			page,
+			roleDefinePermissionsPage,
+			rolePage,
+			rolesPage,
 		});
 	});
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -1167,6 +1167,12 @@ test('A user with only "View" permission', async ({
 			page.getByRole('menuitem', {name: 'Permissions'})
 		).not.toBeVisible();
 	});
+
+	await test.step('Check that "Delete" is not visible', async () => {
+		await expect(
+			page.getByRole('menuitem', {name: 'Permissions'})
+		).not.toBeVisible();
+	});
 });
 
 test('A user without "View" permission on Data Set items', async ({

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -42,9 +42,9 @@ const dataSetsTabsTest = mergeTests(
 	})
 );
 
+const createdDataSetERCs = [];
 const createdRoleIds = [];
 const createdUserIds = [];
-const dataSetERCs = [];
 
 let loggedInAsAdmin = true;
 
@@ -304,13 +304,13 @@ test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers, page}) => {
 		await performLogin(page, 'test');
 	}
 
-	for (const erc of dataSetERCs) {
+	for (const erc of createdDataSetERCs) {
 		await dataSetManagerApiHelpers.deleteDataSet({
 			erc,
 		});
 	}
 
-	dataSetERCs.length = 0;
+	createdDataSetERCs.length = 0;
 
 	for (const id of createdRoleIds) {
 		await apiHelpers.headlessAdminUser.deleteRole(id);
@@ -433,7 +433,7 @@ test('Can paginate created Data Sets', async ({
 
 	await test.step('Create collection of Data Sets', async () => {
 		for (const DATA_SET_ERC of testDataSetERCs) {
-			dataSetERCs.push(DATA_SET_ERC);
+			createdDataSetERCs.push(DATA_SET_ERC);
 			await dataSetManagerApiHelpers.createDataSet({
 				...tableSectionsDataSetConfig,
 				erc: DATA_SET_ERC,
@@ -516,7 +516,7 @@ test('Sort data sets by different columns', async ({
 
 	await test.step('Create collection of Data Sets', async () => {
 		const blogPostDataSetERC = getRandomString();
-		dataSetERCs.push(blogPostDataSetERC);
+		createdDataSetERCs.push(blogPostDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...blogPostsDataSetConfig,
@@ -525,7 +525,7 @@ test('Sort data sets by different columns', async ({
 		});
 
 		const catalogsDataSetERC = getRandomString();
-		dataSetERCs.push(catalogsDataSetERC);
+		createdDataSetERCs.push(catalogsDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...catalogsDataSetConfig,
@@ -533,7 +533,7 @@ test('Sort data sets by different columns', async ({
 			label: catalogsDataSetConfig.name,
 		});
 
-		dataSetERCs.push(productsDataSetERC);
+		createdDataSetERCs.push(productsDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...productsDataSetConfig,
@@ -542,7 +542,7 @@ test('Sort data sets by different columns', async ({
 		});
 
 		const skuDataSetERC = getRandomString();
-		dataSetERCs.push(skuDataSetERC);
+		createdDataSetERCs.push(skuDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...skusDataSetConfig,
@@ -901,7 +901,7 @@ test('A user with "View" and "Permissions" permission', async ({
 }) => {
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
-		dataSetERCs.push(blogPostDataSetERC);
+		createdDataSetERCs.push(blogPostDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...blogPostsDataSetConfig,
@@ -1016,7 +1016,7 @@ test('A user with only "View" permission', async ({
 }) => {
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
-		dataSetERCs.push(blogPostDataSetERC);
+		createdDataSetERCs.push(blogPostDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...blogPostsDataSetConfig,
@@ -1076,7 +1076,7 @@ test('A user without "View" permission on Data Set items', async ({
 }) => {
 	await test.step('Create a data set', async () => {
 		const blogPostDataSetERC = getRandomString();
-		dataSetERCs.push(blogPostDataSetERC);
+		createdDataSetERCs.push(blogPostDataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			...blogPostsDataSetConfig,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -39,7 +39,8 @@ const dataSetsTabsTest = mergeTests(
 	test,
 	featureFlagsTest({
 		'LPD-37531': true,
-	})
+	}),
+	loginTest()
 );
 
 const createdDataSetERCs = [];
@@ -298,9 +299,37 @@ async function setupUserRoleAndLoginAsUser({
 	});
 }
 
+test.beforeEach(async ({page}) => {
+
+	// Unsure why this happens, but sometimes this can start off as not
+	// signed in, so this attempts to log in again or else the headless
+	// requests will fail.
+
+	if (
+		await page
+			.getByRole('button', {
+				name: 'Sign In',
+			})
+			.isVisible()
+	) {
+		await test.step('Sign in as admin', async () => {
+			await performLogin(page, 'test');
+		});
+	}
+});
+
 test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers, page}) => {
 	if (!loggedInAsAdmin) {
-		await performLogout(page);
+		if (
+			!(await page
+				.getByRole('button', {
+					name: 'Sign In',
+				})
+				.isVisible())
+		) {
+			await performLogout(page);
+		}
+
 		await performLogin(page, 'test');
 	}
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -725,6 +725,175 @@ test(
 	}
 );
 
+test('A user with "View" and "Permissions" permission', async ({
+	dataSetManagerApiHelpers,
+	dataSetsPage,
+	page,
+}) => {
+
+	// @TODO Create user with "Permissions" permission and login as that user.
+
+	await test.step('Create a data set', async () => {
+		const blogPostDataSetERC = getRandomString();
+		dataSetERCs.push(blogPostDataSetERC);
+
+		await dataSetManagerApiHelpers.createDataSet({
+			...blogPostsDataSetConfig,
+			erc: blogPostDataSetERC,
+			label: blogPostsDataSetConfig.name,
+		});
+	});
+
+	await test.step('Go to Data Sets', async () => {
+		await dataSetsPage.goto();
+	});
+
+	await test.step('Open actions dropdown', async () => {
+		const dataSetRows = await page
+			.locator('.data-set-content-wrapper .dnd-tbody .dnd-tr')
+			.filter({
+				hasText: blogPostsDataSetConfig.name,
+			});
+
+		await dataSetRows
+			.first()
+			.getByRole('button', {name: 'Actions'})
+			.click();
+	});
+
+	await test.step('Check that "Permissions" is visible', async () => {
+		await expect(
+			page.getByRole('menuitem', {name: 'Permissions'})
+		).toBeVisible();
+	});
+
+	await test.step('Open Permissions modal', async () => {
+		await page.getByRole('menuitem', {name: 'Permissions'}).click();
+	});
+
+	await test.step('Enable "View" permission for "User" role', async () => {
+		await page
+			.frameLocator('iframe[title="Permissions"]')
+			.locator('#user_ACTION_VIEW')
+			.setChecked(true);
+	});
+
+	await test.step('Save Permissions modal', async () => {
+		await page
+			.frameLocator('iframe[title="Permissions"]')
+			.getByRole('button', {name: 'Save'})
+			.click();
+	});
+
+	await test.step('Click "Cancel" in the Permissions modal', async () => {
+		await page
+			.frameLocator('iframe[title="Permissions"]')
+			.getByRole('button', {name: 'Cancel'})
+			.click();
+	});
+	await test.step('Check that the Permissions modal is closed', async () => {
+		await expect(
+			page.getByRole('heading', {name: 'Permissions'})
+		).not.toBeVisible();
+	});
+
+	await test.step('Open actions dropdown', async () => {
+		const dataSetRows = await page
+			.locator('.data-set-content-wrapper .dnd-tbody .dnd-tr')
+			.filter({
+				hasText: blogPostsDataSetConfig.name,
+			});
+
+		await dataSetRows
+			.first()
+			.getByRole('button', {name: 'Actions'})
+			.click();
+	});
+
+	await test.step('Open Permissions modal', async () => {
+		await page.getByRole('menuitem', {name: 'Permissions'}).click();
+	});
+
+	await test.step('Confirm "View" permission is persisted', async () => {
+		await expect(
+			page
+				.frameLocator('iframe[title="Permissions"]')
+				.locator('#user_ACTION_VIEW')
+		).toBeChecked();
+	});
+});
+
+test('A user with only "View" permission', async ({
+	dataSetManagerApiHelpers,
+	dataSetsPage,
+	page,
+}) => {
+
+	// @TODO Create user with only "View" permission and login as that user.
+
+	await test.step('Create a data set', async () => {
+		const blogPostDataSetERC = getRandomString();
+		dataSetERCs.push(blogPostDataSetERC);
+
+		await dataSetManagerApiHelpers.createDataSet({
+			...blogPostsDataSetConfig,
+			erc: blogPostDataSetERC,
+			label: blogPostsDataSetConfig.name,
+		});
+	});
+
+	await test.step('Go to Data Sets', async () => {
+		await dataSetsPage.goto();
+	});
+
+	await test.step('Open actions dropdown', async () => {
+		const dataSetRows = await page
+			.locator('.data-set-content-wrapper .dnd-tbody .dnd-tr')
+			.filter({
+				hasText: blogPostsDataSetConfig.name,
+			});
+
+		await dataSetRows
+			.first()
+			.getByRole('button', {name: 'Actions'})
+			.click();
+	});
+
+	await test.step('Check that "Permissions" is not visible', async () => {
+		await expect(
+			page.getByRole('menuitem', {name: 'Permissions'})
+		).not.toBeVisible();
+	});
+});
+
+test('A user without "View" permission on Data Set items', async ({
+	dataSetManagerApiHelpers,
+	dataSetsPage,
+	page,
+}) => {
+
+	// @TODO Create user without "View" permission and login as that user.
+
+	await test.step('Create a data set', async () => {
+		const blogPostDataSetERC = getRandomString();
+		dataSetERCs.push(blogPostDataSetERC);
+
+		await dataSetManagerApiHelpers.createDataSet({
+			...blogPostsDataSetConfig,
+			erc: blogPostDataSetERC,
+			label: blogPostsDataSetConfig.name,
+		});
+	});
+
+	await test.step('Go to Data Sets', async () => {
+		await dataSetsPage.goto();
+	});
+
+	await test.step('Assert that no data sets appear on the table', async () => {
+		assertTableRowsCount(page, 0);
+	});
+});
+
 dataSetsTabsTest(
 	'Check that there are two different tabs to navigate between Custom and System Data Sets',
 	{tag: '@LPD-37431'},

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dataSets.spec.ts
@@ -42,7 +42,11 @@ const dataSetsTabsTest = mergeTests(
 	})
 );
 
+const createdRoleIds = [];
+const createdUserIds = [];
 const dataSetERCs = [];
+
+let loggedInAsAdmin = true;
 
 const blogPostsDataSetConfig = {
 	name: 'BlogPosting',
@@ -210,6 +214,8 @@ async function setupUserRoleAndLoginAsUser({
 			],
 			roleType: 'regular',
 		});
+
+		createdRoleIds.push(dataSetUserRole.id);
 	});
 
 	await test.step('Create a new user', async () => {
@@ -220,6 +226,8 @@ async function setupUserRoleAndLoginAsUser({
 			password: 'test',
 			surname: userAccount.familyName,
 		};
+
+		createdUserIds.push(userAccount.id);
 	});
 
 	await test.step('Assign new role to user', async () => {
@@ -285,10 +293,17 @@ async function setupUserRoleAndLoginAsUser({
 	await test.step('Do login with the new user', async () => {
 		await performLogout(page);
 		await performLogin(page, userAccount.alternateName);
+
+		loggedInAsAdmin = false;
 	});
 }
 
-test.afterEach(async ({dataSetManagerApiHelpers}) => {
+test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers, page}) => {
+	if (!loggedInAsAdmin) {
+		await performLogout(page);
+		await performLogin(page, 'test');
+	}
+
 	for (const erc of dataSetERCs) {
 		await dataSetManagerApiHelpers.deleteDataSet({
 			erc,
@@ -296,6 +311,18 @@ test.afterEach(async ({dataSetManagerApiHelpers}) => {
 	}
 
 	dataSetERCs.length = 0;
+
+	for (const id of createdRoleIds) {
+		await apiHelpers.headlessAdminUser.deleteRole(id);
+	}
+
+	createdRoleIds.length = 0;
+
+	for (const id of createdUserIds) {
+		await apiHelpers.headlessAdminUser.deleteUserAccount(id);
+	}
+
+	createdUserIds.length = 0;
 });
 
 test(

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/DataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/DataSetsPage.ts
@@ -120,8 +120,14 @@ export class DataSetsPage {
 		await this.newDataSetModal.heading.isHidden();
 	}
 
-	async goto(dataSetsType: string = 'Custom Data Sets') {
-		await this.applicationsMenuPage.goToDataSetManager();
+	async goto({
+		checkTabVisibility,
+		dataSetsType = 'Custom Data Sets',
+	}: {
+		checkTabVisibility?: boolean;
+		dataSetsType?: string;
+	} = {}) {
+		await this.applicationsMenuPage.goToDataSetManager(checkTabVisibility);
 
 		if (dataSetsType === 'System Data Sets') {
 			await this.systemDataSetsTab.click();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41466

Mainly for @kresimir-coko and @chestofwonders: An update on the branch I shared in the group chat. The most notable part is the `setupUserRoleAndLoginAsUser` function that now allows different actions to be selected. An example use would be:

```
await setupUserRoleAndLoginAsUser({
	apiHelpers,
	dataSetResourcePermissions: [
		{
			actions: ['Permissions', 'View'],
			name: 'Data Set',
		},
	],
	page,
	roleDefinePermissionsPage,
	rolePage,
	rolesPage,
});
```

All that's missing is the cleanup steps to delete the created role and user which we could do something similar to the `test.afterEach` in collecting the created role/user ids or ercs.