### PR TITLE
LPD-44865 Update Selected Item Count to Reflect Total Data Set Selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -576,7 +576,7 @@ const FrontendDataSet = ({
 				selectionType={selectionType}
 				showSearch={showSearch}
 				sidePanelId={dataSetSupportSidePanelId}
-				total={items?.length ?? 0}
+				total={total}
 			/>
 		</div>
 	) : null;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -148,13 +148,21 @@ function BulkActions({
 						<ul className="navbar-nav">
 							<li className="nav-item">
 								<span className="text-truncate">
-									{sub(
-										Liferay.Language.get(
-											'x-of-x-items-selected'
-										),
-										selectedItemsValue.length,
-										total
-									)}
+									{selectedItemsValue.length === total
+										? sub(
+												Liferay.Language.get(
+													'all-selected-x-of-x-items'
+												),
+												selectedItemsValue.length,
+												total
+											)
+										: sub(
+												Liferay.Language.get(
+													'x-of-x-items-selected'
+												),
+												selectedItemsValue.length,
+												total
+											)}
 								</span>
 
 								<ClayLink

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -1368,6 +1368,7 @@ all-searchable-types=All Searchable Types
 all-section=All Section
 all-selected=All Selected
 all-selected-sites-will-be-combined-in-to-a-single-property=All selected sites will be combined in to a single property
+all-selected-x-of-x-items=All Selected ({0} of {1} Items)
 all-service-providers-are-processed.-continuing-sign-out-automatically-in-x-seconds=All service providers are processed. Continuing to sign out automatically in {0} seconds.
 all-site-owners=All Site Owners
 all-site-pages-variations=All Site Pages Variations

--- a/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
@@ -604,6 +604,44 @@ test(
 	}
 );
 
+test('Select items count label in bulk actions', async ({page}) => {
+	await test.step('Change delta to 60 items', async () => {
+		await page.getByLabel('Items Per Page').click();
+
+		await page.getByRole('option', {name: '60 Items'}).click();
+	});
+
+	await test.step('Select all checkboxes using the select all checkbox', async () => {
+		await page
+			.locator('input[name="table-head-selector"]')
+			.setChecked(true);
+	});
+
+	await test.step('Check the label displays "10 of 75 Items Selected"', async () => {
+		await expect(page.getByText('60 of 75 Items Selected')).toBeVisible();
+	});
+
+	await test.step('Go to 2nd page', async () => {
+		await page.getByLabel('Go to page, 2').click();
+	});
+
+	await test.step('Select all checkboxes on 2nd page by selecting the checkboxes for each row', async () => {
+		for (let i = 1; i <= 15; i++) {
+			await page
+				.locator(
+					`.dnd-tbody div:nth-child(${i}) > div > .custom-control > label > input[type="checkbox"]`
+				)
+				.setChecked(true);
+		}
+	});
+
+	await test.step('Check the label displays "All Selected (75 of 75 Items)"', async () => {
+		await expect(
+			page.getByText('All Selected (75 of 75 Items)')
+		).toBeVisible();
+	});
+});
+
 accountSettingsTest(
 	'Set time zone from theme display in a datetime renderer',
 	{

--- a/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
@@ -617,7 +617,7 @@ test('Select items count label in bulk actions', async ({page}) => {
 			.setChecked(true);
 	});
 
-	await test.step('Check the label displays "10 of 75 Items Selected"', async () => {
+	await test.step('Check the label displays "60 of 75 Items Selected"', async () => {
 		await expect(page.getByText('60 of 75 Items Selected')).toBeVisible();
 	});
 
@@ -629,7 +629,7 @@ test('Select items count label in bulk actions', async ({page}) => {
 		for (let i = 1; i <= 15; i++) {
 			await page
 				.locator(
-					`.dnd-tbody div:nth-child(${i}) > div > .custom-control > label > input[type="checkbox"]`
+					`tbody tr:nth-child(${i}) > .cell-select-item input[type="checkbox"]`
 				)
 				.setChecked(true);
 		}


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPD-42581
**Task:** https://liferay.atlassian.net/browse/LPD-44865


---

- Changes the "Items Selected" label to show the data total instead of just the current page total.

- I also wanted to make a short note about now there is some possibly strange UX behavior where the "Select All" button replaces all the selected items to only the current page's selection (whereas selecting a row 1 by 1 will add on to the already selected items from different pages)

---

## Demo

https://github.com/user-attachments/assets/0552074e-1a55-4e82-911e-7b8a2adcaaac

