### PR TITLE
LPD-47508 - Add API for bundling submodules

### DIFF
--- a/modules/_node-scripts/bundle/esbuild/bundleJavaScriptMain.mjs
+++ b/modules/_node-scripts/bundle/esbuild/bundleJavaScriptMain.mjs
@@ -27,7 +27,7 @@ export default async function bundleJavaScriptMain(
 	projectEntryPoints,
 	projectWebContextPath
 ) {
-	const {main: mainEntryPoint} = projectEntryPoints;
+	const {main: mainEntryPoint, submodules = {}} = projectEntryPoints;
 
 	if (!mainEntryPoint) {
 		return;
@@ -35,8 +35,13 @@ export default async function bundleJavaScriptMain(
 
 	const esbuildConfig = {
 		bundle: true,
-		entryNames: 'index',
-		entryPoints: [path.resolve(mainEntryPoint)],
+		entryPoints: [
+			...Object.keys(submodules).map((submoduleName) => ({
+				in: path.resolve(submodules[submoduleName]),
+				out: submoduleName,
+			})),
+			{in: path.resolve(mainEntryPoint), out: 'index'},
+		],
 		external: getExternals(globalImports, projectWebContextPath, 'main'),
 		format: 'esm',
 		loader: {

--- a/modules/_node-scripts/configuration/getProjectEntryPoints.mjs
+++ b/modules/_node-scripts/configuration/getProjectEntryPoints.mjs
@@ -11,11 +11,16 @@ import projectScopeRequire from '../util/projectScopeRequire.mjs';
  *
  * {
  *   main: 'src/main/resources/META-INF/resources/index.js',
- *   typescript: 'src/main/resources/META-INF/resources/index.d.ts'
+ *   submodules: {
+ *   	foo: 'src/main/resources/META-INF/resources/foo.js'
+ *   },
+ *   typescript: {
+ *   	main: 'src/main/resources/META-INF/resources/index.d.ts'
+ *   }
  * }
  */
 export default function getProjectEntryPoints(projectDir = '.') {
-	const {main, typescript} = projectScopeRequire(
+	const {main, submodules, typescript} = projectScopeRequire(
 		'./node-scripts.config.js',
 		projectDir
 	);
@@ -23,13 +28,38 @@ export default function getProjectEntryPoints(projectDir = '.') {
 	const entryPoints = {};
 
 	if (main) {
+		verifyResourcePath(main, 'main');
+
 		entryPoints.main = main;
 		entryPoints.typescript = main;
 	}
 
 	if (typescript && typescript.main) {
+		verifyResourcePath(typescript.main, 'typescript');
+
 		entryPoints.typescript = typescript.main;
 	}
 
+	if (submodules) {
+		Object.values(submodules).forEach((submodulePath) => {
+			verifyResourcePath(submodulePath, 'submodule');
+		});
+
+		entryPoints.submodules = submodules;
+	}
+
 	return entryPoints;
+}
+
+function verifyResourcePath(resourcePath, type) {
+	if (
+		resourcePath.startsWith('src/main/resources/META-INF/resources') ||
+		resourcePath.startsWith('src/node/')
+	) {
+		return true;
+	}
+
+	throw Error(
+		`❌ '${type}' path '${resourcePath}' is not allowed, it must be located under 'src/main/resources/META-INF/resources/*'.`
+	);
 }

--- a/modules/_node-scripts/package.json
+++ b/modules/_node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "fa7d3f842259dc5ba968a3ba2ffc1424e66bbf6b76cb3f1515af2cf869ac513f"
+		"sha256": "44f17117f9e2825487d687243040e9cede466ec802c04850894a9d8fecd8a276"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",


### PR DESCRIPTION
This is a new API we provide for bundling javascript in modules via node-scirpts.

The new config allows for something like this in your `node-scripts.config.js`

```js
module.exports = {
	main: 'src/main/resources/META-INF/resources/js/index.js',
	submodules: {
		'date-time': 'src/main/resources/META-INF/resources/js/date-time/index.js',
                 [BUNDLE_NAME]: PATH_TO_ENTRY_POINT
	},
};
```

This now creates two bundles, one for your primary entry point at `index.js` and a separate one called `date-time.js`


main bundle - `import * as myThing from '@liferay/my-module'`
submodule bundle - `import * as myThing from '@liferay/my-module/date-time'`

Note:

If you import your submodule into your main entry point, that code will be duplicated and exist in both bundles.