### PR TITLE
LPD-46963 Fix broken test. Updating locators for tabs and selecting AlloyEditor tab before checking content in the editor

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -125,9 +125,7 @@ test('Add a toolbar button to an Alloy Editor @LPD-11056', async ({
 			`${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
 		);
 
-		await expect(
-			editorSamplesPage.balloonEditorContainer.getByText('Lorem ipsum')
-		).toBeInViewport();
+		await page.getByRole('link', { name: 'CKEditor 4' }).click();
 
 		await editorSamplesPage.selectTab({tabLabel: 'Alloy'});
 

--- a/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/editorConfigContributor.spec.ts
@@ -125,7 +125,7 @@ test('Add a toolbar button to an Alloy Editor @LPD-11056', async ({
 			`${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
 		);
 
-		await page.getByRole('link', { name: 'CKEditor 4' }).click();
+		await page.getByRole('link', {name: 'CKEditor 4'}).click();
 
 		await editorSamplesPage.selectTab({tabLabel: 'Alloy'});
 

--- a/modules/test/playwright/tests/client-extension-web/pages/EditorSamplesPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/EditorSamplesPage.ts
@@ -23,9 +23,7 @@ export class EditorSamplesPage {
 	}
 
 	async selectTab({tabLabel}: {tabLabel: string}) {
-		const tab = this.page.
-			locator('.nav-link').
-			filter({hasText: tabLabel});
+		const tab = this.page.locator('.nav-link').filter({hasText: tabLabel});
 
 		await tab.click();
 	}

--- a/modules/test/playwright/tests/client-extension-web/pages/EditorSamplesPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/EditorSamplesPage.ts
@@ -23,10 +23,9 @@ export class EditorSamplesPage {
 	}
 
 	async selectTab({tabLabel}: {tabLabel: string}) {
-		const tab = this.page.getByRole('tab', {
-			exact: true,
-			name: tabLabel,
-		});
+		const tab = this.page.
+			locator('.nav-link').
+			filter({hasText: tabLabel});
 
 		await tab.click();
 	}


### PR DESCRIPTION
This test was broken for two reasons:
 * On one side, we need to choose CKEditor 4 page before accessing to AlloyEditor. That was not happening before adding CKEditor 5 ahead of CKEditor 4 in our sample.
 * Tab selection had to be fixed since they don't include a role="tab".