### PR TITLE
LPD-46024 Data Set object definition model can't be imported when virtual instance default locale is changed

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
@@ -13,6 +13,7 @@
 	},
 	"items": [
 		{
+			"defaultLanguageId": "en_US",
 			"externalReferenceCode": "L_DATA_SET",
 			"label": {
 				"en_US": "Data Set"
@@ -390,6 +391,7 @@
 			"titleObjectFieldName": "label"
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_ACTION",
 			"label": {
@@ -636,6 +638,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"externalReferenceCode": "L_DATA_SET_CARDS_SECTION",
 			"label": {
 				"en_US": "Data Set Cards Section"
@@ -702,6 +705,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_CLIENT_EXTENSION_FILTER",
 			"label": {
@@ -772,6 +776,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_DATE_FILTER",
 			"label": {
@@ -874,6 +879,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"externalReferenceCode": "L_DATA_SET_LIST_SECTION",
 			"label": {
 				"en_US": "Data Set List Section"
@@ -940,6 +946,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_SELECTION_FILTER",
 			"label": {
@@ -1154,6 +1161,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_SORT",
 			"label": {
@@ -1240,6 +1248,7 @@
 			"system": true
 		},
 		{
+			"defaultLanguageId": "en_US",
 			"enableLocalization": true,
 			"externalReferenceCode": "L_DATA_SET_TABLE_SECTION",
 			"label": {

--- a/modules/apps/frontend-data-set/frontend-data-set-test/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Frontend Data Set Test
+Bundle-SymbolicName: com.liferay.frontend.data.set.test
+Bundle-Version: 1.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-test/build.gradle
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/test/DataSetObjectDefinitionsImportTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/test/DataSetObjectDefinitionsImportTest.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.data.set.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
+import com.liferay.batch.engine.unit.BatchEngineUnitReader;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.File;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Daniel Sanz
+ */
+@FeatureFlags({"LPD-34594", "LPS-164563"})
+@RunWith(Arquillian.class)
+public class DataSetObjectDefinitionsImportTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_triggerObjectDefinitionsBatchImport();
+	}
+
+	@Test
+	public void testImportObjectDefinitionsWithNondefaultLocale()
+		throws Exception {
+
+		_assertDataSetObjectDefinitionLabel("Data Set");
+
+		ObjectDefinition dataSetObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_DATA_SET", TestPropsValues.getCompanyId());
+
+		dataSetObjectDefinition.setLabel("Foo", LocaleUtil.SPAIN);
+
+		_objectDefinitionLocalService.updateObjectDefinition(
+			dataSetObjectDefinition);
+
+		_assertDataSetObjectDefinitionLabel("Foo");
+
+		Set<Locale> availableLocales = LanguageUtil.getAvailableLocales();
+		Locale defaultLocale = LocaleUtil.getDefault();
+
+		try {
+			CompanyTestUtil.resetCompanyLocales(
+				TestPropsValues.getCompanyId(),
+				SetUtil.fromArray(LocaleUtil.SPAIN), LocaleUtil.SPAIN);
+
+			_triggerObjectDefinitionsBatchImport();
+
+			_assertDataSetObjectDefinitionLabel("Data Set");
+		}
+		finally {
+			CompanyTestUtil.resetCompanyLocales(
+				TestPropsValues.getCompanyId(), availableLocales,
+				defaultLocale);
+		}
+	}
+
+	private void _assertDataSetObjectDefinitionLabel(String label)
+		throws Exception {
+
+		ObjectDefinition dataSetObjectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_DATA_SET", TestPropsValues.getCompanyId());
+
+		Assert.assertNotNull(dataSetObjectDefinition);
+
+		Assert.assertEquals(
+			label, dataSetObjectDefinition.getLabel(LocaleUtil.SPAIN));
+	}
+
+	private void _triggerObjectDefinitionsBatchImport() {
+		Bundle testBundle = FrameworkUtil.getBundle(
+			DataSetObjectDefinitionsImportTest.class);
+
+		BundleContext bundleContext = testBundle.getBundleContext();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			if (Objects.equals(
+					bundle.getSymbolicName(),
+					"com.liferay.frontend.data.set.impl")) {
+
+				File processedFile = bundle.getDataFile(
+					".com.liferay.frontend.data.set.internal.batch.01.object." +
+						"definition.batch.engine.data.json.0.processed");
+
+				if ((processedFile != null) && processedFile.exists()) {
+					processedFile.delete();
+				}
+
+				CompletableFuture<Void> completableFuture =
+					_batchEngineUnitProcessor.processBatchEngineUnits(
+						_batchEngineUnitReader.getBatchEngineUnits(bundle));
+
+				completableFuture.join();
+			}
+		}
+	}
+
+	@Inject
+	private BatchEngineUnitProcessor _batchEngineUnitProcessor;
+
+	@Inject
+	private BatchEngineUnitReader _batchEngineUnitReader;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+}

--- a/test.properties
+++ b/test.properties
@@ -4754,7 +4754,8 @@
 
     test.batch.names[frontend-data-set]=\
         functional-tomcat90-mysql57,\
-        js-unit
+        js-unit,\
+        modules-integration-mysql57
 
     test.batch.run.property.query[functional-tomcat90-mysql57][frontend-data-set]=\
         (portal.upstream == true) AND \


### PR DESCRIPTION
Reference: https://liferay.atlassian.net/browse/LPD-46024

In this PR we are making the DSM object definitions import process work when target company configures a different locale. This solution has been discussed with the BPM team after different considerations.

I'm adding an integration test that triggers the import process with the real json file. This can signal any issue in the process before our code reaches master. For the moment it's present in the `frontend` and `frontend-data-set` routines

kudos to @ccorreagg as he inspired this approach.
 
