### PR TITLE
LPD-42582 Preserve selected items after pagination

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -339,24 +339,59 @@ const FrontendDataSet = ({
 		}
 	}, [itemsProp]);
 
-	function selectItems(value) {
+	function deselectItems(value) {
 		if (Array.isArray(value)) {
-			return setSelectedItemsValue(value);
-		}
-
-		if (selectionType === 'single') {
-			return setSelectedItemsValue([value]);
-		}
-
-		const itemAdded = selectedItemsValue.find((item) => item === value);
-
-		if (itemAdded) {
-			setSelectedItemsValue(
-				selectedItemsValue.filter((element) => element !== value)
+			return setSelectedItemsValue(
+				selectedItemsValue.filter((item) => !value.includes(item))
 			);
 		}
+
+		setSelectedItemsValue(
+			selectedItemsValue.filter((item) => item !== value)
+		);
+	}
+
+	function selectItems(value) {
+		if (Liferay.FeatureFlags['LPD-42570']) {
+			if (Array.isArray(value)) {
+				const newItems = value.filter(
+					(item) => !selectedItemsValue.includes(item)
+				);
+
+				return setSelectedItemsValue([
+					...selectedItemsValue,
+					...newItems,
+				]);
+			}
+
+			if (selectedItemsValue.includes(value)) {
+				setSelectedItemsValue(
+					selectedItemsValue.filter((item) => item !== value)
+				);
+			}
+			else {
+				setSelectedItemsValue([...selectedItemsValue, value]);
+			}
+		}
 		else {
-			setSelectedItemsValue(selectedItemsValue.concat(value));
+			if (Array.isArray(value)) {
+				return setSelectedItemsValue(value);
+			}
+
+			if (selectionType === 'single') {
+				return setSelectedItemsValue([value]);
+			}
+
+			const itemAdded = selectedItemsValue.find((item) => item === value);
+
+			if (itemAdded) {
+				setSelectedItemsValue(
+					selectedItemsValue.filter((element) => element !== value)
+				);
+			}
+			else {
+				setSelectedItemsValue(selectedItemsValue.concat(value));
+			}
 		}
 	}
 
@@ -559,6 +594,7 @@ const FrontendDataSet = ({
 			<ManagementBar
 				bulkActions={bulkActions}
 				creationMenu={creationMenu}
+				deselectItems={(items) => deselectItems(items)}
 				fluid={style === 'fluid'}
 				items={items}
 				selectItems={(items) => selectItems(items)}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -13,6 +13,7 @@ import ActiveFiltersBar from './controls/filters/ActiveFiltersBar';
 function ManagementBar({
 	bulkActions,
 	creationMenu,
+	deselectItems,
 	fluid,
 	items,
 	selectItems,
@@ -23,12 +24,18 @@ function ManagementBar({
 	showSearch,
 	total,
 }) {
+	const pageSelectedItemsValue = selectedItemsValue.filter((id) =>
+		items.some((item) => item.id === id)
+	);
+
 	function handleCheckboxClick() {
-		if (selectedItemsValue.length === items.length) {
-			return selectItems([]);
+		const itemKeys = items.map((item) => item[selectedItemsKey]);
+
+		if (pageSelectedItemsValue.length === items.length) {
+			return deselectItems(itemKeys);
 		}
 
-		return selectItems(items.map((item) => item[selectedItemsKey]));
+		return selectItems(itemKeys);
 	}
 
 	return (
@@ -39,6 +46,7 @@ function ManagementBar({
 					fluid={fluid}
 					handleCheckboxClick={handleCheckboxClick}
 					items={items}
+					pageSelectedItemsValue={pageSelectedItemsValue}
 					selectItems={selectItems}
 					selectedItems={selectedItems}
 					selectedItemsKey={selectedItemsKey}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -35,6 +35,7 @@ function BulkActions({
 	fluid,
 	handleCheckboxClick,
 	items,
+	pageSelectedItemsValue,
 	selectItems,
 	selectedItems,
 	selectedItemsKey,
@@ -242,7 +243,7 @@ function BulkActions({
 											}
 											items={items}
 											selectedItemsValue={
-												selectedItemsValue
+												pageSelectedItemsValue
 											}
 										/>
 									</li>

--- a/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/customized.spec.ts
@@ -674,7 +674,7 @@ test(
 	}
 );
 
-test('Select items count label in bulk actions', async ({page}) => {
+test('Check selection behavior', async ({page}) => {
 	const itemsSelectorCheckbox = page.locator('input[name="items-selector"]');
 
 	await test.step('Change delta to 60 items', async () => {
@@ -693,17 +693,7 @@ test('Select items count label in bulk actions', async ({page}) => {
 		await expect(page.getByText('60 of 75 Items Selected')).toBeVisible();
 	});
 
-	await test.step('Unselect all items in current page using the bulk actions checkbox', async () => {
-		await itemsSelectorCheckbox.setChecked(false);
-
-		await expect(itemsSelectorCheckbox).not.toBeChecked();
-	});
-
 	await test.step('Select all items', async () => {
-		await itemsSelectorCheckbox.setChecked(true);
-
-		await expect(page.getByText('60 of 75 Items Selected')).toBeVisible();
-
 		await page.getByLabel('Go to page, 2').click();
 
 		for (let i = 1; i <= 15; i++) {
@@ -717,6 +707,22 @@ test('Select items count label in bulk actions', async ({page}) => {
 		await expect(
 			page.getByText('All Selected (75 of 75 Items)')
 		).toBeVisible();
+	});
+
+	await test.step('Check that selection are preserved through page navigation', async () => {
+		await page.getByLabel('Go to page, 1').click();
+
+		await expect(
+			page.getByText('All Selected (75 of 75 Items)')
+		).toBeVisible();
+	});
+
+	await test.step('Unselect all items in current page using the bulk actions checkbox', async () => {
+		await itemsSelectorCheckbox.setChecked(false);
+
+		await expect(itemsSelectorCheckbox).not.toBeChecked();
+
+		await expect(page.getByText('15 of 75 Items Selected')).toBeVisible();
 	});
 });
 


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-42582

<h1>Preserve selected items after pagination</h1>

:warning: FF LPD-42570 should be enabled :warning:

The goal of this PR is to preserve selected items in data sets through navigation, and manage bulk actions checkbox state based on current page's selection, not the entire data set.

<h2>Acceptance Criteria:</h2>

**The checkbox has 3 status**

- Checked: All items on the current page selected
- Empty: No items in the current page selected
- Undefined: Some intems in the current page selected

**Persist Selection Across Pages**

- When the user selects items on one page and navigates to another, the selections from the previous page will be retained.

Example: If 10 items are selected on page 1, navigating to page 2 will not clear the selections from page 1 and the count will be 10 of N items selected

**Independent View Selection**

When the user presses the main checkbox on a page:

- Only the items visible on that page are selected or deselected.
- This action does not affect selections made on other pages.

**Checkbox status**

When the user selects all items on a page and change to another page the checkbox will show the state of the new page based on 1)

- If the current page changes the items through filtering the checkbox has to update its state if necessary.
- If the current page changes the items through change page size the checkbox has to update its state if necessary.
- If the current page changes the items through sorting the checkbox has to update its state if necessary.