### PR TITLE
LPD-48424 - CKEditor 5 tooltip styles

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -84,4 +84,19 @@
 			}
 		}
 	}
+
+	&.ck-balloon-panel.ck-tooltip {
+		background-color: $dark-d2;
+		border-radius: 0.25rem;
+		box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
+		max-width: 230px;
+		padding: 0.75rem;
+		text-align: center;
+		white-space: pre-line;
+
+		& .ck-tooltip__text {
+			color: $light-l2;
+			font-size: 0.85rem;
+		}
+	}
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -5,35 +5,18 @@
 }
 
 .ck {
-	&.lfr-editor {
-		&-heading_paragraph .ck-button__label {
-			@include font-size($font-size-base);
-		}
+	&.ck-balloon-panel.ck-tooltip {
+		background-color: $dark-d2;
+		border-radius: 0.25rem;
+		box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
+		max-width: 230px;
+		padding: 0.75rem;
+		text-align: center;
+		white-space: pre-line;
 
-		&-heading_heading1 .ck-button__label {
-			@include font-size($h1-font-size);
-		}
-
-		&-heading_heading2 .ck-button__label {
-			@include font-size($h2-font-size);
-		}
-
-		&-heading_heading3 .ck-button__label {
-			@include font-size($h3-font-size);
-		}
-	}
-
-	&[class*='lfr-editor-heading_heading'] {
-		color: $headings-color;
-		font-family: $headings-font-family;
-		font-weight: $headings-font-weight;
-	}
-
-	&.ck-toolbar {
-		& > .ck-toolbar__items > *:not(.ck-toolbar__line-break),
-		& > .ck.ck-toolbar__grouped-dropdown {
-			margin-bottom: 6px;
-			margin-top: 6px;
+		& .ck-tooltip__text {
+			color: $light-l2;
+			font-size: 0.85rem;
 		}
 	}
 
@@ -72,6 +55,30 @@
 		}
 	}
 
+	&.lfr-editor {
+		&-heading_paragraph .ck-button__label {
+			@include font-size($font-size-base);
+		}
+
+		&-heading_heading1 .ck-button__label {
+			@include font-size($h1-font-size);
+		}
+
+		&-heading_heading2 .ck-button__label {
+			@include font-size($h2-font-size);
+		}
+
+		&-heading_heading3 .ck-button__label {
+			@include font-size($h3-font-size);
+		}
+	}
+
+	&[class*='lfr-editor-heading_heading'] {
+		color: $headings-color;
+		font-family: $headings-font-family;
+		font-weight: $headings-font-weight;
+	}
+
 	&.ck-style-panel .ck-style-grid {
 		.ck-style-grid__button {
 			&:focus,
@@ -85,18 +92,11 @@
 		}
 	}
 
-	&.ck-balloon-panel.ck-tooltip {
-		background-color: $dark-d2;
-		border-radius: 0.25rem;
-		box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.4);
-		max-width: 230px;
-		padding: 0.75rem;
-		text-align: center;
-		white-space: pre-line;
-
-		& .ck-tooltip__text {
-			color: $light-l2;
-			font-size: 0.85rem;
+	&.ck-toolbar {
+		& > .ck-toolbar__items > *:not(.ck-toolbar__line-break),
+		& > .ck.ck-toolbar__grouped-dropdown {
+			margin-bottom: 6px;
+			margin-top: 6px;
 		}
 	}
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
@@ -63,6 +63,11 @@ const ClassicEditor = ({config}: {config?: EditorConfig}) => {
 			Underline,
 		],
 		toolbar: ['undo', 'redo', '|', 'bold', 'italic', 'underline'],
+		ui: {
+			viewportOffset: {
+				top: 56
+			}
+		}
 	};
 
 	if (!Liferay.FeatureFlags['LPD-11235']) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
@@ -76,6 +76,15 @@ const ClassicEditor = ({config}: {config?: EditorConfig}) => {
 				...config,
 			}}
 			editor={BaseClassicEditor}
+			onReady={(editor: BaseClassicEditor) => {
+				editor.ui.view.toolbar.items.map((item: any) => {
+					if (item.buttonView) {
+						item.buttonView.tooltipPosition = 'n';
+					}
+
+					item.tooltipPosition = 'n';
+				});
+			}}
 		/>
 	);
 };

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/ClassicEditor.tsx
@@ -65,9 +65,9 @@ const ClassicEditor = ({config}: {config?: EditorConfig}) => {
 		toolbar: ['undo', 'redo', '|', 'bold', 'italic', 'underline'],
 		ui: {
 			viewportOffset: {
-				top: 56
-			}
-		}
+				top: 56,
+			},
+		},
 	};
 
 	if (!Liferay.FeatureFlags['LPD-11235']) {


### PR DESCRIPTION
## Story / Task
[LPD-48423](https://liferay.atlassian.net/browse/LPD-48423) / [LPD-48424](https://liferay.atlassian.net/browse/LPD-48424)

## Goal
Update CKEditor5 tooltip style to match DXP style.

Default position of the button tooltip in CKEditor 5 is below the buttons, while CKEditor 4 display the tooltips above the button. 

|ckeditor4_tooltip|ckeditor5_tooltip|
| ------------- | ------------- |
| ![ckeditor4_tooltip](https://github.com/user-attachments/assets/575f6dbe-5d0f-4c7a-9846-3dca3704333a) |![ckeditor5_tooltip](https://github.com/user-attachments/assets/e5a01942-905d-4550-b4f4-8a566ec7c7e3)|


It is possible to loop over all toolbar items (buttons and dropdowns) and change the position.

![image](https://github.com/user-attachments/assets/41637b72-7ee3-438d-90d4-8f66802987ff)
