### PR TITLE
LPD-1935 Language change to en_US after session_click request v4

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/session.es.js
@@ -23,7 +23,7 @@ function getSessionClickFormData(cmd) {
 }
 
 function getSessionClickURL() {
-	return `${Liferay.ThemeDisplay.getPortalURL()}${Liferay.ThemeDisplay.getPathMain()}/portal/session_click`;
+	return `${Liferay.ThemeDisplay.getPortalURL()}${Liferay.ThemeDisplay.getPathMain()}/portal/session_click?p_l_id=${Liferay.ThemeDisplay.getPlid()}`;
 }
 
 /**

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/session.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/session.es.js
@@ -9,8 +9,13 @@ import {
 } from '../../../src/main/resources/META-INF/resources/liferay/util/session.es';
 
 describe('Session API', () => {
+	const sessionClickURL =
+		'http://localhost:8080/c/portal/session_click?p_l_id=1';
+
 	beforeEach(() => {
 		fetch.mockResponse('');
+
+		window.Liferay.ThemeDisplay.getPlid = () => 1;
 	});
 
 	describe('getSessionValue', () => {
@@ -20,7 +25,7 @@ describe('Session API', () => {
 			expect(fetch).toHaveBeenCalledTimes(1);
 
 			expect(fetch).toHaveBeenCalledWith(
-				'http://localhost:8080/c/portal/session_click',
+				sessionClickURL,
 				expect.anything()
 			);
 		});
@@ -53,9 +58,7 @@ describe('Session API', () => {
 
 			expect(fetch).toHaveBeenCalledTimes(1);
 
-			expect(fetch.mock.calls[0][0]).toBe(
-				'http://localhost:8080/c/portal/session_click'
-			);
+			expect(fetch.mock.calls[0][0]).toBe(sessionClickURL);
 
 			expect(fetch.mock.calls[0][1].body.get('key')).toBe('value');
 		});
@@ -68,9 +71,7 @@ describe('Session API', () => {
 
 			expect(fetch).toHaveBeenCalledTimes(1);
 
-			expect(fetch.mock.calls[0][0]).toBe(
-				'http://localhost:8080/c/portal/session_click'
-			);
+			expect(fetch.mock.calls[0][0]).toBe(sessionClickURL);
 
 			expect(fetch.mock.calls[0][1].body.get('key')).toBe(
 				'serialize://{"key1":"value1","key2":"value2"}'

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -56,6 +56,7 @@ import {config as frontendDataSetAdminWebConfig} from './tests/frontend-data-set
 import {config as frontendDataSetWebConfig} from './tests/frontend-data-set-web/config';
 import {config as frontendEditorCKEditorWebConfig} from './tests/frontend-editor-ckeditor-web/config';
 import {config as frontendJsSpaWebConfig} from './tests/frontend-js-spa-web/config';
+import {config as frontendJsWebConfig} from './tests/frontend-js-web/config';
 import {config as frontendTaglibClayConfig} from './tests/frontend-taglib-clay/config';
 import {config as frontendTaglibConfig} from './tests/frontend-taglib/config';
 import {config as frontendTheme} from './tests/frontend-theme/config';
@@ -182,6 +183,7 @@ export default defineConfig({
 		frontendDataSetWebConfig,
 		frontendEditorCKEditorWebConfig,
 		frontendJsSpaWebConfig,
+		frontendJsWebConfig,
 		frontendTaglibClayConfig,
 		frontendTaglibConfig,
 		frontendTheme,

--- a/modules/test/playwright/tests/frontend-js-web/config.ts
+++ b/modules/test/playwright/tests/frontend-js-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'frontend-js-web',
+	testDir: 'tests/frontend-js-web',
+};

--- a/modules/test/playwright/tests/frontend-js-web/session.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-web/session.spec.ts
@@ -91,7 +91,11 @@ test(
 				})
 				.click();
 
-			await expect(page.getByText('Páginas estáticas')).toBeVisible();
+			const bcp47LanguageId = await page.evaluate(() =>
+				Liferay.ThemeDisplay.getBCP47LanguageId()
+			);
+
+			expect(bcp47LanguageId).toEqual('es-ES');
 		});
 
 		await test.step('Make any session request', async () => {
@@ -109,7 +113,11 @@ test(
 		await test.step('Refresh page and check locale is preserved', async () => {
 			await page.reload();
 
-			await expect(page.getByText('Páginas estáticas')).toBeVisible();
+			const bcp47LanguageId = await page.evaluate(() =>
+				Liferay.ThemeDisplay.getBCP47LanguageId()
+			);
+
+			expect(bcp47LanguageId).toEqual('es-ES');
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-js-web/session.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-web/session.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
+import {siteSettingsPagesTest} from '../../fixtures/siteSettingsPagesTest';
+import getRandomString from '../../utils/getRandomString';
+import {performUserSwitch, userData} from '../../utils/performLogin';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	productMenuPageTest,
+	siteSettingsPagesTest
+);
+
+test(
+	'Using session utils does not change locale',
+	{tag: '@LPD-1935'},
+	async ({
+		apiHelpers,
+		page,
+		productMenuPage,
+		site,
+		siteSettingsLocalizationPage,
+	}) => {
+		let layout: Layout;
+
+		await test.step('Create site with default Spanish locale', async () => {
+			layout = await apiHelpers.headlessDelivery.createSitePage({
+				siteId: site.id,
+				title: getRandomString(),
+			});
+
+			await siteSettingsLocalizationPage.goto(site.friendlyUrlPath);
+
+			await siteSettingsLocalizationPage.setCustomDefaultLanguage(
+				'es_ES',
+				site.friendlyUrlPath
+			);
+		});
+
+		await test.step('Create new Spanish user and assign to site as administrator', async () => {
+			const user = await apiHelpers.headlessAdminUser.postUserAccount({
+				languageId: 'es_ES',
+			});
+
+			userData[user.alternateName] = {
+				name: user.givenName,
+				password: 'test',
+				surname: user.familyName,
+			};
+
+			const siteAdminRole =
+				await apiHelpers.headlessAdminUser.getRoleByName(
+					'Site Administrator'
+				);
+
+			await apiHelpers.headlessAdminUser.assignUserToSite(
+				siteAdminRole.id,
+				site.id,
+				user.id
+			);
+
+			await performUserSwitch(page, user.alternateName);
+		});
+
+		await test.step('Go to any control menu site page, see it in Spanish', async () => {
+			await page.goto(
+				`/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+			);
+
+			await productMenuPage.goToPages();
+
+			await page.reload();
+
+			await page
+				.getByRole('link', {
+					name: 'Mostrar la página en español (España).',
+				})
+				.click();
+
+			await expect(page.getByText('Páginas estáticas')).toBeVisible();
+		});
+
+		await test.step('Make any session request', async () => {
+			await page.evaluate(() => {
+				Liferay.Util.Session.get('foo');
+			});
+
+			await page.waitForResponse(
+				(response: any) =>
+					response.status() === 200 &&
+					response.url().includes('session_click')
+			);
+		});
+
+		await test.step('Refresh page and check locale is preserved', async () => {
+			await page.reload();
+
+			await expect(page.getByText('Páginas estáticas')).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/frontend-js-web/test.properties
+++ b/modules/test/playwright/tests/frontend-js-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Frontend JS API

--- a/modules/test/playwright/types/account.d.ts
+++ b/modules/test/playwright/types/account.d.ts
@@ -9,6 +9,7 @@ type TUserAccount = {
 	familyName?: string;
 	givenName?: string;
 	id?: string;
+	languageId?: string;
 	name?: string;
 	password?: string;
 };


### PR DESCRIPTION
### References

- Parent LPP: [LPP-57327 Language change to en_US after session_click request](https://issues.liferay.com/browse/LPP-57327)
- v1: https://github.com/liferay-frontend/liferay-portal/pull/3430
- v2: https://github.com/liferay-frontend/liferay-portal/pull/3598
- v3: https://github.com/liferay-frontend/liferay-portal/pull/3739

### What is the goal of this PR?

A bugfix. See technical notes inline.

### What does it look like?

#### Before PR

https://github.com/user-attachments/assets/5d12b4fd-4900-4123-87b0-06b02da8932b

#### After PR

https://github.com/user-attachments/assets/f8210bfc-c162-4fa1-aff4-e2e8dde90baa


![image](https://github.com/user-attachments/assets/b7c3d9cb-5843-4062-a0b1-b8e4fcecd62c)


### Steps to reproduce

See steps in JIRA ticket.
