### PR TITLE
LPD-47736 Stop using UI code from frontend-js-spa-web

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@liferay/frontend-icons-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "init.js",

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/LiferayApp.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/LiferayApp.js
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {buildFragment, openToast} from 'frontend-js-web';
+import {buildFragment} from 'frontend-js-web';
 
 import LiferaySurface from '../surface/Surface';
+import {openToast} from '../util/openToast';
 import {getPortletBoundaryId, getUid, resetAllPortlets} from '../util/utils';
 import App from './App';
 
@@ -380,11 +381,7 @@ class LiferayApp extends App {
 
 			Liferay.Data.layoutConfig = this.dataLayoutConfig_;
 
-			this._createNotification({
-				message,
-				title: Liferay.Language.get('error'),
-				type: 'danger',
-			});
+			openToast('error', Liferay.Language.get('error'), message);
 		}
 	}
 
@@ -450,24 +447,6 @@ class LiferayApp extends App {
 	}
 
 	/**
-	 * Creates a user notification
-	 * @param  {!Object} configuration object that's passed to `Liferay.Notification`
-	 * @return {!Promise} A promise that renders a notification when
-	 * resolved
-	 */
-
-	_createNotification(config) {
-		return new Promise((resolve) => {
-			resolve(
-				openToast({
-					type: 'warning',
-					...config,
-				})
-			);
-		});
-	}
-
-	/**
 	 * Hides the request timeout alert
 	 */
 
