### PR TITLE
LPD-43531 Disable searchbar when building ManagementToolbar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web-test/src/testIntegration/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/test/ClaySamplePortletTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web-test/src/testIntegration/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/test/ClaySamplePortletTest.java
@@ -91,6 +91,36 @@ public class ClaySamplePortletTest {
 		}
 	}
 
+	@Test
+	public void testSearchbarIsDisabled() throws Exception {
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), layout, _PORTLET_NAME, "column-1",
+			null);
+
+		PortletContainerTestUtil.Response response =
+			PortletContainerTestUtil.request(
+				PortletURLBuilder.create(
+					_portletURLFactory.create(
+						PortletContainerTestUtil.getHttpServletRequest(
+							_group, layout),
+						_PORTLET_NAME, layout.getPlid(),
+						PortletRequest.RENDER_PHASE)
+				).buildString());
+
+		String htmlBody = response.getBody();
+
+		Assert.assertTrue(htmlBody.contains(_DISABLED_SEARCHBAR));
+	}
+
+	private static final String _DISABLED_SEARCHBAR =
+		"<input class=\"form-control form-control input-group-inset " +
+			"input-group-inset-after\" disabled";
+
 	private static final String _PORTLET_NAME =
 		"com_liferay_clay_sample_web_portlet_ClaySamplePortlet";
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -1074,11 +1074,7 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			jspWriter.write(" role=\"search\"><div class=\"input-group\"><div");
 			jspWriter.write(" class=\"input-group-item\"><input class=\"");
 			jspWriter.write("form-control form-control input-group-inset");
-			jspWriter.write(" input-group-inset-after\"");
-
-			if (disabled) {
-				jspWriter.write(" disabled");
-			}
+			jspWriter.write(" input-group-inset-after\" disabled");
 
 			String searchInputName = getSearchInputName();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPP-56855
https://liferay.atlassian.net/browse/LPD-43531


The issue is when there is a slow connection, the user can add text to the searchbar and once everything is fully loaded, the searchbar is cleared and the text is lost.

By disabling the searchbar at the start, the user will not be able to enter any text until the page is fully loaded.

Please let me know if there are any questions about this.
Thank you!