### PR TITLE
LPD-42578 Add "Clear" Action to Remove Selection

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -614,6 +614,7 @@ const FrontendDataSet = ({
 				deselectItems={(items) => deselectItems(items)}
 				fluid={style === 'fluid'}
 				items={items}
+				onBulkActionsClear={() => deselectItems(selectedItemsValue)}
 				selectItems={(items) => selectItems(items)}
 				selectedItems={selectedItems}
 				selectedItemsKey={selectedItemsKey}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -16,6 +16,7 @@ function ManagementBar({
 	deselectItems,
 	fluid,
 	items,
+	onBulkActionsClear,
 	selectItems,
 	selectedItems,
 	selectedItemsKey,
@@ -46,6 +47,7 @@ function ManagementBar({
 					fluid={fluid}
 					handleCheckboxClick={handleCheckboxClick}
 					items={items}
+					onClear={onBulkActionsClear}
 					pageSelectedItemsValue={pageSelectedItemsValue}
 					selectItems={selectItems}
 					selectedItems={selectedItems}
@@ -83,8 +85,10 @@ ManagementBar.propTypes = {
 		primaryItems: PropTypes.array,
 		secondaryItems: PropTypes.array,
 	}),
+	deselectItems: PropTypes.func.isRequired,
 	fluid: PropTypes.bool,
 	items: PropTypes.array.isRequired,
+	onBulkActionsClear: PropTypes.func.isRequired,
 	selectItems: PropTypes.func.isRequired,
 	selectedItems: PropTypes.array,
 	selectedItemsKey: PropTypes.string,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -35,6 +35,7 @@ function BulkActions({
 	fluid,
 	handleCheckboxClick,
 	items,
+	onClear,
 	pageSelectedItemsValue,
 	selectItems,
 	selectedItems,
@@ -270,6 +271,19 @@ function BulkActions({
 											)}
 								</span>
 
+								{Liferay.FeatureFlags['LPD-42570'] && (
+									<ClayLink
+										className="ml-3"
+										href="#"
+										onClick={(event) => {
+											event.preventDefault();
+											onClear();
+										}}
+									>
+										{Liferay.Language.get('clear')}
+									</ClayLink>
+								)}
+
 								<ClayLink
 									className="ml-3"
 									href="#"
@@ -343,6 +357,7 @@ BulkActions.propTypes = {
 	),
 	handleCheckboxClick: PropTypes.func.isRequired,
 	items: PropTypes.array.isRequired,
+	onClear: PropTypes.func.isRequired,
 	selectedItemsKey: PropTypes.string.isRequired,
 	selectedItemsValue: PropTypes.array.isRequired,
 	total: PropTypes.number,

--- a/modules/test/playwright/tests/frontend-data-set-web/advanced.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/advanced.spec.ts
@@ -724,6 +724,16 @@ test('Check selection behavior', async ({page}) => {
 
 		await expect(page.getByText('15 of 75 Items Selected')).toBeVisible();
 	});
+
+	await test.step('Unselect all items using clear button', async () => {
+		await page.getByText('Clear').click();
+
+		await expect(itemsSelectorCheckbox).not.toBeChecked();
+
+		await expect(
+			page.getByText('15 of 75 Items Selected')
+		).not.toBeVisible();
+	});
 });
 
 accountSettingsTest(


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-42578

<h1>Add "Clear" Action to Remove Selection</h1>

:warning: FF LPD-42570 must be enabled


The goal of this PR is to provide a button to clear all selected items in data sets


![image](https://github.com/user-attachments/assets/a64282b4-4080-4911-a6e4-dee702c8f77e)

<h3>Acceptance Criteria</h3>

- When some items on any page are selected, it's shown a "Clear" button
- Clicking the "Clear" button deselect all items, including those across other pages
- The button works for all visualization modes