### PR TITLE
LPD-45713 playwright - Check for Brazilian variant of Portuguese when looking for a locator

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/customElement.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/customElement.spec.ts
@@ -220,7 +220,9 @@ test.describe('Client Extension admin', () => {
 				.click();
 
 			await page
-				.getByRole('menuitem', {name: /Not translated into Portuguese/})
+				.getByRole('menuitem', {
+					name: /Not translated into Portuguese \(Brazil\)/,
+				})
 				.click();
 
 			await clientExtensionsPage.fillNewCustomElementFormModal({


### PR DESCRIPTION
[Jira ticket](https://liferay.atlassian.net/browse/LPD-42310)

The problem was that CI had both regular and Brazilian Portuguese options for translations, whereas locally there is only one present.

The solution makes the selector more specific - it includes the `(Brazilian)` string to make sure it finds only one element.