### PR TITLE
LPS-47244 Rework data set serialization (sorts)

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/serializer/FDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/serializer/FDSSerializer.java
@@ -7,6 +7,7 @@ package com.liferay.frontend.data.set.serializer;
 
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.portal.kernel.json.JSONArray;
 
@@ -40,6 +41,9 @@ public interface FDSSerializer {
 		String fdsName, HttpServletRequest httpServletRequest);
 
 	public List<FDSActionDropdownItem> serializeItemsActions(
+		String fdsName, HttpServletRequest httpServletRequest);
+
+	public FDSSortItemList serializeSorts(
 		String fdsName, HttpServletRequest httpServletRequest);
 
 	public JSONArray serializeViews(

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/sort/FDSSorts.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/sort/FDSSorts.java
@@ -6,22 +6,20 @@
 package com.liferay.frontend.data.set.sort;
 
 import com.liferay.frontend.data.set.FDSEntryItemImportPolicy;
-import com.liferay.frontend.data.set.model.FDSSortItem;
-
-import java.util.List;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
 
 import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Daniel Sanz
  */
-public interface FDSSortList {
+public interface FDSSorts {
 
 	public default FDSEntryItemImportPolicy getFDSEntryItemImportPolicy() {
 		return FDSEntryItemImportPolicy.DETACHED;
 	}
 
-	public List<FDSSortItem> getFDSSortItemList(
+	public FDSSortItemList getFDSSortItemList(
 		HttpServletRequest httpServletRequest);
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/sort/FDSSortsRegistry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/sort/FDSSortsRegistry.java
@@ -8,8 +8,8 @@ package com.liferay.frontend.data.set.sort;
 /**
  * @author Daniel Sanz
  */
-public interface FDSSortListRegistry {
+public interface FDSSortsRegistry {
 
-	public FDSSortList getFDSSortList(String fdsName);
+	public FDSSorts getFDSSorts(String fdsName);
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/sort/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/sort/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -12,6 +12,8 @@ import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.internal.url.FDSAPIURLBuilder;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSSortItemBuilder;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
 import com.liferay.frontend.data.set.serializer.FDSSerializer;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -256,6 +258,47 @@ public class CustomFDSSerializer
 
 				return fdsActionDropdownItem;
 			});
+	}
+
+	@Override
+	public FDSSortItemList serializeSorts(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		FDSSortItemList fdsSortItemList = new FDSSortItemList();
+
+		fdsSortItemList.addAll(
+			TransformUtil.transform(
+				getSortedRelatedObjectEntries(
+					fdsName, httpServletRequest, (Predicate<ObjectEntry>)null,
+					"sortsOrder", "dataSetToDataSetSorts"),
+				objectEntry -> {
+					Map<String, Object> properties =
+						objectEntry.getProperties();
+
+					String label = (String)properties.get("label");
+
+					if (Validator.isNull(label)) {
+						Map<String, String> labelI18n =
+							(Map<String, String>)properties.get("label_i18n");
+
+						label = labelI18n.get(
+							LocaleUtil.toLanguageId(
+								LocaleUtil.getSiteDefault()));
+					}
+
+					return FDSSortItemBuilder.setActive(
+						Boolean.valueOf(
+							String.valueOf(properties.get("default")))
+					).setDirection(
+						String.valueOf(properties.get("orderType"))
+					).setKey(
+						String.valueOf(properties.get("fieldName"))
+					).setLabel(
+						label
+					).build();
+				}));
+
+		return fdsSortItemList;
 	}
 
 	@Override

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -20,6 +20,7 @@ import com.liferay.list.type.model.ListTypeDefinition;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeDefinitionLocalService;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
+import com.liferay.object.entry.util.ObjectEntryThreadLocal;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
@@ -486,6 +487,8 @@ public class CustomFDSSerializer
 				false, null, null, null, null,
 				LocaleUtil.getMostRelevantLocale(), null, null);
 
+		ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
+
 		DefaultObjectEntryManager defaultObjectEntryManager =
 			DefaultObjectEntryManagerProvider.provide(
 				_objectEntryManagerRegistry.getObjectEntryManager(
@@ -504,6 +507,9 @@ public class CustomFDSSerializer
 					exception);
 			}
 		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(false);
+		}
 
 		return objectEntry;
 	}
@@ -511,6 +517,8 @@ public class CustomFDSSerializer
 	private Collection<ObjectEntry> _getRelatedObjectEntries(
 		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
 		Predicate<ObjectEntry> predicate, String relationshipName) {
+
+		ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(true);
 
 		Collection<ObjectEntry> objectEntries = null;
 
@@ -543,6 +551,9 @@ public class CustomFDSSerializer
 						relationshipName,
 					exception);
 			}
+		}
+		finally {
+			ObjectEntryThreadLocal.setSkipObjectEntryResourcePermission(false);
 		}
 
 		return objectEntries;

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
@@ -18,7 +18,11 @@ import com.liferay.frontend.data.set.filter.FDSFilterContextContributor;
 import com.liferay.frontend.data.set.filter.FDSFilterContextContributorRegistry;
 import com.liferay.frontend.data.set.filter.FDSFilterRegistry;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSSortItem;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
 import com.liferay.frontend.data.set.serializer.FDSSerializer;
+import com.liferay.frontend.data.set.sort.FDSSorts;
+import com.liferay.frontend.data.set.sort.FDSSortsRegistry;
 import com.liferay.frontend.data.set.view.FDSView;
 import com.liferay.frontend.data.set.view.FDSViewContextContributor;
 import com.liferay.frontend.data.set.view.FDSViewContextContributorRegistry;
@@ -138,6 +142,19 @@ public class SystemFDSSerializer
 	}
 
 	@Override
