### PR TITLE
LPD-44561 Refactor cookies-banner-web view.jsp to remove inline styles

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/css/main.scss
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/css/main.scss
@@ -3,6 +3,7 @@
 .cookies-banner {
 	background-color: $cadmin-white;
 	box-shadow: $cadmin-box-shadow-lg;
+	display: none;
 	left: 0;
 	right: 0;
 	z-index: 990;

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/dynamic_include/init.jsp" %>
 
-<div aria-label="banner cookies" class="cookies-banner cookies-banner-bottom" role="dialog" style="display: none;">
+<div aria-label="banner cookies" class="cookies-banner cookies-banner-bottom" role="dialog">
 	<liferay-portlet:runtime
 		portletName="<%= CookiesBannerPortletKeys.COOKIES_BANNER %>"
 	/>


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-44561

<h1>Refactor cookies-banner-web view.jsp to remove inline styles</h1>

The goal of this PR is to remove inline styles from `modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/dynamic_include/view.jsp ` as part of our plan to comply with the CSP policies.

The patter has been to move inline style to portlet `main.css` file. As code relies on `cookies-banner` class to toggle cookies banner appearance, I've place the `display: none` rule inside the rest of that class' rules.