### PR TITLE
LPD-43308 Make LogoSelectorTag renderable within a fragment

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 13.7.3
+Bundle-Version: 13.8.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.constants,\

--- a/modules/apps/frontend-taglib/frontend-taglib/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/frontend-taglib/frontend-taglib/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")
 	compileOnly project(":core:petra:petra-string")
-	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testImplementation project(":apps:frontend-js:frontend-js-web")
 	testImplementation project(":core:petra:petra-reflect")
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -23,5 +23,5 @@
 		"checkFormat": "node-scripts format --check",
 		"format": "node-scripts format"
 	},
-	"version": "13.7.3"
+	"version": "13.8.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
@@ -146,6 +146,9 @@ public class LogoSelectorTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-frontend:logo-selector:logoURL",
 			_getLogoURL(httpServletRequest));
+		httpServletRequest.setAttribute(
+			"liferay-frontend:logo-selector:portletNamespace",
+			_getPortletNamespace(httpServletRequest));
 
 		String randomKey = PortalUtil.generateRandomKey(
 			httpServletRequest, "taglib_ui_logo_selector");
@@ -180,6 +183,12 @@ public class LogoSelectorTag extends IncludeTag {
 		}
 
 		return getCurrentLogoURL();
+	}
+
+	private String _getPortletNamespace(HttpServletRequest httpServletRequest) {
+		return PortalUtil.getLiferayPortletResponse(
+			_getPortletResponse(httpServletRequest)
+		).getNamespace();
 	}
 
 	private PortletResponse _getPortletResponse(

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
@@ -54,6 +54,10 @@ public class LogoSelectorTag extends IncludeTag {
 		return _label;
 	}
 
+	public String getPortletNamespace() {
+		return _portletNamespace;
+	}
+
 	public boolean isDisabled() {
 		return _disabled;
 	}
@@ -93,6 +97,10 @@ public class LogoSelectorTag extends IncludeTag {
 		setServletContext(ServletContextUtil.getServletContext());
 	}
 
+	public void setPortletNamespace(String portletNamespace) {
+		_portletNamespace = portletNamespace;
+	}
+
 	public void setPreserveRatio(boolean preserveRatio) {
 		_preserveRatio = preserveRatio;
 	}
@@ -107,6 +115,7 @@ public class LogoSelectorTag extends IncludeTag {
 		_description = null;
 		_disabled = false;
 		_label = null;
+		_portletNamespace = null;
 		_preserveRatio = false;
 	}
 
@@ -131,7 +140,7 @@ public class LogoSelectorTag extends IncludeTag {
 			_getLogoURL(httpServletRequest));
 		httpServletRequest.setAttribute(
 			"liferay-frontend:logo-selector:portletNamespace",
-			PortletKeys.IMAGE_UPLOADER);
+			_portletNamespace);
 
 		String randomKey = PortalUtil.generateRandomKey(
 			httpServletRequest, "taglib_ui_logo_selector");
