### PR TITLE
LPD-40961 Indicate and Disable Used Java/Code Data Sets in System Data Set Creation Modal

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/package.json
@@ -20,6 +20,7 @@
 		"@clayui/multi-select": "3.124.0",
 		"@clayui/navigation-bar": "3.123.1",
 		"@clayui/panel": "3.119.0",
+		"@clayui/sticker": "3.111.0",
 		"@clayui/table": "3.111.0",
 		"@clayui/tabs": "3.119.0",
 		"@clayui/tooltip": "3.119.0",

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
@@ -142,19 +142,6 @@ public class FDSAdminDisplayContext {
 			));
 	}
 
-	public String getGetSystemDataSetsURL() {
-		ResourceURL resourceURL =
-			(ResourceURL)PortalUtil.getControlPanelPortletURL(
-				_renderRequest, _themeDisplay.getScopeGroup(),
-				FDSAdminPortletKeys.FDS_ADMIN, 0, 0,
-				RenderRequest.RESOURCE_PHASE);
-
-		resourceURL.setResourceID(
-			"/frontend_data_set_admin/get_system_data_sets");
-
-		return resourceURL.toString();
-	}
-
 	public String getImportSystemDataSetURL() {
 		ResourceURL resourceURL =
 			(ResourceURL)PortalUtil.getControlPanelPortletURL(
@@ -235,6 +222,19 @@ public class FDSAdminDisplayContext {
 
 		resourceURL.setResourceID(
 			"/frontend_data_set_admin/save_data_set_table_sections");
+
+		return resourceURL.toString();
+	}
+
+	public String getSystemDataSetsURL() {
+		ResourceURL resourceURL =
+			(ResourceURL)PortalUtil.getControlPanelPortletURL(
+				_renderRequest, _themeDisplay.getScopeGroup(),
+				FDSAdminPortletKeys.FDS_ADMIN, 0, 0,
+				RenderRequest.RESOURCE_PHASE);
+
+		resourceURL.setResourceID(
+			"/frontend_data_set_admin/get_system_data_sets");
 
 		return resourceURL.toString();
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/display/context/FDSAdminDisplayContext.java
@@ -142,6 +142,19 @@ public class FDSAdminDisplayContext {
 			));
 	}
 
+	public String getGetSystemDataSetsURL() {
+		ResourceURL resourceURL =
+			(ResourceURL)PortalUtil.getControlPanelPortletURL(
+				_renderRequest, _themeDisplay.getScopeGroup(),
+				FDSAdminPortletKeys.FDS_ADMIN, 0, 0,
+				RenderRequest.RESOURCE_PHASE);
+
+		resourceURL.setResourceID(
+			"/frontend_data_set_admin/get_system_data_sets");
+
+		return resourceURL.toString();
+	}
+
 	public String getImportSystemDataSetURL() {
 		ResourceURL resourceURL =
 			(ResourceURL)PortalUtil.getControlPanelPortletURL(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -65,8 +65,9 @@ public class GetSystemDataSetsMVCResourceCommand
 					WebKeys.THEME_DISPLAY);
 
 			ObjectDefinition dataSetObjectDefinition =
-				_objectDefinitionLocalService.fetchObjectDefinition(
-					themeDisplay.getCompanyId(), "DataSet");
+				_objectDefinitionLocalService.
+					getObjectDefinitionByExternalReferenceCode(
+						"L_DATA_SET", themeDisplay.getCompanyId());
 
 			HttpServletRequest httpServletRequest =
 				_portal.getOriginalServletRequest(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -8,11 +8,17 @@ package com.liferay.frontend.data.set.admin.web.internal.portlet.action;
 import com.liferay.frontend.data.set.SystemFDSEntry;
 import com.liferay.frontend.data.set.SystemFDSEntryRegistry;
 import com.liferay.frontend.data.set.admin.web.internal.constants.FDSAdminPortletKeys;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Set;
 
@@ -40,6 +46,13 @@ public class GetSystemDataSetsMVCResourceCommand
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		ObjectDefinition dataSetObjectDefinition =
+			_objectDefinitionLocalService.fetchObjectDefinition(
+				themeDisplay.getCompanyId(), "DataSet");
+
 		Set<String> systemFDSNames =
 			_systemFDSEntryRegistry.getSystemFDSNames();
 
@@ -60,9 +73,23 @@ public class GetSystemDataSetsMVCResourceCommand
 								_systemFDSEntryRegistry.getSystemFDSEntry(
 									systemFDSName);
 
+							ObjectEntry objectEntry =
+								_objectEntryLocalService.fetchObjectEntry(
+									systemFDSEntry.getName(),
+									dataSetObjectDefinition.
+										getObjectDefinitionId());
+
+							boolean customized = false;
+
+							if (objectEntry != null) {
+								customized = true;
+							}
+
 							return JSONUtil.put(
 								"additionalAPIURLParameters",
 								systemFDSEntry.getAdditionalAPIURLParameters()
+							).put(
+								"customized", customized
 							).put(
 								"defaultItemsPerPage",
 								systemFDSEntry.getDefaultItemsPerPage()
@@ -88,6 +115,12 @@ public class GetSystemDataSetsMVCResourceCommand
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private SystemFDSEntryRegistry _systemFDSEntryRegistry;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -58,78 +58,78 @@ public class GetSystemDataSetsMVCResourceCommand
 			JSONPortletResponseUtil.writeJSON(
 				resourceRequest, resourceResponse,
 				JSONUtil.put("items", _jsonFactory.createJSONArray()));
+
+			return;
 		}
-		else {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)resourceRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
 
-			ObjectDefinition dataSetObjectDefinition =
-				_objectDefinitionLocalService.
-					getObjectDefinitionByExternalReferenceCode(
-						"L_DATA_SET", themeDisplay.getCompanyId());
+		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
-			HttpServletRequest httpServletRequest =
-				_portal.getOriginalServletRequest(
-					_portal.getHttpServletRequest(resourceRequest));
+		ObjectDefinition dataSetObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_DATA_SET", themeDisplay.getCompanyId());
 
-			String search = ParamUtil.getString(httpServletRequest, "search");
+		HttpServletRequest httpServletRequest =
+			_portal.getOriginalServletRequest(
+				_portal.getHttpServletRequest(resourceRequest));
 
-			JSONPortletResponseUtil.writeJSON(
-				resourceRequest, resourceResponse,
-				JSONUtil.put(
-					"items",
-					JSONUtil.toJSONArray(
-						systemFDSNames,
-						systemFDSName -> {
-							SystemFDSEntry systemFDSEntry =
-								_systemFDSEntryRegistry.getSystemFDSEntry(
-									systemFDSName);
+		String search = ParamUtil.getString(httpServletRequest, "search");
 
-							if (!StringUtil.matchesIgnoreCase(
-									systemFDSEntry.getTitle(), search)) {
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse,
+			JSONUtil.put(
+				"items",
+				JSONUtil.toJSONArray(
+					systemFDSNames,
+					systemFDSName -> {
+						SystemFDSEntry systemFDSEntry =
+							_systemFDSEntryRegistry.getSystemFDSEntry(
+								systemFDSName);
 
-								return null;
-							}
+						if (!StringUtil.matchesIgnoreCase(
+								systemFDSEntry.getTitle(), search)) {
 
-							ObjectEntry objectEntry =
-								_objectEntryLocalService.fetchObjectEntry(
-									systemFDSEntry.getName(),
-									dataSetObjectDefinition.
-										getObjectDefinitionId());
+							return null;
+						}
 
-							boolean customized = false;
+						ObjectEntry objectEntry =
+							_objectEntryLocalService.fetchObjectEntry(
+								systemFDSEntry.getName(),
+								dataSetObjectDefinition.
+									getObjectDefinitionId());
 
-							if (objectEntry != null) {
-								customized = true;
-							}
+						boolean customized = false;
 
-							return JSONUtil.put(
-								"additionalAPIURLParameters",
-								systemFDSEntry.getAdditionalAPIURLParameters()
-							).put(
-								"customized", customized
-							).put(
-								"defaultItemsPerPage",
-								systemFDSEntry.getDefaultItemsPerPage()
-							).put(
-								"description", systemFDSEntry.getDescription()
-							).put(
-								"name", systemFDSEntry.getName()
-							).put(
-								"restApplication",
-								systemFDSEntry.getRESTApplication()
-							).put(
-								"restEndpoint", systemFDSEntry.getRESTEndpoint()
-							).put(
-								"restSchema", systemFDSEntry.getRESTSchema()
-							).put(
-								"symbol", systemFDSEntry.getSymbol()
-							).put(
-								"title", systemFDSEntry.getTitle()
-							);
-						})));
-		}
+						if (objectEntry != null) {
+							customized = true;
+						}
+
+						return JSONUtil.put(
+							"additionalAPIURLParameters",
+							systemFDSEntry.getAdditionalAPIURLParameters()
+						).put(
+							"customized", customized
+						).put(
+							"defaultItemsPerPage",
+							systemFDSEntry.getDefaultItemsPerPage()
+						).put(
+							"description", systemFDSEntry.getDescription()
+						).put(
+							"name", systemFDSEntry.getName()
+						).put(
+							"restApplication",
+							systemFDSEntry.getRESTApplication()
+						).put(
+							"restEndpoint", systemFDSEntry.getRESTEndpoint()
+						).put(
+							"restSchema", systemFDSEntry.getRESTSchema()
+						).put(
+							"symbol", systemFDSEntry.getSymbol()
+						).put(
+							"title", systemFDSEntry.getTitle()
+						);
+					})));
 	}
 
 	@Reference

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -103,12 +103,12 @@ public class GetSystemDataSetsMVCResourceCommand
 							"additionalAPIURLParameters",
 							systemFDSEntry.getAdditionalAPIURLParameters()
 						).put(
-							"created", objectEntry != null
-						).put(
 							"defaultItemsPerPage",
 							systemFDSEntry.getDefaultItemsPerPage()
 						).put(
 							"description", systemFDSEntry.getDescription()
+						).put(
+							"imported", objectEntry != null
 						).put(
 							"name", systemFDSEntry.getName()
 						).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.admin.web.internal.portlet.action;
