### PR TITLE
LPD-43260 Adds support to deprecated badged in vertical navigation

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -6,18 +6,23 @@
 package com.liferay.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.IconItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 
@@ -296,14 +301,17 @@ public class VerticalNavTag extends BaseContainerTag {
 			jspWriter.write(
 				HtmlUtil.escape((String)verticalNavItem.get("label")));
 
-			if (GetterUtil.getBoolean(verticalNavItem.get("locked"))) {
-				jspWriter.write("<svg title=\"\" class=\"lexicon-icon");
-				jspWriter.write(" lexicon-icon-lock c-ml-1 text-muted");
-				jspWriter.write(" role=\"presentation\">");
-				jspWriter.write(
-					"<use href=\"http://localhost:8080/o/admin-theme/");
-				jspWriter.write("images/clay/icons.svg#lock\">");
-				jspWriter.write("</use></svg>");
+			List<IconItem> iconItems = (List<IconItem>)verticalNavItem.get(
+				"icons");
+
+			if (ListUtil.isNotEmpty(iconItems)) {
+				for (IconItem iconItem : iconItems) {
+					String symbol = (String)iconItem.get("symbol");
+
+					if (Validator.isNotNull(symbol)) {
+						_writeIcon(symbol, jspWriter);
+					}
+				}
 			}
 
 			if (GetterUtil.getBoolean(verticalNavItem.get("deprecated"))) {
@@ -346,6 +354,25 @@ public class VerticalNavTag extends BaseContainerTag {
 		}
 
 		jspWriter.write("</ul>");
+	}
+
+	private void _writeIcon(String icon, JspWriter jspWriter) throws Exception {
+		jspWriter.write("<svg class=\"lexicon-icon lexicon-icon-");
+		jspWriter.write(icon);
+		jspWriter.write(" c-ml-2 text-muted\" role=\"presentation\">");
+		jspWriter.write("<use xlink:href=\"");
+
+		HttpServletRequest httpServletRequest = getRequest();
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		jspWriter.write(themeDisplay.getPathThemeSpritemap());
+
+		jspWriter.write("#");
+		jspWriter.write(icon);
+		jspWriter.write("\" /></svg></span>");
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:vertical_nav:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -10,19 +10,16 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.IconItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.JspWriter;
 
@@ -308,9 +305,16 @@ public class VerticalNavTag extends BaseContainerTag {
 				for (IconItem iconItem : iconItems) {
 					String symbol = (String)iconItem.get("symbol");
 
-					if (Validator.isNotNull(symbol)) {
-						_writeIcon(symbol, jspWriter);
+					if (Validator.isNull(symbol)) {
+						continue;
 					}
+
+					IconTag iconTag = new IconTag();
+
+					iconTag.setCssClass("c-ml-2 text-muted");
+					iconTag.setSymbol(symbol);
+
+					iconTag.doTag(pageContext);
 				}
 			}
 
@@ -354,25 +358,6 @@ public class VerticalNavTag extends BaseContainerTag {
 		}
 
 		jspWriter.write("</ul>");
-	}
-
-	private void _writeIcon(String icon, JspWriter jspWriter) throws Exception {
-		jspWriter.write("<svg class=\"lexicon-icon lexicon-icon-");
-		jspWriter.write(icon);
-		jspWriter.write(" c-ml-2 text-muted\" role=\"presentation\">");
-		jspWriter.write("<use xlink:href=\"");
-
-		HttpServletRequest httpServletRequest = getRequest();
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		jspWriter.write(themeDisplay.getPathThemeSpritemap());
-
-		jspWriter.write("#");
-		jspWriter.write(icon);
-		jspWriter.write("\" /></svg></span>");
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:vertical_nav:";

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -8,6 +8,8 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -293,6 +295,15 @@ public class VerticalNavTag extends BaseContainerTag {
 
 			jspWriter.write(
 				HtmlUtil.escape((String)verticalNavItem.get("label")));
+
+			if (GetterUtil.getBoolean(verticalNavItem.get("deprecated"))) {
+				jspWriter.write("<span class=\"badge badge-warning c-ml-2");
+				jspWriter.write(" text-uppercase badge-translucent\">");
+				jspWriter.write("<span class=\"badge-item ");
+				jspWriter.write("badge-item-expand\">");
+				jspWriter.write(LanguageUtil.get(getRequest(), "deprecated"));
+				jspWriter.write("</span></span>");
+			}
 
 			if (items != null) {
 				IconTag iconTag = new IconTag();

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -296,6 +296,16 @@ public class VerticalNavTag extends BaseContainerTag {
 			jspWriter.write(
 				HtmlUtil.escape((String)verticalNavItem.get("label")));
 
+			if (GetterUtil.getBoolean(verticalNavItem.get("locked"))) {
+				jspWriter.write("<svg title=\"\" class=\"lexicon-icon");
+				jspWriter.write(" lexicon-icon-lock c-ml-1 text-muted");
+				jspWriter.write(" role=\"presentation\">");
+				jspWriter.write(
+					"<use href=\"http://localhost:8080/o/admin-theme/");
+				jspWriter.write("images/clay/icons.svg#lock\">");
+				jspWriter.write("</use></svg>");
+			}
+
 			if (GetterUtil.getBoolean(verticalNavItem.get("deprecated"))) {
 				jspWriter.write("<span class=\"badge badge-warning c-ml-2");
 				jspWriter.write(" text-uppercase badge-translucent\">");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
@@ -95,8 +95,4 @@ public class NavigationItem extends HashMap<String, Object> {
 		put("label", label);
 	}
 
-	public void setLocked(boolean locked) {
-		put("locked", locked);
-	}
-
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/util/NavigationItem.java
@@ -95,4 +95,8 @@ public class NavigationItem extends HashMap<String, Object> {
 		put("label", label);
 	}
 
+	public void setLocked(boolean locked) {
+		put("locked", locked);
+	}
+
 }

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayBadge from '@clayui/badge';
 import {VerticalNav as ClayVerticalNav} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
+import {FeatureIndicator} from 'frontend-js-components-web';
 import React from 'react';
 
 export default function VerticalNav({
@@ -58,12 +58,9 @@ export default function VerticalNav({
 					})}
 
 					{item.deprecated ? (
-						<ClayBadge
-							className="c-ml-2 text-uppercase"
-							displayType="warning"
-							label={Liferay.Language.get('deprecated')}
-							translucent
-						/>
+						<span className="c-ml-2">
+							<FeatureIndicator type="deprecated" />
+						</span>
 					) : null}
 				</ClayVerticalNav.Item>
 			)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -49,7 +49,7 @@ export default function VerticalNav({
 					{item.icons?.map((icon) => {
 						return (
 							<ClayIcon
-								className="c-ml-1 text-muted"
+								className="c-ml-2 text-muted"
 								key={icon.symbol}
 								symbol={icon.symbol}
 								title={icon.title}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayBadge from '@clayui/badge';
 import {VerticalNav as ClayVerticalNav} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
 import React from 'react';
@@ -55,6 +56,15 @@ export default function VerticalNav({
 							/>
 						);
 					})}
+
+					{item.deprecated ? (
+						<ClayBadge
+							className="c-ml-2 text-uppercase"
+							displayType="warning"
+							label={Liferay.Language.get('deprecated')}
+							translucent
+						/>
+					) : null}
 				</ClayVerticalNav.Item>
 			)}
 		</ClayVerticalNav>


### PR DESCRIPTION
Motivation
-----

Render deprecation badged in vertical navigation taglib.

Proposed Solution
-----

Take into account if a navigation item is deprecated or not in vertical navigation.

This pr also includes some rendering improvements to prevent view issues before react load.

<img width="1407" alt="Captura de pantalla 2024-12-02 a las 14 51 33" src="https://github.com/user-attachments/assets/cd277c8c-64bd-4bce-afc0-6c674811bab2">