### PR TITLE
LPD-42473 Images with no width should be rendered inside CKEditor

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/package.json
@@ -7,7 +7,7 @@
 		"ckeditor4-react": "1.4.2",
 		"ckeditor5": "43.3.1",
 		"frontend-js-web": "*",
-		"liferay-ckeditor": "4.21.0-liferay.5",
+		"liferay-ckeditor": "4.21.0-liferay.9",
 		"prop-types": "15.7.2",
 		"react": "18.2.0"
 	},

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -51,6 +51,30 @@
 			}
 		},
 
+		_checkImageWidth(editor, editorContent, imageSrc) {
+			if (imageSrc.url) {
+				imageSrc = imageSrc.url;
+			}
+
+			if (
+				!editor.window.$.AlloyEditor &&
+				!editorContent.id.endsWith('BalloonEditor')
+			) {
+				editorContent =
+					editorContent.querySelector('iframe').contentDocument;
+			}
+
+			const imgElement = editorContent.querySelector(
+				`img[src='${imageSrc}']`
+			);
+
+			imgElement.onload = function () {
+				if (this.width === 0) {
+					this.setAttribute('width', '150px');
+				}
+			};
+		},
+
 		_commitAudioValue(value, node) {
 			const instance = this;
 
@@ -252,14 +276,20 @@
 				const imageSrc = instance._getItemSrc(editor, selectedItem);
 
 				if (imageSrc) {
+					const editorContent = editor.window.$.AlloyEditor
+						? document.getElementById(`${editor.name}Container`)
+						: document.getElementById(`cke_${editor.name}`);
+
 					if (typeof callback === 'function') {
 						callback(imageSrc, selectedItem);
+
+						instance._checkImageWidth(
+							editor,
+							editorContent,
+							imageSrc
+						);
 					}
 					else {
-						const editorContent = document.getElementById(
-							`${editor.id}_contents`
-						);
-
 						const editorContentHeight =
 							editorContent.getBoundingClientRect().height;
 
@@ -281,6 +311,12 @@
 							editor.insertHtml(elementOuterHtml);
 
 							editor.focus();
+
+							instance._checkImageWidth(
+								editor,
+								editorContent,
+								imageSrc
+							);
 						};
 					}
 				}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -52,20 +52,16 @@
 		},
 
 		_checkImageWidth(editor, editorContent, imageSrc) {
-			if (imageSrc.url) {
-				imageSrc = imageSrc.url;
-			}
+			const url = imageSrc.url ? imageSrc.url : imageSrc;
 
-			if (
+			const editorContentDocument =
 				!editor.window.$.AlloyEditor &&
 				!editorContent.id.endsWith('BalloonEditor')
-			) {
-				editorContent =
-					editorContent.querySelector('iframe').contentDocument;
-			}
+					? editorContent.querySelector('iframe').contentDocument
+					: editorContent;
 
-			const imgElement = editorContent.querySelector(
-				`img[src='${imageSrc}']`
+			const imgElement = editorContentDocument.querySelector(
+				`img[src='${url}']`
 			);
 
 			imgElement.onload = function () {

--- a/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-dependencies-web/package.json
@@ -16,7 +16,7 @@
 		"html-to-image": "1.11.11",
 		"image-promise": "5.0.1",
 		"jspdf": "2.5.1",
-		"liferay-ckeditor": "4.21.0-liferay.5",
+		"liferay-ckeditor": "4.21.0-liferay.9",
 		"lodash.groupby": "4.6.0",
 		"lodash.isequal": "4.5.0",
 		"moment": "2.29.4",

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/tests/ckeditor4/classic.spec.ts
@@ -76,70 +76,97 @@ test(
 	}
 );
 
-test('Able to drag and drop images', {tag: '@LPD-41443'}, async ({page}) => {
-	await test.step('Drag and drop image', async () => {
-		const ckeditorEditorBody = page
-			.frameLocator('iframe[title="editor"]')
-			.getByRole('heading', {name: 'Classic Editor'});
+test(
+	'Able to drag and drop images with the right width',
+	{tag: ['@LPD-41443', '@LPD-42473']},
+	async ({page}) => {
+		await test.step('Drag and drop image', async () => {
+			const ckeditorEditorBody = page
+				.frameLocator('iframe[title="editor"]')
+				.getByRole('heading', {name: 'Classic Editor'});
 
-		await ckeditorEditorBody.click();
+			await ckeditorEditorBody.click();
 
-		await page.keyboard.press('Enter');
+			await page.keyboard.press('Enter');
 
-		const imageButton = page.getByLabel('Image', {exact: true});
+			const imageButton = page.getByLabel('Image', {exact: true});
 
-		await imageButton.waitFor({state: 'visible'});
-		await imageButton.click();
+			await imageButton.waitFor({state: 'visible'});
+			await imageButton.click();
 
-		const siteAndLibrariesLink = page
-			.frameLocator('iframe[title="Select Item"]')
-			.getByRole('link', {name: 'Sites and Libraries'});
+			const siteAndLibrariesLink = page
+				.frameLocator('iframe[title="Select Item"]')
+				.getByRole('link', {name: 'Sites and Libraries'});
 
-		await siteAndLibrariesLink.waitFor({state: 'visible'});
-		await siteAndLibrariesLink.click();
+			await siteAndLibrariesLink.waitFor({state: 'visible'});
+			await siteAndLibrariesLink.click();
 
-		const liferayLink = page
-			.frameLocator('iframe[title="Select Item"]')
-			.getByRole('link', {name: 'Liferay'});
+			const liferayLink = page
+				.frameLocator('iframe[title="Select Item"]')
+				.getByRole('link', {name: 'Liferay'});
 
-		await liferayLink.waitFor({state: 'visible'});
-		await liferayLink.click();
+			await liferayLink.waitFor({state: 'visible'});
+			await liferayLink.click();
 
-		const liferayImagesLink = page
-			.frameLocator('iframe[title="Select Item"]')
-			.getByRole('link', {name: 'Provided by Liferay'});
+			const liferayImagesLink = page
+				.frameLocator('iframe[title="Select Item"]')
+				.getByRole('link', {name: 'Provided by Liferay'});
 
-		await liferayImagesLink.waitFor({state: 'visible'});
-		await liferayImagesLink.click();
+			await liferayImagesLink.waitFor({state: 'visible'});
+			await liferayImagesLink.click();
 
-		const astronautImage = page
-			.frameLocator('iframe[title="Select Item"]')
-			.getByText('astronaut.png');
+			const astronautImage = page
+				.frameLocator('iframe[title="Select Item"]')
+				.getByText('astronaut.png');
 
-		await astronautImage.waitFor({state: 'visible'});
-		await astronautImage.click();
+			await astronautImage.waitFor({state: 'visible'});
+			await astronautImage.click();
 
-		const astronautEditorImage = page
-			.getByRole('application', {name: 'Rich Text Editor,'})
-			.frameLocator('iframe[title="editor"]')
-			.locator('img')
-			.first();
+			const astronautEditorImage = page
+				.getByRole('application', {name: 'Rich Text Editor,'})
+				.frameLocator('iframe[title="editor"]')
+				.locator('img')
+				.first();
 
-		await astronautEditorImage.waitFor({state: 'visible'});
-		await astronautEditorImage.hover();
+			await astronautEditorImage.waitFor({state: 'visible'});
+			await astronautEditorImage.hover();
 
-		const dragAndDropButton = page
-			.getByRole('application', {name: 'Rich Text Editor,'})
-			.frameLocator('iframe[title="editor"]')
-			.getByTitle('Click and drag to move');
+			const dragAndDropButton = page
+				.getByRole('application', {name: 'Rich Text Editor,'})
+				.frameLocator('iframe[title="editor"]')
+				.getByTitle('Click and drag to move');
 
-		await dragAndDropButton.dragTo(ckeditorEditorBody);
+			await dragAndDropButton.dragTo(ckeditorEditorBody);
 
-		const astronautImageElement = page
-			.getByRole('application', {name: 'Rich Text Editor,'})
-			.frameLocator('iframe[title="editor"]')
-			.locator('h1 > * > img.cke_widget_element');
+			const astronautImageElement = page
+				.getByRole('application', {name: 'Rich Text Editor,'})
+				.frameLocator('iframe[title="editor"]')
+				.locator('h1 > * > img.cke_widget_element');
 
-		await expect(astronautImageElement).toBeVisible();
-	});
-});
+			await expect(astronautImageElement).toBeVisible();
+		});
+
+		await test.step('Check image is not occupying the whole editor width', async () => {
+			const astronautImageElement = page
+				.getByRole('application', {name: 'Rich Text Editor,'})
+				.frameLocator('iframe[title="editor"]')
+				.locator('h1 > * > img.cke_widget_element');
+
+			const astronautImageElementBoundingBox =
+				await astronautImageElement.boundingBox();
+			const astronautImageElementWidth =
+				astronautImageElementBoundingBox.width;
+
+			const imageContainer = page
+				.getByRole('application', {name: 'Rich Text Editor,'})
+				.frameLocator('iframe[title="editor"]')
+				.locator('h1 > span.cke_widget_wrapper');
+
+			const imageContainerBoundingBox =
+				await imageContainer.boundingBox();
+			const imageContainerWidth = imageContainerBoundingBox.width;
+
+			await expect(astronautImageElementWidth).toBe(imageContainerWidth);
+		});
+	}
+);

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -12004,10 +12004,10 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-liferay-ckeditor@4.21.0-liferay.5:
-  version "4.21.0-liferay.5"
-  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.21.0-liferay.5.tgz#ba48f3ad9de2c9f4b1c777b525f6df1e1f18bee9"
-  integrity sha512-2JWBeik/hP1hsJDGfmgHyTjz5uC3SiwGLphc3LlE4bwK7HIBAjzl/0RjIJ0jn08RZ6CbAbbrlDmLkc+wtgltmQ==
+liferay-ckeditor@4.21.0-liferay.9:
+  version "4.21.0-liferay.9"
+  resolved "https://registry.yarnpkg.com/liferay-ckeditor/-/liferay-ckeditor-4.21.0-liferay.9.tgz#eeb225f71c6a80ac7ff3541d9e69fb5373742d18"
+  integrity sha512-1Z4jQoxVHReX6qPjlSeMOpWU5fOibOp4/2Or54e4DQOaAQRjHAGRVvH5PxlnDbH28E88S4d5Lurb5FFpCyoOiw==
 
 liferay-frontend-common-css@1.0.4, liferay-frontend-common-css@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Hi, 

In [LPD-42473](https://liferay.atlassian.net/browse/LPD-42473) they are reporting image alignment is not working fine while using CKEditor. That's caused by the [changes we introduced in liferay-ckeditor v4.21.0-liferay.3](https://github.com/liferay/liferay-ckeditor/commit/9f4745ac63e9c7bf9ecfc95a971c6fa4cb0c0ef1) to show images in the editor even when they don't have a width (it might be the case with some SVG files).

Since those changes cause this regression bug, I've reverted them in liferay-ckeditor, published a new version and updating here to that version. Then, I've created a new solution to fix the original problem, rendering images with no width. As I explained in [a previous pull request](https://github.com/liferay/liferay-ckeditor/pull/215#issue-2675748888):

> So instead of assigning a default width based on percentage I'm doing it based on a fix width, 150px, which might sound arbitrary but I took it from https://github.com/ckeditor/ckeditor4/pull/2668, which never got committed because the sender didn't make changes requested but the idea of a fix 150px width for this kind of images seemed ok to ckeditor's developers.

Since this plugin is used by all our editor: Classic CKEditor, Ballon Editor and Alloy Editor I've considered all those cases. 

I've also considered the cases when Adaptive Media is enabled/disabled for CKEditor because it also affects.