### PR TITLE
LPD-43582 Language Selector in Web Content doesn't update when changed

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -217,9 +217,7 @@ export default function TranslationAdminSelector({
 					});
 				}}
 				selectedItem={activeLocales.find(
-					(locale) =>
-						locale.id === selectedLanguageId ||
-						locale.id === defaultLanguageId
+					(locale) => locale.id === selectedLanguageId
 				)}
 				selectedKey={selectedLanguageId}
 			>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {act, cleanup, fireEvent, render} from '@testing-library/react';
+import {act, cleanup, fireEvent, render, within} from '@testing-library/react';
 import React from 'react';
 
 import '@testing-library/jest-dom';
+
+import '@testing-library/jest-dom/extend-expect';
 
 import TranslationAdminSelector from '../../src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector';
 
@@ -274,7 +276,9 @@ describe('TranslationAdminSelector', () => {
 	});
 
 	it('calls onSelectedLocaleChange callback on dropdown locale selection', () => {
-		const {getByTitle} = render(<TranslationAdminSelector {...props} />);
+		const {getByRole, getByTitle} = render(
+			<TranslationAdminSelector {...props} />
+		);
 
 		const trigger = getByTitle('select-a-language');
 
@@ -298,6 +302,10 @@ describe('TranslationAdminSelector', () => {
 		expect(props.onSelectedLanguageIdChange).toHaveBeenLastCalledWith(
 			'ca_ES'
 		);
+
+		const languageSelector = getByRole('combobox');
+
+		expect(within(languageSelector).getByText('ca-ES')).toBeInTheDocument();
 	});
 
 	it('is used as a controlled component', () => {


### PR DESCRIPTION
# What is this trying to solve?

The language selector in Web Content does not update when we change the lanugage.  
This is caused by [https://liferay.atlassian.net/browse/LPD-40105](https://liferay.atlassian.net/browse/LPD-40105,)

[Link to ticket](https://liferay.atlassian.net/browse/LPD-43582)

# Proposed solution
Revert the changes [sent here](https://github.com/liferay-frontend/liferay-portal/pull/4510) , because it causes the bug, with this change it always takes the `defaultLanguageId` for the `selectedItem` in the Picker and that's wrong.
Moreover, I'm adding a step for the test in `TranslationAdminSelector.js`, as the test 'calls onSelectedLocaleChange callback on dropdown locale selection' only verifies that `onSelectedLanguageIdChange` is called with the right language but we need to ensure that in the selector the right language is selected too, that's why with [this change](https://github.com/liferay-frontend/liferay-portal/pull/4510) the bug was not detected.

# How can I test it?
Run the test or follow the steps in the bug