+
+import com.liferay.frontend.data.set.SystemFDSEntry;
+import com.liferay.frontend.data.set.SystemFDSEntryRegistry;
+import com.liferay.frontend.data.set.admin.web.internal.constants.FDSAdminPortletKeys;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+
+import java.util.Set;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Kevin Tan
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + FDSAdminPortletKeys.FDS_ADMIN,
+		"mvc.command.name=/frontend_data_set_admin/get_system_data_sets"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetSystemDataSetsMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		Set<String> systemFDSNames =
+			_systemFDSEntryRegistry.getSystemFDSNames();
+
+		if (systemFDSNames == null) {
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put("items", _jsonFactory.createJSONArray()));
+		}
+		else {
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put(
+					"items",
+					JSONUtil.toJSONArray(
+						systemFDSNames,
+						systemFDSName -> {
+							SystemFDSEntry systemFDSEntry =
+								_systemFDSEntryRegistry.getSystemFDSEntry(
+									systemFDSName);
+
+							return JSONUtil.put(
+								"additionalAPIURLParameters",
+								systemFDSEntry.getAdditionalAPIURLParameters()
+							).put(
+								"defaultItemsPerPage",
+								systemFDSEntry.getDefaultItemsPerPage()
+							).put(
+								"description", systemFDSEntry.getDescription()
+							).put(
+								"name", systemFDSEntry.getName()
+							).put(
+								"restApplication",
+								systemFDSEntry.getRESTApplication()
+							).put(
+								"restEndpoint", systemFDSEntry.getRESTEndpoint()
+							).put(
+								"restSchema", systemFDSEntry.getRESTSchema()
+							).put(
+								"symbol", systemFDSEntry.getSymbol()
+							).put(
+								"title", systemFDSEntry.getTitle()
+							);
+						})));
+		}
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private SystemFDSEntryRegistry _systemFDSEntryRegistry;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -99,17 +99,17 @@ public class GetSystemDataSetsMVCResourceCommand
 								dataSetObjectDefinition.
 									getObjectDefinitionId());
 
