### PR TITLE
LPD-45630 Parse HTML only when necessary

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor4/BaseEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor4/BaseEditor.js
@@ -104,6 +104,10 @@ const BaseEditor = forwardRef(
 				data = data.replace(/(\u200B){7}/, '');
 			}
 
+			if (editor.config?.extraPlugins.search(/bbcode|creole/) > -1) {
+				return data;
+			}
+
 			return createElementFromHTML(data);
 		}, [contents]);
 

--- a/modules/test/playwright/tests/message-boards-web/mbThread.spec.ts
+++ b/modules/test/playwright/tests/message-boards-web/mbThread.spec.ts
@@ -44,3 +44,27 @@ test(
 		await expect(messageBoardsEditThreadPage.bodyTextBox).toBeVisible();
 	}
 );
+
+test(
+	'BBcode not parsed as HTML',
+	{
+		tag: '@LPD-45630',
+	},
+	async ({messageBoardsEditThreadPage, page, site}) => {
+		await messageBoardsEditThreadPage.publishNewBasicThread(
+			'MB subject',
+			`
+- [b]BBcode list item strong / bold[/b]
+
+- Another BBCode list item
+(Lorem ipsum dolor sit amet consectetur adipisicing elit)
+
+- Lorem ipsum dolor sit amet consectetur adipisicing   40  elit
+   (consectetur adipisicing elit) ab 01/2022
+`,
+			site.friendlyUrlPath
+		);
+
+		expect(page.getByText('&nbsp;')).toBeHidden();
+	}
+);


### PR DESCRIPTION
>[!NOTE]
> **LPP related:** https://liferay.atlassian.net/browse/LPP-57283


# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-45630

After this [change in BaseEditor.js](https://github.com/liferay-frontend/liferay-portal/pull/3540/files#diff-3e4a5ce50757bceeee06d561c2f04f810e021a19c89c439e949205c85292a616R61) ([LPS-187501](https://liferay.atlassian.net/browse/LPS-187501)) we assume that we are always working with HTML, but sometimes we are working on bbcode (in messageboard by default) or creole (in wiki).

# How am I fixing it?

I only executed `createElementFromHTML` if I did not find `bbcode` or `creole` in the `editor.config.extraPlugins`


# How can you verify that it works?
Follow the reproduction steps https://liferay.atlassian.net/browse/LPD-45630

## Before the PR
![image](https://github.com/user-attachments/assets/0894d66f-216b-4d47-b29a-d36dfb468e6a)


## After the PR

![image](https://github.com/user-attachments/assets/8228e60d-754c-4519-95ee-65b7e5f4bb73)
