### PR TITLE
LPD-48956 Fix Clay Sample widget panel content from replacing tab contents

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -75,7 +75,7 @@ export default function render(
 		if (hasBodyContent) {
 			const tagBodyContent = container.querySelector('.tag-body-content');
 
-			if (tagBodyContent && tagBodyContent.children.length) {
+			if (tagBodyContent?.children.length) {
 				componentProps.children = tagBodyContent.children;
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
+++ b/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx
@@ -73,12 +73,10 @@ export default function render(
 		}
 
 		if (hasBodyContent) {
-			const children = container.querySelectorAll(
-				'.tag-body-content > *'
-			);
+			const tagBodyContent = container.querySelector('.tag-body-content');
 
-			if (children.length) {
-				componentProps.children = children;
+			if (tagBodyContent && tagBodyContent.children.length) {
+				componentProps.children = tagBodyContent.children;
 			}
 		}
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/Tabs.js
@@ -6,7 +6,7 @@
 import ClayTabs from '@clayui/tabs';
 import React, {useEffect, useRef, useState} from 'react';
 
-const Panel = ({children: tabPanel}) => {
+const TabPanelContent = ({children: tabPanel}) => {
 	const ref = useRef();
 
 	useEffect(() => {
@@ -69,7 +69,7 @@ export default function Tabs({
 				<ClayTabs.Panels>
 					{Array.from(panelsContent).map((panelContent, i) => (
 						<ClayTabs.TabPanel key={i}>
-							<Panel>{panelContent}</Panel>
+							<TabPanelContent>{panelContent}</TabPanelContent>
 						</ClayTabs.TabPanel>
 					))}
 				</ClayTabs.Panels>

--- a/modules/test/playwright/tests/frontend-taglib-clay/verticalNavTag.spec.ts
+++ b/modules/test/playwright/tests/frontend-taglib-clay/verticalNavTag.spec.ts
@@ -22,7 +22,7 @@ export const test = mergeTests(
 );
 
 test.describe('Vertical Nav apostrophes are not displayed correctly on vocabularies names', () => {
-	test.skip(
+	test(
 		'Label is being escaped',
 		{tag: '@LPD-30368'},
 		async ({apiHelpers, claySamplePage, page, site}) => {
@@ -33,7 +33,7 @@ test.describe('Vertical Nav apostrophes are not displayed correctly on vocabular
 			await test.step('Select Vertical Nav tab', async () => {
 				await claySamplePage.selectTab(
 					'Vertical Nav',
-					page.getByText('Panel Content 5')
+					page.getByText('DEFAULT VERTICAL NAV')
 				);
 			});
 


### PR DESCRIPTION
**Task:** https://liferay.atlassian.net/browse/LPD-47904
**Subtask:** https://liferay.atlassian.net/browse/LPD-48956

---

❌  **The issue:** The Panel body was being passed into the Tab's children so it was rendering additional tab contents.
- In a simplified example, here is the mismatch of tabs and tab contents:
<img width="732" alt="Screenshot 2025-02-13 at 3 44 11 PM" src="https://github.com/user-attachments/assets/1a68a4e5-d8ff-4431-9a57-a398daa164d4" />

✅  **The solution:** `frontend-js-react-web`'s `render.tsx` uses the selector `container.querySelectorAll( '.tag-body-content > *' )` which was getting all nested taglib bodies https://github.com/liferay/liferay-portal/blob/b41ce67760316899ef4c8c53b6679f95ef249b8f/modules/apps/frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/render.tsx#L76-L82 so I changed it to only grab the first `.tag-body-content` class found.