### PR TITLE
LPD-44863 Add traces to log OSGi notifications about CX deployments/undeployments

### DIFF
--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -57,18 +57,18 @@ public class CETConfigurationFactory {
 
 	@Activate
 	protected void activate(Map<String, Object> properties) throws Exception {
-		String name = (String)properties.get("name");
+		String erc = _getExternalReferenceCode(properties);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				"Notified from OSGi about activation of client extension " +
-					name);
+					erc);
 		}
 
 		if (_log.isDebugEnabled()) {
-			_log.info(
+			_log.debug(
 				StringBundler.concat(
-					"Properties for activated client extension ", name, ":\n",
+					"Properties for activated client extension ", erc, ":\n",
 					MapUtil.toString(properties)));
 		}
 
@@ -82,13 +82,13 @@ public class CETConfigurationFactory {
 						_log.info(
 							StringBundler.concat(
 								"Adding CET for company ", companyId, " and ",
-								"client extension ", name));
+								"client extension ", erc));
 					}
 
 					_cet = _cetManager.addCET(
 						ConfigurableUtil.createConfigurable(
 							CETConfiguration.class, properties),
-						companyId, _getExternalReferenceCode(properties));
+						companyId, erc);
 
 					if (Objects.equals(
 							_cet.getType(),
@@ -99,7 +99,7 @@ public class CETConfigurationFactory {
 								StringBundler.concat(
 									"Adding control panel theme CSS relation ",
 									"for company ", companyId, " and client ",
-									"extension ", name));
+									"extension ", erc));
 						}
 
 						_addControlPanelThemeCSSClientExtensionEntryRel(
@@ -109,8 +109,8 @@ public class CETConfigurationFactory {
 				catch (Exception exception) {
 					_log.error(
 						StringBundler.concat(
-							"Unable to add CET for company ", companyId,
-							" and client extension ", name),
+							"Unable to activate CET for company ", companyId,
+							" and client extension ", erc),
 						exception);
 
 					throw exception;
@@ -120,12 +120,12 @@ public class CETConfigurationFactory {
 
 	@Deactivate
 	protected void deactivate() {
-		String name = (String)_properties.get("name");
+		String erc = _getExternalReferenceCode(_properties);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				"Notified from OSGi about deactivation of client extension " +
-					name);
+					erc);
 		}
 
 		ConfigurationFactoryUtil.executeAsCompany(
@@ -136,7 +136,7 @@ public class CETConfigurationFactory {
 						_log.info(
 							StringBundler.concat(
 								"Deleting CET for company ", companyId, " and ",
-								"client extension ", name));
+								"client extension ", erc));
 					}
 
 					_cetManager.deleteCET(_cet);
@@ -146,7 +146,7 @@ public class CETConfigurationFactory {
 							StringBundler.concat(
 								"Deleting client extension relations (if any) ",
 								"for company ", companyId, " and client ",
-								"extension ", name));
+								"extension ", erc));
 					}
 
 					_clientExtensionEntryRelLocalService.
@@ -156,8 +156,8 @@ public class CETConfigurationFactory {
 				catch (Exception exception) {
 					_log.error(
 						StringBundler.concat(
-							"Unable to delete CET for company ", companyId,
-							" and client extension ", name),
+							"Unable to deactivate CET for company ", companyId,
+							" and client extension ", erc),
 						exception);
 
 					throw exception;
@@ -169,18 +169,18 @@ public class CETConfigurationFactory {
 
 	@Modified
 	protected void modified(Map<String, Object> properties) throws Exception {
-		String name = (String)_properties.get("name");
+		String erc = _getExternalReferenceCode(properties);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
-				"Notified from OSGi about deactivation of client extension " +
-					name);
+				"Notified from OSGi about modification of client extension " +
+					erc);
 		}
 
 		if (_log.isDebugEnabled()) {
-			_log.info(
+			_log.debug(
 				StringBundler.concat(
-					"Properties for modified client extension ", name, ":\n",
+					"Properties for modified client extension ", erc, ":\n",
 					MapUtil.toString(properties)));
 		}
 
@@ -194,7 +194,7 @@ public class CETConfigurationFactory {
 						_log.info(
 							StringBundler.concat(
 								"Deleting CET for company ", companyId, " and ",
-								"client extension ", name));
+								"client extension ", erc));
 					}
 
 					_cetManager.deleteCET(_cet);
@@ -203,13 +203,13 @@ public class CETConfigurationFactory {
 						_log.info(
 							StringBundler.concat(
 								"Adding CET for company ", companyId, " and ",
-								"client extension ", name));
+								"client extension ", erc));
 					}
 
 					_cet = _cetManager.addCET(
 						ConfigurableUtil.createConfigurable(
 							CETConfiguration.class, properties),
-						companyId, _getExternalReferenceCode(properties));
+						companyId, erc);
 
 					if (Objects.equals(
 							_cet.getType(),
@@ -220,7 +220,7 @@ public class CETConfigurationFactory {
 								StringBundler.concat(
 									"Deleting client extension relations (if ",
 									"any) for company ", companyId, " and ",
-									"client extension ", name));
+									"client extension ", erc));
 						}
 
 						_clientExtensionEntryRelLocalService.
