### PR TITLE
LPD-43955 Relocate Checkbox for Bulk Action Consistency Across Visualization Modes

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
@@ -40,7 +40,7 @@ public class FDSSampleDisplayContext {
 	}
 
 	public String getAPIURL() {
-		return "/o/c/fdssamples";
+		return "/o/c/fdssamples?sort=title:asc";
 	}
 
 	public List<DropdownItem> getBulkActionDropdownItems() {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -567,9 +567,8 @@ const FrontendDataSet = ({
 				bulkActions={bulkActions}
 				creationMenu={creationMenu}
 				fluid={style === 'fluid'}
-				selectAllItems={() =>
-					selectItems(items.map((item) => item[selectedItemsKey]))
-				}
+				items={items}
+				selectItems={(items) => selectItems(items)}
 				selectedItems={selectedItems}
 				selectedItemsKey={selectedItemsKey}
 				selectedItemsValue={selectedItemsValue}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -14,7 +14,8 @@ function ManagementBar({
 	bulkActions,
 	creationMenu,
 	fluid,
-	selectAllItems,
+	items,
+	selectItems,
 	selectedItems,
 	selectedItemsKey,
 	selectedItemsValue,
@@ -22,13 +23,23 @@ function ManagementBar({
 	showSearch,
 	total,
 }) {
+	function handleCheckboxClick() {
+		if (selectedItemsValue.length === items.length) {
+			return selectItems([]);
+		}
+
+		return selectItems(items.map((item) => item[selectedItemsKey]));
+	}
+
 	return (
 		<>
 			{selectionType === 'multiple' && (
 				<BulkActions
 					bulkActions={bulkActions}
 					fluid={fluid}
-					selectAllItems={selectAllItems}
+					handleCheckboxClick={handleCheckboxClick}
+					items={items}
+					selectItems={selectItems}
 					selectedItems={selectedItems}
 					selectedItemsKey={selectedItemsKey}
 					selectedItemsValue={selectedItemsValue}
@@ -37,7 +48,12 @@ function ManagementBar({
 			)}
 
 			{(!selectedItemsValue.length || selectionType === 'single') && (
-				<NavBar creationMenu={creationMenu} showSearch={showSearch} />
+				<NavBar
+					creationMenu={creationMenu}
+					handleCheckboxClick={handleCheckboxClick}
+					items={items}
+					showSearch={showSearch}
+				/>
 			)}
 
 			<ActiveFiltersBar disabled={!!selectedItemsValue.length} />
@@ -60,6 +76,8 @@ ManagementBar.propTypes = {
 		secondaryItems: PropTypes.array,
 	}),
 	fluid: PropTypes.bool,
+	items: PropTypes.array.isRequired,
+	selectItems: PropTypes.func.isRequired,
 	selectedItems: PropTypes.array,
 	selectedItemsKey: PropTypes.string,
 	selectedItemsValue: PropTypes.array,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -216,7 +216,14 @@ function BulkActions({
 
 	return showBulkActionsManagementBar && selectedItemsValue.length ? (
 		<FrontendDataSetContext.Consumer>
-			{({formId, formName, loadData, namespace, selectable, sidePanelId}) => (
+			{({
+				formId,
+				formName,
+				loadData,
+				namespace,
+				selectable,
+				sidePanelId,
+			}) => (
 				<nav className="management-bar management-bar-primary navbar navbar-expand-md pb-2 pt-2 subnav-tbar">
 					<div
 						className={classNames(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -232,17 +232,23 @@ function BulkActions({
 						)}
 					>
 						<ul className="navbar-nav">
-							{!!total && selectable && (
-								<li className="nav-item">
-									<SelectionCheckbox
-										handleCheckboxClick={
-											handleCheckboxClick
-										}
-										items={items}
-										selectedItemsValue={selectedItemsValue}
-									/>
-								</li>
-							)}
+							{!!total &&
+								selectable &&
+								(Liferay.FeatureFlags['LPD-42570'] ? (
+									<li className="nav-item">
+										<SelectionCheckbox
+											handleCheckboxClick={
+												handleCheckboxClick
+											}
+											items={items}
+											selectedItemsValue={
+												selectedItemsValue
+											}
+										/>
+									</li>
+								) : (
+									<li className="ml-3 nav-item"></li>
+								))}
 
 							<li className="nav-item">
 								<span className="text-truncate">

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -15,6 +15,7 @@ import React, {useContext, useEffect, useState} from 'react';
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import {OPEN_SIDE_PANEL} from '../../utils/eventsDefinitions';
 import {getOpenedSidePanel} from '../../utils/sidePanels';
+import SelectionCheckbox from './SelectionCheckbox';
 
 function getQueryString(key, values = []) {
 	return `?${key}=${values.join(',')}`;
@@ -32,7 +33,9 @@ function getRichPayload(payload, key, values = []) {
 function BulkActions({
 	bulkActions,
 	fluid,
-	selectAllItems,
+	handleCheckboxClick,
+	items,
+	selectItems,
 	selectedItems,
 	selectedItemsKey,
 	selectedItemsValue,
@@ -213,7 +216,7 @@ function BulkActions({
 
 	return showBulkActionsManagementBar && selectedItemsValue.length ? (
 		<FrontendDataSetContext.Consumer>
-			{({formId, formName, loadData, namespace, sidePanelId}) => (
+			{({formId, formName, loadData, namespace, selectable, sidePanelId}) => (
 				<nav className="management-bar management-bar-primary navbar navbar-expand-md pb-2 pt-2 subnav-tbar">
 					<div
 						className={classNames(
@@ -222,6 +225,18 @@ function BulkActions({
 						)}
 					>
 						<ul className="navbar-nav">
+							{!!total && selectable && (
+								<li className="nav-item">
+									<SelectionCheckbox
+										handleCheckboxClick={
+											handleCheckboxClick
+										}
+										items={items}
+										selectedItemsValue={selectedItemsValue}
+									/>
+								</li>
+							)}
+
 							<li className="nav-item">
 								<span className="text-truncate">
 									{selectedItemsValue.length === total
@@ -246,7 +261,11 @@ function BulkActions({
 									href="#"
 									onClick={(event) => {
 										event.preventDefault();
-										selectAllItems();
+										selectItems(
+											items.map(
+												(item) => item[selectedItemsKey]
+											)
+										);
 									}}
 								>
 									{Liferay.Language.get('select-all')}
@@ -308,9 +327,11 @@ BulkActions.propTypes = {
 			target: PropTypes.oneOf(['sidePanel', 'modal']),
 		})
 	),
+	handleCheckboxClick: PropTypes.func.isRequired,
+	items: PropTypes.array.isRequired,
 	selectedItemsKey: PropTypes.string.isRequired,
 	selectedItemsValue: PropTypes.array.isRequired,
-	total: PropTypes.number.isRequired,
+	total: PropTypes.number,
 };
 
 export default BulkActions;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
@@ -9,8 +9,8 @@ import {ManagementToolbar} from 'frontend-js-components-web';
 import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
-import ViewsContext from '../../views/ViewsContext';
 import FrontendDataSetContext from '../../FrontendDataSetContext';
+import ViewsContext from '../../views/ViewsContext';
 import ActiveViewSelector from './ActiveViewSelector';
 import CreationMenu from './CreationMenu';
 import CustomViewsControls from './CustomViewsControls';
@@ -33,7 +33,7 @@ function NavBar({creationMenu, handleCheckboxClick, items, showSearch}) {
 			data-qa-id="management-toolbar"
 		>
 			<ManagementToolbar.ItemList>
-				{!!items.length && 	selectable && (
+				{!!items.length && selectable && (
 					<ManagementToolbar.Item>
 						<SelectionCheckbox
 							handleCheckboxClick={handleCheckboxClick}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
@@ -35,11 +35,13 @@ function NavBar({creationMenu, handleCheckboxClick, items, showSearch}) {
 			<ManagementToolbar.ItemList>
 				{!!items.length && selectable && (
 					<ManagementToolbar.Item>
-						<SelectionCheckbox
-							handleCheckboxClick={handleCheckboxClick}
-							items={items}
-							selectedItemsValue={[]}
-						/>
+						{Liferay.FeatureFlags['LPD-42570'] && (
+							<SelectionCheckbox
+								handleCheckboxClick={handleCheckboxClick}
+								items={items}
+								selectedItemsValue={[]}
+							/>
+						)}
 					</ManagementToolbar.Item>
 				)}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
@@ -10,14 +10,18 @@ import PropTypes from 'prop-types';
 import React, {useContext, useState} from 'react';
 
 import ViewsContext from '../../views/ViewsContext';
+import FrontendDataSetContext from '../../FrontendDataSetContext';
 import ActiveViewSelector from './ActiveViewSelector';
 import CreationMenu from './CreationMenu';
 import CustomViewsControls from './CustomViewsControls';
 import MainSearch from './MainSearch';
+import SelectionCheckbox from './SelectionCheckbox';
 import SortDropdown from './SortDropdown';
 import FiltersDropdown from './filters/FiltersDropdown';
 
-function NavBar({creationMenu, showSearch}) {
+function NavBar({creationMenu, handleCheckboxClick, items, showSearch}) {
+	const {selectable} = useContext(FrontendDataSetContext);
+
 	const [{customViewsEnabled, filters, sorts, views}] =
 		useContext(ViewsContext);
 
@@ -29,6 +33,16 @@ function NavBar({creationMenu, showSearch}) {
 			data-qa-id="management-toolbar"
 		>
 			<ManagementToolbar.ItemList>
+				{!!items.length && 	selectable && (
+					<ManagementToolbar.Item>
+						<SelectionCheckbox
+							handleCheckboxClick={handleCheckboxClick}
+							items={items}
+							selectedItemsValue={[]}
+						/>
+					</ManagementToolbar.Item>
+				)}
+
 				{!!filters.length && (
 					<ManagementToolbar.Item>
 						<FiltersDropdown />
@@ -96,14 +110,9 @@ NavBar.propTypes = {
 		primaryItems: PropTypes.array,
 		secondaryItems: PropTypes.array,
 	}),
-	setActiveView: PropTypes.func,
+	handleCheckboxClick: PropTypes.func.isRequired,
+	items: PropTypes.array.isRequired,
 	showSearch: PropTypes.bool,
-	views: PropTypes.arrayOf(
-		PropTypes.shape({
-			label: PropTypes.string.isRequired,
-			thumbnail: PropTypes.string.isRequired,
-		})
-	),
 };
 
 NavBar.defaultProps = {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/SelectionCheckbox.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/SelectionCheckbox.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import React from 'react';
+
+interface SelectionCheckboxProps {
+	handleCheckboxClick: () => void;
+	items: Array<any>;
+	selectedItemsValue: any;
+}
+
+const SelectionCheckbox = ({
+	handleCheckboxClick,
+	items,
+	selectedItemsValue,
+}: SelectionCheckboxProps) => {
+	return (
+		<ClayCheckbox
+			checked={!!selectedItemsValue.length}
+			indeterminate={
+				!!selectedItemsValue.length &&
+				items.length !== selectedItemsValue.length
+			}
+			name="items-selector"
+			onChange={handleCheckboxClick}
+			title={
+				items.length !== selectedItemsValue.length
+					? Liferay.Language.get('select-items')
+					: Liferay.Language.get('clear-selection')
+			}
+		/>
+	);
+};
+
+export default SelectionCheckbox;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -86,10 +86,20 @@ const getVisibleFields = ({
 
 const Head = ({
 	fields,
+	items,
+	selectItems,
 	selectable,
+	selectedItemsKey,
+	selectedItemsValue,
+	selectionType,
 }: {
 	fields: Array<Field>;
+	items: Array<any>;
+	selectItems: Function;
 	selectable?: boolean;
+	selectedItemsKey: string;
+	selectedItemsValue: any;
+	selectionType?: string;
 }) => {
 	return (
 		<ClayTableHead
@@ -101,16 +111,59 @@ const Head = ({
 
 				(field) => {
 					if (field.fieldName === 'select') {
-						return (
-							<ClayTableCell
-								key="select"
-								scope="col"
-								textValue={Liferay.Language.get('select-items')}
-								width="51px"
-							>
-								{null}
-							</ClayTableCell>
-						);
+						if (!!items.length && selectionType !== 'multiple') {
+							return (
+								<ClayTableCell
+									key="select"
+									scope="col"
+									width="51px"
+								>
+									{null}
+								</ClayTableCell>
+							);
+						}
+						if (!Liferay.FeatureFlags['LPD-42570']) {
+							const title =
+								items.length !== selectedItemsValue.length
+									? Liferay.Language.get('select-items')
+									: Liferay.Language.get('clear-selection');
+
+							return (
+								<ClayTableCell
+									className="cell-select-item"
+									key="select"
+									scope="col"
+									textValue={title}
+									width="51px"
+								>
+									<ClayCheckbox
+										checked={!!selectedItemsValue.length}
+										indeterminate={
+											!!selectedItemsValue.length &&
+											items.length !==
+												selectedItemsValue.length
+										}
+										name="table-head-selector"
+										onChange={() => {
+											if (
+												selectedItemsValue.length ===
+												items.length
+											) {
+												return selectItems([]);
+											}
+
+											return selectItems(
+												items.map(
+													(item) =>
+														item[selectedItemsKey]
+												)
+											);
+										}}
+										title={title}
+									/>
+								</ClayTableCell>
+							);
+						}
 					}
 
 					return (
@@ -660,7 +713,6 @@ const Table = ({
 	items: Array<any>;
 	itemsActions: Array<IItemsActions>;
 	schema: ITableSchema;
-	style: string;
 }) => {
 	const {
 		appURL,
@@ -806,7 +858,12 @@ const Table = ({
 			>
 				<Head
 					fields={schema.fields as Array<Field>}
+					items={items}
+					selectItems={selectItems}
 					selectable={selectable}
+					selectedItemsKey={selectedItemsKey}
+					selectedItemsValue={selectedItemsValue}
+					selectionType={selectionType}
 				/>
 
 				<Body

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -86,20 +86,10 @@ const getVisibleFields = ({
 
 const Head = ({
 	fields,
-	items,
-	selectItems,
 	selectable,
-	selectedItemsKey,
-	selectedItemsValue,
-	selectionType,
 }: {
 	fields: Array<Field>;
-	items: Array<any>;
-	selectItems: Function;
 	selectable?: boolean;
-	selectedItemsKey: string;
-	selectedItemsValue: any;
-	selectionType?: string;
 }) => {
 	return (
 		<ClayTableHead
@@ -111,55 +101,14 @@ const Head = ({
 
 				(field) => {
 					if (field.fieldName === 'select') {
-						if (!!items.length && selectionType !== 'multiple') {
-							return (
-								<ClayTableCell
-									key="select"
-									scope="col"
-									width="51px"
-								>
-									{null}
-								</ClayTableCell>
-							);
-						}
-
-						const title =
-							items.length !== selectedItemsValue.length
-								? Liferay.Language.get('select-items')
-								: Liferay.Language.get('clear-selection');
-
 						return (
 							<ClayTableCell
-								className="cell-select-item"
 								key="select"
 								scope="col"
-								textValue={title}
+								textValue={Liferay.Language.get('select-items')}
 								width="51px"
 							>
-								<ClayCheckbox
-									checked={!!selectedItemsValue.length}
-									indeterminate={
-										!!selectedItemsValue.length &&
-										items.length !==
-											selectedItemsValue.length
-									}
-									name="table-head-selector"
-									onChange={() => {
-										if (
-											selectedItemsValue.length ===
-											items.length
-										) {
-											return selectItems([]);
-										}
-
-										return selectItems(
-											items.map(
-												(item) => item[selectedItemsKey]
-											)
-										);
-									}}
-									title={title}
-								/>
+								{null}
 							</ClayTableCell>
 						);
 					}
@@ -857,12 +806,7 @@ const Table = ({
 			>
 				<Head
 					fields={schema.fields as Array<Field>}
-					items={items}
-					selectItems={selectItems}
 					selectable={selectable}
-					selectedItemsKey={selectedItemsKey}
-					selectedItemsValue={selectedItemsValue}
-					selectionType={selectionType}
 				/>
 
 				<Body

--- a/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
@@ -521,19 +521,19 @@ test(
 
 			await expect(idColumnHeader).toBeInViewport();
 
-			let cells = await page.locator('td').allInnerTexts();
-
-			await expect(page.locator('td').nth(1)).toHaveText(cells[1]);
-			await expect(page.locator('td').nth(11)).toHaveText(cells[11]);
-			await expect(page.locator('td').nth(21)).toHaveText(cells[21]);
-			await expect(page.locator('td').nth(31)).toHaveText(cells[31]);
-
 			await Promise.all([
 				idColumnHeader.click(),
 				page.waitForResponse(
 					(response: any) => response.status() === 200
 				),
 			]);
+
+			let cells = await page.locator('td').allInnerTexts();
+
+			await expect(page.locator('td').nth(1)).toHaveText(cells[1]);
+			await expect(page.locator('td').nth(11)).toHaveText(cells[11]);
+			await expect(page.locator('td').nth(21)).toHaveText(cells[21]);
+			await expect(page.locator('td').nth(31)).toHaveText(cells[31]);
 
 			const ascendingIDCells = [
 				cells[1],

--- a/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
@@ -626,27 +626,37 @@ test(
 );
 
 test('Select items count label in bulk actions', async ({page}) => {
+	const itemsSelectorCheckbox = page.locator('input[name="items-selector"]');
+
 	await test.step('Change delta to 60 items', async () => {
 		await page.getByLabel('Items Per Page').click();
 
 		await page.getByRole('option', {name: '60 Items'}).click();
+
+		await expect(
+			page.getByText('Showing 1 to 60 of 75 entries.')
+		).toBeVisible();
 	});
 
-	await test.step('Select all checkboxes using the select all checkbox', async () => {
-		await page
-			.locator('input[name="table-head-selector"]')
-			.setChecked(true);
-	});
+	await test.step('Select all items in current page using the bulk actions checkbox', async () => {
+		await itemsSelectorCheckbox.setChecked(true);
 
-	await test.step('Check the label displays "60 of 75 Items Selected"', async () => {
 		await expect(page.getByText('60 of 75 Items Selected')).toBeVisible();
 	});
 
-	await test.step('Go to 2nd page', async () => {
-		await page.getByLabel('Go to page, 2').click();
+	await test.step('Unselect all items in current page using the bulk actions checkbox', async () => {
+		await itemsSelectorCheckbox.setChecked(false);
+
+		await expect(itemsSelectorCheckbox).not.toBeChecked();
 	});
 
-	await test.step('Select all checkboxes on 2nd page by selecting the checkboxes for each row', async () => {
+	await test.step('Select all items', async () => {
+		await itemsSelectorCheckbox.setChecked(true);
+
+		await expect(page.getByText('60 of 75 Items Selected')).toBeVisible();
+
+		await page.getByLabel('Go to page, 2').click();
+
 		for (let i = 1; i <= 15; i++) {
 			await page
 				.locator(
@@ -654,9 +664,7 @@ test('Select items count label in bulk actions', async ({page}) => {
 				)
 				.setChecked(true);
 		}
-	});
 
-	await test.step('Check the label displays "All Selected (75 of 75 Items)"', async () => {
 		await expect(
 			page.getByText('All Selected (75 of 75 Items)')
 		).toBeVisible();


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-42571

<h1>Relocate Checkbox for Bulk Action Consistency Across Visualization Modes</h1>

The goal of this PR is to move the 'select all' checkbox from `Table.tsx` to the management bar, so it can be used for bulk actions in all visualization modes.

If there's no items, the checkbox won't appear:
![image](https://github.com/user-attachments/assets/c17df978-af9b-4c18-a703-28d084e36d9e)

If there's selected items, the checkbox will be in intermediate checked state:
![image](https://github.com/user-attachments/assets/03a2ccd8-c511-4196-8024-41b0eea95c37)

If not all items are selected items, to check the checkbox will select all items:
![image](https://github.com/user-attachments/assets/3d16fe80-aa59-48d1-a23d-df62e92d5b93)

If all items are selected, to check the checkbox will deselect all items:
![image](https://github.com/user-attachments/assets/aaaf805b-de95-4aa4-b16e-29fbce061a41)

