### PR TITLE
LPD-37261 Write a test using an unautenticated user accessing a page with a fragment

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -81,7 +81,7 @@ test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers}) => {
 });
 
 test(
-	'Assing a data set to the "Data Set" fragment, change and delete assignment',
+	'Assign a data set to the "Data Set" fragment, change and delete assignment',
 	{
 		tag: '@LPS-172403',
 	},
@@ -136,7 +136,7 @@ test(
 			await dataSetFragmentPage.selectDataSet(dataSetLabel1);
 		});
 
-		await test.step('Change assigment to second data set', async () => {
+		await test.step('Change assignment to second data set', async () => {
 			await dataSetFragmentPage.changeDataSetButton.click();
 
 			const selectionListContainer =

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -11,7 +11,7 @@ import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../../utils/getRandomString';
-import {performLogout} from '../../../../utils/performLogin';
+import performLogin, {performLogout} from '../../../../utils/performLogin';
 
 // Structured Content utilities
 
@@ -559,19 +559,26 @@ test('An unauthorized user accessing a page with a data set fragment', async ({
 		await expect(page.getByRole('button', {name: 'Sign In'})).toBeVisible();
 	});
 
-	await test.step('Go to Data Set fragment page', async () => {
-		await dataSetFragmentPage.goToPage({layout});
+	try {
+		await test.step('Go to Data Set fragment page', async () => {
+			await dataSetFragmentPage.goToPage({layout});
 
-		await page
-			.locator('.data-set-content-wrapper')
-			.waitFor({state: 'visible'});
-	});
-
-	await test.step('Assert that no results are displayed', async () => {
-		await expect(
-			page
+			await page
 				.locator('.data-set-content-wrapper')
-				.getByText('No Results Found')
-		).toBeVisible();
-	});
+				.waitFor({state: 'visible'});
+		});
+
+		await test.step('Assert that no results are displayed', async () => {
+			await expect(
+				page
+					.locator('.data-set-content-wrapper')
+					.getByText('No Results Found')
+			).toBeVisible();
+		});
+	}
+	finally {
+		await test.step('Log back in as admin', async () => {
+			await performLogin(page, 'test');
+		});
+	}
 });

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -11,6 +11,7 @@ import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../../utils/getRandomString';
+import {performLogout} from '../../../../utils/performLogin';
 
 // Structured Content utilities
 
@@ -518,3 +519,59 @@ test(
 		});
 	}
 );
+
+test('An unauthorized user accessing a page with a data set fragment', async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	page,
+}) => {
+	const dataSetERC = getRandomString();
+	const dataSetLabel = getRandomString();
+
+	dataSetERCs.push(dataSetERC);
+
+	await test.step('Create data set', async () => {
+		await dataSetManagerApiHelpers.createDataSet({
+			erc: dataSetERC,
+			label: dataSetLabel,
+		});
+	});
+
+	await test.step('Create sample data for data sets', async () => {
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC,
+			fieldName: 'fieldName',
+			label_i18n: {en_US: 'Field Name'},
+		});
+	});
+
+	await test.step('Configure Data Set fragment', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step('Log out', async () => {
+		await performLogout(page);
+
+		await expect(page.getByRole('button', {name: 'Sign In'})).toBeVisible();
+	});
+
+	await test.step('Go to Data Set fragment page', async () => {
+		await dataSetFragmentPage.goToPage({layout});
+
+		await page
+			.locator('.data-set-content-wrapper')
+			.waitFor({state: 'visible'});
+	});
+
+	await test.step('Assert that no results are displayed', async () => {
+		await expect(
+			page
+				.locator('.data-set-content-wrapper')
+				.getByText('No Results Found')
+		).toBeVisible();
+	});
+});

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -77,6 +77,8 @@ test.afterEach(async ({apiHelpers, dataSetManagerApiHelpers}) => {
 				article.articleId
 			);
 		});
+
+		article = null;
 	}
 });
 


### PR DESCRIPTION
Task: https://liferay.atlassian.net/browse/LPD-19841
Subtask: https://liferay.atlassian.net/browse/LPD-37261

- Adds a test for an unauthenticated user viewing a data set fragment
- Added to the `data-set-fragment/dataSets.spec.ts`. Maybe a similar `dataSetsPermissions.spec.ts` could be created for `data-set-fragment`, but since this is just a single test it seemed fine keeping it in `dataSets.spec.ts` for now.
