### PR TITLE
LPD-41706 - Fix FDS Card link actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/css/Actions.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/css/Actions.scss
@@ -1,7 +1,7 @@
 @import 'atlas-variables';
 @import 'cadmin-variables';
 
-html#{$cadmin-selector} {
+html#{$cadmin-selector} .cadmin {
 	.dsm-actions-icon-selection-modal ul li {
 		color: $gray-600;
 		cursor: pointer;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -12,6 +12,7 @@ import FrontendDataSetContext, {
 } from '../../FrontendDataSetContext';
 import {IItemsActions} from '../../index';
 import filterItemActions from '../../utils/actionItems/filterItemActions';
+import formatActionURL from '../../utils/actionItems/formatActionURL';
 import handleActionClick from '../../utils/actionItems/handleActionClick';
 import {getLocalizedValue} from '../../utils/getLocalizedValue';
 import getRandomId from '../../utils/getRandomId';
@@ -61,14 +62,16 @@ const Card = ({item, schema}: {item: any; schema: ICardSchema}) => {
 	const localizedTitle = getLocalizedValue(item, schema.title)?.value || '';
 	const selectedItemKey = selectedItemsKey && item[selectedItemsKey];
 	const formattedActions =
-		actionsRef.current &&
-		(filterItemActions(actionsRef.current, item) as any);
+		actionsRef?.current &&
+		(filterItemActions(actionsRef?.current, item) as any);
 
 	return (
 		<ClayCardWithInfo
 			actions={formattedActions?.map((action: IItemsActions) => ({
 				...action,
-				href: isLink(action.target, null) ? action.href : null,
+				href: isLink(action.target, null)
+					? formatActionURL(action.href, item, action.target)
+					: null,
 				onClick: (event: Event) => {
 					handleActionClick({
 						action,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
@@ -222,9 +222,8 @@ test.describe('Item Actions in Data Set fragment', () => {
 					exact: true,
 					name: 'Actions',
 				});
-				const dropdownId = await button.evaluate((node) =>
-					node.getAttribute('aria-controls')
-				);
+
+				const dropdownId = await button.getAttribute('aria-controls');
 
 				await button.click();
 
@@ -248,9 +247,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				name: 'Actions',
 			});
 
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 
@@ -286,9 +283,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				name: 'Actions',
 			});
 
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 
@@ -322,6 +317,138 @@ test.describe('Item Actions in Data Set fragment', () => {
 			await page.keyboard.press('Escape');
 
 			await expect(sidePanel).not.toBeInViewport();
+		});
+	});
+
+	test('Link item action works in Cards, List and Visualization modes', async ({
+		dataSetFragmentPage,
+		dataSetManagerApiHelpers,
+		layout,
+		page,
+	}) => {
+		await test.step('Create sample data for the data set cards and list', async () => {
+			await dataSetManagerApiHelpers.createDataSetCardsSection({
+				dataSetERC,
+				fieldName: 'id',
+				name: 'title',
+			});
+
+			await dataSetManagerApiHelpers.createDataSetListSection({
+				dataSetERC,
+				fieldName: 'id',
+				name: 'title',
+			});
+		});
+
+		await test.step('Create a link Item Action with an interpolated argument', async () => {
+			await dataSetManagerApiHelpers.createDataSetItemAction({
+				dataSetERC,
+				label_i18n: {en_US: LINK_ITEM_ACTION_NAME},
+				target: EItemActionTarget.LINK,
+				url: '/detail/{id}',
+			});
+		});
+
+		await test.step('Configure Data Set in the page', async () => {
+			await dataSetFragmentPage.configureDataSetFragment({
+				dataSetLabel,
+				layout,
+			});
+		});
+
+		await test.step('Action is visible in the Cards visualization mode', async () => {
+			await dataSetFragmentPage.cardsWrapper.waitFor({
+				state: 'visible',
+			});
+
+			await expect(dataSetFragmentPage.cardsWrapper).toBeInViewport();
+
+			await dataSetFragmentPage.page.locator('.card').first().waitFor();
+
+			const firstCard = dataSetFragmentPage.page.locator('.card').first();
+
+			const itemId = await firstCard
+				.locator('.card-title')
+				.allInnerTexts();
+
+			const cardActionsDropdownId = await firstCard
+				.getByLabel('More Actions')
+				.getAttribute('aria-controls');
+
+			await firstCard.getByLabel('More Actions').click();
+
+			await page
+				.locator(`#${cardActionsDropdownId}`)
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			const itemAction = await page
+				.locator(`#${cardActionsDropdownId}`)
+				.getByRole('menuitem', {name: LINK_ITEM_ACTION_NAME});
+
+			await expect(
+				(await itemAction.getAttribute('href')).valueOf()
+			).toContain(`/detail/${itemId}`);
+		});
+
+		await test.step('Change visualization mode to List', async () => {
+			await dataSetFragmentPage.changeVisualizationMode('List');
+		});
+
+		await test.step('Action is visible in the List visualization mode', async () => {
+			await dataSetFragmentPage.listWrapper.waitFor({
+				state: 'visible',
+			});
+
+			await expect(dataSetFragmentPage.listWrapper).toBeInViewport();
+
+			await dataSetFragmentPage.page
+				.locator('.list-group-item')
+				.first()
+				.waitFor();
+
+			const firstListItem = dataSetFragmentPage.page
+				.locator('.list-group-item')
+				.first();
+
+			const itemId = await firstListItem
+				.locator('.list-group-title')
+				.allInnerTexts();
+
+			const listActionLink = await firstListItem.getByLabel(
+				LINK_ITEM_ACTION_NAME
+			);
+
+			await expect(
+				(await listActionLink.getAttribute('href')).valueOf()
+			).toContain(`/detail/${itemId}`);
+		});
+
+		await test.step('Change visualization mode to Table', async () => {
+			await dataSetFragmentPage.changeVisualizationMode('Table');
+		});
+
+		await test.step('Action is visible in the Table visualization mode', async () => {
+			await dataSetFragmentPage.tableWrapper.waitFor({
+				state: 'visible',
+			});
+
+			await expect(dataSetFragmentPage.tableWrapper).toBeInViewport();
+
+			const tableRow = page.locator('.dnd-td.item-actions').first();
+
+			const itemId = await tableRow
+				.locator('.dnd-td')
+				.first()
+				.allInnerTexts();
+
+			const tableActionLink = await tableRow.getByLabel(
+				LINK_ITEM_ACTION_NAME
+			);
+
+			await expect(
+				(await tableActionLink.getAttribute('href')).valueOf()
+			).toContain(`/detail/${itemId}`);
 		});
 	});
 
@@ -380,15 +507,13 @@ test.describe('Item Actions in Data Set fragment', () => {
 						exact: true,
 						name: 'Actions',
 					})
-				).toBeVisible;
+				).toBeVisible();
 
 				const button = await tableRow.getByRole('button', {
 					exact: true,
 					name: 'Actions',
 				});
-				const dropdownId = await button.evaluate((node) =>
-					node.getAttribute('aria-controls')
-				);
+				const dropdownId = await button.getAttribute('aria-controls');
 
 				await button.click();
 
@@ -426,9 +551,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				name: 'Actions',
 			});
 
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 
@@ -458,9 +581,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				name: 'Actions',
 			});
 
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 
@@ -534,9 +655,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				exact: true,
 				name: 'Actions',
 			});
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 
@@ -568,9 +687,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				name: 'Actions',
 			});
 
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 
@@ -606,9 +723,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				name: 'Actions',
 			});
 
-			const dropdownId = await button.evaluate((node) =>
-				node.getAttribute('aria-controls')
-			);
+			const dropdownId = await button.getAttribute('aria-controls');
 
 			await button.click();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-41706

## Issue
When a user creates a Data Set and defines an action, the URL field allows the interpolation of parameters that will be parsed in the fragment and replaced by the correct value. Parsing the URL is working fine, but we were not taking into account the case of actions of with `target: link` in the Cards Visualization mode.

In DSM, an action with an URL like: `/view/{id}`

Will be transformed in FDS into: `/view/1234`

![image](https://github.com/user-attachments/assets/05005a56-6d89-410e-8c9e-8169db78b723)
