### PR TITLE
LPD-44097 Deprecated Badge Adjustments

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -181,7 +181,7 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentEnt
 							</clay:content-col>
 
 							<c:if test="<%= (fragmentCollectionContributor != null) && fragmentCollectionContributor.isDeprecated() %>">
-								<div class="c-ml-2">
+								<div class="c-ml-3">
 									<liferay-frontend:feature-indicator
 										interactive="<%= true %>"
 										type="deprecated"

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/feature_indicator/FeatureIndicator.tsx
@@ -92,10 +92,12 @@ export default function FeatureIndicator({
 								title={tooltipTitle}
 								translucent
 							>
-								<span className="inline-item">{label}</span>
+								<span className="inline-item text-uppercase">
+									{label}
+								</span>
 
 								{symbol && (
-									<span className="inline-item inline-item-after">
+									<span className="inline-item inline-item-after ml-2">
 										<ClayIcon symbol={symbol} />
 									</span>
 								)}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalNavTag.java
@@ -311,7 +311,7 @@ public class VerticalNavTag extends BaseContainerTag {
 
 					IconTag iconTag = new IconTag();
 
-					iconTag.setCssClass("c-ml-2 text-muted");
+					iconTag.setCssClass("c-ml-2 c-mr-2 text-muted");
 					iconTag.setSymbol(symbol);
 
 					iconTag.doTag(pageContext);
@@ -319,7 +319,7 @@ public class VerticalNavTag extends BaseContainerTag {
 			}
 
 			if (GetterUtil.getBoolean(verticalNavItem.get("deprecated"))) {
-				jspWriter.write("<span class=\"badge badge-warning c-ml-2");
+				jspWriter.write("<span class=\"badge badge-warning");
 				jspWriter.write(" text-uppercase badge-translucent\">");
 				jspWriter.write("<span class=\"badge-item ");
 				jspWriter.write("badge-item-expand\">");

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/VerticalNav.js
@@ -49,7 +49,7 @@ export default function VerticalNav({
 					{item.icons?.map((icon) => {
 						return (
 							<ClayIcon
-								className="c-ml-2 text-muted"
+								className="c-ml-2 c-mr-2 text-muted"
 								key={icon.symbol}
 								symbol={icon.symbol}
 								title={icon.title}
@@ -58,9 +58,7 @@ export default function VerticalNav({
 					})}
 
 					{item.deprecated ? (
-						<span className="c-ml-2">
-							<FeatureIndicator type="deprecated" />
-						</span>
+						<FeatureIndicator type="deprecated" />
 					) : null}
 				</ClayVerticalNav.Item>
 			)}


### PR DESCRIPTION
## Motivation

Hello, team!

I am sending this pr to solve some design differences that we have found between the Feature Indicator component we have and the design of it in figma. It has been just adjust some margins and use capital letters for the button text as we use it for the Clay Badge.

[LPD-44097](https://liferay.atlassian.net/browse/LPD-44097)

## Changes

Adapt styles to match the figma component

## Steps

Activate the FF [LPD-40529](https://liferay.atlassian.net/browse/LPD-40529)
Navigate to Fragments in the Product Menu

## Results

<img width="341" alt="image" src="https://github.com/user-attachments/assets/b861f45d-1773-43ca-8297-e6dc5862c729" />
<img width="266" alt="image" src="https://github.com/user-attachments/assets/abfa1a73-e80c-4340-99b6-922755120322" />

[LPD-44097]: https://liferay.atlassian.net/browse/LPD-44097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-40529]: https://liferay.atlassian.net/browse/LPD-40529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