@@ -520,13 +499,11 @@ class LiferayApp extends App {
 
 				this._hideTimeoutAlert();
 
-				this._createNotification({
-					message: this.userNotification.message,
-					title: this.userNotification.title,
-					type: 'warning',
-				}).then((alert) => {
-					this.timeoutAlert = alert;
-				});
+				this.timeoutAlert = openToast(
+					'warn',
+					this.userNotification.title,
+					this.userNotification.message
+				);
 			}, this.userNotification.timeout);
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "29759a0d31913875f3881946866b38f6423579eb",
+	"@generated": "74f058a5ff5eac160f6ce3941e7702fd8216cc6b",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"@liferay/frontend-icons-web": [
+				"../../../../../../../frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-icons/frontend-icons-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/util/openToast.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/util/openToast.js
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * This is an alternative lightweight implementation of openToast() method of
+ * frontend-js-web.
+ *
+ * Its main goal is to make Clay and React unnecessary when rendering the popup
+ * so that applications using SPA don't pull those dependencies.
+ * @param  {!String} type 'warn' or 'error'
+ * @param  {!String} title
+ * @param  {!String} message
+ * @return {!Object}
+ * An object containing a dispose field pointing to a function than can be
+ * invoked to close the popup.
+ */
+
+const CLASS_NAME_MAP = {
+	error: 'danger',
+	warn: 'warning',
+};
+const ICON_MAP = {
+	error: 'exclamation-full',
+	warn: 'warning-full',
+};
+
+export function openToast(type, title, message) {
+	const {spritemap} = Liferay.Icons;
+
+	const html = `
+<div class="alert-container cadmin container">
+	<div class="alert-notifications alert-notifications-fixed" id="ToastAlertContainer">
+		<div class="lfr-tooltip-scope">
+			<div class="mb-3 alert alert-dismissible alert-${CLASS_NAME_MAP[type]}">
+				<div role="alert" class="alert-autofit-row autofit-row">
+					<div class="autofit-col">
+						<div class="autofit-section">
+							<span class="alert-indicator">
+								<svg class="lexicon-icon lexicon-icon-${ICON_MAP[type]}" role="presentation">
+									<use href="${spritemap}#${ICON_MAP[type]}"></use>
+								</svg>
+							</span>
+						</div>
+					</div>
+					<div class="autofit-col autofit-col-expand">
+						<div class="autofit-section">
+							<div>
+								<strong class="lead">
+									${title}
+								</strong>
+								${message}
+							</div>
+						</div>
+					</div>
+				</div>
+				<button aria-label="Close" class="close" type="button">
+					<svg class="lexicon-icon lexicon-icon-times" role="presentation">
+						<use href="${spritemap}#times"></use>
+					</svg>
+				</button>
+			</div>
+		</div>
+	</div>
+</div>`;
+
+	const div = document.createElement('div');
+	div.innerHTML = html;
+
+	const button = div.querySelector('button');
+	button.onclick = () => div.remove();
+
+	document.body.appendChild(div);
+
+	return {
+		dispose: () => div.remove(),
+	};
+}

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/util/openToast.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/util/openToast.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {getSpritemap} from '@liferay/frontend-icons-web';
+
 /**
  * This is an alternative lightweight implementation of openToast() method of
  * frontend-js-web.
@@ -27,7 +29,7 @@ const ICON_MAP = {
 };
 
 export function openToast(type, title, message) {
-	const {spritemap} = Liferay.Icons;
+	const spritemap = getSpritemap();
 
 	const html = `
 <div class="alert-container cadmin container">

--- a/modules/test/playwright/tests/frontend-js-spa-web/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/settings.spec.ts
@@ -106,12 +106,12 @@ test(
 			expect(await isSPAEnabled({page})).toBeTruthy();
 		});
 
-		await test.step('Change the default timeout from 30000ms to 30ms', async () => {
+		await test.step('Change the default timeout from 30000ms to 1ms', async () => {
 			await userNotificationTimeoutLabel.waitFor({state: 'visible'});
 			expect(userNotificationTimeoutLabel).toHaveValue('30000');
 
 			await userNotificationTimeoutLabel.click();
-			await userNotificationTimeoutLabel.fill('30');
+			await userNotificationTimeoutLabel.fill('1');
 
 			if (await saveButton.isVisible()) {
 				await saveButton.click();
@@ -128,6 +128,21 @@ test(
 
 			await userNotificationTimeoutLabel.waitFor({state: 'visible'});
 
+			// Install a Promise in the browser that resolves when endNavigate
+			// is fired. This is needed because endNavigate causes the alert to
+			// disappear so we cannot test it from Playwright code unless we
+			// intercept it in the browser.
+
+			await page.evaluate(() => {
+				window['alertPromise'] = new Promise((resolve) => {
+					Liferay.on('endNavigate', () => {
+						resolve(
+							document.querySelector('.alert-warning')?.innerHTML
+						);
+					});
+				});
+			});
+
 			if (await saveButton.isVisible()) {
 				await saveButton.click();
 			}
@@ -135,16 +150,21 @@ test(
 				await updateButton.click();
 			}
 
-			await waitForAlert(
-				page,
-				'Oops:It looks like this is taking longer than expected.',
-				{type: 'warning'}
+			// Wait for the Promise we installed a few lines above then return
+			// its value to Playwright domain.
+
+			const innerHTML = await page.evaluate(
+				async () => await window['alertPromise']
+			);
+
+			expect(innerHTML).toContain(
+				'It looks like this is taking longer than expected.'
 			);
 		});
 
 		await test.step('Change the timeout back to 30000ms', async () => {
 			await userNotificationTimeoutLabel.waitFor({state: 'visible'});
-			expect(userNotificationTimeoutLabel).toHaveValue('30');
+			expect(userNotificationTimeoutLabel).toHaveValue('1');
 
 			await userNotificationTimeoutLabel.click();
 			await userNotificationTimeoutLabel.fill('30000');


### PR DESCRIPTION
LPD: https://liferay.atlassian.net/browse/LPD-47736

This PR assumes there will always be a theme in place and that it will contain CSS classes for clay stuff.

We could change that assumption but we would still need to place CSS code that resembles clay L&F somewhere, so why bother? We can simply use CSS class names and that will be our "contract" if the customers want to style the SPA alerts. 

Does that make sense?


