### PR TITLE
LPD-41251 Extract inline event handlers in RowChecker

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/EmptyOnClickRowChecker.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.dao.search;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyHTMLRewriterUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -38,9 +39,21 @@ public class EmptyOnClickRowChecker extends RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
-		StringBundler sb = new StringBundler(20);
+		return StringBundler.concat(
+			"<div class=\"custom-checkbox custom-control\"><label>",
+			_getInput(
+				httpServletRequest, checked, disabled, name, value,
+				checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick),
+			"<span class=\"custom-control-label\"></span></label></div>");
+	}
 
-		sb.append("<div class=\"custom-checkbox custom-control\"><label>");
+	private String _getInput(
+		HttpServletRequest httpServletRequest, boolean checked,
+		boolean disabled, String name, String value, String checkBoxRowIds,
+		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+
+		StringBundler sb = new StringBundler(18);
+
 		sb.append("<input ");
 
 		String rowElementId = (String)httpServletRequest.getAttribute(
@@ -78,10 +91,10 @@ public class EmptyOnClickRowChecker extends RowChecker {
 					checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick));
 		}
 
-		sb.append("><span class=\"custom-control-label\"></span></label>");
-		sb.append("</div>");
+		sb.append(">");
 
-		return sb.toString();
+		return ContentSecurityPolicyHTMLRewriterUtil.rewriteInlineEventHandlers(
+			sb.toString(), httpServletRequest, false);
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/search/RowChecker.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.dao.search;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyHTMLRewriterUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -192,12 +193,18 @@ public class RowChecker {
 		}
 
 		return StringBundler.concat(
-			"<label><input name=\"", name, "\" title=\"",
-			LanguageUtil.get(getLocale(httpServletRequest), "select-all"),
-			"\" type=\"checkbox\" ", HtmlUtil.buildData(_data),
-			"onClick=\"Liferay.Util.checkAll(AUI().one(this).ancestor(",
-			"'.table'), ", checkBoxRowIds,
-			", this, 'tr:not(.d-none)');\"></label>");
+			"<label>",
+			ContentSecurityPolicyHTMLRewriterUtil.rewriteInlineEventHandlers(
+				StringBundler.concat(
+					"<input name=\"", name, "\" title=\"",
+					LanguageUtil.get(
+						getLocale(httpServletRequest), "select-all"),
+					"\" type=\"checkbox\" ", HtmlUtil.buildData(_data),
+					"onClick=\"Liferay.Util.checkAll(AUI().one(this).ancestor(",
+					"'.table'), ", checkBoxRowIds,
+					", this, 'tr:not(.d-none)');\">"),
+				httpServletRequest, false),
+			"</label>");
 	}
 
 	protected Locale getLocale(HttpServletRequest httpServletRequest) {
@@ -261,9 +268,22 @@ public class RowChecker {
 		boolean disabled, String name, String value, String checkBoxRowIds,
 		String checkBoxAllRowIds, String checkBoxPostOnClick) {
 
+		return StringBundler.concat(
+			"<label>",
+			_getInput(
+				httpServletRequest, checked, disabled, name, value,
+				checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick),
+			"</label>");
+	}
+
+	private String _getInput(
+		HttpServletRequest httpServletRequest, boolean checked,
+		boolean disabled, String name, String value, String checkBoxRowIds,
+		String checkBoxAllRowIds, String checkBoxPostOnClick) {
+
 		StringBundler sb = new StringBundler(17);
 
-		sb.append("<label><input ");
+		sb.append("<input ");
 
 		String rowElementId = (String)httpServletRequest.getAttribute(
 			"liferay-ui:search-container-row:rowElementId");
@@ -299,9 +319,10 @@ public class RowChecker {
 					checkBoxRowIds, checkBoxAllRowIds, checkBoxPostOnClick));
 		}
 
-		sb.append("></label>");
+		sb.append(">");
 
-		return sb.toString();
+		return ContentSecurityPolicyHTMLRewriterUtil.rewriteInlineEventHandlers(
+			sb.toString(), httpServletRequest, false);
 	}
 
 	private String _align = ALIGN;


### PR DESCRIPTION
**QA analysis**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4565#issuecomment-2487901166
**Sign-off**: :green_circle: https://github.com/liferay-frontend/liferay-portal/pull/4565#pullrequestreview-2447840999

----

This is part of https://github.com/liferay-frontend/liferay-portal/pull/4466 (root PR for CSP inline event handlers).

It is in the high risk group, which is composed of infra stuff used pervasively that may break a lot of tests for different teams.

> ⚠️ Note that even though this PR may break tests it doesn't mean it breaks the product.
> Tests can break because:
>
> 1. A bug is introduced in the product, or
> 2. They rely on internals of the taglib changed in the PR

Since the taglib is used almost everywhere we don't have any specific CI test suite to run (we would need to run all of them to make sure). And since we run all tests suites every day on a batch schedule we will rely on that to detect big failures unless someone can find a better way (I'm open to suggestions).

In any case, I've tested one occurence of the tag by hand following the procedure described at https://liferay.atlassian.net/browse/LPD-41251?focusedCommentId=2790402 and https://liferay.atlassian.net/browse/LPD-41251?focusedCommentId=2790383 to make sure it's not very badly broken.