### PR TITLE
LPD-47864 For Global files keep sites favicon

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
+++ b/modules/apps/frontend-theme/frontend-theme-favicon-servlet/src/main/java/com/liferay/frontend/theme/favicon/servlet/internal/FaviconServlet.java
@@ -64,6 +64,8 @@ public class FaviconServlet extends HttpServlet {
 			return;
 		}
 
+		String faviconURL = _getFaviconURL(layoutSet);
+
 		String referer = GetterUtil.getString(
 			httpServletRequest.getHeader(HttpHeaders.REFERER));
 
@@ -71,7 +73,13 @@ public class FaviconServlet extends HttpServlet {
 			layoutSet = _getLayoutSet(layoutSet, referer);
 		}
 
-		String faviconURL = _getFaviconURL(layoutSet);
+		String layoutSetFaviconURL = _getFaviconURL(layoutSet);
+
+		if (Validator.isNotNull(layoutSetFaviconURL)) {
+			httpServletResponse.sendRedirect(layoutSetFaviconURL);
+
+			return;
+		}
 
 		if (Validator.isNotNull(faviconURL)) {
 			httpServletResponse.sendRedirect(faviconURL);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-47864
https://liferay.atlassian.net/browse/LPP-57537

When a user creates a document in Global Site and opens the document, the favicon displays the default classic theme favicon.
By checking the favicon for both layoutset, we can avoid defaulting the favicon and avoid a regression for https://liferay.atlassian.net/browse/LPS-193159.

Please let me know if there are any questions or comments about this. 