### PR TITLE
LPD-43413 Target exact CKE version to prevent CI build issues

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"ckeditor5": "^43.3.0",
+		"ckeditor5": "43.3.1",
 		"frontend-editor-ckeditor-web": "*",
 		"react": "16.12.0"
 	},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -1,11 +1,11 @@
 {
 	"dependencies": {
-		"@ckeditor/ckeditor5-react": "^9.3.1",
+		"@ckeditor/ckeditor5-react": "9.3.1",
 		"@clayui/loading-indicator": "3.111.0",
 		"@liferay/cookies-banner-web": "*",
 		"ckeditor4": "4.22.1",
 		"ckeditor4-react": "1.4.2",
-		"ckeditor5": "^43.3.0",
+		"ckeditor5": "43.3.1",
 		"frontend-js-web": "*",
 		"liferay-ckeditor": "4.21.0-liferay.5",
 		"prop-types": "15.7.2",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -34,7 +34,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.24.7", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.0.tgz#9374b5cd068d128dac0b94ff482594273b1c2815"
   integrity sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==
@@ -69,7 +69,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.24.7", "@babel/generator@^7.25.9", "@babel/generator@^7.26.0", "@babel/generator@^7.8.4":
+"@babel/generator@^7.25.9", "@babel/generator@^7.26.0":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.2.tgz#87b75813bec87916210e5e01939a4c823d6bb74f"
   integrity sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==
@@ -161,7 +161,7 @@
   dependencies:
     "@babel/types" "^7.24.7"
 
-"@babel/helper-member-expression-to-functions@^7.24.7", "@babel/helper-member-expression-to-functions@^7.25.9":
+"@babel/helper-member-expression-to-functions@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz#9dfffe46f727005a5ea29051ac835fb735e4c1a3"
   integrity sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==
@@ -186,7 +186,7 @@
     "@babel/helper-validator-identifier" "^7.25.9"
     "@babel/traverse" "^7.25.9"
 
-"@babel/helper-optimise-call-expression@^7.24.7", "@babel/helper-optimise-call-expression@^7.25.9":
+"@babel/helper-optimise-call-expression@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz#3324ae50bae7e2ab3c33f60c9a877b6a0146b54e"
   integrity sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==
@@ -264,7 +264,7 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
-"@babel/helpers@^7.26.0", "@babel/helpers@^7.8.4":
+"@babel/helpers@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.26.0.tgz#30e621f1eba5aa45fe6f4868d2e9154d884119a4"
   integrity sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==
@@ -282,7 +282,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.24.4", "@babel/parser@^7.24.7", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.2", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.4":
+"@babel/parser@^7.1.0", "@babel/parser@^7.24.4", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.2", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.2.tgz#fd7b6f487cfea09889557ef5d4eeb9ff9a5abd11"
   integrity sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==
@@ -1089,7 +1089,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/template@^7.24.7", "@babel/template@^7.25.9", "@babel/template@^7.7.4", "@babel/template@^7.8.3":
+"@babel/template@^7.24.7", "@babel/template@^7.25.9", "@babel/template@^7.7.4":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.25.9.tgz#ecb62d81a8a6f5dc5fe8abfc3901fc52ddf15016"
   integrity sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==
@@ -1098,7 +1098,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.4":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.24.7", "@babel/traverse@^7.25.9", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
   integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
@@ -1111,7 +1111,7 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.24.7", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.8.3":
+"@babel/types@^7.0.0", "@babel/types@^7.24.7", "@babel/types@^7.25.9", "@babel/types@^7.26.0", "@babel/types@^7.3.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.0.tgz#deabd08d6b753bc8e0f198f8709fb575e31774ff"
   integrity sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==
@@ -1129,465 +1129,465 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz#6110f918d273fe2af8ea1c4398a88774bb9fc12f"
   integrity sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==
 
-"@ckeditor/ckeditor5-adapter-ckfinder@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-43.3.0.tgz#09692f2c3428da86947d531e7b30566b063a1e2d"
-  integrity sha512-cAG7zXdpo8IFFTbGxgbwyT3+fJa0Xx9pKuhBV+m/9b+aGuvzVqxu9Lqow/kHb6dTTPY3L7i7ayc3Yt4cAgxBaA==
+"@ckeditor/ckeditor5-adapter-ckfinder@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-43.3.1.tgz#1a501861886cb361614dc1fc87882a65555e189b"
+  integrity sha512-fOnEq31euR9B/awWZCOc8KfgLwwG4ACtqBhSv7Hu6VOgHa5TKWyWAdhr9ILSiUp7NMfYJoTQStbxcXZIWPqQXQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-upload" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-upload" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-alignment@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-43.3.0.tgz#acb2946dd4234be6205f43f04fd213965029d1e0"
-  integrity sha512-G5UoIpvBo6X41XBhXcPnNdhvUY3W+xrz9isNyxSU3ob1i96T8g5RpVwvE7CYptuHTEJ/xfQ4G9EcbaNvsIZLFw==
+"@ckeditor/ckeditor5-alignment@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-43.3.1.tgz#cfdb25e501028a7c5448f84563bb53cf47813a47"
+  integrity sha512-E+04zNdNBFDNgQajrWl8iFQqA1sB29y/XDFFRK+bzhcUaWdMadr88yodjHHdcax8/zI+GzBElCvWGEGchyrL+Q==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-autoformat@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-43.3.0.tgz#7c03babe28f937b887cb20a1f4b8fa1dbccc0e41"
-  integrity sha512-XVhu9H8bQwKSRJt0WUchyfhuXlRPuDGs3+87PHHC7y8bH1ebM99cQ1azO05Bs+m854/CTQeys/miJUeHEC9eNA==
+"@ckeditor/ckeditor5-autoformat@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-43.3.1.tgz#76bf51f861be564493a1a4e7cb74c978a179a423"
+  integrity sha512-hSQxIXIObrMfxijMPmz8odOtz/wD5SwuGZWVoF5km3EtRQxZwAcQr1Vjy+VHHPo6PZ+o3YoLP+IHCaULtNobYg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-autosave@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-43.3.0.tgz#1f50a5cbd60f7ca9798fe6cc56e1f8f29f1e4d8c"
-  integrity sha512-U0nDsisI5lq6othcFVW8yQbF8I2agYK5sQ7KbRAVyZGRb9rsw7Mcmau+hXLLs1nF0dgrtjbg4rXpf5H45IJYMw==
+"@ckeditor/ckeditor5-autosave@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-43.3.1.tgz#5331d992e1886bd976085c26c4cf89dc1b29d6bf"
+  integrity sha512-28667m7ea0wBZMb3uIzgipanB4DrDvKn4o+mRUDExlRT8M14vn1u/ILX8ZJy28Rihbg2wPcVh6rP3zoQjcucHw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-basic-styles@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-43.3.0.tgz#374306291a51b99f509f02223d27395c55856e15"
-  integrity sha512-y2KwtLf++X0uRYzDM/PwVxtzv55amN1y+hFtxzK2p+O3snUvyZtHSz+ZGG5lkYYBEkr7Z/5fjBSuAKyytrur6A==
+"@ckeditor/ckeditor5-basic-styles@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-43.3.1.tgz#9a13605ea06aba21b624b995ffb47e7925bd3257"
+  integrity sha512-1RBnPmgsIoxPL7wZhId2KsfPujITbEAfzHhi0c6m4kuWlkmcVXYldWvUvCvAUguAznx4LOxhKlp6RdFSPTFTbg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-block-quote@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-43.3.0.tgz#e5cd3b872ad62f64eaf614715d4d149372791cff"
-  integrity sha512-VuBOFb/SUxMgaNeEYNn0AC47BD+/3UMCYuoP3w/m0hxBjLXMBVh0upoMzDgh1Mg1fGFMofMd1+XbBvW/rSUDcw==
+"@ckeditor/ckeditor5-block-quote@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-43.3.1.tgz#fc66bbdae60836d55e825b4a51e5e431396bda80"
+  integrity sha512-cgY4GKwMlIVLnhszPoc1ortp+T/s3TLowrwRFtWYxTKSsHWBGFlZUL6oMASPunpXvvJqHcgnKlCMxVSh2VMCkQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-ckbox@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-43.3.0.tgz#c29692bc438754c2e32ddab87dc71e33ba995c38"
-  integrity sha512-+s8fztTSFRbeIPQgQKB57Pfa0pV9/9/rjiG28Nd0u0OzlOVHuXZ2aVsVA8usf8T4DHZ+ntXI9Uum7Hi1fKCSDQ==
+"@ckeditor/ckeditor5-ckbox@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-43.3.1.tgz#86ad4c31d2e32039e688b59a69f2e9365d4202a5"
+  integrity sha512-KObL9w/QBWJi0lG2zfm+x124Kzd7aVt+UaJHJEwsAPwhZvqM0LCUeR6wwb0oCN6ph5qrCjXoj09z7z8Txk5IwA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-upload" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-upload" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
     blurhash "2.0.5"
-    ckeditor5 "43.3.0"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-ckfinder@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-43.3.0.tgz#2d6bc4286d94f8e49b518f805e725a8eb1b16c55"
-  integrity sha512-1XJtywnDWZjVmA5WwaX6bZgWJzZK50sT+dofgWOX0PQsaZ79XJM/aCKnJq3OJKI0BQhpnoUaePQzcmbK3tE6AA==
+"@ckeditor/ckeditor5-ckfinder@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-43.3.1.tgz#bfe4ef301e3c823d87aab743e2c8428fe6177911"
+  integrity sha512-Yji6c1/0H5fExDcT+NNyQQePx2cd8Ul1Xuko1UVmsLN2Vhi7VIDJjEkCFndJozd8VQqI62Obe1GTyjmapBV5+A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-clipboard@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-43.3.0.tgz#352bd767720fc234d1170c323b02dd92f6d14bf7"
-  integrity sha512-6GBKuK7Jqn0x96hh9/1bQaPEtexa8HdCMzRDrpMUDwqWcKa8VH1KNCgLe4Q6XSMhnpK+jKp594rT/TnookmikQ==
+"@ckeditor/ckeditor5-clipboard@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-43.3.1.tgz#6522a502c395b233fe66832179f390a48e106dd8"
+  integrity sha512-Ke6fVEy1fF3AWHMtKvF1pAoDYBVOG4q+gDHD8+dcV6KPK1uA/CR0mw6TZsslQQquT4jC79y05IWu2bq1Mxv01w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-cloud-services@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-43.3.0.tgz#3facc5aaeb90c1f98e3a334ad43932827f49692c"
-  integrity sha512-e2GyVUUTZtTiH3n5NTbgFT+z3eJNnvyJDOQUIo0JQoaw9paEsxpDyhbwxQWpLtyoPQdl39cCnympSdrnrG8vrQ==
+"@ckeditor/ckeditor5-cloud-services@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-43.3.1.tgz#295527180a2e10e70a7b3a7897fde1513845d20e"
+  integrity sha512-JppySF+uWedDXPTVZBsTfZCe3qedDAdWSgw0Ww/qi4/sPFcgf/MaQ0LBHbl2Ii7JlJjng82F1F2kv9Ny/Rkauw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-code-block@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-43.3.0.tgz#f24c8674a0dd32cc645281923c89050f4b143a07"
-  integrity sha512-f6CtNncZQsLCY4D2sL40s3VLCKPP2MmvqVekwJ0jEYsI281mZwCBTb9aW3UN+SPlXVGtMgnQOEvCPQMINScCXQ==
+"@ckeditor/ckeditor5-code-block@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-43.3.1.tgz#a50a84950d6bd62aefc762b4f7b6e7b8250cdf44"
+  integrity sha512-UGhGCPNfFXLua0TmszLSWX6BlkemaPULN1EZ+FBPsUZb757qWWWVWI9GKLmAc4jSPqOv+azU+JAZJzX9bE1oYA==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-core@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-43.3.0.tgz#6b8fe3789a4355bcd00c59026948bb4e61736495"
-  integrity sha512-n47iDxt1eUUhBcdvpbyc9pPanQTURbKnV4MuBasQoHsfpcI/JQoWlN+nsRXW/aztFvSs5zCRIH6FiDTbzZpudQ==
+"@ckeditor/ckeditor5-core@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-43.3.1.tgz#f899230fbf068ce2b0d253a388f863fdee94b84c"
+  integrity sha512-6pil2OF4auF3PKrg1Oa86CqC91ZYc+NuHih0ebM0JW/I06d+0smnJg5dw4yN7mKbghbJS8mNrusxA5cf6Hkh6w==
   dependencies:
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-watchdog" "43.3.0"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-watchdog" "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-easy-image@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-43.3.0.tgz#e7ae6412c10e601d8b74b627bc3a05dbf12aab93"
-  integrity sha512-z4sfFxzPC1ZCziS14+o6cqUy99e+IK8jm0hOP6HCy6rM6zkk2iqXMZSr6kTGZXc3zsZ3S4GemHaiaeugV9K07Q==
+"@ckeditor/ckeditor5-easy-image@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-43.3.1.tgz#4a23a0ce823415efbc6d9c665298dd092af63bd9"
+  integrity sha512-Cd5NojL0Vfa1SQj6uzbP3oSHvQY5ys2hXF/2jNsYKLePTCybSvGkg5REv1JifM6kSNRH1VXdad7a2LkqvXnCnA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-upload" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-upload" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-editor-balloon@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-43.3.0.tgz#1ecbedb120b9d5079a455d37e34dd5a0157f5ea0"
-  integrity sha512-v3gKnHpgeZfTRdDY1GcqaFqAohE/ENvMCcrNEac42s3WnAv2U5uzGNz4Ulocr27YK+3pYO4Uhjc1noA+CfyROg==
+"@ckeditor/ckeditor5-editor-balloon@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-43.3.1.tgz#3ec05924d77b525da41c01bc1e2cec1378aee1c7"
+  integrity sha512-klS1FZG29nJE/XbfRXrXtwYU/9uCFdi7xGbYfaJnmyNt54h46aiquKacosbiffA87Tr5sT3Oqm3dBbNlsU158w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-editor-classic@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-43.3.0.tgz#67b5b2f52381faf08c99cd90734c2519263bfa12"
-  integrity sha512-SY8s5MVRZPNdPHUuy5ooJqaaNrFa+T4WxT+HD8HOm/n4Vd9H/2CD7v3I+uKE+Frh76ri3XhntHwHb4xtF3hCwg==
+"@ckeditor/ckeditor5-editor-classic@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-43.3.1.tgz#0c4101aa6742a9edefe9094fbb3233860c961707"
+  integrity sha512-wjBeXUQBuvz6CmGlb5XncJ9cHE7tozU6eoorycfSTQCzqr5uE57LWTlKclU42w7MgS2ya5V2kLnncr0ZqrZ2Vw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-editor-decoupled@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-43.3.0.tgz#13a65734c733e902b8105fb989482348413b75ca"
-  integrity sha512-6qpETB+hTy3A9lW3EYts+QL7rxFJvtsE2pvwTyrtWr4vi+lA+HFaEJiKJDRa5m5KRlJvynpuxgPrdFni5O0Pyg==
+"@ckeditor/ckeditor5-editor-decoupled@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-43.3.1.tgz#f306950ed6da0c857a38a7b03b623f46aa1a6573"
+  integrity sha512-aw2iZ+WCcCu9sUAnsHhsXZWLeVPyiLhZfpZDuEWjPlvsrCfT0RfSuwMcfx7l9PREA09VR8+6MTstm61EG8dmWQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-editor-inline@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-43.3.0.tgz#075009cee936f67987da377bd769e196180bd4c0"
-  integrity sha512-9L0tyN1+cFRg584JdrUpR9ZpKNDYTT0+ZuGCSODG4DuyZ0735OfTRC7TnYBCuTlJUbEXW/AyIKovEO+7lUF6Dg==
+"@ckeditor/ckeditor5-editor-inline@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-43.3.1.tgz#5d173cf46b11b2217c547f6835cad99fb7292121"
+  integrity sha512-3iZiWl2aM1bCnS52NeBoAqCVowABhWrBlns27JEGKZ+LNPZroMie7uKuMX3YQGYE2awFnsyP6XofoJtu6CcKCA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-editor-multi-root@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-43.3.0.tgz#3dcc4d705cd1557cbce8ec462db2676255ef3ee5"
-  integrity sha512-tRO++6fbkLb7af0pkn266CHYaTVC+y1WiQOFPu3N1u3Kt4fgvQDaA4J8FUT4yCC5BLcUAc2C5CcTRBvWGISF/A==
+"@ckeditor/ckeditor5-editor-multi-root@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-43.3.1.tgz#49e4f3092a1417fe0592f66e811563cfe6e224e0"
+  integrity sha512-HDgfTuotrHW91AZ+x+lumwo1tngRRZ87dnHT8kjSRFWAeXPSd2Kw986++Oj9K080+idZaYLF+IutAOqvCT32sw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-engine@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-43.3.0.tgz#b4e6ebe727ae3db176b89522c5ced23fdf8935a3"
-  integrity sha512-zlfhGyYbCO4f/2klmEG6Jn8sNrR4DBO3L9TYnCZsibDxrn2jZzIbesW8T7Hw9AqJFUMYv157PSliPLkS1QD7dw==
+"@ckeditor/ckeditor5-engine@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-43.3.1.tgz#a9b003081c5da9fdd344b6851bdcc0e93f623be1"
+  integrity sha512-Fkv3ibQLDPVHFH0z4/+gA5wrkPVWOen+Cjv/NecNBeAszZUo+F2j9RwvQ1zHwtGb0RWj3+BWOPgo8jhSe7tFgA==
   dependencies:
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-enter@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-43.3.0.tgz#7e3fc12b9844cb76302111d92a87abbcbc156bad"
-  integrity sha512-/ExSpPbbR8ezgnugByv8sQDnsItLxyqcMNz3nhIy4Yc10gWkpjVeAYvJS1bUYt/bYb5+zaX0cCsIi/opLjMbZA==
+"@ckeditor/ckeditor5-enter@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-43.3.1.tgz#225626dffa5699ca5376c191d76b8036703d98b2"
+  integrity sha512-xaHnU2RbfYi8ilfN260pB3YDvJ9lE4SfiFQusyRdWkeBo5gDAGBbQY+qCC/hmxkr/yftNZfK+d7Ow93xXtqEwg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
 
-"@ckeditor/ckeditor5-essentials@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-43.3.0.tgz#08484b319bf754e9848f7e27cf2c48ec59deb6ac"
-  integrity sha512-bhXJQRyGlfNJjUUmnQdnRzqzW3qaAw1jSl5PVT3TCuf8xUvYbB4SVCeN9dnWTeaT3Hmqq2pYhvRsZduDxMuUTw==
+"@ckeditor/ckeditor5-essentials@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-43.3.1.tgz#371ca5db2478298ba0a1b611277d330ced70b44c"
+  integrity sha512-bZtzXhmBz8XF9J4eUxOjURmw0HJPKIqo18a6vNxg07W8z3ouHMb9ke//4z4FF9N/1dbtA7a2+jIACO6WvXrX4A==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-select-all" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-undo" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-select-all" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-undo" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-find-and-replace@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-43.3.0.tgz#9c2a82e18067d8e065adc8a413326d24d70f7b5c"
-  integrity sha512-HxxXFVFagAyBrbci1hpLD1wm4e4atSQCQlzY/N2mlH08WDWt+VIIBjMPCNaI/6VC555k1MzfqIw/4BHrFpsRQw==
+"@ckeditor/ckeditor5-find-and-replace@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-43.3.1.tgz#8eb61d8d58ecd2f8879a1ca9898b83d12ee08728"
+  integrity sha512-U9dyK8yQgxGTUphRbqdUJbvfi5v7zzijCo3Kj51NxyWwOFh7SGReQxHDGn44DmSRold6lg4F1sbXeFdwu1o+WA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-font@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-43.3.0.tgz#0cc7a72746f508a31630765e21c230160443092c"
-  integrity sha512-10QlCeHThx7CC/3KkTTbE0gQfWikvpyCAFyjnVtjpiPNfDZrXMgIb06OEoJl/Sc7Qoutm0evrZ+snQNjAcbdog==
+"@ckeditor/ckeditor5-font@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-43.3.1.tgz#495d2f761917233561e56ba584c8657d375791a3"
+  integrity sha512-NOeBtScqMuBLVWFPuW0snleh7rMFkNb006yzDIG6JApnF3Vxi0JLQXub/lPHPgw5srqJ3z159DWT++exoyz/mQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-heading@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-43.3.0.tgz#7502bd701f24d3c0deaf949376ce41347ba2aa09"
-  integrity sha512-NHjGOQ7v3w+geshWBy163WejDLUXCfcFfGSTLRjIyXeubi8k7rxZpQR+7xrHzB4JDocP+yMCLw4lMtxnOC2qHg==
+"@ckeditor/ckeditor5-heading@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-43.3.1.tgz#439a7a47d289f35f225bb7ddf1c95179fb518771"
+  integrity sha512-cc8H027Y2OwvYDGMTbBSzE+oZaiLMZtlUnkgiolMw/OQ59ysONYi+KqyMzBMTuaXrkP3CLM57ZbsVGASQ3IQmQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-paragraph" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-paragraph" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-highlight@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-43.3.0.tgz#fcdaf14bbed618b1bc08ee9e840b128fdee07b94"
-  integrity sha512-NMyUPHIbov05CZc517S1WCafkFqa0Yjc8eP0N9KYYp8RufvoCx1psO5xeGkummqh26FTUqG7+LKPBOINzg9H+Q==
+"@ckeditor/ckeditor5-highlight@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-43.3.1.tgz#73ce4cc849f733a3036e6f6b2b6f4d26c88bf492"
+  integrity sha512-XVJq1YP4IAaWQBAyY1xlKOfzkpnclUH8zTUPaW3TZUGK5t6W/vFT+KAzYfUp7PdBb+PP8/O47FwKTvIQBkbqFw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-horizontal-line@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-43.3.0.tgz#fb39586a34ca288e5678580c5f694181c3c647a6"
-  integrity sha512-MC1Mjmu08hcx7VvHQtDPCN9wy/GBk8M8aZt+VqdCQXQGq54ksW06COJcDF1frViu05kaC0YSeSw0AZv8WsvfmA==
+"@ckeditor/ckeditor5-horizontal-line@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-43.3.1.tgz#d9564cf85a5d3f87dbf9727a0aa64c09b6eeb968"
+  integrity sha512-zkKe0S9gBXwveBUzUuCBPWyrzHQor/zcMCCX9YQk1StUxtRRsURNvWOoFeoG+Vf5jMGSA2gpnBgIo70WrX4A3A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-html-embed@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-43.3.0.tgz#660489a1f18abe1432c0e2a47fcaafc091a25b04"
-  integrity sha512-gKXiAsACKcV4tVu3CqgGn3iLTE/SZ2qsvhOLEsqKgLq15CrS30wS+NLt1gQGDAbVtRi9QzY7keXveUyori/KhA==
+"@ckeditor/ckeditor5-html-embed@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-43.3.1.tgz#957098ff7a6055a078d4f35a480413a0979c3087"
+  integrity sha512-VqIhhPwMgAzmPqjvQUQYaFmCFglkg203W+LSVCwrvgVZ9mVtKbkhwCHBJnLhG7qatar7Gg93bObfAFdAjsaR2A==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-html-support@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-43.3.0.tgz#ede33931c30b21ca84bd319eef952148c5b42f32"
-  integrity sha512-9xLQuOr7n0DCJkLPuvyNM2toOvKzBdv0lQ8z3fibk4JWaD3q1HAh0XtHspM82/Scmr22aZBt5RhtYb/4VsGYzQ==
+"@ckeditor/ckeditor5-html-support@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-43.3.1.tgz#8f546437f5792cb6d0d212ecb9135ba279766565"
+  integrity sha512-cnQ+kCPYH5GiSe5S+13Fr0vuS7DzT4Onx11fvOkssUujtAJ1e/C7hNf5Ehd+SOAgr5IzevutA/+OeR2KHGjIag==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-image@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-43.3.0.tgz#4f7f290588e26726a458fc7254db1ce237855818"
-  integrity sha512-ERS4CURtdRVwdtIpSHFrWn9NIMklQYaVGhaF/cyTfTphP0hQPu5i4VelDb7cSOCg2AiyeJaAKBUVHdQSeTYOrw==
+"@ckeditor/ckeditor5-image@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-43.3.1.tgz#b79defdcf73ef778e5dc0775cc2e987f5868f308"
+  integrity sha512-QgHxZtWpclzQ5SUrh1oMsGFCvjykxge5IKe96iKUyAVrhyQp60RhW8DdAElHnPUg3wwILMYE7cKMphknCxcVkQ==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-undo" "43.3.0"
-    "@ckeditor/ckeditor5-upload" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-undo" "43.3.1"
+    "@ckeditor/ckeditor5-upload" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-indent@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-43.3.0.tgz#c5d7d78ba59f3485df8683ccc5984712645653f2"
-  integrity sha512-6En69K49p39NAJakPKjX3Wr8jSTMaJFOIWYH2tVjCLW+CuzDJ4j7CISpiCqMGW91GnV+KTxW0cCpjr1XBGtMDw==
+"@ckeditor/ckeditor5-indent@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-43.3.1.tgz#6bc00cf3862abbc5ef14c8b0c737bae97b84cc69"
+  integrity sha512-CPU50tumKH7rJ6f9QEB/LHSyzKul9xP/43F1IesvOBWnOkAxQ2QI51oORT5WdKn4B0Z56ojAm48Q/ZUtsef+3w==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
 "@ckeditor/ckeditor5-integrations-common@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.0.tgz#3eb75e21eddc880c87a675125ec3fcfe0c258847"
   integrity sha512-qH68tqgyMibuejo+VAJ+iSH3ZmZweqBEzaawv9hZb4zzSMkBityWBjSc2hKXMtmJgCNsbSK84cyHpa5J/MNyLg==
 
-"@ckeditor/ckeditor5-language@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-43.3.0.tgz#625b61bf8310557946d47ea8446b691be7a725f1"
-  integrity sha512-MGhM0yCtpac3TklC8KsxjtI7JU4T2NC7ZwGXkGChchsDLmHAxSOJO9T48ScSwiv+GF4lrYN+6KQ6WY6oe7YuSg==
+"@ckeditor/ckeditor5-language@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-43.3.1.tgz#2007aeaa7ec83bfb4f22c426f7fbc06bb61df77c"
+  integrity sha512-M7npJRhLoZksnvjZ0fS+6hbAN4RebgZCE2bT9b3Z8Df2Alfy0GJEwJL5aQsYpr+78QFeytTpqzjxXLNLjOyEqA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-link@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-43.3.0.tgz#537e1ffcbaca76fcb4af416fba3da1e684780b56"
-  integrity sha512-ubATMIKyaBcTnzRPo0SOTl+tI5LXK4aq/+GuurBeCFGb4pxx9WE3KcSSOkMNPAUitHusNZRanQUPmEOOGpkVDg==
+"@ckeditor/ckeditor5-link@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-43.3.1.tgz#ec3e8ac66202374fc2863d6c4b0b0e3a2263eb7a"
+  integrity sha512-duTA7harmvZPZ2LbJ8tHnOrhx5lGk6AGavbDzK2xuicMncivm+amrkl/b771uA3Rr6gclHY77ZPcOuVaK+dp/g==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-list@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-43.3.0.tgz#a4bcc71376f0f71b804109a61ac17b1b3cc68ff2"
-  integrity sha512-ctjn6Y8IqkOM3v0PhraDELh8/GU4ADRc6nQz+BWfCkMbx0IDg7TFZRScc3Yx/gKhSkQT0CrgWa2rzrsI7lDwtw==
+"@ckeditor/ckeditor5-list@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-43.3.1.tgz#1eeeaef71b9a1c7b43afc7da3b4d425d3ac1bab8"
+  integrity sha512-PuR6uJ/SKvaXIgqTO3MUnX+00/xB/TalStiVqZqqG0xlYg47/eb6hul+4fmTPV7ahlJaon6Y3nO49TsPbbhApQ==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-markdown-gfm@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-43.3.0.tgz#dbbc91000be827430ce2e9a0ed00b701fdc4bce4"
-  integrity sha512-vOca4VNRg2WVPziMyImcZipz7qJXsKHm8pqoDIcpzz94rnb4JMlafHu3f4ttrrING2uHLyJ64KI8JH+zFFQUEg==
+"@ckeditor/ckeditor5-markdown-gfm@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-43.3.1.tgz#13691899c1afb2d0e8c41c3ced1660d2f8a049c5"
+  integrity sha512-aVP2FqQP7okSAorQoItcYRbOd0J2O1ubGjtvGGzl3uC5TuKAtlWYWcBfiVTHKxCCtxywPRiEgBxwoGuB5mlwhA==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    ckeditor5 "43.3.1"
     marked "4.0.12"
     turndown "7.2.0"
     turndown-plugin-gfm "1.0.2"
 
-"@ckeditor/ckeditor5-media-embed@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-43.3.0.tgz#cf04c0c0a62400ccc159072eb868265009d7bd53"
-  integrity sha512-/5t6bq0kjNPevuL0oxxHPH7ib+hUqE8PeRtKPosFRTj2RXAvmKSfgM4Z9Vv7CnmwIAieEhuAuCRSrRCNK9UEYQ==
+"@ckeditor/ckeditor5-media-embed@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-43.3.1.tgz#ee0ecceaf9e5e63219c4442ba7b13406f8824889"
+  integrity sha512-3xMIaH/NTNEKv+lu1cRIIPGgDJgYI1DB+5NMXNVL3UGQkXdqW7PtgFDsOnhQwTAbyKpy+fHDngLb3eZuRdDkKw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-undo" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-undo" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-mention@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-43.3.0.tgz#86f2a13e4054f95682a9a033c31b804933c6ebef"
-  integrity sha512-+WDVzjUxIx1PhCxZ4v6TUYlm35sHBT4SyuNG8t/kxWvE/NfrX7XgtLYsGw2/5fIYO3ovaiIEZqFZF55OiF7+sQ==
+"@ckeditor/ckeditor5-mention@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-43.3.1.tgz#0d8c9946dee6e968286ac42bdb26b7dd9c68b89d"
+  integrity sha512-yrOdynVNOS72RjTjhFHzv3Ofbm0eTBKFhuibxdKFfHtTR0QIqSVB5jU+aW1+Jq5LG73E+9eYtip5paSjkqJMWQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-minimap@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-43.3.0.tgz#7019f716a89afc0c26f0dfaa4aaba2b4ab1ec07a"
-  integrity sha512-pjBeBX62/hzzbtb76DFMYn332+TbSBR+8BmNa8BLEjiq0E7R5bV5pCSEhxiBVedtOa4NlGWqEgwHHxIxIkrzeA==
+"@ckeditor/ckeditor5-minimap@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-43.3.1.tgz#82fa44ef75e93d495753007761dbd7659d104d92"
+  integrity sha512-2b0b4mZtRIHAvN/MFAVeqiGt58TZI7ixLcgJo0MHNesYlIk6v13opDWhQ9oefNe8OwJMkD3fAHMlAcg+fUqA9g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-page-break@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-43.3.0.tgz#503c6c4aa0b1c219224cc05dc678f18cd13f2046"
-  integrity sha512-IGxF2IuocNM+V2oTIzzGw19Bs8Z76dh35u1exnluXI8v9mg2F7qUAG5/T9Es4jcXlAMozY39bi/Zsfbsdz88KQ==
+"@ckeditor/ckeditor5-page-break@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-43.3.1.tgz#0989c7b6017340adc964d61cb167157eef0e437c"
+  integrity sha512-6AI2GGJveEm/2GESUY01wSPM7AeqHqVuX4Hon20uCAXHYCQkDubOHJ0yV3oFXl7iHeO6Ue2DdlSLayIUXCLoEQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-paragraph@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-43.3.0.tgz#8c26fc3921841372815651568c0874b3028e72df"
-  integrity sha512-fPmvzFlbBpr5oAnnFt+vefCc6ClDC6H4dJy8e0qBeos4WUts6C2ibAeAHN/rSG4sdPUxr4RXuFV4YQjRViYdNQ==
+"@ckeditor/ckeditor5-paragraph@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-43.3.1.tgz#b4f272758160f1aa02b8a550dc4aaa033e9a24df"
+  integrity sha512-16ry56X+uXuZEzGZwLS8zpX2DtWN/CHHu5pSz0r2VDZ1zUGLsq/MXutotZfzMMjgdED3x4mJRQE+WgiyRrlKDg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
 
-"@ckeditor/ckeditor5-paste-from-office@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-43.3.0.tgz#e4ba5747ca86b2747cfc4f1ee6dae287590af0ca"
-  integrity sha512-xYNiPCrFPjT5BWbcm8x82AHqOUyKFrnpsXYt/cMHgUMI9NeabNNbckbgzp5OAcHT95H1WLPRPWqNro8kh8pH0A==
+"@ckeditor/ckeditor5-paste-from-office@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-43.3.1.tgz#3e2973bda795872a600677bd6dce513eebc43e19"
+  integrity sha512-LLf1KB11jeYLDpQPq0d2QVPxQxp9kEibPAF4rGD4stPpRx9d+DbwmE59Y5wVASKvYJo+yNpR9CGWsE4ZgjwTWw==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    ckeditor5 "43.3.1"
 
 "@ckeditor/ckeditor5-react@9.3.1":
   version "9.3.1"
@@ -1597,177 +1597,177 @@
     "@ckeditor/ckeditor5-integrations-common" "^2.1.0"
     prop-types "^15.7.2"
 
-"@ckeditor/ckeditor5-remove-format@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-43.3.0.tgz#967b4a9e5cb47e01c6fc461b60c17217b791ecb6"
-  integrity sha512-/NgMcI5H7Axr/syY34xGu0pTmknYruA4TVezPk+GkQY59qzpREYMQjlLQcASN9BEJ6qOTHWYo35KpoX8lDRvjA==
+"@ckeditor/ckeditor5-remove-format@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-43.3.1.tgz#b55c9e6d247472a75234ff7aeab8ee750bbd3460"
+  integrity sha512-m7zvvYzHN/HExT0NoILXauVFI/AKQyuzPqqCI/VO1Ft5mLswXGuK6vmO1U10SmGz85etYZjEipKuouf2Anyqxg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-restricted-editing@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-43.3.0.tgz#9ecbb07576acd2808f50194ec293fca7d1c41ff0"
-  integrity sha512-FpmPHarZt2UjeXdMRbuNtIScS/gvPLu80KgIv8q1SgD2ALcfTpZyV7JrL5MYQbaCrU7pjKeDNKiBLQDP6lXOow==
+"@ckeditor/ckeditor5-restricted-editing@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-43.3.1.tgz#ead5e00ed927d248c6b65115ddbb9e71a5d7586b"
+  integrity sha512-L6sA6UrUPy4Q3AzF8yQGsgEadO1IcZv53Ijevk9KuD7dwLF4f9x4ukUFLlGRpoYHPAW/+RpADp2PPegjKHo9QQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-select-all@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-43.3.0.tgz#c071f6166b3940cf41dbcd8c8d97674f8e046599"
-  integrity sha512-PzR3ySQaQuAUmdymCkuDPgs2QjIQaJT4kd+mrUVA6YlM3TYxZWDpjCN9qMYLBCh2Ts9XrjXsOfai8WBp32nszA==
+"@ckeditor/ckeditor5-select-all@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-43.3.1.tgz#17513dc18c5dd723b8b83cc9da17e63b872659ac"
+  integrity sha512-oYQ8uF6hmlX7OefpJ0FflvKddAkEffg3fKMT2FAINwqxhX+O7h9RQZ79AiOkTab7HUTIkbhM5AlhFJIXiX0Z7Q==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
 
-"@ckeditor/ckeditor5-show-blocks@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-43.3.0.tgz#ba93509d2052c38d0504faa574a84febfb181970"
-  integrity sha512-s4EyoO1h0SABwrI3fXiXYRb77dmjFcv0hIKXEBlluqfHivtJSp/wboaEWXwU9qtt4CDlFTzGyE0noij6BRVeYA==
+"@ckeditor/ckeditor5-show-blocks@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-43.3.1.tgz#cab764d940d7d7d7704d502e8ca9132ed11d0d09"
+  integrity sha512-o+IhZnjMmoF2qd4l1GqQqroeIEA29QAIOYfvrdMKZGrzVGmjbvwyNkbJRyZlAYhZqX8tLDPaPGn0tl+onhWtzw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-source-editing@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-43.3.0.tgz#a44f4cb1810ab5d9dcc47fdab88ef55887109694"
-  integrity sha512-BD6mW/yosLhMCcgSeMj9ESHUsJQr1VEXVQewhHV0ufNYgHk+6LB8aIOWoomdi9UBYWoLhVX5d9FQhdxqnANZnA==
+"@ckeditor/ckeditor5-source-editing@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-43.3.1.tgz#3364e52899791ebae0496941eb245f291948edfe"
+  integrity sha512-Pq7WthQAiKa3A3q82bHqNRjQ/xlOpSX9kZHLm+CDH8XACxZbBF6Unz4JPR9zJRuQxkoFs314DM/PG6pPZQgXXA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-theme-lark" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-theme-lark" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-special-characters@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-43.3.0.tgz#042169d4725e45645a4c4697bc2e5f649af1a25b"
-  integrity sha512-UH7su7jkU0guYYTKcydWMRYw9818JT3xSH4lTpRrjsJFgV0j8rOsdxyVcCdEKv3NFn9iLAyDHaV24KHqNcEhjg==
+"@ckeditor/ckeditor5-special-characters@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-43.3.1.tgz#9653ec9b0e266d9ca2182d2778894d210ac00768"
+  integrity sha512-3iwrtISndl5hc+/LuSXht69xqkEv95zg8Qxv+ovREA3pvtgt5u9O0t7ELcmUeTTEs/hJkF2FDplIYQj5zIvO+g==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
 
-"@ckeditor/ckeditor5-style@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-43.3.0.tgz#485e58642ca5e6b3d9d02c210f2c7414cafbb378"
-  integrity sha512-4p9qXYktAFK8GC3NWtzeOh0Mwa/WnIE+x0/967bDIjCn8CgmJ0ngt8+MP05Uz4lEDDJOF4/drm64b18ze+4zuA==
+"@ckeditor/ckeditor5-style@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-43.3.1.tgz#7712b29eb9c24d75e6493d6d5d290d7f022a0eff"
+  integrity sha512-2+ATPa5y4ZUkak5xFTTDeUPhuCAYB4OPNt/QjMvrQjpEwXoWDJ4f8GqR9oFFsqEGMm65GrUp/xIQW8WRH43Kng==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-table@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-43.3.0.tgz#fc95363ba746ac6ac2fff67df3f32e92b8ab3dde"
-  integrity sha512-RVdy5jaKHPQKs251Y4KO5XZO4rVXbPGAStsuwsUCDav0Idt3lW2M+zQzVimiZEiIsqTXJC8hu/0ViwqY+vCCrA==
+"@ckeditor/ckeditor5-table@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-43.3.1.tgz#a8dcf9ddc451639a04e54e97be862ac767ecd2fc"
+  integrity sha512-Qr3GkKELnG1EY7Bu9dGQBkGTqhVnygeHKDCTEG9m218shYsI5L6jFftGUzWmJzMpm3hNFkyYv+1YWaIoqfRzIQ==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-theme-lark@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.3.0.tgz#757ab4771d0e9916b8940a3bac8e2a075b8d0ac1"
-  integrity sha512-o/DbzTunv/0mkxRXolm+CdGBaadlW1g5ajRiiEpwL92xBHb2iAdgVb2VR4ajXy8Qkd3/9jN9QWY+kmFfZH6vng==
+"@ckeditor/ckeditor5-theme-lark@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.3.1.tgz#af79ad1929d6f5e3ea27b7a4b8ac590f62ae736e"
+  integrity sha512-kAgeGx66jT31FFYwAoc43oX5ehQtiYE57OJWlPTXrDXxyq0Y+LYFW2/bp4UVYdZK+OKv9dp1Do3VQfxJoGzFjg==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "43.3.0"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
 
-"@ckeditor/ckeditor5-typing@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-43.3.0.tgz#154a2f116e204674febe5af2fdeada0c5043d7a1"
-  integrity sha512-ZKQAVeTLHiw8EW/MpmymFJ5DdNnK5FVp2k4qBU2wulU2LZ17g7rQ4GY5O00krjyMR/RMU/LzTTtW3mzlnM/D4w==
+"@ckeditor/ckeditor5-typing@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-43.3.1.tgz#6ddfc3e629af9790f2e2af591538265b6bcabb20"
+  integrity sha512-sK45GlrOHqWOphVnzDKe3kofVJGhSRk34UQJnyXgMN+35QJqypnJeBYBnnHWL8+nK0S4zk9oQO3PuiRH6gg/WQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-ui@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-43.3.0.tgz#c505c8ed201b61710c1aa24253da024f341df505"
-  integrity sha512-AisR6QdzbyhzGKnL4kMbclTRHicEf9CsMfXVc5i9uz3HHrP+YVnnQlLk3KSj7ONWjbZvAxWcOHMHABTVP0pW9g==
+"@ckeditor/ckeditor5-ui@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-43.3.1.tgz#c2bb1689b998fae123499a35a5f8c91929d6d006"
+  integrity sha512-dbR4FK6mCkI89h4Joyf1PZt0Xsq0N+sZg05Z6BpYz6GS9U35C7J9bHxN469dvaIc8bJws4eYJ5x+St3LcvlduQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
     color-convert "2.0.1"
     color-parse "1.4.2"
     lodash-es "4.17.21"
     vanilla-colorful "0.7.2"
 
-"@ckeditor/ckeditor5-undo@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-43.3.0.tgz#1915b459085bd4137fe48044ebd0fcf7132375d0"
-  integrity sha512-J5rquC0Kb5xb3o80UpQcJTpUNOJwvzlSeWXwb9v7mpqc2S/aZe+cj/1lyIqluppfwFTVbAMTwnE2g91M4e7cDQ==
+"@ckeditor/ckeditor5-undo@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-43.3.1.tgz#377f56ec5d80d06aba6d5208b7de42cd526bfe53"
+  integrity sha512-UxrWPlHzL/DKuxp4R5mlQvy995Ozehh5hQxY5yvL285Dzv6PY5pk627Wv/qS8AyfLMyVNiFO9bDWBIcT9igQRA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
 
-"@ckeditor/ckeditor5-upload@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-43.3.0.tgz#de7eaae1f6d407998ad323a1e9b0c28427a3292b"
-  integrity sha512-CQXY2e/2jso2FwJ5SzPPLyTid6i1+4PLqfRpsNmw5aO/KiYJfH2U3WZDHltGUnL/fR24xXXRIIqmbBlIHnSjXw==
+"@ckeditor/ckeditor5-upload@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-43.3.1.tgz#7c21a1d9d65ae315b24cdd760a3d285d80bd5754"
+  integrity sha512-uOEhCgqgiK4V/CnbnuwHU/NUOG4ioQE5KUUtVmRG2xjQKg5C1uIT2dig+wnKw8vOdwVTMD2hVt7/OC/whQuheQ==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
 
-"@ckeditor/ckeditor5-utils@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-43.3.0.tgz#c32b76722039fc3d947f428ed508795f9b61381a"
-  integrity sha512-wiWFwdl/nUsTpPbi1MLT1sdFwXM8P0KVKxnvt4naF//ETn1LECPrIMBEIAeFnn17mamLaQYTEV+5/FadqIYolg==
+"@ckeditor/ckeditor5-utils@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-43.3.1.tgz#28380a51e99180f6bd4a2bae2e0cd85a7ca33832"
+  integrity sha512-4CyM3AP+DcfuPuw+zceI3UTh3HcusnvFVeRPPw6j3Qe29/jadZYsdvkdo9KsDaiwgx0ctooKCuY9SfAcd/CZNQ==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "43.3.0"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-watchdog@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-43.3.0.tgz#6e9c613c8f5ee0ca72c84e085b97846072ea55c3"
-  integrity sha512-jqJU/F5eST+2Q0eELti3oobDbd+aqtR01uTYE2Ys9429/XgUP7f18ApCzqlr6iLrtQSHAj5245CA2KSD6Chjfw==
+"@ckeditor/ckeditor5-watchdog@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-43.3.1.tgz#5014354ceccc71019cd6d9fb575a22493b426e2f"
+  integrity sha512-d9gh0QIrrImIe2SFLo/IBLdpgC9REVkvUTv//qLbUaM2ffBboMnpJYPAB/hgl8ev4lkDvCrivlGjc/80COfGTQ==
   dependencies:
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-widget@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-43.3.0.tgz#470cc66f02024acd500c0ec507b94d06f80bf448"
-  integrity sha512-E7RRAAQNB5KuFXyblOa2/J4mDlp+5qJ+n2R1dMskv30xJZHQtCSOONFA0kZIMG3tQhJgvXYH0F6++HUmlmeypQ==
+"@ckeditor/ckeditor5-widget@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-43.3.1.tgz#97ee9dad199182f76c2f44eb66520bd7e293126b"
+  integrity sha512-0naXUVC6BFLnuj3lu5aTfRxmqV6py9+zqGHdJJZ0x8uSg9qcfUCLEQvA59bqzNteRya/lZeZhYKj8IcGnbB1oA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-word-count@43.3.0":
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-43.3.0.tgz#5c5474d447d474ab450b5028b8e47c13d3fb1c82"
-  integrity sha512-gkQaT/O/vjouopS4Ojnx1WVg1l+7XEWeVL+KFrQlo2n+Az4QxpWDJIteiRu+OX47Mol1OlRQGJAJlGNXVAWGVw==
+"@ckeditor/ckeditor5-word-count@43.3.1":
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-43.3.1.tgz#837aeca069a0fd35d6cb8244397babbaa1532ff2"
+  integrity sha512-W0Ic7y4/ePVqW22pHuXv5HRAbaDJFO13rUqyTZqU2H2ExZdMbJN6eT/UVhnO1XvKs/+jdKGO3LGWXt9QmmtkhA==
   dependencies:
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    ckeditor5 "43.3.0"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    ckeditor5 "43.3.1"
     lodash-es "4.17.21"
 
 "@clayui/alert@3.111.0":
@@ -5564,7 +5564,7 @@ browserslist-config-clay-components@^2.0.3:
   resolved "https://registry.yarnpkg.com/browserslist-config-clay-components/-/browserslist-config-clay-components-2.1.12.tgz#30fa5f60006454badb61ec0a0d837f69365f0cce"
   integrity sha1-MPpfYABkVLrbYewKDYN/aTZfDM4=
 
-browserslist@^4.14.5, browserslist@^4.22.2, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.8.3:
+browserslist@^4.14.5, browserslist@^4.23.0, browserslist@^4.24.0, browserslist@^4.8.3:
   version "4.24.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.2.tgz#f5845bc91069dbd55ee89faf9822e1d885d16580"
   integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
@@ -5898,68 +5898,68 @@ ckeditor4@4.22.1:
   resolved "https://registry.yarnpkg.com/ckeditor4/-/ckeditor4-4.22.1.tgz#a4e79db1bac2ccb9a672c47e601ba4882afaf455"
   integrity sha512-Yj4vTHX5YxHwc48gNqUqTm+KLkRr9tuyb4O2VIABu4oKHWRNVIdLdy6vUNe/XNx+RiTavMejfA1MVOU/MxLjqQ==
 
-ckeditor5@43.3.0:
-  version "43.3.0"
-  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-43.3.0.tgz#07821b128d9118f59d4550349aed8f03c3e14083"
-  integrity sha512-KV2A7BKggE+NS1mZLcgYSw73LoyUJo3qLwjKMwfX/nErRVcbG/kJ5Kuufe6Mc2OQqiRa76XLG2CJ1fZx9kmaOg==
+ckeditor5@43.3.1:
+  version "43.3.1"
+  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-43.3.1.tgz#95db2b8f793191987bf2fc01e22b0a9a4d62250c"
+  integrity sha512-ZZ6nIdlr9rCCp21o9d5/mVUeVPwpQKEVxkeq1MU/Jax1w8U6rnMiQWxB954Ky/HNjhZ1v1ll2+VRzb7XA+1emA==
   dependencies:
-    "@ckeditor/ckeditor5-adapter-ckfinder" "43.3.0"
-    "@ckeditor/ckeditor5-alignment" "43.3.0"
-    "@ckeditor/ckeditor5-autoformat" "43.3.0"
-    "@ckeditor/ckeditor5-autosave" "43.3.0"
-    "@ckeditor/ckeditor5-basic-styles" "43.3.0"
-    "@ckeditor/ckeditor5-block-quote" "43.3.0"
-    "@ckeditor/ckeditor5-ckbox" "43.3.0"
-    "@ckeditor/ckeditor5-ckfinder" "43.3.0"
-    "@ckeditor/ckeditor5-clipboard" "43.3.0"
-    "@ckeditor/ckeditor5-cloud-services" "43.3.0"
-    "@ckeditor/ckeditor5-code-block" "43.3.0"
-    "@ckeditor/ckeditor5-core" "43.3.0"
-    "@ckeditor/ckeditor5-easy-image" "43.3.0"
-    "@ckeditor/ckeditor5-editor-balloon" "43.3.0"
-    "@ckeditor/ckeditor5-editor-classic" "43.3.0"
-    "@ckeditor/ckeditor5-editor-decoupled" "43.3.0"
-    "@ckeditor/ckeditor5-editor-inline" "43.3.0"
-    "@ckeditor/ckeditor5-editor-multi-root" "43.3.0"
-    "@ckeditor/ckeditor5-engine" "43.3.0"
-    "@ckeditor/ckeditor5-enter" "43.3.0"
-    "@ckeditor/ckeditor5-essentials" "43.3.0"
-    "@ckeditor/ckeditor5-find-and-replace" "43.3.0"
-    "@ckeditor/ckeditor5-font" "43.3.0"
-    "@ckeditor/ckeditor5-heading" "43.3.0"
-    "@ckeditor/ckeditor5-highlight" "43.3.0"
-    "@ckeditor/ckeditor5-horizontal-line" "43.3.0"
-    "@ckeditor/ckeditor5-html-embed" "43.3.0"
-    "@ckeditor/ckeditor5-html-support" "43.3.0"
-    "@ckeditor/ckeditor5-image" "43.3.0"
-    "@ckeditor/ckeditor5-indent" "43.3.0"
-    "@ckeditor/ckeditor5-language" "43.3.0"
-    "@ckeditor/ckeditor5-link" "43.3.0"
-    "@ckeditor/ckeditor5-list" "43.3.0"
-    "@ckeditor/ckeditor5-markdown-gfm" "43.3.0"
-    "@ckeditor/ckeditor5-media-embed" "43.3.0"
-    "@ckeditor/ckeditor5-mention" "43.3.0"
-    "@ckeditor/ckeditor5-minimap" "43.3.0"
-    "@ckeditor/ckeditor5-page-break" "43.3.0"
-    "@ckeditor/ckeditor5-paragraph" "43.3.0"
-    "@ckeditor/ckeditor5-paste-from-office" "43.3.0"
-    "@ckeditor/ckeditor5-remove-format" "43.3.0"
-    "@ckeditor/ckeditor5-restricted-editing" "43.3.0"
-    "@ckeditor/ckeditor5-select-all" "43.3.0"
-    "@ckeditor/ckeditor5-show-blocks" "43.3.0"
-    "@ckeditor/ckeditor5-source-editing" "43.3.0"
-    "@ckeditor/ckeditor5-special-characters" "43.3.0"
-    "@ckeditor/ckeditor5-style" "43.3.0"
-    "@ckeditor/ckeditor5-table" "43.3.0"
-    "@ckeditor/ckeditor5-theme-lark" "43.3.0"
-    "@ckeditor/ckeditor5-typing" "43.3.0"
-    "@ckeditor/ckeditor5-ui" "43.3.0"
-    "@ckeditor/ckeditor5-undo" "43.3.0"
-    "@ckeditor/ckeditor5-upload" "43.3.0"
-    "@ckeditor/ckeditor5-utils" "43.3.0"
-    "@ckeditor/ckeditor5-watchdog" "43.3.0"
-    "@ckeditor/ckeditor5-widget" "43.3.0"
-    "@ckeditor/ckeditor5-word-count" "43.3.0"
+    "@ckeditor/ckeditor5-adapter-ckfinder" "43.3.1"
+    "@ckeditor/ckeditor5-alignment" "43.3.1"
+    "@ckeditor/ckeditor5-autoformat" "43.3.1"
+    "@ckeditor/ckeditor5-autosave" "43.3.1"
+    "@ckeditor/ckeditor5-basic-styles" "43.3.1"
+    "@ckeditor/ckeditor5-block-quote" "43.3.1"
+    "@ckeditor/ckeditor5-ckbox" "43.3.1"
+    "@ckeditor/ckeditor5-ckfinder" "43.3.1"
+    "@ckeditor/ckeditor5-clipboard" "43.3.1"
+    "@ckeditor/ckeditor5-cloud-services" "43.3.1"
+    "@ckeditor/ckeditor5-code-block" "43.3.1"
+    "@ckeditor/ckeditor5-core" "43.3.1"
+    "@ckeditor/ckeditor5-easy-image" "43.3.1"
+    "@ckeditor/ckeditor5-editor-balloon" "43.3.1"
+    "@ckeditor/ckeditor5-editor-classic" "43.3.1"
+    "@ckeditor/ckeditor5-editor-decoupled" "43.3.1"
+    "@ckeditor/ckeditor5-editor-inline" "43.3.1"
+    "@ckeditor/ckeditor5-editor-multi-root" "43.3.1"
+    "@ckeditor/ckeditor5-engine" "43.3.1"
+    "@ckeditor/ckeditor5-enter" "43.3.1"
+    "@ckeditor/ckeditor5-essentials" "43.3.1"
+    "@ckeditor/ckeditor5-find-and-replace" "43.3.1"
+    "@ckeditor/ckeditor5-font" "43.3.1"
+    "@ckeditor/ckeditor5-heading" "43.3.1"
+    "@ckeditor/ckeditor5-highlight" "43.3.1"
+    "@ckeditor/ckeditor5-horizontal-line" "43.3.1"
+    "@ckeditor/ckeditor5-html-embed" "43.3.1"
+    "@ckeditor/ckeditor5-html-support" "43.3.1"
+    "@ckeditor/ckeditor5-image" "43.3.1"
+    "@ckeditor/ckeditor5-indent" "43.3.1"
+    "@ckeditor/ckeditor5-language" "43.3.1"
+    "@ckeditor/ckeditor5-link" "43.3.1"
+    "@ckeditor/ckeditor5-list" "43.3.1"
+    "@ckeditor/ckeditor5-markdown-gfm" "43.3.1"
+    "@ckeditor/ckeditor5-media-embed" "43.3.1"
+    "@ckeditor/ckeditor5-mention" "43.3.1"
+    "@ckeditor/ckeditor5-minimap" "43.3.1"
+    "@ckeditor/ckeditor5-page-break" "43.3.1"
+    "@ckeditor/ckeditor5-paragraph" "43.3.1"
+    "@ckeditor/ckeditor5-paste-from-office" "43.3.1"
+    "@ckeditor/ckeditor5-remove-format" "43.3.1"
+    "@ckeditor/ckeditor5-restricted-editing" "43.3.1"
+    "@ckeditor/ckeditor5-select-all" "43.3.1"
+    "@ckeditor/ckeditor5-show-blocks" "43.3.1"
+    "@ckeditor/ckeditor5-source-editing" "43.3.1"
+    "@ckeditor/ckeditor5-special-characters" "43.3.1"
+    "@ckeditor/ckeditor5-style" "43.3.1"
+    "@ckeditor/ckeditor5-table" "43.3.1"
+    "@ckeditor/ckeditor5-theme-lark" "43.3.1"
+    "@ckeditor/ckeditor5-typing" "43.3.1"
+    "@ckeditor/ckeditor5-ui" "43.3.1"
+    "@ckeditor/ckeditor5-undo" "43.3.1"
+    "@ckeditor/ckeditor5-upload" "43.3.1"
+    "@ckeditor/ckeditor5-utils" "43.3.1"
+    "@ckeditor/ckeditor5-watchdog" "43.3.1"
+    "@ckeditor/ckeditor5-widget" "43.3.1"
+    "@ckeditor/ckeditor5-word-count" "43.3.1"
 
 class-utils@^0.3.5:
   version "0.3.6"
@@ -6313,7 +6313,7 @@ continuable-cache@^0.3.1:
   resolved "https://registry.yarnpkg.com/continuable-cache/-/continuable-cache-0.3.1.tgz#bd727a7faed77e71ff3985ac93351a912733ad0f"
   integrity sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=
 
-convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -8854,7 +8854,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -11280,11 +11280,6 @@ jsdom@^15.1.1:
     ws "^7.0.0"
     xml-name-validator "^3.0.0"
 
-jsesc@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
-  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
-
 jsesc@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
@@ -11342,7 +11337,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.0, json5@^2.2.3:
+json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -11877,7 +11872,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@4.17.21, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0:
+lodash@4.17.21, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -14949,7 +14944,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.19.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1, resolve@^1.9.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.19.0, resolve@^1.4.0, resolve@^1.8.1, resolve@^1.9.0:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -15212,7 +15207,7 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -15776,7 +15771,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15810,6 +15805,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15885,7 +15889,7 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15919,6 +15923,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"


### PR DESCRIPTION
The theory behind this test is that that [^ in version of CKEditor](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json#L8) might be causing CI issues, where either
1. Something went wrong with latest patch release of CKEditor - or -
1. There is a delay of dependencies resolution, so latest one is temporarily not available

Successful build of this PR would confirm (1) or (2). This one failing and https://github.com/liferay-frontend/liferay-portal/pull/4592 succeeding would confirm (1).