@@ -232,7 +232,7 @@ public class CETConfigurationFactory {
 								StringBundler.concat(
 									"Adding control panel theme CSS relation ",
 									"for company ", companyId, " and client ",
-									"extension ", name));
+									"extension ", erc));
 						}
 
 						_addControlPanelThemeCSSClientExtensionEntryRel(
@@ -243,7 +243,7 @@ public class CETConfigurationFactory {
 					_log.error(
 						StringBundler.concat(
 							"Unable to modify CET for company ", companyId,
-							" and client extension ", name),
+							" and client extension ", erc),
 						exception);
 
 					throw exception;

--- a/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
+++ b/modules/apps/client-extension/client-extension-type-impl/src/main/java/com/liferay/client/extension/type/internal/configuration/CETConfigurationFactory.java
@@ -13,6 +13,7 @@ import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.client.extension.type.configuration.CETConfiguration;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.osgi.util.configuration.ConfigurationFactoryUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.util.List;
@@ -55,38 +57,111 @@ public class CETConfigurationFactory {
 
 	@Activate
 	protected void activate(Map<String, Object> properties) throws Exception {
+		String name = (String)properties.get("name");
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Notified from OSGi about activation of client extension " +
+					name);
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Properties for activated client extension ", name, ":\n",
+					MapUtil.toString(properties)));
+		}
+
 		_properties = properties;
 
 		ConfigurationFactoryUtil.executeAsCompany(
 			_companyLocalService, properties,
 			companyId -> {
-				CETConfiguration cetConfiguration =
-					ConfigurableUtil.createConfigurable(
-						CETConfiguration.class, properties);
+				try {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Adding CET for company ", companyId, " and ",
+								"client extension ", name));
+					}
 
-				_cet = _cetManager.addCET(
-					cetConfiguration, companyId,
-					_getExternalReferenceCode(properties));
+					_cet = _cetManager.addCET(
+						ConfigurableUtil.createConfigurable(
+							CETConfiguration.class, properties),
+						companyId, _getExternalReferenceCode(properties));
 
-				if (Objects.equals(
-						_cet.getType(),
-						ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+					if (Objects.equals(
+							_cet.getType(),
+							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
 
-					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								StringBundler.concat(
+									"Adding control panel theme CSS relation ",
+									"for company ", companyId, " and client ",
+									"extension ", name));
+						}
+
+						_addControlPanelThemeCSSClientExtensionEntryRel(
+							companyId);
+					}
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to add CET for company ", companyId,
+							" and client extension ", name),
+						exception);
+
+					throw exception;
 				}
 			});
 	}
 
 	@Deactivate
 	protected void deactivate() {
+		String name = (String)_properties.get("name");
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Notified from OSGi about deactivation of client extension " +
+					name);
+		}
+
 		ConfigurationFactoryUtil.executeAsCompany(
 			_companyLocalService, _properties,
 			companyId -> {
-				_cetManager.deleteCET(_cet);
+				try {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Deleting CET for company ", companyId, " and ",
+								"client extension ", name));
+					}
 
-				_clientExtensionEntryRelLocalService.
-					deleteClientExtensionEntryRels(
-						companyId, _cet.getExternalReferenceCode());
+					_cetManager.deleteCET(_cet);
+
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Deleting client extension relations (if any) ",
+								"for company ", companyId, " and client ",
+								"extension ", name));
+					}
+
+					_clientExtensionEntryRelLocalService.
+						deleteClientExtensionEntryRels(
+							companyId, _cet.getExternalReferenceCode());
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to delete CET for company ", companyId,
+							" and client extension ", name),
+						exception);
+
+					throw exception;
+				}
 			});
 
 		_properties = null;
@@ -94,30 +169,84 @@ public class CETConfigurationFactory {
 
 	@Modified
 	protected void modified(Map<String, Object> properties) throws Exception {
+		String name = (String)_properties.get("name");
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Notified from OSGi about deactivation of client extension " +
+					name);
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Properties for modified client extension ", name, ":\n",
+					MapUtil.toString(properties)));
+		}
+
 		_properties = properties;
 
 		ConfigurationFactoryUtil.executeAsCompany(
 			_companyLocalService, properties,
 			companyId -> {
-				_cetManager.deleteCET(_cet);
+				try {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Deleting CET for company ", companyId, " and ",
+								"client extension ", name));
+					}
 
-				CETConfiguration cetConfiguration =
-					ConfigurableUtil.createConfigurable(
-						CETConfiguration.class, properties);
+					_cetManager.deleteCET(_cet);
 
-				_cet = _cetManager.addCET(
-					cetConfiguration, companyId,
-					_getExternalReferenceCode(properties));
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Adding CET for company ", companyId, " and ",
+								"client extension ", name));
+					}
 