+	public FDSSortItemList serializeSorts(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		FDSSorts fdsSorts = fdsSortsRegistry.getFDSSorts(fdsName);
+
+		if (fdsSorts == null) {
+			return FDSSortItemList.of((FDSSortItem)null);
+		}
+
+		return fdsSorts.getFDSSortItemList(httpServletRequest);
+	}
+
+	@Override
 	public JSONArray serializeViews(
 		String fdsName, HttpServletRequest httpServletRequest) {
 
@@ -207,6 +224,9 @@ public class SystemFDSSerializer
 
 	@Reference
 	protected FDSItemsActionsRegistry fdsItemsActionsRegistry;
+
+	@Reference
+	protected FDSSortsRegistry fdsSortsRegistry;
 
 	@Reference
 	protected FDSViewContextContributorRegistry

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/sort/FDSSortsRegistryImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/sort/FDSSortsRegistryImpl.java
@@ -5,8 +5,8 @@
 
 package com.liferay.frontend.data.set.internal.sort;
 
-import com.liferay.frontend.data.set.sort.FDSSortList;
-import com.liferay.frontend.data.set.sort.FDSSortListRegistry;
+import com.liferay.frontend.data.set.sort.FDSSorts;
+import com.liferay.frontend.data.set.sort.FDSSortsRegistry;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerCustomizerFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
@@ -21,12 +21,23 @@ import org.osgi.service.component.annotations.Deactivate;
 /**
  * @author Daniel Sanz
  */
-@Component(service = FDSSortListRegistry.class)
-public class FDSSortListRegistryImpl implements FDSSortListRegistry {
+@Component(service = FDSSortsRegistry.class)
+public class FDSSortsRegistryImpl implements FDSSortsRegistry {
+
+	public FDSSortsRegistryImpl() {
+	}
+
+	public FDSSortsRegistryImpl(
+		ServiceTrackerMap
+			<String, ServiceTrackerCustomizerFactory.ServiceWrapper<FDSSorts>>
+				serviceTrackerMap) {
+
+		_serviceTrackerMap = serviceTrackerMap;
+	}
 
 	@Override
-	public FDSSortList getFDSSortList(String fdsName) {
-		ServiceTrackerCustomizerFactory.ServiceWrapper<FDSSortList>
+	public FDSSorts getFDSSorts(String fdsName) {
+		ServiceTrackerCustomizerFactory.ServiceWrapper<FDSSorts>
 			serviceWrapper = _serviceTrackerMap.getService(fdsName);
 
 		if (serviceWrapper == null) {
@@ -45,8 +56,8 @@ public class FDSSortListRegistryImpl implements FDSSortListRegistry {
 	@Activate
 	protected void activate(BundleContext bundleContext) {
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
-			bundleContext, FDSSortList.class, "frontend.data.set.name",
-			ServiceTrackerCustomizerFactory.<FDSSortList>serviceWrapper(
+			bundleContext, FDSSorts.class, "frontend.data.set.name",
+			ServiceTrackerCustomizerFactory.<FDSSorts>serviceWrapper(
 				bundleContext));
 	}
 
@@ -56,10 +67,10 @@ public class FDSSortListRegistryImpl implements FDSSortListRegistry {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		FDSSortListRegistryImpl.class);
+		FDSSortsRegistryImpl.class);
 
 	private ServiceTrackerMap
-		<String, ServiceTrackerCustomizerFactory.ServiceWrapper<FDSSortList>>
+		<String, ServiceTrackerCustomizerFactory.ServiceWrapper<FDSSorts>>
 			_serviceTrackerMap;
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializerTestCase.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializerTestCase.java
@@ -86,6 +86,8 @@ public abstract class BaseFDSSerializerTestCase {
 	protected static final String[] DESCRIPTIONS = RandomTestUtil.randomStrings(
 		2);
 
+	protected static final String[] FDS_NAMES = RandomTestUtil.randomStrings(2);
+
 	protected static final String[] FIELD_NAMES = RandomTestUtil.randomStrings(
 		3);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -111,22 +111,22 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		_resetFDSSerializer(fdsAPIURLResolverRegistry);
 
-		_mockSerializeAPIURL("fdsName", new String[] {"creator.name"});
+		_mockSerializeAPIURL(FDS_NAMES[0], new String[] {"creator.name"});
 
 		Assert.assertEquals(
 			"/o/app/endpoint?nestedFields=creator",
 			_customFDSSerializer.serializeAPIURL(
-				"fdsName", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		_resetFDSSerializer(fdsAPIURLResolverRegistry);
 
 		// Nested fields: creator.name and status.id
 
 		_mockSerializeAPIURL(
-			"fdsName", new String[] {"creator.name", "status.id"});
+			FDS_NAMES[0], new String[] {"creator.name", "status.id"});
 
 		String url = _customFDSSerializer.serializeAPIURL(
-			"fdsName", httpServletRequest);
+			FDS_NAMES[0], httpServletRequest);
 
 		Assert.assertTrue(url.startsWith("/o/app/endpoint?"));
 
@@ -143,13 +143,13 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Nested fields depth
 
 		_mockSerializeAPIURL(
-			"fdsName",
+			FDS_NAMES[0],
 			new String[] {
 				"creator.name", "status.id", "relation.creator.name"
 			});
 
 		url = _customFDSSerializer.serializeAPIURL(
-			"fdsName", httpServletRequest);
+			FDS_NAMES[0], httpServletRequest);
 
 		Assert.assertTrue(url.startsWith("/o/app/endpoint?"));
 
@@ -170,12 +170,12 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// No parameters
 
-		_mockSerializeAPIURL("fdsName", null);
+		_mockSerializeAPIURL(FDS_NAMES[0], null);
 
 		Assert.assertEquals(
 			"/o/app/endpoint",
 			_customFDSSerializer.serializeAPIURL(
-				"fdsName", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		serviceTrackerMap.close();
 	}
@@ -186,11 +186,11 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Different creation menu
 
 		_mockSerializeCreationMenu(
-			"fdsName1", new String[] {TITLES[0], TITLES[1]});
-		_mockSerializeCreationMenu("fdsName2", new String[] {TITLES[2]});
+			FDS_NAMES[0], new String[] {TITLES[0], TITLES[1]});
+		_mockSerializeCreationMenu(FDS_NAMES[1], new String[] {TITLES[2]});
 
 		CreationMenu creationMenu1 = _customFDSSerializer.serializeCreationMenu(
-			"fdsName1", httpServletRequest);
+			FDS_NAMES[0], httpServletRequest);
 
 		Assert.assertEquals(2, _getPrimaryItemsSize(creationMenu1));
 		Assert.assertFalse(_containsTitle(creationMenu1, TITLES[2]));
@@ -198,7 +198,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		Assert.assertTrue(_containsTitle(creationMenu1, TITLES[1]));
 
 		CreationMenu creationMenu2 = _customFDSSerializer.serializeCreationMenu(
-			"fdsName2", httpServletRequest);
+			FDS_NAMES[1], httpServletRequest);
 
 		Assert.assertEquals(1, _getPrimaryItemsSize(creationMenu2));
 		Assert.assertFalse(_containsTitle(creationMenu2, TITLES[0]));
@@ -209,19 +209,19 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// No creation menu
 
-		_mockSerializeCreationMenu("fdsName", null);
+		_mockSerializeCreationMenu(FDS_NAMES[0], null);
 
 		Assert.assertTrue(
 			_customFDSSerializer.serializeCreationMenu(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_resetFDSSerializer();
 
 		// Shared creation menu
 
-		_testSerializeCreationMenu("fdsName1");
-		_testSerializeCreationMenu("fdsName2");
+		_testSerializeCreationMenu(FDS_NAMES[0]);
+		_testSerializeCreationMenu(FDS_NAMES[1]);
 	}
 
 	@Test
@@ -330,7 +330,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		_customFDSSerializer.cetManager = cetManager;
 
 		_mockSerializeFilters(
-			"fdsName",
+			FDS_NAMES[0],
 			HashMapBuilder.<String, Object>put(
 				"clientExtensionEntryERC", cetExternalReferenceCode
 			).put(
@@ -355,7 +355,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_customFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -364,7 +364,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Date range filter
 
 		_mockSerializeFilters(
-			"fdsName",
+			FDS_NAMES[0],
 			HashMapBuilder.<String, Object>put(
 				"fieldName", FIELD_NAMES[0]
 			).put(
@@ -413,7 +413,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_customFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -422,7 +422,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Different filters
 
 		_mockSerializeFilters(
-			"fdsName1",
+			FDS_NAMES[0],
 			HashMapBuilder.<String, Object>put(
 				"fieldName", FIELD_NAMES[0]
 			).put(
@@ -433,7 +433,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				"type", FDSEntityFieldTypes.DATE
 			).build());
 		_mockSerializeFilters(
-			"fdsName2",
+			FDS_NAMES[1],
 			HashMapBuilder.<String, Object>put(
 				"fieldName", FIELD_NAMES[1]
 			).put(
@@ -446,10 +446,10 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		JSONAssert.assertNotEquals(
 			_customFDSSerializer.serializeFilters(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_customFDSSerializer.serializeFilters(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -457,12 +457,12 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// No filter
 
-		_mockSerializeFilters("fdsName", null);
+		_mockSerializeFilters(FDS_NAMES[0], null);
 
 		JSONAssert.assertEquals(
 			"[]",
 			_customFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -471,7 +471,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Selection filter
 
 		_mockSerializeFilters(
-			"fdsName",
+			FDS_NAMES[0],
 			HashMapBuilder.<String, Object>put(
 				"fieldName", FIELD_NAMES[0]
 			).put(
@@ -541,7 +541,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_customFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 	}
@@ -552,12 +552,12 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Different items actions
 
 		_mockSerializeItemsActions(
-			"fdsName1", new String[] {LABELS[0], LABELS[1]});
-		_mockSerializeItemsActions("fdsName2", new String[] {LABELS[2]});
+			FDS_NAMES[0], new String[] {LABELS[0], LABELS[1]});
+		_mockSerializeItemsActions(FDS_NAMES[1], new String[] {LABELS[2]});
 
 		List<FDSActionDropdownItem> fdsActionDropdownItems1 =
 			_customFDSSerializer.serializeItemsActions(
-				"fdsName1", httpServletRequest);
+				FDS_NAMES[0], httpServletRequest);
 
 		Assert.assertFalse(_containsLabel(fdsActionDropdownItems1, LABELS[2]));
 		Assert.assertTrue(_containsLabel(fdsActionDropdownItems1, LABELS[0]));
@@ -566,7 +566,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		List<FDSActionDropdownItem> fdsActionDropdownItems2 =
 			_customFDSSerializer.serializeItemsActions(
-				"fdsName2", httpServletRequest);
+				FDS_NAMES[1], httpServletRequest);
 
 		Assert.assertFalse(_containsLabel(fdsActionDropdownItems2, LABELS[1]));
 		Assert.assertFalse(_containsLabel(fdsActionDropdownItems2, LABELS[0]));
@@ -577,19 +577,19 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// No items actions
 
-		_mockSerializeItemsActions("fdsName", null);
+		_mockSerializeItemsActions(FDS_NAMES[0], null);
 
 		Assert.assertTrue(
 			_customFDSSerializer.serializeItemsActions(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_resetFDSSerializer();
 
 		// Shared items actions
 
-		_testSerializeItemsActions("fdsName1");
-		_testSerializeItemsActions("fdsName2");
+		_testSerializeItemsActions(FDS_NAMES[0]);
+		_testSerializeItemsActions(FDS_NAMES[1]);
 	}
 
 	@Test
@@ -619,7 +619,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				"orderType", "desc"
 			).build();
 
-		_mockSerializeSorts("fdsName1", sortProperties1, sortProperties2);
+		_mockSerializeSorts(FDS_NAMES[0], sortProperties1, sortProperties2);
 
 		Map<String, Object> sortProperties3 =
 			HashMapBuilder.<String, Object>put(
@@ -632,10 +632,10 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				"orderType", "asc"
 			).build();
 
-		_mockSerializeSorts("fdsName2", sortProperties3);
+		_mockSerializeSorts(FDS_NAMES[1], sortProperties3);
 
 		FDSSortItemList fdsSortItemList1 = _customFDSSerializer.serializeSorts(
-			"fdsName1", httpServletRequest);
+			FDS_NAMES[0], httpServletRequest);
 
 		Assert.assertFalse(
 			_containsSortProperties(fdsSortItemList1, sortProperties3));
@@ -646,7 +646,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		Assert.assertTrue(fdsSortItemList1.size() == 2);
 
 		FDSSortItemList fdsSortItemList2 = _customFDSSerializer.serializeSorts(
-			"fdsName2", httpServletRequest);
+			FDS_NAMES[1], httpServletRequest);
 
 		Assert.assertFalse(
 			_containsSortProperties(fdsSortItemList2, sortProperties1));
@@ -660,19 +660,19 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// No sorts
 
-		_mockSerializeSorts("fdsName", null);
+		_mockSerializeSorts(FDS_NAMES[0], null);
 
 		Assert.assertTrue(
 			_customFDSSerializer.serializeSorts(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_resetFDSSerializer();
 
 		// Shared sorts
 
-		_testSerializeSorts("fdsName1", sortProperties1, sortProperties2);
-		_testSerializeSorts("fdsName2", sortProperties1, sortProperties2);
+		_testSerializeSorts(FDS_NAMES[0], sortProperties1, sortProperties2);
+		_testSerializeSorts(FDS_NAMES[1], sortProperties1, sortProperties2);
 	}
 
 	@Test
@@ -683,7 +683,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		mockLanguage();
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName",
+			FDS_NAMES[0],
 			HashMapBuilder.put(
 				"image", IMAGES[0]
 			).put(
@@ -711,7 +711,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_customFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -720,7 +720,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Different views
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName1",
+			FDS_NAMES[0],
 			HashMapBuilder.put(
 				"image", IMAGES[0]
 			).put(
@@ -729,7 +729,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 			"dataSetToDataSetCardsSections");
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName2",
+			FDS_NAMES[1],
 			HashMapBuilder.put(
 				"image", IMAGES[1]
 			).put(
@@ -739,10 +739,10 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		JSONAssert.assertNotEquals(
 			_customFDSSerializer.serializeViews(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_customFDSSerializer.serializeViews(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -751,12 +751,13 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Empty view
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName", Collections.emptyMap(), "dataSetToDataSetListSections");
+			FDS_NAMES[0], Collections.emptyMap(),
+			"dataSetToDataSetListSections");
 
 		JSONAssert.assertEquals(
 			"[]",
 			_customFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -765,7 +766,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// List view
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName",
+			FDS_NAMES[0],
 			HashMapBuilder.put(
 				"image", IMAGES[0]
 			).put(
@@ -793,7 +794,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_customFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -808,19 +809,21 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		).build();
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName1", sectionsMap, "dataSetToDataSetListSections");
+			FDS_NAMES[0], sectionsMap, "dataSetToDataSetListSections");
 
 		_mockSerializeViewsCardsOrList(
-			"fdsName2", sectionsMap, "dataSetToDataSetListSections");
+			FDS_NAMES[1], sectionsMap, "dataSetToDataSetListSections");
 
 		JSONAssert.assertEquals(
 			_customFDSSerializer.serializeViews(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_customFDSSerializer.serializeViews(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
+
+		_resetFDSSerializer();
 
 		// Table view
 
@@ -875,7 +878,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 			).build());
 
 		_mockSerializeViewsTable(
-			"fdsName", tableSectionObjectEntriesProperties);
+			FDS_NAMES[0], tableSectionObjectEntriesProperties);
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -929,7 +932,7 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_customFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -23,6 +23,8 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONSerializer;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -220,8 +222,27 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// Shared creation menu
 
-		_testSerializeCreationMenu(FDS_NAMES[0]);
-		_testSerializeCreationMenu(FDS_NAMES[1]);
+		_mockSerializeCreationMenu(FDS_NAMES[0], TITLES);
+		_mockSerializeCreationMenu(FDS_NAMES[1], TITLES);
+
+		JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
+
+		JSONAssert.assertEquals(
+			jsonSerializer.serializeDeep(
+				_customFDSSerializer.serializeCreationMenu(
+					FDS_NAMES[0], httpServletRequest)
+			).toString(),
+			jsonSerializer.serializeDeep(
+				_customFDSSerializer.serializeCreationMenu(
+					FDS_NAMES[1], httpServletRequest)
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		Assert.assertEquals(
+			TITLES.length,
+			_getPrimaryItemsSize(
+				_customFDSSerializer.serializeCreationMenu(
+					FDS_NAMES[1], httpServletRequest)));
 	}
 
 	@Test
@@ -468,6 +489,35 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		_resetFDSSerializer();
 
+		// Shared filter
+
+		Map<String, Object> filterProperties =
+			HashMapBuilder.<String, Object>put(
+				"fieldName", FIELD_NAMES[0]
+			).put(
+				"from", "2000-12-31T00:00:00.000Z"
+			).put(
+				"label", LABELS[0]
+			).put(
+				"to", "2025-10-03T00:00:00.000Z"
+			).put(
+				"type", FDSEntityFieldTypes.DATE
+			).build();
+
+		_mockSerializeFilters(FDS_NAMES[0], filterProperties);
+		_mockSerializeFilters(FDS_NAMES[1], filterProperties);
+
+		JSONAssert.assertEquals(
+			_customFDSSerializer.serializeFilters(
+				FDS_NAMES[0], httpServletRequest
+			).toString(),
+			_customFDSSerializer.serializeFilters(
+				FDS_NAMES[1], httpServletRequest
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		_resetFDSSerializer();
+
 		// Selection filter
 
 		_mockSerializeFilters(
@@ -588,8 +638,27 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// Shared items actions
 
-		_testSerializeItemsActions(FDS_NAMES[0]);
-		_testSerializeItemsActions(FDS_NAMES[1]);
+		_mockSerializeItemsActions(FDS_NAMES[0], LABELS);
+		_mockSerializeItemsActions(FDS_NAMES[1], LABELS);
+
+		JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
+
+		JSONAssert.assertEquals(
+			jsonSerializer.serializeDeep(
+				_customFDSSerializer.serializeItemsActions(
+					FDS_NAMES[0], httpServletRequest)
+			).toString(),
+			jsonSerializer.serializeDeep(
+				_customFDSSerializer.serializeItemsActions(
+					FDS_NAMES[1], httpServletRequest)
+			).toString(),
+			JSONCompareMode.STRICT);
+
+		Assert.assertEquals(
+			_customFDSSerializer.serializeItemsActions(
+				FDS_NAMES[0], httpServletRequest
+			).size(),
+			LABELS.length);
 	}
 
 	@Test
@@ -671,8 +740,21 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// Shared sorts
 
-		_testSerializeSorts(FDS_NAMES[0], sortProperties1, sortProperties2);
-		_testSerializeSorts(FDS_NAMES[1], sortProperties1, sortProperties2);
+		_mockSerializeSorts(FDS_NAMES[0], sortProperties1, sortProperties2);
+		_mockSerializeSorts(FDS_NAMES[1], sortProperties1, sortProperties2);
+
+		JSONSerializer jsonSerializer = JSONFactoryUtil.createJSONSerializer();
+
+		JSONAssert.assertEquals(
+			jsonSerializer.serializeDeep(
+				_customFDSSerializer.serializeSorts(
+					FDS_NAMES[0], httpServletRequest)
+			).toString(),
+			jsonSerializer.serializeDeep(
+				_customFDSSerializer.serializeSorts(
+					FDS_NAMES[1], httpServletRequest)
+			).toString(),
+			JSONCompareMode.STRICT);
 	}
 
 	@Test
@@ -1370,49 +1452,6 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		_customFDSSerializer.fdsAPIURLResolverRegistry =
 			fdsAPIURLResolverRegistry;
-	}
-
-	private void _testSerializeCreationMenu(String fdsName) {
-		_mockSerializeCreationMenu(fdsName, TITLES);
-
-		CreationMenu creationMenu = _customFDSSerializer.serializeCreationMenu(
-			fdsName, httpServletRequest);
-
-		for (String title : TITLES) {
-			Assert.assertTrue(_containsTitle(creationMenu, title));
-		}
-
-		Assert.assertEquals(TITLES.length, _getPrimaryItemsSize(creationMenu));
-	}
-
-	private void _testSerializeItemsActions(String fdsName) {
-		_mockSerializeItemsActions(fdsName, LABELS);
-
-		List<FDSActionDropdownItem> fdsActionDropdownItems =
-			_customFDSSerializer.serializeItemsActions(
-				fdsName, httpServletRequest);
-
-		for (String label : LABELS) {
-			Assert.assertTrue(_containsLabel(fdsActionDropdownItems, label));
-		}
-
-		Assert.assertTrue(LABELS.length == fdsActionDropdownItems.size());
-	}
-
-	private void _testSerializeSorts(
-		String fdsName, Map<String, Object>... sortMaps) {
-
-		_mockSerializeSorts(fdsName, sortMaps);
-
-		FDSSortItemList fdsSortItemList = _customFDSSerializer.serializeSorts(
-			fdsName, httpServletRequest);
-
-		for (Map<String, Object> sortMap : sortMaps) {
-			Assert.assertTrue(
-				_containsSortProperties(fdsSortItemList, sortMap));
-		}
-
-		Assert.assertTrue(sortMaps.length == fdsSortItemList.size());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -11,6 +11,8 @@ import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.internal.url.FDSAPIURLResolverRegistryImpl;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSSortItem;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
 import com.liferay.frontend.data.set.url.FDSAPIURLResolver;
 import com.liferay.frontend.data.set.url.FDSAPIURLResolverRegistry;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.CreationMenu;
@@ -42,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Predicate;
 
@@ -590,6 +593,89 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 	}
 
 	@Test
+	public void testSerializeSorts() throws Exception {
+
+		// Different sorts
+
+		Map<String, Object> sortProperties1 =
+			HashMapBuilder.<String, Object>put(
+				"default", true
+			).put(
+				"fieldName", FIELD_NAMES[0]
+			).put(
+				"label", LABELS[0]
+			).put(
+				"orderType", "asc"
+			).build();
+
+		Map<String, Object> sortProperties2 =
+			HashMapBuilder.<String, Object>put(
+				"default", false
+			).put(
+				"fieldName", FIELD_NAMES[1]
+			).put(
+				"label", LABELS[1]
+			).put(
+				"orderType", "desc"
+			).build();
+
+		_mockSerializeSorts("fdsName1", sortProperties1, sortProperties2);
+
+		Map<String, Object> sortProperties3 =
+			HashMapBuilder.<String, Object>put(
+				"default", true
+			).put(
+				"fieldName", FIELD_NAMES[2]
+			).put(
+				"label", LABELS[2]
+			).put(
+				"orderType", "asc"
+			).build();
+
+		_mockSerializeSorts("fdsName2", sortProperties3);
+
+		FDSSortItemList fdsSortItemList1 = _customFDSSerializer.serializeSorts(
+			"fdsName1", httpServletRequest);
+
+		Assert.assertFalse(
+			_containsSortProperties(fdsSortItemList1, sortProperties3));
+		Assert.assertTrue(
+			_containsSortProperties(fdsSortItemList1, sortProperties1));
+		Assert.assertTrue(
+			_containsSortProperties(fdsSortItemList1, sortProperties2));
+		Assert.assertTrue(fdsSortItemList1.size() == 2);
+
+		FDSSortItemList fdsSortItemList2 = _customFDSSerializer.serializeSorts(
+			"fdsName2", httpServletRequest);
+
+		Assert.assertFalse(
+			_containsSortProperties(fdsSortItemList2, sortProperties1));
+		Assert.assertFalse(
+			_containsSortProperties(fdsSortItemList2, sortProperties2));
+		Assert.assertTrue(
+			_containsSortProperties(fdsSortItemList2, sortProperties3));
+		Assert.assertTrue(fdsSortItemList2.size() == 1);
+
+		_resetFDSSerializer();
+
+		// No sorts
+
+		_mockSerializeSorts("fdsName", null);
+
+		Assert.assertTrue(
+			_customFDSSerializer.serializeSorts(
+				"fdsName", httpServletRequest
+			).isEmpty());
+
+		_resetFDSSerializer();
+
+		// Shared sorts
+
+		_testSerializeSorts("fdsName1", sortProperties1, sortProperties2);
+		_testSerializeSorts("fdsName2", sortProperties1, sortProperties2);
+	}
+
+	@Test
 	public void testSerializeViews() throws Exception {
 
 		// Cards view
@@ -862,6 +948,27 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		return false;
 	}
 
+	private boolean _containsSortProperties(
+		FDSSortItemList fdsSortItemList, Map<String, Object> sortProperties) {
+
+		for (FDSSortItem fdsSortItem : fdsSortItemList) {
+			if (Objects.equals(
+					fdsSortItem.get("active"), sortProperties.get("default")) &&
+				Objects.equals(
+					fdsSortItem.get("direction"),
+					sortProperties.get("orderType")) &&
+				Objects.equals(
+					fdsSortItem.get("key"), sortProperties.get("fieldName")) &&
+				Objects.equals(
+					fdsSortItem.get("label"), sortProperties.get("label"))) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	private boolean _containsTitle(CreationMenu creationMenu, String title) {
 		for (DropdownItem dropdownItem :
 				(List<DropdownItem>)creationMenu.get("primaryItems")) {
@@ -1048,6 +1155,33 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		Mockito.when(
 			_customFDSSerializer.serializeItemsActions(
 				fdsName, httpServletRequest)
+		).thenCallRealMethod();
+	}
+
+	private void _mockSerializeSorts(
+		String fdsName, Map<String, Object>... sortsMaps) {
+
+		List<ObjectEntry> objectEntries = TransformUtil.transformToList(
+			sortsMaps,
+			sortsMap -> {
+				ObjectEntry objectEntry = new ObjectEntry();
+
+				objectEntry.setProperties(sortsMap);
+
+				return objectEntry;
+			});
+
+		Mockito.when(
+			_customFDSSerializer.getSortedRelatedObjectEntries(
+				Mockito.eq(fdsName), Mockito.eq(httpServletRequest),
+				Mockito.any(), Mockito.eq("sortsOrder"),
+				Mockito.eq("dataSetToDataSetSorts"))
+		).thenReturn(
+			objectEntries
+		);
+
+		Mockito.when(
+			_customFDSSerializer.serializeSorts(fdsName, httpServletRequest)
 		).thenCallRealMethod();
 	}
 
@@ -1260,6 +1394,22 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		}
 
 		Assert.assertTrue(LABELS.length == fdsActionDropdownItems.size());
+	}
+
+	private void _testSerializeSorts(
+		String fdsName, Map<String, Object>... sortMaps) {
+
+		_mockSerializeSorts(fdsName, sortMaps);
+
+		FDSSortItemList fdsSortItemList = _customFDSSerializer.serializeSorts(
+			fdsName, httpServletRequest);
+
+		for (Map<String, Object> sortMap : sortMaps) {
+			Assert.assertTrue(
+				_containsSortProperties(fdsSortItemList, sortMap));
+		}
+
+		Assert.assertTrue(sortMaps.length == fdsSortItemList.size());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
@@ -137,24 +137,25 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		);
 
 		_registerServices(
-			_registerSystemFDSEntry("nestedFields=creator", "fdsName"));
+			_registerSystemFDSEntry("nestedFields=creator", FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			"/o/app/endpoint?nestedFields=creator",
 			_systemFDSSerializer.serializeAPIURL(
-				"fdsName", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		_unregisterServices();
 
 		// Nested fields: creator and status
 
 		_registerServices(
-			_registerSystemFDSEntry("nestedFields=creator,status", "fdsName"));
+			_registerSystemFDSEntry(
+				"nestedFields=creator,status", FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			"/o/app/endpoint?nestedFields=creator,status",
 			_systemFDSSerializer.serializeAPIURL(
-				"fdsName", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		_unregisterServices();
 
@@ -163,24 +164,24 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		_registerServices(
 			_registerSystemFDSEntry(
 				"nestedFields=creator,status,relation&nestedFieldsDepth=2",
-				"fdsName"));
+				FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			"/o/app/endpoint?nestedFields=creator,status,relation&" +
 				"nestedFieldsDepth=2",
 			_systemFDSSerializer.serializeAPIURL(
-				"fdsName", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		_unregisterServices();
 
 		// No parameters
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			"/o/app/endpoint",
 			_systemFDSSerializer.serializeAPIURL(
-				"fdsName", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		_unregisterServices();
 
@@ -211,13 +212,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					"headless"));
 
 		_registerServices(
-			_registerFDSBulkActions(fdsActionDropdownItems1, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName1"));
+			_registerFDSBulkActions(fdsActionDropdownItems1, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			fdsActionDropdownItems1,
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName1", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		List<FDSActionDropdownItem> fdsActionDropdownItems2 =
 			ListUtil.fromArray(
@@ -226,29 +227,29 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					"modal-permissions"));
 
 		_registerServices(
-			_registerFDSBulkActions(fdsActionDropdownItems2, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSBulkActions(fdsActionDropdownItems2, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			fdsActionDropdownItems2,
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		Assert.assertNotEquals(
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName1", httpServletRequest),
+				FDS_NAMES[0], httpServletRequest),
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
 		// No bulk actions
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertTrue(
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_unregisterServices();
@@ -261,16 +262,16 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				"headless"));
 
 		_registerServices(
-			_registerFDSBulkActions(fdsActionDropdownItems1, "fdsName1"),
-			_registerFDSBulkActions(fdsActionDropdownItems1, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSBulkActions(fdsActionDropdownItems1, FDS_NAMES[0]),
+			_registerFDSBulkActions(fdsActionDropdownItems1, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName1", httpServletRequest),
+				FDS_NAMES[0], httpServletRequest),
 			_systemFDSSerializer.serializeBulkActions(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
@@ -303,13 +304,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		).build();
 
 		_registerServices(
-			_registerFDSCreationMenu(creationMenu1, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName1"));
+			_registerFDSCreationMenu(creationMenu1, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			creationMenu1,
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName1", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		CreationMenu creationMenu2 = CreationMenuBuilder.addDropdownItem(
 			DropdownItemBuilder.setIcon(
@@ -320,29 +321,29 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		).build();
 
 		_registerServices(
-			_registerFDSCreationMenu(creationMenu2, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSCreationMenu(creationMenu2, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			creationMenu2,
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		Assert.assertNotEquals(
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName1", httpServletRequest),
+				FDS_NAMES[0], httpServletRequest),
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
 		// No creation menu
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertTrue(
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_unregisterServices();
@@ -358,16 +359,16 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		).build();
 
 		_registerServices(
-			_registerFDSCreationMenu(creationMenu1, "fdsName1"),
-			_registerFDSCreationMenu(creationMenu1, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSCreationMenu(creationMenu1, FDS_NAMES[0]),
+			_registerFDSCreationMenu(creationMenu1, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName1", httpServletRequest),
+				FDS_NAMES[0], httpServletRequest),
 			_systemFDSSerializer.serializeCreationMenu(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
@@ -436,13 +437,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					}
 
 				},
-				"fdsName"),
+				FDS_NAMES[0]),
 			_bundleContext.registerService(
 				FDSFilterContextContributor.class,
 				new ClientExtensionFDSFilterContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.filter.type", "clientExtension")),
-			_registerSystemFDSEntry(null, "fdsName"));
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -464,7 +465,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_systemFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -482,13 +483,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					).put(
 						"to", new DateFDSFilterItem(27, 5, 1995)
 					).build()),
-				"fdsName"),
+				FDS_NAMES[0]),
 			_bundleContext.registerService(
 				FDSFilterContextContributor.class,
 				new DateRangeFDSFilterContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.filter.type", "dateRange")),
-			_registerSystemFDSEntry(null, "fdsName"));
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -542,7 +543,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_systemFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -555,26 +556,26 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				_createFDSFilterDate(
 					IDS[0], LABELS[0], new DateFDSFilterItem(1, 1, 1980),
 					new DateFDSFilterItem(0, 0, 0), null),
-				"fdsName1"),
+				FDS_NAMES[0]),
 			_registerFDSFilter(
 				_createFDSFilterDate(
 					IDS[1], LABELS[1], new DateFDSFilterItem(31, 12, 1987),
 					new DateFDSFilterItem(1, 2, 1900), null),
-				"fdsName2"),
+				FDS_NAMES[1]),
 			_bundleContext.registerService(
 				FDSFilterContextContributor.class,
 				new DateRangeFDSFilterContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.filter.type", "dateRange")),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		JSONAssert.assertNotEquals(
 			_systemFDSSerializer.serializeFilters(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_systemFDSSerializer.serializeFilters(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -607,13 +608,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					}
 
 				},
-				"fdsName"),
-			_registerSystemFDSEntry(null, "fdsName"));
+				FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			"[]",
 			_systemFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -621,12 +622,12 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// No filter
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			"[]",
 			_systemFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -695,13 +696,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					}
 
 				},
-				"fdsName"),
+				FDS_NAMES[0]),
 			_bundleContext.registerService(
 				FDSFilterContextContributor.class,
 				new SelectionFDSFilterContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.filter.type", "selection")),
-			_registerSystemFDSEntry(null, "fdsName"));
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -743,7 +744,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_systemFDSSerializer.serializeFilters(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -756,17 +757,17 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 			new DateFDSFilterItem(0, 0, 0), null);
 
 		_registerServices(
-			_registerFDSFilter(dateRangeFDSFilter, "fdsName1"),
-			_registerFDSFilter(dateRangeFDSFilter, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSFilter(dateRangeFDSFilter, FDS_NAMES[0]),
+			_registerFDSFilter(dateRangeFDSFilter, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		JSONAssert.assertEquals(
 			_systemFDSSerializer.serializeFilters(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_systemFDSSerializer.serializeFilters(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -806,34 +807,34 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					"modal-permissions"));
 
 		_registerServices(
-			_registerFDSItemsActions(fdsActionDropdownItems1, "fdsName1"),
-			_registerFDSItemsActions(fdsActionDropdownItems2, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSItemsActions(fdsActionDropdownItems1, FDS_NAMES[0]),
+			_registerFDSItemsActions(fdsActionDropdownItems2, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			fdsActionDropdownItems1,
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName1", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 		Assert.assertEquals(
 			fdsActionDropdownItems2,
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 		Assert.assertNotEquals(
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName1", httpServletRequest),
+				FDS_NAMES[0], httpServletRequest),
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
 		// No items actions
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertTrue(
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_unregisterServices();
@@ -846,16 +847,16 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				"headless"));
 
 		_registerServices(
-			_registerFDSItemsActions(fdsActionDropdownItems1, "fdsName1"),
-			_registerFDSItemsActions(fdsActionDropdownItems1, "fdsName2"),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSItemsActions(fdsActionDropdownItems1, FDS_NAMES[0]),
+			_registerFDSItemsActions(fdsActionDropdownItems1, FDS_NAMES[1]),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName1", httpServletRequest),
+				FDS_NAMES[0], httpServletRequest),
 			_systemFDSSerializer.serializeItemsActions(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
@@ -910,13 +911,13 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		).build();
 
 		_registerServices(
-			_registerFDSSorts("fdsName1", fdsSortItemList1),
-			_registerSystemFDSEntry(null, "fdsName1"));
+			_registerFDSSorts(FDS_NAMES[0], fdsSortItemList1),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			fdsSortItemList1,
 			_systemFDSSerializer.serializeSorts(
-				"fdsName1", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest));
 
 		FDSSortItemList fdsSortItemList2 = FDSSortItemListBuilder.add(
 			FDSSortItemBuilder.setActive(
@@ -951,28 +952,29 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		).build();
 
 		_registerServices(
-			_registerFDSSorts("fdsName2", fdsSortItemList2),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSSorts(FDS_NAMES[1], fdsSortItemList2),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
 			fdsSortItemList2,
 			_systemFDSSerializer.serializeSorts(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[1], httpServletRequest));
 
 		Assert.assertNotEquals(
-			_systemFDSSerializer.serializeSorts("fdsName1", httpServletRequest),
 			_systemFDSSerializer.serializeSorts(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest),
+			_systemFDSSerializer.serializeSorts(
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
 		// No sorts
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		Assert.assertTrue(
 			_systemFDSSerializer.serializeSorts(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).isEmpty());
 
 		_unregisterServices();
@@ -980,15 +982,16 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		// Shared sort
 
 		_registerServices(
-			_registerFDSSorts("fdsName1", fdsSortItemList1),
-			_registerFDSSorts("fdsName2", fdsSortItemList1),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSSorts(FDS_NAMES[0], fdsSortItemList1),
+			_registerFDSSorts(FDS_NAMES[1], fdsSortItemList1),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		Assert.assertEquals(
-			_systemFDSSerializer.serializeSorts("fdsName1", httpServletRequest),
 			_systemFDSSerializer.serializeSorts(
-				"fdsName2", httpServletRequest));
+				FDS_NAMES[0], httpServletRequest),
+			_systemFDSSerializer.serializeSorts(
+				FDS_NAMES[1], httpServletRequest));
 
 		_unregisterServices();
 
@@ -1068,8 +1071,8 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				new CardsFDSViewContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.view.name", FDSConstants.CARDS)),
-			_registerFDSView("fdsName", cardsFDSView),
-			_registerSystemFDSEntry(null, "fdsName"));
+			_registerFDSView(FDS_NAMES[0], cardsFDSView),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -1101,7 +1104,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_systemFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -1149,17 +1152,17 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				new ListFDSViewContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.view.name", FDSConstants.LIST)),
-			_registerFDSView("fdsName1", cardsFDSView),
-			_registerFDSView("fdsName2", listFDSView),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSView(FDS_NAMES[0], cardsFDSView),
+			_registerFDSView(FDS_NAMES[1], listFDSView),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		JSONAssert.assertNotEquals(
 			_systemFDSSerializer.serializeViews(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_systemFDSSerializer.serializeViews(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -1167,12 +1170,12 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 
 		// Empty view
 
-		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+		_registerServices(_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			"[]",
 			_systemFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -1186,8 +1189,8 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				new ListFDSViewContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.view.name", FDSConstants.LIST)),
-			_registerFDSView("fdsName", listFDSView),
-			_registerSystemFDSEntry(null, "fdsName"));
+			_registerFDSView(FDS_NAMES[0], listFDSView),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -1217,7 +1220,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_systemFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 
@@ -1231,19 +1234,21 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				new CardsFDSViewContextContributor(),
 				MapUtil.singletonDictionary(
 					"frontend.data.set.view.name", FDSConstants.CARDS)),
-			_registerFDSView("fdsName1", cardsFDSView),
-			_registerFDSView("fdsName2", cardsFDSView),
-			_registerSystemFDSEntry(null, "fdsName1"),
-			_registerSystemFDSEntry(null, "fdsName2"));
+			_registerFDSView(FDS_NAMES[0], cardsFDSView),
+			_registerFDSView(FDS_NAMES[1], cardsFDSView),
+			_registerSystemFDSEntry(null, FDS_NAMES[0]),
+			_registerSystemFDSEntry(null, FDS_NAMES[1]));
 
 		JSONAssert.assertEquals(
 			_systemFDSSerializer.serializeViews(
-				"fdsName1", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			_systemFDSSerializer.serializeViews(
-				"fdsName2", httpServletRequest
+				FDS_NAMES[1], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
+
+		_unregisterServices();
 
 		// Table view
 
@@ -1254,7 +1259,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				MapUtil.singletonDictionary(
 					"frontend.data.set.view.name", FDSConstants.TABLE)),
 			_registerFDSView(
-				"fdsName",
+				FDS_NAMES[0],
 				new BaseTableFDSView() {
 
 					@Override
@@ -1285,7 +1290,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					}
 
 				}),
-			_registerSystemFDSEntry(null, "fdsName"));
+			_registerSystemFDSEntry(null, FDS_NAMES[0]));
 
 		JSONAssert.assertEquals(
 			JSONUtil.putAll(
@@ -1346,7 +1351,7 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				)
 			).toString(),
 			_systemFDSSerializer.serializeViews(
-				"fdsName", httpServletRequest
+				FDS_NAMES[0], httpServletRequest
 			).toString(),
 			JSONCompareMode.STRICT);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
@@ -27,6 +27,7 @@ import com.liferay.frontend.data.set.internal.filter.DateRangeFDSFilterContextCo
 import com.liferay.frontend.data.set.internal.filter.FDSFilterContextContributorRegistryImpl;
 import com.liferay.frontend.data.set.internal.filter.FDSFilterRegistryImpl;
 import com.liferay.frontend.data.set.internal.filter.SelectionFDSFilterContextContributor;
+import com.liferay.frontend.data.set.internal.sort.FDSSortsRegistryImpl;
 import com.liferay.frontend.data.set.internal.url.FDSAPIURLResolverRegistryImpl;
 import com.liferay.frontend.data.set.internal.view.FDSViewContextContributorRegistryImpl;
 import com.liferay.frontend.data.set.internal.view.FDSViewRegistryImpl;
@@ -35,6 +36,10 @@ import com.liferay.frontend.data.set.internal.view.list.ListFDSViewContextContri
 import com.liferay.frontend.data.set.internal.view.table.FDSTableSchemaBuilderImpl;
 import com.liferay.frontend.data.set.internal.view.table.TableFDSViewContextContributor;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
+import com.liferay.frontend.data.set.model.FDSSortItemBuilder;
+import com.liferay.frontend.data.set.model.FDSSortItemList;
+import com.liferay.frontend.data.set.model.FDSSortItemListBuilder;
+import com.liferay.frontend.data.set.sort.FDSSorts;
 import com.liferay.frontend.data.set.url.FDSAPIURLResolver;
 import com.liferay.frontend.data.set.view.FDSView;
 import com.liferay.frontend.data.set.view.FDSViewContextContributor;
@@ -858,6 +863,139 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 	}
 
 	@Test
+	public void testSerializeSortItems() throws Exception {
+
+		// Different sorts
+
+		ServiceTrackerMap
+			<String, ServiceTrackerCustomizerFactory.ServiceWrapper<FDSSorts>>
+				serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+					_bundleContext, FDSSorts.class, "frontend.data.set.name",
+					ServiceTrackerCustomizerFactory.<FDSSorts>serviceWrapper(
+						_bundleContext));
+
+		_systemFDSSerializer.fdsSortsRegistry = new FDSSortsRegistryImpl(
+			serviceTrackerMap);
+
+		FDSSortItemList fdsSortItemList1 = FDSSortItemListBuilder.add(
+			FDSSortItemBuilder.setActive(
+				true
+			).setDirection(
+				"asc"
+			).setKey(
+				IDS[0]
+			).setLabel(
+				LABELS[0]
+			).build()
+		).add(
+			FDSSortItemBuilder.setActive(
+				false
+			).setDirection(
+				"desc"
+			).setKey(
+				IDS[1]
+			).setLabel(
+				LABELS[1]
+			).build()
+		).add(
+			FDSSortItemBuilder.setActive(
+				false
+			).setDirection(
+				"desc"
+			).setKey(
+				IDS[2]
+			).setLabel(
+				LABELS[2]
+			).build()
+		).build();
+
+		_registerServices(
+			_registerFDSSorts("fdsName1", fdsSortItemList1),
+			_registerSystemFDSEntry(null, "fdsName1"));
+
+		Assert.assertEquals(
+			fdsSortItemList1,
+			_systemFDSSerializer.serializeSorts(
+				"fdsName1", httpServletRequest));
+
+		FDSSortItemList fdsSortItemList2 = FDSSortItemListBuilder.add(
+			FDSSortItemBuilder.setActive(
+				false
+			).setDirection(
+				"asc"
+			).setKey(
+				IDS[2]
+			).setLabel(
+				LABELS[0]
+			).build()
+		).add(
+			FDSSortItemBuilder.setActive(
+				true
+			).setDirection(
+				"asc"
+			).setKey(
+				IDS[1]
+			).setLabel(
+				LABELS[1]
+			).build()
+		).add(
+			FDSSortItemBuilder.setActive(
+				false
+			).setDirection(
+				"asc"
+			).setKey(
+				IDS[0]
+			).setLabel(
+				LABELS[2]
+			).build()
+		).build();
+
+		_registerServices(
+			_registerFDSSorts("fdsName2", fdsSortItemList2),
+			_registerSystemFDSEntry(null, "fdsName2"));
+
+		Assert.assertEquals(
+			fdsSortItemList2,
+			_systemFDSSerializer.serializeSorts(
+				"fdsName2", httpServletRequest));
+
+		Assert.assertNotEquals(
+			_systemFDSSerializer.serializeSorts("fdsName1", httpServletRequest),
+			_systemFDSSerializer.serializeSorts(
+				"fdsName2", httpServletRequest));
+
+		_unregisterServices();
+
+		// No sorts
+
+		_registerServices(_registerSystemFDSEntry(null, "fdsName"));
+
+		Assert.assertTrue(
+			_systemFDSSerializer.serializeSorts(
+				"fdsName", httpServletRequest
+			).isEmpty());
+
+		_unregisterServices();
+
+		// Shared sort
+
+		_registerServices(
+			_registerFDSSorts("fdsName1", fdsSortItemList1),
+			_registerFDSSorts("fdsName2", fdsSortItemList1),
+			_registerSystemFDSEntry(null, "fdsName1"),
+			_registerSystemFDSEntry(null, "fdsName2"));
+
+		Assert.assertEquals(
+			_systemFDSSerializer.serializeSorts("fdsName1", httpServletRequest),
+			_systemFDSSerializer.serializeSorts(
+				"fdsName2", httpServletRequest));
+
+		_unregisterServices();
+
+		serviceTrackerMap.close();
+	}
+
+	@Test
 	public void testSerializeViews() throws Exception {
 
 		// Cards view
@@ -1313,6 +1451,24 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 					HttpServletRequest httpServletRequest) {
 
 					return fdsActionDropdownItems;
+				}
+
+			},
+			MapUtil.singletonDictionary("frontend.data.set.name", fdsName));
+	}
+
+	private ServiceRegistration<FDSSorts> _registerFDSSorts(
+		String fdsName, FDSSortItemList fdsSortItemList) {
+
+		return _bundleContext.registerService(
+			FDSSorts.class,
+			new FDSSorts() {
+
+				@Override
+				public FDSSortItemList getFDSSortItemList(
+					HttpServletRequest httpServletRequest) {
+
+					return fdsSortItemList;
 				}
 
 			},


### PR DESCRIPTION
Fifth of a series of 6 PR about FDS rendering homogeneization. This time, sorts are being serialized, following usual patterns.

I'm leaving for a future PR the homogeneization of `L_DATA_SET_SORT` object entry field naming and `FDSSortItem` class. This will be addressed when we include `active` flag into serialization logic