### PR TITLE
LPD-43223 - Predefined value table is either not visible or non interactive on object Actions when Clay table FF is enabled

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/thunks/persistVisibleFieldNames.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/thunks/persistVisibleFieldNames.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+// @ts-ignore
+
 import {saveViewSettings} from '../utils/saveViewSettings';
+
+// @ts-ignore
+
 import {VIEWS_ACTION_TYPES} from '../views/viewsReducer';
 
 export type VisibleFieldNames = {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/thunks/persistVisibleFieldNames.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/thunks/persistVisibleFieldNames.ts
@@ -16,9 +16,9 @@ export default function persistVisibleFieldNames({
 	portletId,
 	visibleFieldNames,
 }: {
-	appURL: string;
-	id: string;
-	portletId: string;
+	appURL?: string;
+	id?: string;
+	portletId?: string;
 	visibleFieldNames: VisibleFieldNames;
 }) {
 	return (viewsDispatch: any) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/thunks/persistVisibleFieldNames.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/thunks/persistVisibleFieldNames.ts
@@ -6,13 +6,22 @@
 import {saveViewSettings} from '../utils/saveViewSettings';
 import {VIEWS_ACTION_TYPES} from '../views/viewsReducer';
 
+export type VisibleFieldNames = {
+	[fieldName: string]: boolean;
+};
+
 export default function persistVisibleFieldNames({
 	appURL,
 	id,
 	portletId,
 	visibleFieldNames,
+}: {
+	appURL: string;
+	id: string;
+	portletId: string;
+	visibleFieldNames: VisibleFieldNames;
 }) {
-	return (viewsDispatch) => {
+	return (viewsDispatch: any) => {
 		viewsDispatch({
 			type: VIEWS_ACTION_TYPES.UPDATE_VISIBLE_FIELD_NAMES,
 			value: visibleFieldNames,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
@@ -24,7 +24,7 @@ import {getInternalCellRenderer} from '../../cell_renderers/getInternalCellRende
 
 // @ts-ignore
 
-import persistVisibleFieldNames from '../../thunks/persistVisibleFieldNames';
+import persistVisibleFieldNames, {VisibleFieldNames} from '../../thunks/persistVisibleFieldNames';
 import {
 	ILocalizedItemDetails,
 	getLocalizedValue,
@@ -158,7 +158,17 @@ export function ClayTable({
 			}}
 			nestedKey={nestedItemsReferenceKey}
 			onSortChange={setSort}
-			onVisibleColumnsChange={(columns) => {
+			onVisibleColumnsChange={(visibleColumns) => {
+				const visibleFieldNames: VisibleFieldNames = {};
+
+				fields.forEach(({fieldName}) => {
+					visibleFieldNames[fieldName] = false;
+				});
+
+				visibleColumns.forEach((value, key) => {
+					visibleFieldNames[key] = true;
+				});
+
 				viewsDispatch(
 					persistVisibleFieldNames({
 						appURL,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
@@ -260,7 +260,7 @@ export function ClayTable({
 			</Head>
 
 			<Body
-				defaultItems={
+				items={
 					inlineAddingSettings
 						? [...filteredItems, defaultAddItem]
 						: items

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/ClayTable.tsx
@@ -24,7 +24,9 @@ import {getInternalCellRenderer} from '../../cell_renderers/getInternalCellRende
 
 // @ts-ignore
 
-import persistVisibleFieldNames, {VisibleFieldNames} from '../../thunks/persistVisibleFieldNames';
+import persistVisibleFieldNames, {
+	VisibleFieldNames,
+} from '../../thunks/persistVisibleFieldNames';
 import {
 	ILocalizedItemDetails,
 	getLocalizedValue,
@@ -68,6 +70,7 @@ type Props = {
 	selectedItemsKey: string;
 	selectedItemsValue: any;
 	selectionType?: string;
+	visibleFields: Array<Field>;
 };
 
 type Sorting = {
@@ -96,11 +99,12 @@ export function ClayTable({
 	selectedItemsKey,
 	selectedItemsValue,
 	selectionType,
+	visibleFields,
 }: Props) {
 	const {appURL, id, itemsChanges, portletId, updateItem} = useContext(
 		FrontendDataSetContext
 	);
-	const [{visibleFieldNames}, viewsDispatch] = useContext(ViewsContext);
+	const [, viewsDispatch] = useContext(ViewsContext);
 	const [sort, setSort] = useState<Sorting | null>(null);
 
 	const filteredItems = useMemo(() => {
@@ -174,12 +178,12 @@ export function ClayTable({
 						appURL,
 						id,
 						portletId,
-						visibleFieldNames: Object.fromEntries(columns),
+						visibleFieldNames,
 					})
 				);
 			}}
 			sort={sort}
-			visibleColumns={new Map(Object.entries(visibleFieldNames))}
+			visibleColumns={getVisibleFieldsMap(visibleFields, selectable)}
 		>
 			<Head
 				items={selectable ? [{fieldName: 'select'}, ...fields] : fields}
@@ -273,14 +277,17 @@ export function ClayTable({
 					(item) => {
 						const id = item[selectedItemsKey ?? 'id'];
 
-						const items = [...fields, {fieldName: 'actions'}];
+						const columns = [
+							...visibleFields,
+							{fieldName: 'actions'},
+						];
 
 						return (
 							<Row
 								items={
 									selectable
-										? [{fieldName: 'select'}, ...items]
-										: items
+										? [{fieldName: 'select'}, ...columns]
+										: columns
 								}
 							>
 								{
@@ -492,6 +499,26 @@ export function ClayTable({
 			</Body>
 		</Table>
 	);
+}
+
+function getVisibleFieldsMap(
+	visibleFields: Array<Field>,
+	selectable?: boolean
+) {
+	const visibleFieldsMap = new Map();
+
+	if (selectable) {
+		visibleFieldsMap.set('select', 0);
+	}
+
+	visibleFields.forEach((field, index) =>
+		visibleFieldsMap.set(
+			String(field.fieldName),
+			selectable ? index + 1 : index
+		)
+	);
+
+	return visibleFieldsMap;
 }
 
 /**

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -420,11 +420,7 @@ const Table = ({
 
 	if (Liferay.FeatureFlags['LPS-193005']) {
 		return (
-			<DndTable.TableContextProvider
-				columnNames={visibleFields.map((field) =>
-					String(field.fieldName)
-				)}
-			>
+			<DndTable.TableContextProvider columnNames={columnNames}>
 				<ClayTable
 					fields={schema.fields as any}
 					inlineAddingSettings={inlineAddingSettings}
@@ -438,6 +434,7 @@ const Table = ({
 					selectedItemsKey={selectedItemsKey}
 					selectedItemsValue={selectedItemsValue}
 					selectionType={selectionType}
+					visibleFields={visibleFields}
 				/>
 			</DndTable.TableContextProvider>
 		);


### PR DESCRIPTION
Resending from: https://github.com/liferay-platform-experience/liferay-portal/pull/865


https://liferay.atlassian.net/browse/LPD-43223

The main approach here requires switching the table to a controlled component. Otherwise inline editable cells will not work correctly since they need to pass in the updated html that results from editing.

This also reveals another bug in the Clay Table. [This](https://github.com/liferay/clay/blob/961c6715dfbc08da721fb1b8c97033bcd450958c/packages/clay-core/src/table/Head.tsx#L75) is only called at first render, but we need this to be called every time the collection changes. This results in an extra cell added to the body rows of the table when you hide a column. This issue can be reproduced by navigating to Commerce products and hiding a column in the table. 

<img width="1275" alt="Screenshot 2024-12-16 at 9 11 38 PM" src="https://github.com/user-attachments/assets/ce2acae8-c238-4196-a069-f1d25e15b33a" />

This is caused by the collection sizing not being updated correctly which causes [this](https://github.com/liferay/clay/blob/961c6715dfbc08da721fb1b8c97033bcd450958c/packages/clay-core/src/table/Row.tsx#L247) to evaluate to true when it shouldn't. As a result an extra cell is added to the body that is not in the header.

This will be fixed by: https://github.com/liferay/clay/pull/5903