### PR TITLE
LPD-47701 - Close actions dropdown menu after click in any item

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -21,14 +21,10 @@ function Actions({
 	actions,
 	itemData,
 	itemId,
-	menuActive,
-	onMenuActiveChange,
 }: {
 	actions: Array<IItemsActions>;
 	itemData: any;
 	itemId: string | number;
-	menuActive?: boolean;
-	onMenuActiveChange?: Function;
 }) {
 	const {
 		executeAsyncItemAction,
@@ -48,6 +44,7 @@ function Actions({
 	]: any = useContext(ViewsContext);
 
 	const [loading, setLoading] = useState(false);
+	const [menuActive, setMenuActive] = useState(false);
 
 	const inlineEditingAvailable =
 		inlineEditingSettings && itemData.actions?.update;
@@ -110,7 +107,7 @@ function Actions({
 				loading={loading}
 				menuActive={menuActive}
 				onClick={handleClick}
-				onMenuActiveChange={onMenuActiveChange}
+				onMenuActiveChange={setMenuActive}
 				setLoading={setLoading}
 			/>
 		</>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.js
@@ -10,7 +10,7 @@ import ClayList from '@clayui/list';
 import ClaySticker from '@clayui/sticker';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import Actions from '../../actions/Actions';
@@ -78,8 +78,6 @@ const ListItem = ({item, schema}) => {
 		selectionType,
 	} = useContext(FrontendDataSetContext);
 
-	const [menuActive, setMenuActive] = useState(false);
-
 	const {description, image, sticker, symbol, title, titleRenderer} = schema;
 
 	const SelectionInput =
@@ -88,9 +86,8 @@ const ListItem = ({item, schema}) => {
 	return (
 		<ClayList.Item
 			className={classNames({
-				'menu-active': menuActive,
 				selectable,
-				'selected': selectedItemsValue.includes(item[selectedItemsKey]),
+				selected: selectedItemsValue.includes(item[selectedItemsKey]),
 			})}
 			flex
 			onClick={() => {
@@ -150,8 +147,6 @@ const ListItem = ({item, schema}) => {
 						actions={itemsActions || item.actionDropdownItems}
 						itemData={item}
 						itemId={item[selectedItemsKey]}
-						menuActive={menuActive}
-						onMenuActiveChange={setMenuActive}
 					/>
 				)}
 			</ClayList.ItemField>

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
@@ -301,8 +301,9 @@ test.describe('Item Actions in Data Set fragment', () => {
 
 			await expect(
 				page
-				.locator(`#${dropdownId}`)
-				.filter({has: page.getByRole('menu')})).not.toBeVisible()
+					.locator(`#${dropdownId}`)
+					.filter({has: page.getByRole('menu')})
+			).not.toBeVisible();
 
 			const frame = dataSetFragmentPage.sidePanelFrame;
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
@@ -299,13 +299,18 @@ test.describe('Item Actions in Data Set fragment', () => {
 				})
 				.click();
 
+			await expect(
+				page
+				.locator(`#${dropdownId}`)
+				.filter({has: page.getByRole('menu')})).not.toBeVisible()
+
 			const frame = dataSetFragmentPage.sidePanelFrame;
 
 			await expect(
 				frame.locator('.side-panel-iframe-header')
 			).not.toBeInViewport();
 
-			await expect(frame.getByTitle('Go to Liferay DXP')).toBeVisible();
+			await expect(frame.getByText('Welcome to Liferay')).toBeVisible();
 
 			await page.keyboard.press('Escape');
 


### PR DESCRIPTION
## Bug
https://liferay.atlassian.net/browse/LPD-47701

## Issue
Actions dropdown in the FDS Table visualization mode was visible after selecting an action. This causes the dropdown menu to appear on top of any element of the page (side panel).

https://github.com/user-attachments/assets/a53dc26f-66fe-4c3d-9be6-65c0bbae4ba2
