### PR TITLE
LPD-41256 Extract inline event handlers in <clay:alert>

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/AlertTag.java
@@ -6,7 +6,9 @@
 package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyHTMLRewriterUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.taglib.util.TagResourceBundleUtil;
@@ -134,22 +136,29 @@ public class AlertTag extends BaseContainerTag {
 		jspWriter.write("</div></div>");
 
 		if (_dismissible) {
-			jspWriter.write("<button aria-label=\"");
-			jspWriter.write(
+			StringBundler sb = new StringBundler(7);
+
+			sb.append("<button aria-label=\"");
+			sb.append(
 				LanguageUtil.get(
 					TagResourceBundleUtil.getResourceBundle(pageContext),
 					"close"));
-			jspWriter.write("\" class=\"close\" onclick=\"");
-			jspWriter.write("event.target.closest('[role=alert]').remove()\"");
-			jspWriter.write(" type=\"button\">");
+			sb.append("\" class=\"close\" onclick=\"");
+			sb.append("event.target.closest('[role=alert]').remove()\" ");
+			sb.append("type=\"button\">");
 
 			IconTag iconTag = new IconTag();
 
 			iconTag.setSymbol("times");
 
-			iconTag.doTag(pageContext);
+			sb.append(iconTag.doTagAsString(pageContext));
 
-			jspWriter.write("</button>");
+			sb.append("</button>");
+
+			jspWriter.write(
+				ContentSecurityPolicyHTMLRewriterUtil.
+					rewriteInlineEventHandlers(
+						sb.toString(), getRequest(), false));
 		}
 
 		if (Validator.isNotNull(_variant) && _variant.equals("stripe")) {


### PR DESCRIPTION
**QA analysis**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4560#issuecomment-2483498580
**Sign-off**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4560#pullrequestreview-2448275653

----

This is part of https://github.com/liferay-frontend/liferay-portal/pull/4466 (root PR for CSP inline event handlers).

It is in the high risk group, which is composed of infra stuff used pervasively that may break a lot of tests for different teams.

> ⚠️ Note that even though this PR may break tests it doesn't mean it breaks the product.
> Tests can break because:
>
> 1. A bug is introduced in the product, or
> 2. They rely on internals of the taglib changed in the PR

Since the taglib is used almost everywhere we don't have any specific CI test suite to run (we would need to run all of them to make sure). And since we run all tests suites every day on a batch schedule we will rely on that to detect big failures unless someone can find a better way (I'm open to suggestions).

In any case, I've tested one occurence of the tag by hand following the procedure described at https://liferay.atlassian.net/browse/LPD-41256?focusedCommentId=2789345 to make sure it's not very badly broken.