### PR TITLE
LPD-45477 Disable checkbox when building ManagementToolbar

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web-test/src/testIntegration/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/test/ClaySamplePortletTest.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web-test/src/testIntegration/java/com/liferay/frontend/taglib/clay/sample/web/internal/portlet/test/ClaySamplePortletTest.java
@@ -60,6 +60,35 @@ public class ClaySamplePortletTest {
 	}
 
 	@Test
+	public void testCheckboxIsDisabled() throws Exception {
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		LayoutTestUtil.addPortletToLayout(
+			TestPropsValues.getUserId(), layout, _PORTLET_NAME, "column-1",
+			null);
+
+		PortletContainerTestUtil.Response response =
+			PortletContainerTestUtil.request(
+				PortletURLBuilder.create(
+					_portletURLFactory.create(
+						PortletContainerTestUtil.getHttpServletRequest(
+							_group, layout),
+						_PORTLET_NAME, layout.getPlid(),
+						PortletRequest.RENDER_PHASE)
+				).buildString());
+
+		String body = response.getBody();
+
+		Assert.assertTrue(
+			body.contains(
+				"<li class=\"nav-item\"><div class=\"custom-control " +
+					"custom-checkbox\"><label><input disabled"));
+	}
+
+	@Test
 	public void testPublishLayoutWithClaySamplePortlet() throws Exception {
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ManagementToolbarTag.java
@@ -756,20 +756,18 @@ public class ManagementToolbarTag extends BaseContainerTag {
 			pageContext);
 
 		Boolean disabled = isDisabled();
+
 		Integer itemsTotal = getItemsTotal();
 		String localizedItemsType = _getLocalizedItemsType();
 		Integer selectedItems = getSelectedItems();
 
 		if (isSelectable()) {
 			jspWriter.write("<li class=\"nav-item\"><div class=\"");
-			jspWriter.write("custom-control custom-checkbox\"><label><input");
+			jspWriter.write(
+				"custom-control custom-checkbox\"><label><input disabled");
 
 			if (active) {
 				jspWriter.write(" checked");
-			}
-
-			if (disabled) {
-				jspWriter.write(" disabled");
 			}
 
 			jspWriter.write(" aria-label=\"");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-45477

With a slow connection, the toolbar checkbox can be interacted with and when the page fully loads it will get reset.
To avoid this, I disabled the checkbox and once the page is fully loaded it will enable again.

Please let me know if there are any questions or comments about this.
Thank you!