### PR TITLE
LPS-42610 Fix for browser console error

### DIFF
--- a/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
+++ b/portal-web/docroot/html/taglib/ui/page_iterator/start.jsp
@@ -526,9 +526,9 @@ NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
 
 <aui:script senna="temporary" type="text/javascript">
 	var pageIterator = document.getElementById('<%= namespace + id %>');
+	var button = pageIterator?.querySelector('.pagination .dropdown-toggle');
 
-	if (pageIterator) {
-		var button = pageIterator.querySelector('.pagination .dropdown-toggle');
+	if (button) {
 		var list = pageIterator.querySelector('.pagination .dropdown-menu');
 		var options = list?.querySelectorAll('.pagination .dropdown-item');
 


### PR DESCRIPTION
Hi,

After LPS-42610 was merged in master, it was reported an error in browser console sometimes.

The issue came because unified the code for both dropdowns in the page (to select items per page and to show intermediate pages in the iterator), however the second one is not always present when there is a page iterator., for example, when you have fewer than 6 pages to iterate through.

Although that was not affecting functionality, there was an error in browser console because we were attaching listeners to non-existing elements. This fix is avoiding that error, since we only run the code to handle key presses when there's a button for intermediate pages.

Thanks.