@@ -203,6 +212,7 @@ public class LogoSelectorTag extends IncludeTag {
 	private String _description;
 	private boolean _disabled;
 	private String _label;
+	private String _portletNamespace;
 	private boolean _preserveRatio;
 
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
@@ -9,18 +9,35 @@ import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.portlet.InvokerPortlet;
+import com.liferay.portal.kernel.portlet.LiferayRenderRequest;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletInstanceFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
+import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portlet.RenderRequestFactory;
+import com.liferay.portlet.RenderResponseFactory;
 import com.liferay.taglib.util.IncludeTag;
 
+import javax.portlet.PortletConfig;
+import javax.portlet.PortletException;
+import javax.portlet.PortletMode;
 import javax.portlet.PortletResponse;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
@@ -151,12 +168,9 @@ public class LogoSelectorTag extends IncludeTag {
 		long fileEntryId = ParamUtil.getLong(httpServletRequest, "fileEntryId");
 
 		if (fileEntryId > 0) {
-			PortletResponse portletResponse =
-				(PortletResponse)httpServletRequest.getAttribute(
-					JavaConstants.JAVAX_PORTLET_RESPONSE);
-
 			return ResourceURLBuilder.createResourceURL(
-				PortalUtil.getLiferayPortletResponse(portletResponse),
+				PortalUtil.getLiferayPortletResponse(
+					_getPortletResponse(httpServletRequest)),
 				PortletKeys.IMAGE_UPLOADER
 			).setMVCResourceCommandName(
 				"/image_uploader/upload_image"
@@ -168,15 +182,60 @@ public class LogoSelectorTag extends IncludeTag {
 		return getCurrentLogoURL();
 	}
 
-	private String _getSelectLogoURL(
-		HttpServletRequest httpServletRequest, String randomNamespace) {
+	private PortletResponse _getPortletResponse(
+		HttpServletRequest httpServletRequest) {
 
 		PortletResponse portletResponse =
 			(PortletResponse)httpServletRequest.getAttribute(
 				JavaConstants.JAVAX_PORTLET_RESPONSE);
 
+		if (portletResponse != null) {
+			return portletResponse;
+		}
+
+		try {
+			Portlet portlet = PortletLocalServiceUtil.getPortletById(
+				PortletKeys.IMAGE_UPLOADER);
+
+			InvokerPortlet invokerPortlet = PortletInstanceFactoryUtil.create(
+				portlet, httpServletRequest.getServletContext());
+
+			PortletConfig portletConfig = PortletConfigFactoryUtil.create(
+				portlet, httpServletRequest.getServletContext());
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			LiferayRenderRequest liferayRenderRequest =
+				RenderRequestFactory.create(
+					httpServletRequest, portlet, invokerPortlet,
+					portletConfig.getPortletContext(), WindowState.NORMAL,
+					PortletMode.VIEW,
+					PortletPreferencesFactoryUtil.fromDefaultXML(
+						portlet.getDefaultPreferences()),
+					themeDisplay.getPlid());
+
+			portletResponse = RenderResponseFactory.create(
+				themeDisplay.getResponse(), liferayRenderRequest);
+		}
+		catch (PortletException portletException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to get Portlet response", portletException);
+			}
+
+			portletResponse = RenderResponseFactory.create();
+		}
+
+		return portletResponse;
+	}
+
+	private String _getSelectLogoURL(
+		HttpServletRequest httpServletRequest, String randomNamespace) {
+
 		return PortletURLBuilder.createRenderURL(
-			PortalUtil.getLiferayPortletResponse(portletResponse),
+			PortalUtil.getLiferayPortletResponse(
+				_getPortletResponse(httpServletRequest)),
 			PortletKeys.IMAGE_UPLOADER
 		).setMVCRenderCommandName(
 			"/image_uploader/upload_image"
@@ -199,6 +258,9 @@ public class LogoSelectorTag extends IncludeTag {
 	}
 
 	private static final String _PAGE = "/logo_selector/page.jsp";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LogoSelectorTag.class);
 
 	private int _aspectRatio;
 	private String _currentLogoURL;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/LogoSelectorTag.java
@@ -9,35 +9,18 @@ import com.liferay.frontend.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.portlet.InvokerPortlet;
-import com.liferay.portal.kernel.portlet.LiferayRenderRequest;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
-import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
-import com.liferay.portal.kernel.portlet.PortletInstanceFactoryUtil;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.portlet.url.builder.ResourceURLBuilder;
-import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
-import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portlet.RenderRequestFactory;
-import com.liferay.portlet.RenderResponseFactory;
 import com.liferay.taglib.util.IncludeTag;
 
-import javax.portlet.PortletConfig;
-import javax.portlet.PortletException;
-import javax.portlet.PortletMode;
-import javax.portlet.PortletResponse;
-import javax.portlet.WindowState;
+import javax.portlet.PortletRequest;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
@@ -148,7 +131,7 @@ public class LogoSelectorTag extends IncludeTag {
 			_getLogoURL(httpServletRequest));
 		httpServletRequest.setAttribute(
 			"liferay-frontend:logo-selector:portletNamespace",
-			_getPortletNamespace(httpServletRequest));
+			PortletKeys.IMAGE_UPLOADER);
 
 		String randomKey = PortalUtil.generateRandomKey(
 			httpServletRequest, "taglib_ui_logo_selector");
@@ -172,9 +155,9 @@ public class LogoSelectorTag extends IncludeTag {
 
 		if (fileEntryId > 0) {
 			return ResourceURLBuilder.createResourceURL(
-				PortalUtil.getLiferayPortletResponse(
-					_getPortletResponse(httpServletRequest)),
-				PortletKeys.IMAGE_UPLOADER
+				PortletURLFactoryUtil.create(
+					httpServletRequest, PortletKeys.IMAGE_UPLOADER,
+					PortletRequest.RESOURCE_PHASE)
 			).setMVCResourceCommandName(
 				"/image_uploader/upload_image"
 			).setCMD(
@@ -185,67 +168,13 @@ public class LogoSelectorTag extends IncludeTag {
 		return getCurrentLogoURL();
 	}
 
-	private String _getPortletNamespace(HttpServletRequest httpServletRequest) {
-		return PortalUtil.getLiferayPortletResponse(
-			_getPortletResponse(httpServletRequest)
-		).getNamespace();
-	}
-
-	private PortletResponse _getPortletResponse(
-		HttpServletRequest httpServletRequest) {
-
-		PortletResponse portletResponse =
-			(PortletResponse)httpServletRequest.getAttribute(
-				JavaConstants.JAVAX_PORTLET_RESPONSE);
-
-		if (portletResponse != null) {
-			return portletResponse;
-		}
-
-		try {
-			Portlet portlet = PortletLocalServiceUtil.getPortletById(
-				PortletKeys.IMAGE_UPLOADER);
-
-			InvokerPortlet invokerPortlet = PortletInstanceFactoryUtil.create(
-				portlet, httpServletRequest.getServletContext());
-
-			PortletConfig portletConfig = PortletConfigFactoryUtil.create(
-				portlet, httpServletRequest.getServletContext());
-
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
-			LiferayRenderRequest liferayRenderRequest =
-				RenderRequestFactory.create(
-					httpServletRequest, portlet, invokerPortlet,
-					portletConfig.getPortletContext(), WindowState.NORMAL,
-					PortletMode.VIEW,
-					PortletPreferencesFactoryUtil.fromDefaultXML(
-						portlet.getDefaultPreferences()),
-					themeDisplay.getPlid());
-
-			portletResponse = RenderResponseFactory.create(
-				themeDisplay.getResponse(), liferayRenderRequest);
-		}
-		catch (PortletException portletException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug("Unable to get Portlet response", portletException);
-			}
-
-			portletResponse = RenderResponseFactory.create();
-		}
-
-		return portletResponse;
-	}
-
 	private String _getSelectLogoURL(
 		HttpServletRequest httpServletRequest, String randomNamespace) {
 
-		return PortletURLBuilder.createRenderURL(
-			PortalUtil.getLiferayPortletResponse(
-				_getPortletResponse(httpServletRequest)),
-			PortletKeys.IMAGE_UPLOADER
+		return PortletURLBuilder.create(
+			PortletURLFactoryUtil.create(
+				httpServletRequest, PortletKeys.IMAGE_UPLOADER,
+				PortletRequest.RENDER_PHASE)
 		).setMVCRenderCommandName(
 			"/image_uploader/upload_image"
 		).setParameter(
@@ -267,9 +196,6 @@ public class LogoSelectorTag extends IncludeTag {
 	}
 
 	private static final String _PAGE = "/logo_selector/page.jsp";
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		LogoSelectorTag.class);
 
 	private int _aspectRatio;
 	private String _currentLogoURL;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -627,6 +627,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<description>A namespace for the form and its elements. This attribute lets you set a namespace value that differs from the default portlet namespace.</description>
+			<name>portletNamespace</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>preserveRatio</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/logo_selector/LogoSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/logo_selector/LogoSelector.js
@@ -15,7 +15,7 @@ export default function LogoSelector({
 	label,
 	logoName: initialLogoName,
 	logoURL: initialLogoURL,
-	portletNamespace = 'com_liferay_image_uploader_web_portlet_ImageUploaderPortlet_',
+	portletNamespace,
 	selectLogoURL,
 }) {
 	const [changingLogo, setChangingLogo] = useState(false);

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/logo_selector/LogoSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/js/logo_selector/LogoSelector.js
@@ -15,7 +15,7 @@ export default function LogoSelector({
 	label,
 	logoName: initialLogoName,
 	logoURL: initialLogoURL,
-	portletNamespace,
+	portletNamespace = 'com_liferay_image_uploader_web_portlet_ImageUploaderPortlet_',
 	selectLogoURL,
 }) {
 	const [changingLogo, setChangingLogo] = useState(false);

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/page.jsp
@@ -36,7 +36,7 @@ String selectLogoURL = (String)request.getAttribute("liferay-frontend:logo-selec
 			).put(
 				"logoURL", logoURL
 			).put(
-				"portletNamespace", portletNamespace
+				"portletNamespace", () -> portletNamespace
 			).put(
 				"selectLogoURL", selectLogoURL
 			).build()

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/page.jsp
@@ -13,6 +13,7 @@ String description = (String)request.getAttribute("liferay-frontend:logo-selecto
 boolean disabled = (boolean)request.getAttribute("liferay-frontend:logo-selector:disabled");
 String label = (String)request.getAttribute("liferay-frontend:logo-selector:label");
 String logoURL = (String)request.getAttribute("liferay-frontend:logo-selector:logoURL");
+String portletNamespace = (String)request.getAttribute("liferay-frontend:logo-selector:portletNamespace");
 String selectLogoURL = (String)request.getAttribute("liferay-frontend:logo-selector:selectLogoURL");
 %>
 
@@ -34,6 +35,8 @@ String selectLogoURL = (String)request.getAttribute("liferay-frontend:logo-selec
 				"label", label
 			).put(
 				"logoURL", logoURL
+			).put(
+				"portletNamespace", portletNamespace
 			).put(
 				"selectLogoURL", selectLogoURL
 			).build()

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 9.6.0
+version 9.7.0

--- a/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
@@ -86,7 +86,7 @@ test(
 			await apiHelpers.jsonWebServicesFragmentEntry.addFragmentEntry({
 				fragmentCollectionId,
 				groupId: site.id,
-				html: '<div class="fragment-name">[@liferay_frontend["logo-selector"] currentLogoURL="/image/user_female_portrait.png" defaultLogoURL="/image/user_female_portrait.png"/]</div>',
+				html: '<div class="fragment-name">[@liferay_frontend["logo-selector"] currentLogoURL="/image/user_female_portrait.png" defaultLogoURL="/image/user_female_portrait.png" portletNamespace="com_liferay_image_uploader_web_portlet_ImageUploaderPortlet_"/]</div>',
 				name: fragmentName,
 			});
 		});

--- a/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib/tests/frontend-taglib/logoSelector.spec.ts
@@ -5,12 +5,17 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {apiHelpersTest} from '../../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import getRandomString from '../../../../utils/getRandomString';
+import getFragmentDefinition from '../../../layout-content-page-editor-web/utils/getFragmentDefinition';
+import getPageDefinition from '../../../layout-content-page-editor-web/utils/getPageDefinition';
 import {samplePageTest} from '../../fixtures/samplePageTest';
 
-export const test = mergeTests(
+const test = mergeTests(
+	apiHelpersTest,
 	featureFlagsTest({
 		'LPS-178052': {enabled: true},
 	}),
@@ -19,6 +24,8 @@ export const test = mergeTests(
 	samplePageTest
 );
 
+const fragmentName = getRandomString();
+let layout: Layout;
 const linkName = 'Logo Selector';
 
 test(
@@ -59,6 +66,52 @@ test(
 				);
 
 			await expect(secondInput).toHaveValue('Default');
+		});
+	}
+);
+
+test(
+	'Logo Selector can be rendered in a fragment',
+	{tag: '@LPD-43308'},
+	async ({apiHelpers, page, site}) => {
+		await test.step('Create a fragment collection with a custom basic fragment', async () => {
+			const {fragmentCollectionId} =
+				await apiHelpers.jsonWebServicesFragmentCollection.addFragmentCollection(
+					{
+						groupId: site.id,
+						name: getRandomString(),
+					}
+				);
+
+			await apiHelpers.jsonWebServicesFragmentEntry.addFragmentEntry({
+				fragmentCollectionId,
+				groupId: site.id,
+				html: '<div class="fragment-name">[@liferay_frontend["logo-selector"] currentLogoURL="/image/user_female_portrait.png" defaultLogoURL="/image/user_female_portrait.png"/]</div>',
+				name: fragmentName,
+			});
+		});
+
+		await test.step('Add fragment to a page', async () => {
+			const basicFragmentDefinition = getFragmentDefinition({
+				id: getRandomString(),
+				key: fragmentName,
+			});
+
+			layout = await apiHelpers.headlessDelivery.createSitePage({
+				pageDefinition: getPageDefinition([basicFragmentDefinition]),
+				siteId: site.id,
+				title: getRandomString(),
+			});
+		});
+
+		await test.step('Check that logo selector is available on the page', async () => {
+			await page.goto(`/web/${site.name}/${layout.friendlyUrlPath}`);
+
+			const logoSelector = await page.getByRole('img', {
+				name: 'Current Logo',
+			});
+
+			await expect(logoSelector).toBeVisible();
 		});
 	}
 );


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-43308

In this PR we are decoupling `LogoSelectorTag` logic from the existence of a portlet context. This is usually the case, however, when tag is rendered in a fragment, it just can't generate the logo and the select logo URLs (based on the image uploader portlet) because it needs the `PortletResponse` object.

This PR fixes that by providing a synthetic `PortletResponse` object related to the image uploader portlet when the `httpServletRequest` object does not contain one. The pattern to get this is used in other places in DXP.

In addition, for these cases we provide a default `portletNamespace` in the `js` component so that it renders a proper `<input>` field with the `fileEntryId` corresponding to the uploaded image

Note: tests for this are missing, we need some other PRs to be merged in order to add this. @chestofwonders  I'll delegate this part to you.

In the meantine I want to know what CI thinks about this change.