-						boolean customized = false;
+						boolean created = false;
 
 						if (objectEntry != null) {
-							customized = true;
+							created = true;
 						}
 
 						return JSONUtil.put(
 							"additionalAPIURLParameters",
 							systemFDSEntry.getAdditionalAPIURLParameters()
 						).put(
-							"customized", customized
+							"created", created
 						).put(
 							"defaultItemsPerPage",
 							systemFDSEntry.getDefaultItemsPerPage()

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -99,17 +99,11 @@ public class GetSystemDataSetsMVCResourceCommand
 								dataSetObjectDefinition.
 									getObjectDefinitionId());
 
-						boolean created = false;
-
-						if (objectEntry != null) {
-							created = true;
-						}
-
 						return JSONUtil.put(
 							"additionalAPIURLParameters",
 							systemFDSEntry.getAdditionalAPIURLParameters()
 						).put(
-							"created", created
+							"created", objectEntry != null
 						).put(
 							"defaultItemsPerPage",
 							systemFDSEntry.getDefaultItemsPerPage()

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java
@@ -18,12 +18,17 @@ import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Set;
 
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -46,13 +51,6 @@ public class GetSystemDataSetsMVCResourceCommand
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)resourceRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		ObjectDefinition dataSetObjectDefinition =
-			_objectDefinitionLocalService.fetchObjectDefinition(
-				themeDisplay.getCompanyId(), "DataSet");
-
 		Set<String> systemFDSNames =
 			_systemFDSEntryRegistry.getSystemFDSNames();
 
@@ -62,6 +60,20 @@ public class GetSystemDataSetsMVCResourceCommand
 				JSONUtil.put("items", _jsonFactory.createJSONArray()));
 		}
 		else {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)resourceRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			ObjectDefinition dataSetObjectDefinition =
