### PR TITLE
LPD-42415 Ensure no preferences are used to add sample portlet

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web-test/src/testIntegration/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/test/ClaySamplePortletTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web-test/src/testIntegration/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/test/ClaySamplePortletTest.java
@@ -27,7 +27,6 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.HashMap;
 import java.util.List;
 
 import javax.portlet.PortletRequest;
@@ -69,7 +68,7 @@ public class ClaySamplePortletTest {
 
 		LayoutTestUtil.addPortletToLayout(
 			TestPropsValues.getUserId(), layout, _PORTLET_NAME, "column-1",
-			new HashMap<String, String[]>());
+			null);
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"net.htmlparser.jericho", LoggerTestUtil.ERROR)) {


### PR DESCRIPTION
Here we are avoiding the error in the integration test about portlet preferences reported in https://liferay.atlassian.net/browse/LPD-42093

As this portlet does not need preferences, we just pass null instead of an empty map.

Thhis simplifies code and makes test faster