### PR TITLE
LPD-48422 - Apply styles for :focus-visible

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -29,20 +29,59 @@
 		font-weight: $headings-font-weight;
 	}
 
-	&.ck-editor__main > .ck-editor__editable:focus {
-		@include clay-form-control-focus();
+	&.ck-toolbar {
+		& > .ck-toolbar__items > *:not(.ck-toolbar__line-break),
+		& > .ck.ck-toolbar__grouped-dropdown {
+			margin-bottom: 6px;
+			margin-top: 6px;
+		}
 	}
 
-	&.ck-button.ck-on,
-	&.ck-button.ck-on:not(.ck-disabled):hover,
-	&.ck-button:not(.ck-disabled):hover {
-		background: $gray-100;
-		color: $gray-900;
+	&.ck-button {
+		&:active,
+		&.ck-on:focus,
+		&.ck-disabled:active {
+			border-color: transparent;
+		}
+
+		&:focus,
+		&.ck-disabled:active,
+		&.ck-disabled:focus {
+			box-shadow: none;
+		}
+
+		&:focus-visible,
+		&.ck-on:focus-visible,
+		&.ck-disabled:focus-visible {
+			border: var(--ck-focus-ring);
+			box-shadow: $btn-focus-box-shadow;
+		}
+
+		&.ck-on,
+		&.ck-on:not(.ck-disabled):hover,
+		&:not(.ck-disabled):hover {
+			background: $gray-100;
+			color: $gray-900;
+		}
 	}
 
-	&.ck.ck-button:focus {
-		background: $gray-100;
-		box-shadow: $btn-focus-box-shadow;
-		outline: 0;
+	&.ck-dropdown {
+		.ck-button.ck-dropdown__button.ck-off:active:focus,
+		.ck-button.ck-dropdown__button.ck-on:active:focus {
+			box-shadow: none;
+		}
+	}
+
+	&.ck-style-panel .ck-style-grid {
+		.ck-style-grid__button {
+			&:focus,
+			&:not(:focus) {
+				border: 1px solid var(--ck-color-base-border);
+			}
+
+			&:focus-visible {
+				border: var(--ck-focus-ring);
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Story / Task
[LPD-48421](https://liferay.atlassian.net/browse/LPD-48421) / [LPD-48422](https://liferay.atlassian.net/browse/LPD-48422)

## Goal
Modify CKEditor 5 styles to match Clay behavior.
The idea is to make focus visible when users navigate with the keyboard but not if the are using a pointer device.

![button-border](https://github.com/user-attachments/assets/0dcad164-5427-47a1-a2f9-a8e0c9438660)
