### PR TITLE
LPD-49269 Investigate failure in client-extension-web/js.spec.ts > JS client extension can be created with name translations while having a language configuration for the site setting

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/js.spec.ts
+++ b/modules/test/playwright/tests/client-extension-web/js.spec.ts
@@ -469,7 +469,9 @@ test('JS client extension can be created with name translations while having a l
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
-			target: page.getByRole('menuitem', {name: 'spanish'}),
+			target: page.getByRole('menuitem', {
+				name: 'Not translated into Spanish.',
+			}),
 			trigger: page.getByRole('button', {
 				exact: false,
 				name: 'Current translation',
@@ -502,7 +504,9 @@ test('JS client extension can be created with name translations while having a l
 
 		await clickAndExpectToBeVisible({
 			autoClick: true,
-			target: page.getByRole('menuitem', {name: 'spanish'}),
+			target: page.getByRole('menuitem', {
+				name: 'Translated into Spanish.',
+			}),
 			trigger: page.getByRole('button', {
 				exact: false,
 				name: 'Current translation',


### PR DESCRIPTION
**Task:** https://liferay.atlassian.net/browse/LPD-46952
**Subtask:** https://liferay.atlassian.net/browse/LPD-49269

---

- Fixes a playwright test failure in `client-extension-web/js.spec.ts` due to multiple "Spanish" languages found in the menu. This makes it more specific to the Spain one, which is labeled as "Not translated into Spanish." and "Translated into Spanish." which doesn't have any country name in parentheses like `(Argentina)`.