-				if (Objects.equals(
-						_cet.getType(),
-						ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
+					_cet = _cetManager.addCET(
+						ConfigurableUtil.createConfigurable(
+							CETConfiguration.class, properties),
+						companyId, _getExternalReferenceCode(properties));
 
-					_clientExtensionEntryRelLocalService.
-						deleteClientExtensionEntryRels(
-							companyId, _cet.getExternalReferenceCode());
+					if (Objects.equals(
+							_cet.getType(),
+							ClientExtensionEntryConstants.TYPE_THEME_CSS)) {
 
-					_addControlPanelThemeCSSClientExtensionEntryRel(companyId);
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								StringBundler.concat(
+									"Deleting client extension relations (if ",
+									"any) for company ", companyId, " and ",
+									"client extension ", name));
+						}
+
+						_clientExtensionEntryRelLocalService.
+							deleteClientExtensionEntryRels(
+								companyId, _cet.getExternalReferenceCode());
+
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								StringBundler.concat(
+									"Adding control panel theme CSS relation ",
+									"for company ", companyId, " and client ",
+									"extension ", name));
+						}
+
+						_addControlPanelThemeCSSClientExtensionEntryRel(
+							companyId);
+					}
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to modify CET for company ", companyId,
+							" and client extension ", name),
+						exception);
+
+					throw exception;
 				}
 			});
 	}


### PR DESCRIPTION
LPD: https://liferay.atlassian.net/browse/LPD-44863

I'm sending this for two reasons:

1. So that it is used to create a debug hotfix for https://liferay.atlassian.net/browse/LPP-57071
2. So that it is reviewed and sent to master for merging because we want it to be in the product to help diagnosing problems in LXC setups.

I've tested this locally by setting the log level to debug and deploying the `liferay-sample-custom-element-1` sample and this was the output in the server console:

```
2024-12-19 10:30:20.791 INFO  [com.liferay.portal.kernel.deploy.auto.AutoDeployScanner][AutoDeployDir:212] Processing liferay-sample-custom-element-1.zip
2024-12-19 10:30:25.993 INFO  [fileinstall-directory-watcher][BundleStartStopLogger:68] STARTED liferaysamplecustomelement1_7.4.3.131 [1383]
2024-12-19 10:30:26.000 INFO  [CM Event Dispatcher (Fire ConfigurationEvent: pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1)][CETConfigurationFactory:63] Notified from OSGi about activation of client extension Liferay Sample Custom Element 1
2024-12-19 10:30:26.001 INFO  [CM Event Dispatcher (Fire ConfigurationEvent: pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1)][CETConfigurationFactory:69] Properties for activated client extension Liferay Sample Custom Element 1:_{webContextPath=/liferay-sample-custom-element-1, component.id=11565, type=customElement, typeSettings=[friendlyURLMapping=vanilla-counter, instanceable=false, urls=index.ab81e49beb83fc1ae744.js, useESM=false, htmlElementName=vanilla-counter, portletCategoryName=category.client-extensions], projectName=liferay-sample-custom-element-1, _moduleServiceLifecycle.target=(module.service.lifecycle=portal.initialized), properties=[], component.name=com.liferay.client.extension.type.internal.configuration.CETConfigurationFactory, sourceCodeURL=, projectId=liferaysamplecustomelement1, service.factoryPid=com.liferay.client.extension.type.configuration.CETConfiguration, companyId=34309694190670, service.pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1, description=, dxp.lxc.liferay.com.virtualInstanceId=default, baseURL=${portalURL}/o/liferay-sample-custom-element-1, buildTimestamp=1734604219698, name=Liferay Sample Custom Element 1} [Sanitized]
2024-12-19 10:30:26.004 INFO  [CM Event Dispatcher (Fire ConfigurationEvent: pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1)][CETConfigurationFactory:82] Adding CET for company 34309694190670 and client extension Liferay Sample Custom Element 1


2024-12-19 10:35:48.116 INFO  [fileinstall-directory-watcher][BundleStartStopLogger:71] STOPPED liferaysamplecustomelement1_7.4.3.131 [1383]
2024-12-19 10:35:48.127 INFO  [CM Event Dispatcher (Fire ConfigurationEvent: pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1)][CETConfigurationFactory:126] Notified from OSGi about deactivation of client extension Liferay Sample Custom Element 1
2024-12-19 10:35:48.128 INFO  [CM Event Dispatcher (Fire ConfigurationEvent: pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1)][CETConfigurationFactory:136] Deleting CET for company 34309694190670 and client extension Liferay Sample Custom Element 1
2024-12-19 10:35:48.133 INFO  [CM Event Dispatcher (Fire ConfigurationEvent: pid=com.liferay.client.extension.type.configuration.CETConfiguration~liferay-sample-custom-element-1)][CETConfigurationFactory:145] Deleting client extension relations (if any) for company 34309694190670 and client extension Liferay Sample Custom Element 1
```
