### PR TITLE
LPD-44620 Remove inline styles from frontend-js module

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js
@@ -15,7 +15,7 @@ AUI.add(
 		const STR_VALUE = 'value';
 
 		const TPL_FRAME =
-			'<iframe frameborder="0" height="0" id="{0}-poller" src="javascript:void(0);" style="display:none" tabindex="-1" title="empty" width="0"></iframe>';
+			'<iframe frameborder="0" height="0" id="{0}-poller" src="javascript:void(0);" tabindex="-1" title="empty" width="0"></iframe>';
 
 		const TPL_URL_UPDATE =
 			themeDisplay.getPathMain() +
@@ -101,6 +101,8 @@ AUI.add(
 					const tplFrame = Lang.sub(TPL_FRAME, [instance.get('id')]);
 
 					const frame = A.Node.create(tplFrame);
+
+					frame._node.style.display = 'none';
 
 					instance.get('boundingBox').placeBefore(frame);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/layout_exporter.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/layout_exporter.es.js
@@ -53,7 +53,7 @@ export function proposeLayout(options) {
 		contents +=
 			'<textarea name="' +
 			namespace +
-			'description" style="height: 100px; width: 284px;"></textarea><br /><br />' +
+			'description"></textarea><br /><br />' +
 			Liferay.Language.get('reviewer') +
 			' <select name="' +
 			namespace +


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-44620

<h1>LPD-44620 Remove inline styles from frontend-js module</h1>

The goal is to remove inline styles from frontend-js module. This affects two files:

**modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/progress.js** (The `display: none` style has been added directly to iframe node)

**modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/layout_exporter.es.js** (The inline style has been removed, since component is marked as deprecated (see [discussion])(https://liferay.atlassian.net/browse/LPD-44563?focusedCommentId=2823316)).