### PR TITLE
LPD-49131 expose cssClass for navigation-bar from screen-navigation

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
+++ b/modules/apps/frontend-taglib/frontend-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Taglib
 Bundle-SymbolicName: com.liferay.frontend.taglib
-Bundle-Version: 13.8.2
+Bundle-Version: 13.9.0
 Export-Package:\
 	com.liferay.frontend.taglib.servlet.taglib,\
 	com.liferay.frontend.taglib.servlet.taglib.constants,\

--- a/modules/apps/frontend-taglib/frontend-taglib/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib/package.json
@@ -23,5 +23,5 @@
 		"checkFormat": "node-scripts format --check",
 		"format": "node-scripts format"
 	},
-	"version": "13.8.2"
+	"version": "13.9.0"
 }

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/ScreenNavigationTag.java
@@ -100,6 +100,10 @@ public class ScreenNavigationTag extends IncludeTag {
 		return _context;
 	}
 
+	public String getNavBarCssClass() {
+		return _navBarCssClass;
+	}
+
 	public String getNavCssClass() {
 		return _navCssClass;
 	}
@@ -152,6 +156,10 @@ public class ScreenNavigationTag extends IncludeTag {
 		_modelBean = modelBean;
 	}
 
+	public void setNavBarCssClass(String navBarCssClass) {
+		_navBarCssClass = navBarCssClass;
+	}
+
 	public void setNavCssClass(String navCssClass) {
 		_navCssClass = navCssClass;
 	}
@@ -182,6 +190,7 @@ public class ScreenNavigationTag extends IncludeTag {
 		_menubarCssClass =
 			"menubar menubar-transparent menubar-vertical-expand-md";
 		_modelBean = null;
+		_navBarCssClass = StringPool.BLANK;
 		_navCssClass = "col-md-3";
 		_portletURL = null;
 		_screenNavigationCategories = null;
@@ -244,6 +253,9 @@ public class ScreenNavigationTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-frontend:screen-navigation:modelContext",
 			getModelContext());
+		httpServletRequest.setAttribute(
+			"liferay-frontend:screen-navigation:navBarCssClass",
+			_navBarCssClass);
 		httpServletRequest.setAttribute(
 			"liferay-frontend:screen-navigation:navCssClass", _navCssClass);
 		httpServletRequest.setAttribute(
@@ -370,6 +382,7 @@ public class ScreenNavigationTag extends IncludeTag {
 	private String _menubarCssClass =
 		"menubar menubar-transparent menubar-vertical-expand-md";
 	private Object _modelBean;
+	private String _navBarCssClass = StringPool.BLANK;
 	private String _navCssClass = "col-md-3";
 	private PortletURL _portletURL;
 	private List<ScreenNavigationCategory> _screenNavigationCategories;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -755,6 +755,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>navBarCssClass</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>navCssClass</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/screen_navigation/page.jsp
@@ -16,6 +16,7 @@ String id = (String)request.getAttribute("liferay-frontend:screen-navigation:id"
 boolean inverted = (boolean)request.getAttribute("liferay-frontend:screen-navigation:inverted");
 String menubarCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:menubarCssClass");
 Object modelContext = (Object)request.getAttribute("liferay-frontend:screen-navigation:modelContext");
+String navBarCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:navBarCssClass");
 String navCssClass = (String)request.getAttribute("liferay-frontend:screen-navigation:navCssClass");
 PortletURL portletURL = (PortletURL)request.getAttribute("liferay-frontend:screen-navigation:portletURL");
 ScreenNavigationCategory selectedScreenNavigationCategory = (ScreenNavigationCategory)request.getAttribute("liferay-frontend:screen-navigation:selectedScreenNavigationCategory");
@@ -34,6 +35,7 @@ LiferayPortletResponse finalLiferayPortletResponse = liferayPortletResponse;
 
 			<clay:navigation-bar
 				activeItemAriaCurrent='<%= ListUtil.isNotEmpty(screenNavigationEntries) && (screenNavigationEntries.size() > 1) ? "false" : "page" %>'
+				cssClass="<%= navBarCssClass %>"
 				inverted="<%= inverted %>"
 				navigationItems='<%=
 					new JSPNavigationItemList(pageContext) {

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/com/liferay/frontend/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 9.7.0
+version 9.8.0


### PR DESCRIPTION
Hi Team,

I'm sending you this PR for review because we would like to have a class for the screen-navigation's nav element to adress [LPD-48995](https://liferay.atlassian.net/browse/LPD-48995). This is the [commit](https://github.com/liferay-bpm/liferay-portal/pull/4202) we would use if it is approved and merged (although we will gladly adapt it if changes are necessary). 

I've attached the before and after the object definition's image if it helps understand what the change is about.

Could you please review it?

Thanks in advance ❤️

![Before](https://github.com/user-attachments/assets/a308a370-0762-42b1-a8d3-a97c0ef56581)
![after](https://github.com/user-attachments/assets/3a126ff0-f97d-4ff2-8393-5f3bf6a4392c)



[LPD-48995]: https://liferay.atlassian.net/browse/LPD-48995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