+				_objectDefinitionLocalService.fetchObjectDefinition(
+					themeDisplay.getCompanyId(), "DataSet");
+
+			HttpServletRequest httpServletRequest =
+				_portal.getOriginalServletRequest(
+					_portal.getHttpServletRequest(resourceRequest));
+
+			String search = ParamUtil.getString(httpServletRequest, "search");
+
 			JSONPortletResponseUtil.writeJSON(
 				resourceRequest, resourceResponse,
 				JSONUtil.put(
@@ -72,6 +84,12 @@ public class GetSystemDataSetsMVCResourceCommand
 							SystemFDSEntry systemFDSEntry =
 								_systemFDSEntryRegistry.getSystemFDSEntry(
 									systemFDSName);
+
+							if (!StringUtil.matchesIgnoreCase(
+									systemFDSEntry.getTitle(), search)) {
+
+								return null;
+							}
 
 							ObjectEntry objectEntry =
 								_objectEntryLocalService.fetchObjectEntry(
@@ -121,6 +139,9 @@ public class GetSystemDataSetsMVCResourceCommand
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private SystemFDSEntryRegistry _systemFDSEntryRegistry;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/css/DataSets.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/css/DataSets.scss
@@ -22,6 +22,17 @@ html#{$cadmin-selector} .cadmin {
 			border-radius: 4px;
 			margin-bottom: 12px;
 
+			&.disabled {
+				background-color: #f7f7f7;
+
+				.list-group-text,
+				.list-group-title,
+				.sticker {
+					background-color: #f7f7f7;
+					color: #757575;
+				}
+			}
+
 			&.selected {
 				background-color: #f0f5ff;
 				border-color: #80acff;
@@ -30,6 +41,10 @@ html#{$cadmin-selector} .cadmin {
 
 			.selection-control {
 				display: none;
+			}
+
+			.used-label {
+				margin: 0.5rem 0;
 			}
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/css/DataSets.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/css/DataSets.scss
@@ -39,12 +39,12 @@ html#{$cadmin-selector} .cadmin {
 				box-shadow: 0 2px 4px rgba(39, 40, 51, 0.12);
 			}
 
-			.selection-control {
-				display: none;
+			.created-label {
+				margin: 0.5rem 0;
 			}
 
-			.used-label {
-				margin: 0.5rem 0;
+			.selection-control {
+				display: none;
 			}
 		}
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -130,16 +130,16 @@ const SystemDataSetModalList = ({
 
 const SelectSystemDataSetModalContent = ({
 	closeModal,
+	getSystemDataSetsURL,
 	importSystemDataSetURL,
 	loadData,
 	namespace,
-	systemDataSets,
 }: {
 	closeModal: Function;
+	getSystemDataSetsURL: string;
 	importSystemDataSetURL: string;
 	loadData: Function;
 	namespace: string;
-	systemDataSets: Array<ISystemDataSet>;
 }) => {
 	const [createButtonDisabled, setCreateButtonDisabled] = useState(false);
 	const [selectedSystemDataSet, setSelectedSystemDataSet] =
@@ -184,8 +184,8 @@ const SelectSystemDataSetModalContent = ({
 			<ClayModal.Body>
 				<FrontendDataSet
 					{...FDS_DEFAULT_PROPS}
+					apiURL={getSystemDataSetsURL}
 					id="SystemDataSets"
-					items={systemDataSets}
 					onSelect={({
 						selectedItems,
 					}: {
@@ -229,11 +229,13 @@ const SelectSystemDataSetModalContent = ({
 
 const SystemDataSets = ({
 	editDataSetURL,
+	getSystemDataSetsURL,
 	importSystemDataSetURL,
 	namespace,
 	systemDataSets,
 }: {
 	editDataSetURL: string;
+	getSystemDataSetsURL: string;
 	importSystemDataSetURL: string;
 	namespace: string;
 	systemDataSets: Array<ISystemDataSet>;
@@ -319,10 +321,10 @@ const SystemDataSets = ({
 						}) => (
 							<SelectSystemDataSetModalContent
 								closeModal={closeModal}
+								getSystemDataSetsURL={getSystemDataSetsURL}
 								importSystemDataSetURL={importSystemDataSetURL}
 								loadData={loadData}
 								namespace={namespace}
-								systemDataSets={systemDataSets}
 							/>
 						),
 						size: 'lg',

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -35,7 +35,7 @@ interface IFrontendDataSetContext {
 	selectedItemsValue: Array<any>;
 }
 
-const SystemDataSetModalList = ({
+const SystemDataSetsView = ({
 	frontendDataSetContext,
 	items,
 }: {
@@ -197,7 +197,7 @@ const SelectSystemDataSetModalContent = ({
 					selectionType="single"
 					views={[
 						{
-							component: SystemDataSetModalList,
+							component: SystemDataSetsView,
 						},
 					]}
 				/>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -141,7 +141,7 @@ const SelectSystemDataSetModalContent = ({
 	loadData: Function;
 	namespace: string;
 }) => {
-	const [createButtonDisabled, setCreateButtonDisabled] = useState(false);
+	const [createButtonDisabled, setCreateButtonDisabled] = useState(true);
 	const [selectedSystemDataSet, setSelectedSystemDataSet] =
 		useState<ISystemDataSet | null>(null);
 
@@ -215,7 +215,9 @@ const SelectSystemDataSetModalContent = ({
 						</ClayButton>
 
 						<ClayButton
-							disabled={createButtonDisabled}
+							disabled={
+								createButtonDisabled && !selectedSystemDataSet
+							}
 							onClick={onCreateButtonClick}
 						>
 							{Liferay.Language.get('create')}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -56,7 +56,7 @@ const SystemDataSetModalList = ({
 				return (
 					<ClayList.Item
 						className={classNames({
-							disabled: item.customized,
+							disabled: item.created,
 							selectable,
 							selected: selectedItemsValue?.includes(
 								item[selectedItemsKey]
@@ -111,13 +111,13 @@ const SystemDataSetModalList = ({
 							</ClayList.ItemText>
 						</ClayList.ItemField>
 
-						{item.customized && (
+						{item.created && (
 							<ClayList.ItemField>
 								<ClayLabel
-									className="used-label"
+									className="created-label"
 									displayType="warning"
 								>
-									{Liferay.Language.get('used')}
+									{Liferay.Language.get('created')}
 								</ClayLabel>
 							</ClayList.ItemField>
 						)}
@@ -393,7 +393,7 @@ const SystemDataSets = ({
 					image: '/states/empty_state.svg',
 					title: Liferay.Language.get('no-system-data-sets-created'),
 				}}
-				id="CustomizedSystemDataSets"
+				id="CreatedSystemDataSets"
 				itemsActions={[
 					{
 						data: {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -56,7 +56,7 @@ const SystemDataSetsView = ({
 				return (
 					<ClayList.Item
 						className={classNames({
-							disabled: item.created,
+							disabled: item.imported,
 							selectable,
 							selected: selectedItemsValue?.includes(
 								item[selectedItemsKey]
@@ -111,7 +111,7 @@ const SystemDataSetsView = ({
 							</ClayList.ItemText>
 						</ClayList.ItemField>
 
-						{item.created && (
+						{item.imported && (
 							<ClayList.ItemField>
 								<ClayLabel
 									className="created-label"

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -4,12 +4,18 @@
  */
 
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
 
 import '../css/DataSets.scss';
 
 import ClayButton from '@clayui/button';
+import {ClayRadio} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import ClayList from '@clayui/list';
 import ClayModal from '@clayui/modal';
+import ClaySticker from '@clayui/sticker';
+import classNames from 'classnames';
 import {fetch, navigate, openModal} from 'frontend-js-web';
 
 import {
@@ -20,6 +26,107 @@ import {
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 import openDefaultSuccessToast from './utils/openDefaultSuccessToast';
 import {IDataSet, ISystemDataSet} from './utils/types';
+
+interface IFrontendDataSetContext {
+	onSelect: Function;
+	selectItems: Function;
+	selectable: boolean;
+	selectedItemsKey: keyof ISystemDataSet;
+	selectedItemsValue: Array<any>;
+}
+
+const SystemDataSetModalList = ({
+	frontendDataSetContext,
+	items,
+}: {
+	frontendDataSetContext: any;
+	items: Array<ISystemDataSet>;
+}) => {
+	const {
+		onSelect,
+		selectItems,
+		selectable,
+		selectedItemsKey,
+		selectedItemsValue,
+	} = useContext(frontendDataSetContext) as IFrontendDataSetContext;
+
+	return (
+		<ClayList>
+			{items.map((item) => {
+				return (
+					<ClayList.Item
+						className={classNames({
+							disabled: item.customized,
+							selectable,
+							selected: selectedItemsValue?.includes(
+								item[selectedItemsKey]
+							),
+						})}
+						flex
+						key={item.name}
+						onClick={() => {
+							if (selectable) {
+								selectItems(item[selectedItemsKey]);
+
+								onSelect({selectedItems: [item]});
+							}
+						}}
+					>
+						<ClayList.ItemField className="justify-content-center selection-control">
+							<ClayRadio
+								checked={
+									selectedItemsValue
+										? selectedItemsValue
+												.map((element) =>
+													String(element)
+												)
+												.includes(
+													String(
+														item[selectedItemsKey]
+													)
+												)
+										: false
+								}
+								onChange={() => {}}
+								value=""
+							/>
+						</ClayList.ItemField>
+
+						<ClayList.ItemField>
+							<ClaySticker displayType="dark">
+								<ClayIcon symbol={item.symbol} />
+							</ClaySticker>
+						</ClayList.ItemField>
+
+						<ClayList.ItemField
+							className="justify-content-center"
+							expand
+						>
+							<ClayList.ItemTitle>
+								{item.title}
+							</ClayList.ItemTitle>
+
+							<ClayList.ItemText>
+								{item.description}
+							</ClayList.ItemText>
+						</ClayList.ItemField>
+
+						{item.customized && (
+							<ClayList.ItemField>
+								<ClayLabel
+									className="used-label"
+									displayType="warning"
+								>
+									{Liferay.Language.get('used')}
+								</ClayLabel>
+							</ClayList.ItemField>
+						)}
+					</ClayList.Item>
+				);
+			})}
+		</ClayList>
+	);
+};
 
 const SelectSystemDataSetModalContent = ({
 	closeModal,
@@ -90,13 +197,7 @@ const SelectSystemDataSetModalContent = ({
 					selectionType="single"
 					views={[
 						{
-							contentRenderer: 'list',
-							name: 'list',
-							schema: {
-								description: 'description',
-								symbol: 'symbol',
-								title: 'title',
-							},
+							component: SystemDataSetModalList,
 						},
 					]}
 				/>
@@ -224,6 +325,7 @@ const SystemDataSets = ({
 								systemDataSets={systemDataSets}
 							/>
 						),
+						size: 'lg',
 					});
 				},
 			},

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -183,7 +183,7 @@ export interface ISelectionFilter extends IFilter {
 
 export interface ISystemDataSet {
 	additionalAPIURLParameters: string;
-	customized: boolean;
+	created: boolean;
 	defaultItemsPerPage: number;
 	description: string;
 	name: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -183,9 +183,9 @@ export interface ISelectionFilter extends IFilter {
 
 export interface ISystemDataSet {
 	additionalAPIURLParameters: string;
-	created: boolean;
 	defaultItemsPerPage: number;
 	description: string;
+	imported: boolean;
 	name: string;
 	restApplication: string;
 	restEndpoint: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -183,6 +183,7 @@ export interface ISelectionFilter extends IFilter {
 
 export interface ISystemDataSet {
 	additionalAPIURLParameters: string;
+	customized: boolean;
 	defaultItemsPerPage: number;
 	description: string;
 	name: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/system_data_sets.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/system_data_sets.jsp
@@ -14,7 +14,7 @@
 			HashMapBuilder.<String, Object>put(
 				"editDataSetURL", fdsAdminDisplayContext.getEditDataSetURL()
 			).put(
-				"getSystemDataSetsURL", fdsAdminDisplayContext.getGetSystemDataSetsURL()
+				"getSystemDataSetsURL", fdsAdminDisplayContext.getSystemDataSetsURL()
 			).put(
 				"importSystemDataSetURL", fdsAdminDisplayContext.getImportSystemDataSetURL()
 			).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/system_data_sets.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/system_data_sets.jsp
@@ -14,6 +14,8 @@
 			HashMapBuilder.<String, Object>put(
 				"editDataSetURL", fdsAdminDisplayContext.getEditDataSetURL()
 			).put(
+				"getSystemDataSetsURL", fdsAdminDisplayContext.getGetSystemDataSetsURL()
+			).put(
 				"importSystemDataSetURL", fdsAdminDisplayContext.getImportSystemDataSetURL()
 			).put(
 				"namespace", liferayPortletResponse.getNamespace()

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/SystemDataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/SystemDataSetsPage.ts
@@ -11,12 +11,12 @@ export class SystemDataSetsPage {
 	private readonly applicationsMenuPage: ApplicationsMenuPage;
 	readonly createButton: Locator;
 	readonly creationModal: {
-		readonly cancel: Locator;
+		readonly cancelButton: Locator;
 		readonly container: Locator;
 		readonly createButton: Locator;
 		readonly header: Locator;
 		readonly listItems: Locator;
-		readonly search: Locator;
+		readonly searchInput: Locator;
 	};
 	readonly page: Page;
 	readonly pageContainer: Locator;
@@ -38,7 +38,7 @@ export class SystemDataSetsPage {
 		);
 
 		this.creationModal = {
-			cancel: creationModalContainer.getByRole('button', {
+			cancelButton: creationModalContainer.getByRole('button', {
 				name: 'Cancel',
 			}),
 			container: creationModalContainer,
@@ -47,7 +47,7 @@ export class SystemDataSetsPage {
 			}),
 			header: creationModalContainer.locator('.modal-header'),
 			listItems: creationModalContainer.getByRole('listitem'),
-			search: creationModalContainer.getByPlaceholder('Search'),
+			searchInput: creationModalContainer.getByPlaceholder('Search'),
 		};
 		this.page = page;
 		this.pageContainer = systemDataSetsPageContainer;

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
@@ -26,7 +26,7 @@ export const test = mergeTests(
 
 test(
 	'Import a system data set to customize',
-	{tag: '@LPD-37531'},
+	{tag: ['@LPD-37531', '@LPD-40949']},
 	async ({actionsPage, page, systemDataSetsPage}) => {
 		await test.step('Navigate to system data sets page', async () => {
 			await systemDataSetsPage.goto();
@@ -50,19 +50,23 @@ test(
 				)
 			).toBeVisible();
 
-			await expect(creationModal.search).toBeVisible();
+			await expect(creationModal.searchInput).toBeVisible();
 
 			await expect(classicSampleListItem).toBeVisible();
 			await expect(customizedSampleListItem).toBeVisible();
 		});
 
 		await test.step('Search system data set items', async () => {
-			await creationModal.search.fill('Classic');
+			await creationModal.searchInput.fill('Classic');
+
+			await creationModal.searchInput.press('Enter');
 
 			await expect(classicSampleListItem).toBeVisible();
 			await expect(customizedSampleListItem).toBeHidden();
 
-			await creationModal.search.fill('aaa');
+			await creationModal.searchInput.fill('aaa');
+
+			await creationModal.searchInput.press('Enter');
 
 			await expect(classicSampleListItem).toBeHidden();
 			await expect(customizedSampleListItem).toBeHidden();
@@ -71,7 +75,9 @@ test(
 				creationModal.container.getByText('No Results Found')
 			).toBeVisible();
 
-			await creationModal.search.fill('');
+			await creationModal.searchInput.fill('');
+
+			await creationModal.searchInput.press('Enter');
 
 			await expect(classicSampleListItem).toBeVisible();
 			await expect(customizedSampleListItem).toBeVisible();
@@ -93,6 +99,15 @@ test(
 
 		await test.step('Check system data set is imported', async () => {
 			await expect(customizedSampleRow).toBeVisible();
+		});
+
+		await test.step('Check the creation modal labels the data set as created and is disabled', async () => {
+			await systemDataSetsPage.createButton.click();
+
+			await expect(customizedSampleListItem).toContainText('Created');
+			await expect(customizedSampleListItem).toHaveClass(/disabled/);
+
+			await creationModal.cancelButton.click();
 		});
 
 		await test.step('Check item actions are imported', async () => {
@@ -156,11 +171,11 @@ test(
 			await expect(form.headlessActionKeyInput).toHaveValue('update');
 
 			await form.cancelButton.click();
+
+			await page.getByTitle('Back').click();
 		});
 
 		await test.step('Delete system data set', async () => {
-			await page.getByTitle('Back').click();
-
 			await customizedSampleRow.locator('.dropdown-toggle').click();
 
 			await systemDataSetsPage.page
@@ -175,6 +190,15 @@ test(
 			await waitForAlert(systemDataSetsPage.page);
 
 			await expect(customizedSampleRow).toBeHidden();
+		});
+
+		await test.step('Check the creation modal that the data set is enabled', async () => {
+			await systemDataSetsPage.createButton.click();
+
+			await expect(classicSampleListItem).not.toContainText('Created');
+			await expect(classicSampleListItem).not.toHaveClass(/disabled/);
+
+			await creationModal.cancelButton.click();
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
@@ -19,7 +19,6 @@ export const test = mergeTests(
 	featureFlagsTest({
 		'LPD-37531': {enabled: true},
 		'LPS-164563': {enabled: true},
-		'LPS-193005': {enabled: true},
 	}),
 	loginTest()
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
@@ -6,8 +6,10 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {waitForAlert} from '../../../../utils/waitForAlert';
+import {fdsSamplePageTest} from '../../../frontend-data-set-web/fixtures/fdsSamplePageTest';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import {actionsPageTest} from './fixtures/actionsPageTest';
 import {systemDataSetsPageTest} from './fixtures/systemDataSetsPageTest';
@@ -15,6 +17,8 @@ import {systemDataSetsPageTest} from './fixtures/systemDataSetsPageTest';
 export const test = mergeTests(
 	actionsPageTest,
 	dataSetManagerApiHelpersTest,
+	fdsSamplePageTest,
+	isolatedSiteTest,
 	systemDataSetsPageTest,
 	featureFlagsTest({
 		'LPD-37531': {enabled: true},
@@ -26,7 +30,11 @@ export const test = mergeTests(
 test(
 	'Import a system data set to customize',
 	{tag: ['@LPD-37531', '@LPD-40949']},
-	async ({actionsPage, systemDataSetsPage}) => {
+	async ({actionsPage, fdsSamplePage, site, systemDataSetsPage}) => {
+		await test.step('Add FDS Sample Widget for object definition generation', async () => {
+			await fdsSamplePage.setupFDSSampleWidget({site});
+		});
+
 		await test.step('Navigate to system data sets page', async () => {
 			await systemDataSetsPage.goto();
 		});

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/systemDataSets.spec.ts
@@ -26,7 +26,7 @@ export const test = mergeTests(
 test(
 	'Import a system data set to customize',
 	{tag: ['@LPD-37531', '@LPD-40949']},
-	async ({actionsPage, page, systemDataSetsPage}) => {
+	async ({actionsPage, systemDataSetsPage}) => {
 		await test.step('Navigate to system data sets page', async () => {
 			await systemDataSetsPage.goto();
 		});
@@ -96,100 +96,105 @@ test(
 			.locator('.fds tr')
 			.filter({hasText: 'Customized Sample'});
 
-		await test.step('Check system data set is imported', async () => {
-			await expect(customizedSampleRow).toBeVisible();
-		});
-
-		await test.step('Check the creation modal labels the data set as created and is disabled', async () => {
-			await systemDataSetsPage.createButton.click();
-
-			await expect(customizedSampleListItem).toContainText('Created');
-			await expect(customizedSampleListItem).toHaveClass(/disabled/);
-
-			await creationModal.cancelButton.click();
-		});
-
-		await test.step('Check item actions are imported', async () => {
-			await actionsPage.open({dataSetLabel: 'Customized Sample'});
-
-			const itemActionRow = actionsPage.itemActionsTable
-				.locator('tr')
-				.filter({hasText: 'Nav Links'})
-				.first();
-
-			await itemActionRow.locator('.dropdown-toggle').click();
-
-			await actionsPage.page
-				.locator('.dropdown-menu.show')
-				.getByRole('menuitem', {name: 'Edit'})
-				.click();
-
-			const form = actionsPage.actionForm;
-
-			await expect(form.labelInput).toHaveValue('Nav Links');
-			await expect(form.iconInput).toHaveValue('home');
-			await expect(form.typeSelect).toHaveValue('link');
-			await expect(form.urlInput).toHaveValue('#');
-			await expect(form.headlessActionKeyInput).toHaveValue('view');
-			await expect(form.confirmationMessageInput).toHaveValue(
-				'Are you sure?'
-			);
-			await expect(form.confirmationMessageTypeSelect).toHaveValue(
-				'danger'
-			);
-
-			await form.cancelButton.click();
-		});
-
-		await test.step('Check creation actions are imported', async () => {
-			await actionsPage.selectTab({
-				container: actionsPage.actionsTabs,
-				label: 'Creation Actions',
+		try {
+			await test.step('Check system data set is imported', async () => {
+				await expect(customizedSampleRow).toBeVisible();
 			});
 
-			const creationActionRow = actionsPage.creationActionsTable
-				.locator('tr')
-				.filter({hasText: 'Open Form'})
-				.first();
+			await test.step('Check the creation modal labels the data set as created and is disabled', async () => {
+				await systemDataSetsPage.createButton.click();
 
-			await creationActionRow.locator('.dropdown-toggle').click();
+				await expect(customizedSampleListItem).toContainText('Created');
+				await expect(customizedSampleListItem).toHaveClass(/disabled/);
 
-			await actionsPage.page
-				.locator('.dropdown-menu.show')
-				.getByRole('menuitem', {name: 'Edit'})
-				.click();
+				await creationModal.cancelButton.click();
+			});
 
-			const form = actionsPage.actionForm;
+			await test.step('Check item actions are imported', async () => {
+				await actionsPage.open({dataSetLabel: 'Customized Sample'});
 
-			await expect(form.labelInput).toHaveValue('Open Form');
-			await expect(form.iconInput).toHaveValue('bolt');
-			await expect(form.typeSelect).toHaveValue('modal');
-			await expect(form.variantSelect).toHaveValue('full-screen');
-			await expect(form.titleInput).toHaveValue('My Products');
-			await expect(form.urlInput).toHaveValue('#');
-			await expect(form.headlessActionKeyInput).toHaveValue('update');
+				const itemActionRow = actionsPage.itemActionsTable
+					.locator('tr')
+					.filter({hasText: 'Nav Links'})
+					.first();
 
-			await form.cancelButton.click();
+				await itemActionRow.locator('.dropdown-toggle').click();
 
-			await page.getByTitle('Back').click();
-		});
+				await actionsPage.page
+					.locator('.dropdown-menu.show')
+					.getByRole('menuitem', {name: 'Edit'})
+					.click();
 
-		await test.step('Delete system data set', async () => {
-			await customizedSampleRow.locator('.dropdown-toggle').click();
+				const form = actionsPage.actionForm;
 
-			await systemDataSetsPage.page
-				.locator('.dropdown-menu.show')
-				.getByRole('menuitem', {name: 'Delete'})
-				.click();
+				await expect(form.labelInput).toHaveValue('Nav Links');
+				await expect(form.iconInput).toHaveValue('home');
+				await expect(form.typeSelect).toHaveValue('link');
+				await expect(form.urlInput).toHaveValue('#');
+				await expect(form.headlessActionKeyInput).toHaveValue('view');
+				await expect(form.confirmationMessageInput).toHaveValue(
+					'Are you sure?'
+				);
+				await expect(form.confirmationMessageTypeSelect).toHaveValue(
+					'danger'
+				);
 
-			const deleteModal = systemDataSetsPage.page.getByRole('dialog');
+				await form.cancelButton.click();
+			});
 
-			await deleteModal.getByRole('button', {name: 'Delete'}).click();
+			await test.step('Check creation actions are imported', async () => {
+				await actionsPage.selectTab({
+					container: actionsPage.actionsTabs,
+					label: 'Creation Actions',
+				});
 
-			await waitForAlert(systemDataSetsPage.page);
+				const creationActionRow = actionsPage.creationActionsTable
+					.locator('tr')
+					.filter({hasText: 'Open Form'})
+					.first();
 
-			await expect(customizedSampleRow).toBeHidden();
-		});
+				await creationActionRow.locator('.dropdown-toggle').click();
+
+				await actionsPage.page
+					.locator('.dropdown-menu.show')
+					.getByRole('menuitem', {name: 'Edit'})
+					.click();
+
+				const form = actionsPage.actionForm;
+
+				await expect(form.labelInput).toHaveValue('Open Form');
+				await expect(form.iconInput).toHaveValue('bolt');
+				await expect(form.typeSelect).toHaveValue('modal');
+				await expect(form.variantSelect).toHaveValue('full-screen');
+				await expect(form.titleInput).toHaveValue('My Products');
+				await expect(form.urlInput).toHaveValue('#');
+				await expect(form.headlessActionKeyInput).toHaveValue('update');
+
+				await form.cancelButton.click();
+			});
+		}
+		finally {
+			await test.step('Navigate to system data sets page', async () => {
+				await systemDataSetsPage.goto();
+			});
+
+			await test.step('Delete system data set', async () => {
+				await customizedSampleRow.locator('.dropdown-toggle').click();
+
+				await systemDataSetsPage.page
+					.locator('.dropdown-menu.show')
+					.getByRole('menuitem', {name: 'Delete'})
+					.click();
+
+				const deleteModal = systemDataSetsPage.page.getByRole('dialog');
+
+				await deleteModal.getByRole('button', {name: 'Delete'}).click();
+
+				await waitForAlert(systemDataSetsPage.page);
+
+				await expect(customizedSampleRow).toBeHidden();
+			});
+		}
 
 		await test.step('Check the creation modal that the data set is enabled', async () => {
 			await systemDataSetsPage.createButton.click();


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPD-40949
**Subtask:** https://liferay.atlassian.net/browse/LPD-40961

---

- Labels and disables system data sets in the creation modal when a system data set is customized

Mainly wanted to check if this is on the right track:
- This creates an MVCResourceCommand for getting system data sets so when the creation modal is opened, the "used" labels will be up-to-date.
- "Used" system data sets are checked by fetching the object entry with the ERC. https://github.com/thektan/liferay-portal/blob/5f01f976754db36da28621e3574ccbf3ed52a8e6/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/java/com/liferay/frontend/data/set/admin/web/internal/portlet/action/GetSystemDataSetsMVCResourceCommand.java#L94-L98

If this repeated fetching isn't performant, I'm not sure if this possible, but if the System Data Set itself in the `SystemFDSEntryRegistry` could have a boolean property like `customized` that could be updated during the `ImportSystemDataSetMVCResourceCommand`. 

---

## Demo

https://github.com/user-attachments/assets/07879190-67e3-4460-b702-f3dd6a9817dc



