### PR TITLE
PoC - FDS folder support

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -584,7 +584,10 @@ const FrontendDataSet = ({
 				}
 				setDataLoading(false);
 			}
+			Liferay.on(EVENTS.OPEN_FOLDER, openFolder);
 		});
+
+		return () => Liferay.detach(EVENTS.OPEN_FOLDER, openFolder);
 	}, [apiURL, isMounted, requestData, setDataLoading]);
 
 	useEffect(() => {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -43,7 +43,7 @@ const FrontendDataSet = ({
 	actionParameterName,
 	activeViewSettings,
 	additionalAPIURLParameters,
-	apiURL,
+	apiURL: initialApiURL,
 	appURL,
 	bulkActions,
 	creationMenu: initialCreationMenu,
@@ -87,6 +87,7 @@ const FrontendDataSet = ({
 	views,
 }) => {
 	const wrapperRef = useRef(null);
+	const [apiURL, setApiURL] = useState(initialApiURL);
 	const [componentLoading, setComponentLoading] = useState(false);
 	const [creationMenu, setCreationMenu] = useState(initialCreationMenu);
 	const [dataLoading, setDataLoading] = useState(!!apiURL);
@@ -809,6 +810,19 @@ const FrontendDataSet = ({
 		});
 	}
 
+	function openFolder({item}) {
+		const fullUrl = apiURL.startsWith('/')
+			? Liferay.ThemeDisplay.getPortalURL() +
+				Liferay.ThemeDisplay.getPathContext() +
+				apiURL
+			: apiURL;
+
+		const newApiURL = new URL(fullUrl);
+		newApiURL.searchParams.set('entryClassNames', item.entryClassName);
+
+		setApiURL(newApiURL.toString());
+	}
+
 	function toggleItemInlineEdit(itemKey) {
 		setItemsChanges(({[itemKey]: foundItem, ...itemsChanges}) => {
 			return foundItem
@@ -966,6 +980,7 @@ const FrontendDataSet = ({
 				onItemsChange,
 				onSearch,
 				onSelect,
+				openFolder,
 				openModal,
 				openSidePanel,
 				portletId,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -550,6 +550,22 @@ const FrontendDataSet = ({
 		});
 	};
 
+	const openFolder = useCallback(
+		({item}) => {
+			const fullUrl = apiURL.startsWith('/')
+				? Liferay.ThemeDisplay.getPortalURL() +
+					Liferay.ThemeDisplay.getPathContext() +
+					apiURL
+				: apiURL;
+
+			const newApiURL = new URL(fullUrl);
+			newApiURL.searchParams.set('entryClassNames', item.entryClassName);
+
+			setApiURL(newApiURL.toString());
+		},
+		[apiURL]
+	);
+
 	useEffect(() => {
 		if (!apiURL) {
 			return;
@@ -588,7 +604,7 @@ const FrontendDataSet = ({
 		});
 
 		return () => Liferay.detach(EVENTS.OPEN_FOLDER, openFolder);
-	}, [apiURL, isMounted, requestData, setDataLoading]);
+	}, [apiURL, isMounted, openFolder, requestData, setDataLoading]);
 
 	useEffect(() => {
 		function handleRefreshFromTheOutside(event) {
@@ -811,19 +827,6 @@ const FrontendDataSet = ({
 			...itemsChanges,
 			[itemKey]: itemChanges,
 		});
-	}
-
-	function openFolder({item}) {
-		const fullUrl = apiURL.startsWith('/')
-			? Liferay.ThemeDisplay.getPortalURL() +
-				Liferay.ThemeDisplay.getPathContext() +
-				apiURL
-			: apiURL;
-
-		const newApiURL = new URL(fullUrl);
-		newApiURL.searchParams.set('entryClassNames', item.entryClassName);
-
-		setApiURL(newApiURL.toString());
 	}
 
 	function toggleItemInlineEdit(itemKey) {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -1,0 +1,1189 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
+import {useIsMounted, useThunk} from '@liferay/frontend-js-react-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, loadClientExtensions, loadModule} from 'frontend-js-web';
+import React, {
+	useCallback,
+	useEffect,
+	useReducer,
+	useRef,
+	useState,
+} from 'react';
+
+import './styles/main.scss';
+
+import ClayEmptyState from '@clayui/empty-state';
+
+import {
+	IFrontendDataSetProps,
+	IModalConfig,
+	IRequestOptions,
+	ISuccessNotification,
+	TSort,
+	TViews,
+} from './';
+import FrontendDataSetContext, {
+	IDataSetData,
+	TRenderer,
+} from './FrontendDataSetContext';
+
+// @ts-ignore
+
+import ManagementBar from './management_bar/ManagementBar';
+import CreationMenu, {
+	ICreationActionItem,
+} from './management_bar/controls/CreationMenu';
+import {FILTER_IMPLEMENTATIONS} from './management_bar/controls/filters/Filter';
+
+// @ts-ignore
+
+import Modal from './modal/Modal';
+
+// @ts-ignore
+
+import SidePanel from './side_panel/SidePanel';
+import filterCreationActions from './utils/actionItems/filterCreationActions';
+import EVENTS from './utils/eventsDefinitions';
+import getRandomId from './utils/getRandomId';
+
+// @ts-ignore
+
+import {formatItemChanges, getCurrentItemUpdates} from './utils/index';
+import {loadData} from './utils/loadData';
+
+// @ts-ignore
+
+import {logError} from './utils/logError';
+import ViewsContext from './views/ViewsContext';
+
+// @ts-ignore
+
+import getViewComponent from './views/getViewComponent';
+
+// @ts-ignore
+
+import {VIEWS_ACTION_TYPES, viewsReducer} from './views/viewsReducer';
+
+const DEFAULT_PAGINATION_DELTA = 20;
+const DEFAULT_PAGINATION_PAGE_NUMBER = 1;
+
+const FrontendDataSet = ({
+	actionParameterName,
+	activeViewSettings,
+	additionalAPIURLParameters,
+	apiURL: initialApiURL,
+	appURL,
+	bulkActions,
+	creationMenu: initialCreationMenu,
+	currentURL,
+	customDataRenderers,
+	customRenderers,
+	customViews,
+	customViewsEnabled,
+	emptyState,
+	filters: initialFilters,
+	formId,
+	formName,
+	header,
+	id,
+	inlineAddingSettings,
+	inlineEditingSettings,
+	items: itemsProp,
+	itemsActions,
+	namespace,
+	nestedItemsKey,
+	nestedItemsReferenceKey,
+	onActionDropdownItemClick,
+	onBulkActionItemClick,
+	onSelect,
+	onSelectedItemsChange,
+	overrideEmptyResultView,
+	pagination,
+	portletId,
+	selectedItems: initialSelectedItemsValues,
+	selectedItemsKey = 'id',
+	selectionType,
+	showBulkActionsManagementBar,
+	showBulkActionsManagementBarActions,
+	showManagementBar,
+	showPagination,
+	showSearch,
+	sidePanelId,
+	sorts: sortsProp,
+	style,
+	uniformActionsDisplay,
+	views,
+}: IFrontendDataSetProps) => {
+	const wrapperRef = useRef(null);
+	const [apiURL, setApiURL] = useState(initialApiURL);
+	const [componentLoading, setComponentLoading] = useState(false);
+	const [creationMenu, setCreationMenu] = useState(initialCreationMenu);
+	const [dataLoading, setDataLoading] = useState(!!apiURL);
+	const [dataSetSupportModalId] = useState(`support-modal-${getRandomId()}`);
+	const [dataSetSupportSidePanelId] = useState(
+		sidePanelId || `support-side-panel-${getRandomId()}`
+	);
+
+	const [highlightedItemsValue, setHighlightedItemsValue] = useState([]);
+	const [items, setItems] = useState(itemsProp || []);
+	const [itemsChanges, setItemsChanges] = useState<{[key: string]: any}>({});
+	const [pageNumber, setPageNumber] = useState(
+		pagination?.initialPageNumber || DEFAULT_PAGINATION_PAGE_NUMBER
+	);
+	const [searchParam, setSearchParam] = useState('');
+	const [selectedItemsValue, setSelectedItemsValue] = useState(
+		initialSelectedItemsValues || []
+	);
+	const [selectedItems, setSelectedItems] = useState([]);
+	const [total, setTotal] = useState(0);
+
+	const getInitialViewsState = () => {
+		const customInternalViews =
+			customRenderers?.views?.map((customRenderer: TRenderer) => ({
+
+				// Need to check presence of property in TRenderer Union type
+
+				component:
+					'component' in customRenderer && customRenderer.component,
+				default: 'default' in customRenderer && customRenderer?.default,
+				label: 'label' in customRenderer && customRenderer?.label,
+				name: customRenderer.name,
+				schema: 'schema' in customRenderer && customRenderer?.schema,
+				thumbnail: 'symbol' in customRenderer && customRenderer?.symbol,
+			})) || [];
+
+		let initialActiveView =
+			views.find(({default: defaultProp}) => defaultProp) ||
+			customInternalViews?.find(
+				({default: defaultProp}) => defaultProp
+			) ||
+			views[0] ||
+			(customInternalViews?.length && customInternalViews[0]);
+
+		let initialVisibleFieldNames = {};
+
+		if (activeViewSettings) {
+			const {name: activeViewName, visibleFieldNames} =
+				JSON.parse(activeViewSettings);
+
+			if (activeViewName) {
+				const activeView = views.find(
+					({name}) => name === activeViewName
+				);
+
+				if (activeView) {
+					initialActiveView = activeView;
+				}
+			}
+
+			if (visibleFieldNames) {
+				initialVisibleFieldNames = visibleFieldNames;
+			}
+		}
+
+		const activeView = {
+			component: getViewComponent(initialActiveView),
+			...initialActiveView,
+		};
+
+		const filters = initialFilters
+			? initialFilters.map((filter) => {
+					const preloadedData = filter.preloadedData;
+
+					if (preloadedData) {
+						filter.active = true;
+						filter.selectedData = preloadedData;
+
+						const type: keyof typeof FILTER_IMPLEMENTATIONS =
+							filter.type;
+
+						const filterImplementation =
+							FILTER_IMPLEMENTATIONS[type];
+
+						filter.odataFilterString =
+							filterImplementation.getOdataString(filter);
+						filter.selectedItemsLabel =
+							filterImplementation.getSelectedItemsLabel(filter);
+					}
+
+					return filter;
+				})
+			: [];
+
+		const paginationDelta =
+			showPagination &&
+			(pagination?.initialDelta || DEFAULT_PAGINATION_DELTA);
+
+		return {
+			activeView,
+			customViews: customViews && JSON.parse(customViews),
+			customViewsEnabled,
+			defaultView: {
+				activeView,
+				filters,
+				paginationDelta,
+				sorts: sortsProp,
+				visibleFieldNames: initialVisibleFieldNames,
+			},
+			filters,
+			modifiedFields: {},
+			paginationDelta,
+			sorts: sortsProp,
+			views: [...views, ...customInternalViews],
+			visibleFieldNames: initialVisibleFieldNames,
+		};
+	};
+
+	const [viewsState, viewsDispatch] = useThunk(
+		useReducer(viewsReducer, getInitialViewsState())
+	);
+
+	const {activeView, filters, paginationDelta, sorts} = viewsState;
+
+	const {
+		component: View,
+		contentRendererModuleURL,
+		name: activeViewName,
+		...currentViewProps
+	} = activeView;
+
+	const requestData = useCallback(() => {
+		const activeFiltersOdataStrings = filters.reduce(
+
+			// Difficult to type filter as it is a mix of filter from FDS and FILTER_IMPLEMENTATIONS<T>
+
+			(activeFilters: Array<string>, filter: any) =>
+				filter.active && filter.odataFilterString
+					? [...activeFilters, filter.odataFilterString]
+					: activeFilters,
+			[]
+		);
+
+		const activeSorts =
+			sorts.length > 1
+				? sorts.filter((sort: TSort) => sort.active)
+				: sorts;
+
+		if (apiURL) {
+			return loadData({
+				additionalAPIURLParameters,
+				apiURL,
+				currentURL,
+				delta: paginationDelta,
+				odataFiltersStrings: activeFiltersOdataStrings,
+				page: pageNumber,
+				searchParam,
+				sorts: activeSorts,
+			});
+		}
+	}, [
+		additionalAPIURLParameters,
+		apiURL,
+		currentURL,
+		paginationDelta,
+		filters,
+		pageNumber,
+		searchParam,
+		sorts,
+	]);
+
+	const isMounted = useIsMounted();
+
+	function updateDataSetItems(dataSetData: IDataSetData) {
+		setItems(dataSetData.items);
+		setTotal(dataSetData.totalCount);
+
+		if (!dataSetData.items.length && dataSetData.totalCount > 0) {
+			setPageNumber(() => dataSetData.lastPage);
+		}
+	}
+
+	useEffect(() => {
+		loadClientExtensions([
+			{
+				clientExtensionDefinitions: initialFilters
+					? initialFilters
+							.filter((filter) => filter.clientExtensionFilterURL)
+							.map((filter) => ({
+								context: filter,
+								importDeclaration: `default from ${filter.clientExtensionFilterURL}`,
+							}))
+					: [],
+				onLoad: (bindingContexts) => {
+					const newFilters = initialFilters?.map((filter) => {
+						const bindingContext = bindingContexts.find(
+							(bindingContext: any) =>
+								bindingContext.context
+									.clientExtensionFilterURL ===
+								filter.clientExtensionFilterURL
+						);
+
+						if (bindingContext) {
+							return {
+								...filter,
+								clientExtensionFilterImplementation:
+									bindingContext.binding,
+							};
+						}
+
+						return filter;
+					});
+
+					viewsDispatch({
+						type: VIEWS_ACTION_TYPES.UPDATE_FILTERS,
+						value: newFilters,
+					});
+				},
+			},
+			{
+				clientExtensionDefinitions: views.reduce(
+					(clientExtensionDefinitions, view) => {
+
+						// @ts-ignore
+
+						if (!view.schema?.fields?.length) {
+							return clientExtensionDefinitions;
+						}
+
+						// @ts-ignore
+
+						const clientExtensionFields = view.schema.fields.filter(
+							(field: TViews) =>
+								!!field.contentRendererClientExtension
+						);
+
+						for (const field of clientExtensionFields) {
+
+							// @ts-ignore
+
+							clientExtensionDefinitions.push({
+								context: field,
+								importDeclaration:
+									field.contentRendererModuleURL,
+							});
+						}
+
+						return clientExtensionDefinitions;
+					},
+					[]
+				),
+				onLoad: (bindingContexts) => {
+					bindingContexts.forEach(
+						({binding: htmlElementBuilder, context: field}) => {
+							viewsDispatch({
+								type: VIEWS_ACTION_TYPES.UPDATE_FIELD,
+								value: {
+									htmlElementBuilder,
+
+									// @ts-ignore
+
+									name: field.fieldName,
+								},
+							});
+						}
+					);
+				},
+			},
+		]);
+	}, [initialFilters, views, viewsDispatch]);
+
+	useEffect(() => {
+		if (itemsProp) {
+
+			// Assuming default pagination values if data comes from items instead of apiURL
+
+			updateDataSetItems({
+				items: itemsProp,
+				lastPage: 1,
+				page: 1,
+				totalCount: itemsProp.length,
+			});
+		}
+	}, [itemsProp]);
+
+	function deselectItems(value: any) {
+		if (Array.isArray(value)) {
+			return setSelectedItemsValue(
+				selectedItemsValue.filter((item) => !value.includes(item))
+			);
+		}
+
+		setSelectedItemsValue(
+			selectedItemsValue.filter((item) => item !== value)
+		);
+	}
+
+	function selectItems(value: any) {
+		if (Liferay.FeatureFlags['LPD-42570']) {
+			if (Array.isArray(value)) {
+				const newItems = value.filter(
+					(item) => !selectedItemsValue.includes(item)
+				);
+
+				return setSelectedItemsValue([
+					...selectedItemsValue,
+					...newItems,
+				]);
+			}
+
+			if (selectedItemsValue.includes(value)) {
+				setSelectedItemsValue(
+					selectedItemsValue.filter((item) => item !== value)
+				);
+			}
+			else {
+				setSelectedItemsValue([...selectedItemsValue, value]);
+			}
+		}
+		else {
+			if (Array.isArray(value)) {
+				return setSelectedItemsValue(value);
+			}
+
+			if (selectionType === 'single') {
+				return setSelectedItemsValue([value]);
+			}
+
+			const itemAdded = selectedItemsValue.find((item) => item === value);
+
+			if (itemAdded) {
+				setSelectedItemsValue(
+					selectedItemsValue.filter((element) => element !== value)
+				);
+			}
+			else {
+				setSelectedItemsValue(selectedItemsValue.concat(value));
+			}
+		}
+	}
+
+	function highlightItems(value = []): void {
+		if (Array.isArray(value)) {
+			return setHighlightedItemsValue(value);
+		}
+
+		const itemAdded = highlightedItemsValue.find((item) => item === value);
+
+		if (!itemAdded) {
+			setHighlightedItemsValue(highlightedItemsValue.concat(value));
+		}
+	}
+
+	useEffect(() => {
+		if (wrapperRef.current) {
+			const form = (wrapperRef.current as HTMLElement).closest('form');
+
+			if (form?.dataset.sennaOff === null) {
+				form.setAttribute('data-senna-off', '');
+			}
+		}
+	}, [wrapperRef]);
+
+	const refreshData = useCallback(
+		(successNotification?: ISuccessNotification) => {
+			setDataLoading(true);
+
+			return requestData()!
+				.then(({data}) => {
+					if (successNotification?.showSuccessNotification) {
+						openToast({
+							message:
+								successNotification.message ||
+								Liferay.Language.get('table-data-updated'),
+							type: 'success',
+						});
+					}
+
+					if (isMounted()) {
+						updateDataSetItems(data);
+
+						const itemKeys = new Set(
+							data.items.map(
+								(item: any) => item[selectedItemsKey]
+							)
+						);
+
+						setSelectedItemsValue(
+							selectedItemsValue.filter((item) =>
+								itemKeys.has(item)
+							)
+						);
+
+						setDataLoading(false);
+
+						Liferay.fire(EVENTS.DISPLAY_UPDATED, {id});
+					}
+
+					return data;
+				})
+				.catch((error) => {
+					setDataLoading(false);
+
+					throw error;
+				});
+		},
+		[id, isMounted, requestData, selectedItemsKey, selectedItemsValue]
+	);
+
+	useEffect(() => {
+		setSelectedItems((selectedItems) => {
+			const newSelectedItems: any = [];
+
+			selectedItemsValue.forEach((value) => {
+				let selectedItem = items.find(
+					(item) => item[selectedItemsKey] === value
+				);
+
+				if (!selectedItem) {
+					selectedItem = selectedItems.find(
+						(item) => item[selectedItemsKey] === value
+					);
+				}
+
+				if (selectedItem) {
+					newSelectedItems.push(selectedItem);
+				}
+			});
+
+			onSelectedItemsChange && onSelectedItemsChange(newSelectedItems);
+
+			return newSelectedItems;
+		});
+	}, [selectedItemsValue, items, onSelectedItemsChange, selectedItemsKey]);
+
+	useEffect(() => {
+		if (View || !contentRendererModuleURL) {
+			return;
+		}
+
+		setComponentLoading(true);
+
+		loadModule(contentRendererModuleURL)
+			.then((component) => {
+				if (isMounted()) {
+					viewsDispatch({
+						type: VIEWS_ACTION_TYPES.UPDATE_VIEW_COMPONENT,
+						value: {component, name: activeViewName},
+					});
+
+					setComponentLoading(false);
+				}
+			})
+			.catch(() => {
+				openToast({
+					message: Liferay.Language.get('unexpected-error'),
+					type: 'danger',
+				});
+			});
+	}, [
+		View,
+		activeViewName,
+		contentRendererModuleURL,
+		viewsDispatch,
+		isMounted,
+		setComponentLoading,
+	]);
+
+	const handleApiError = ({
+		data,
+		statusCode,
+	}: {
+		data: {
+			status: string;
+			title: string;
+			type?: string;
+		};
+		statusCode: number;
+	}): void => {
+		const apiErrorMessage = `${data.status}, ${data.title}`;
+
+		logError(apiErrorMessage);
+
+		openToast({
+			message: apiErrorMessage,
+			title: `${Liferay.Language.get('error')} ${statusCode}`,
+			type: 'danger',
+		});
+	};
+
+	const openFolder = useCallback(
+		({item}: {item: any}) => {
+			const fullUrl = apiURL?.startsWith('/')
+				? Liferay.ThemeDisplay.getPortalURL() +
+					Liferay.ThemeDisplay.getPathContext() +
+					apiURL
+				: apiURL;
+
+			if (fullUrl) {
+				const newApiURL = new URL(fullUrl);
+				newApiURL.searchParams.set(
+					'entryClassNames',
+					item.entryClassName
+				);
+
+				setApiURL(newApiURL.toString());
+			}
+		},
+		[apiURL]
+	);
+
+	useEffect(() => {
+		if (!apiURL) {
+			return;
+		}
+
+		setDataLoading(true);
+
+		requestData()!.then(({data, ok, status: statusCode}) => {
+			if (isMounted()) {
+				if (!ok) {
+					handleApiError({data, statusCode});
+				}
+				else {
+					setCreationMenu((currentCreationMenu) => {
+						if (
+							!currentCreationMenu ||
+							!currentCreationMenu.primaryItems
+						) {
+							return;
+						}
+
+						const filteredCreationMenu: {
+							primaryItems: Array<ICreationActionItem>;
+						} = {
+							primaryItems: [],
+						};
+
+						filteredCreationMenu.primaryItems =
+							filterCreationActions({
+								customActions: currentCreationMenu.primaryItems,
+								globalCollectionActions: data?.actions,
+							});
+
+						return filteredCreationMenu;
+					});
+
+					updateDataSetItems(data);
+				}
+				setDataLoading(false);
+			}
+			Liferay.on(EVENTS.OPEN_FOLDER, openFolder);
+		});
+
+		return () =>
+			Liferay.detach(EVENTS.OPEN_FOLDER, openFolder as () => void);
+	}, [apiURL, isMounted, openFolder, requestData, setDataLoading]);
+
+	useEffect(() => {
+		function handleRefreshFromTheOutside(event: any) {
+			if (event.id === id) {
+				refreshData();
+			}
+		}
+
+		function handleCloseSidePanel() {
+			setHighlightedItemsValue([]);
+		}
+
+		Liferay.on(EVENTS.SIDE_PANEL_CLOSED, handleCloseSidePanel);
+		Liferay.on(EVENTS.UPDATE_DISPLAY, handleRefreshFromTheOutside);
+
+		return () => {
+			Liferay.detach(EVENTS.SIDE_PANEL_CLOSED, handleCloseSidePanel);
+			Liferay.detach(
+				EVENTS.UPDATE_DISPLAY,
+				handleRefreshFromTheOutside as () => void
+			);
+		};
+	}, [id, refreshData]);
+
+	const managementBar = showManagementBar ? (
+		<div className="management-bar-wrapper">
+			<ManagementBar
+				bulkActions={bulkActions}
+				creationMenu={creationMenu}
+				deselectItems={(items: any) => deselectItems(items)}
+				fluid={style === 'fluid'}
+				items={items}
+				selectItems={(items: any) => selectItems(items)}
+				selectedItems={selectedItems}
+				selectedItemsKey={selectedItemsKey}
+				selectedItemsValue={selectedItemsValue}
+				selectionType={selectionType}
+				showSearch={showSearch}
+				sidePanelId={dataSetSupportSidePanelId}
+				total={total}
+			/>
+		</div>
+	) : null;
+
+	const view =
+		!dataLoading && !componentLoading ? (
+			<div className="data-set-content-wrapper">
+				<input
+					hidden
+					name={`${namespace || id + '_'}${
+						actionParameterName || selectedItemsKey
+					}`}
+					readOnly
+					value={selectedItemsValue.join(',')}
+				/>
+
+				{items?.length ||
+				overrideEmptyResultView ||
+				inlineAddingSettings ? (
+					<View
+						frontendDataSetContext={FrontendDataSetContext}
+						header={header}
+						items={items}
+						itemsActions={itemsActions}
+						style={style}
+						{...currentViewProps}
+					/>
+				) : (
+					<ClayEmptyState
+						description={
+							emptyState?.description ??
+							Liferay.Language.get('sorry,-no-results-were-found')
+						}
+						imgSrc={
+							Liferay.ThemeDisplay.getPathThemeImages() +
+							(emptyState?.image ?? '/states/search_state.svg')
+						}
+						title={
+							emptyState?.title ??
+							Liferay.Language.get('no-results-found')
+						}
+					>
+						{creationMenu && (
+							<CreationMenu {...creationMenu} inEmptyState />
+						)}
+					</ClayEmptyState>
+				)}
+			</div>
+		) : (
+			<ClayLoadingIndicator className="my-7" />
+		);
+
+	const paginationComponent =
+		showPagination && pagination && items?.length && total ? (
+			<div className="data-set-pagination-wrapper">
+				<ClayPaginationBarWithBasicItems
+					active={pageNumber}
+					activeDelta={paginationDelta}
+					deltas={pagination?.deltas}
+					disableEllipsis={items.length / paginationDelta - 5 > 999}
+					ellipsisBuffer={3}
+					labels={{
+						paginationResults: Liferay.Language.get(
+							'showing-x-to-x-of-x-entries'
+						),
+						perPageItems: Liferay.Language.get('x-items'),
+						selectPerPageItems: Liferay.Language.get('x-items'),
+					}}
+					onActiveChange={setPageNumber}
+					onDeltaChange={(delta) => {
+						setPageNumber(1);
+
+						viewsDispatch({
+							type: VIEWS_ACTION_TYPES.UPDATE_PAGINATION_DELTA,
+							value: delta,
+						});
+					}}
+					totalItems={total}
+				/>
+			</div>
+		) : null;
+
+	function executeAsyncItemAction({
+		errorMessage,
+		method = 'GET',
+		requestBody,
+		setActionItemLoading,
+		successMessage,
+		url,
+	}: {
+		errorMessage: string;
+		method: string;
+		requestBody?: string;
+		setActionItemLoading?: Function;
+		successMessage?: string;
+		url: string;
+	}): Promise<void> {
+		const requestOptions: IRequestOptions = {
+			headers: {
+				'Accept': 'application/json',
+				'Accept-Language': Liferay.ThemeDisplay.getBCP47LanguageId(),
+				'Content-Type': 'application/json',
+			},
+			method,
+		};
+
+		if (method.toUpperCase() !== 'GET') {
+			requestOptions.body = requestBody ? requestBody : '{}';
+		}
+
+		return fetch(url, requestOptions)
+			.then((response) => {
+				if (response.ok) {
+					Liferay.fire(EVENTS.ACTION_PERFORMED, {
+						id,
+					});
+
+					openToast({
+						message:
+							successMessage ||
+							Liferay.Language.get(
+								'your-request-completed-successfully'
+							),
+						type: 'success',
+					});
+
+					refreshData();
+				}
+				else {
+					openToast({
+						message:
+							errorMessage ||
+							Liferay.Language.get(
+								'an-unexpected-error-occurred'
+							),
+						type: 'danger',
+					});
+
+					setActionItemLoading?.(false);
+				}
+			})
+			.catch(() => {
+				openToast({
+					message:
+						errorMessage ||
+						Liferay.Language.get('an-unexpected-error-occurred'),
+					type: 'danger',
+				});
+
+				setActionItemLoading?.(false);
+			});
+	}
+
+	function openModal(config: IModalConfig) {
+		return Liferay.fire(EVENTS.OPEN_MODAL, {
+			id: dataSetSupportModalId,
+			onSubmit: refreshData,
+			...config,
+		});
+	}
+
+	function openSidePanel(config: IModalConfig) {
+		return Liferay.fire(EVENTS.OPEN_SIDE_PANEL, {
+			id: dataSetSupportSidePanelId,
+			onSubmit: refreshData,
+			...config,
+		});
+	}
+
+	function onItemsChange({
+		itemKey = 'id',
+		items: itemsChanged,
+	}: {
+		itemKey: string;
+		items: Array<any>;
+	}): void {
+		const updatedItems = new Map(
+			[...items, ...itemsChanged].map((item) => [item[itemKey], item])
+		);
+
+		setItems(Array.from(updatedItems.values()));
+	}
+
+	function updateItem(
+		itemKey: string,
+		property: string,
+		valuePath: string,
+		value = null
+	): void {
+		const itemChanges = getCurrentItemUpdates(
+			items,
+			itemsChanges,
+			selectedItemsKey,
+			itemKey,
+			property,
+			value,
+			valuePath
+		);
+
+		setItemsChanges({
+			...itemsChanges,
+			[itemKey]: itemChanges,
+		});
+	}
+
+	function toggleItemInlineEdit(itemKey: number) {
+		setItemsChanges(({[itemKey]: foundItem, ...itemsChanges}) => {
+			return foundItem
+				? itemsChanges
+				: {
+						...itemsChanges,
+						[itemKey]: {},
+					};
+		});
+	}
+
+	function createInlineItem(): Promise<void> | void {
+		if (!inlineAddingSettings?.apiURL) {
+			return;
+		}
+
+		const defaultBodyContent =
+			inlineAddingSettings?.defaultBodyContent || {};
+		const newItemBodyContent = formatItemChanges(itemsChanges[0]);
+
+		return fetch(inlineAddingSettings.apiURL, {
+			body: JSON.stringify({
+				...defaultBodyContent,
+				...newItemBodyContent,
+			}),
+			headers: {
+				'Accept': 'application/json',
+				'Content-Type': 'application/json',
+			},
+			method: inlineAddingSettings?.method || 'POST',
+		})
+			.then((response) => {
+				if (!isMounted()) {
+					return;
+				}
+
+				if (!response.ok) {
+					return response
+						.json()
+						.then((jsonResponse) =>
+							Promise.reject(new Error(jsonResponse.title))
+						);
+				}
+
+				setItemsChanges((itemsChanges) => ({
+					...itemsChanges,
+					[0]: {},
+				}));
+
+				return refreshData({
+					message: Liferay.Language.get(
+						'item-was-successfully-created'
+					),
+					showSuccessNotification: true,
+				});
+			})
+			.catch((error) => {
+				logError(error);
+				openToast({
+					message: error.message,
+					type: 'danger',
+				});
+
+				throw error;
+			});
+	}
+
+	function applyItemInlineUpdates(itemKey: number): Promise<any> {
+		const itemToBeUpdated = items.find(
+			(item) => item[selectedItemsKey] === itemKey
+		);
+
+		const defaultBody = inlineEditingSettings?.defaultBodyContent || {};
+
+		return fetch(itemToBeUpdated.actions.update.href, {
+			body: JSON.stringify({
+				...defaultBody,
+				...formatItemChanges(itemsChanges[itemKey]),
+			}),
+			headers: {
+				'Accept': 'application/json',
+				'Content-Type': 'application/json',
+			},
+			method: itemToBeUpdated.actions.update.method,
+		})
+			.then((response) => {
+				if (!isMounted()) {
+					return;
+				}
+
+				if (!response.ok) {
+					return response
+						.json()
+						.then((jsonResponse) =>
+							Promise.reject(new Error(jsonResponse.title))
+						);
+				}
+
+				toggleItemInlineEdit(itemKey);
+
+				return refreshData({
+					message: Liferay.Language.get(
+						'item-was-successfully-updated'
+					),
+					showSuccessNotification: true,
+				});
+			})
+			.catch((error) => {
+				logError(error);
+				openToast({
+					message: error.message,
+					type: 'danger',
+				});
+
+				throw error;
+			});
+	}
+
+	const onSearch = ({query}: {query: string}) => {
+		if (apiURL || appURL) {
+			setSearchParam(query);
+		}
+		else {
+			setItems(
+				itemsProp?.length
+					? itemsProp.filter((item) => {
+							return JSON.stringify(Object.values(item)).includes(
+								query
+							);
+						})
+					: []
+			);
+		}
+	};
+
+	return (
+		<FrontendDataSetContext.Provider
+			value={{
+				actionParameterName,
+				apiURL,
+				appURL,
+				applyItemInlineUpdates,
+				createInlineItem,
+				customDataRenderers,
+				customRenderers,
+				executeAsyncItemAction,
+				formId,
+				formName,
+				highlightItems,
+				highlightedItemsValue,
+				id,
+				inlineAddingSettings,
+				inlineEditingSettings,
+				itemsActions,
+				itemsChanges,
+				loadData: refreshData,
+				modalId: dataSetSupportModalId,
+				namespace,
+				nestedItemsKey,
+				nestedItemsReferenceKey,
+				onActionDropdownItemClick,
+				onBulkActionItemClick,
+				onItemsChange,
+				onSearch,
+				onSelect,
+				openFolder,
+				openModal,
+				openSidePanel,
+				portletId,
+				searchParam,
+				selectItems,
+				selectable: Boolean(
+					selectedItemsKey &&
+						(bulkActions?.length || selectionType === 'single')
+				),
+				selectedItemsKey,
+				selectedItemsValue,
+				selectionType,
+				showBulkActionsManagementBar,
+				showBulkActionsManagementBarActions,
+				sidePanelId: dataSetSupportSidePanelId,
+				sorts,
+				style,
+				toggleItemInlineEdit,
+				uniformActionsDisplay,
+				updateDataSetItems,
+				updateItem,
+			}}
+		>
+			<ViewsContext.Provider value={[viewsState, viewsDispatch]}>
+				<div className="fds">
+					<Modal id={dataSetSupportModalId} onClose={refreshData} />
+
+					{!sidePanelId && (
+						<SidePanel
+							id={dataSetSupportSidePanelId}
+							onAfterSubmit={refreshData}
+						/>
+					)}
+
+					<div
+						className={`data-set-wrapper visualization-mode-${activeView.contentRenderer}`}
+						data-testid={`visualization-mode-${activeView.name}`}
+						ref={wrapperRef}
+					>
+						{style === 'default' && (
+							<div className="data-set data-set-inline">
+								{managementBar}
+
+								{view}
+
+								{paginationComponent}
+							</div>
+						)}
+
+						{style === 'stacked' && (
+							<div className="data-set data-set-stacked">
+								{managementBar}
+
+								{view}
+
+								{paginationComponent}
+							</div>
+						)}
+
+						{style === 'fluid' && (
+							<div className="data-set data-set-fluid">
+								{managementBar}
+
+								<div className="container-fluid container-xl mt-3">
+									{view}
+
+									{paginationComponent}
+								</div>
+							</div>
+						)}
+					</div>
+				</div>
+			</ViewsContext.Provider>
+		</FrontendDataSetContext.Provider>
+	);
+};
+
+FrontendDataSet.defaultProps = {
+	bulkActions: [],
+	customViews: '{}',
+	inlineEditingSettings: null,
+	items: null,
+	itemsActions: null,
+	onSelect: () => {},
+	onSelectedItemsChange: () => {},
+	selectedItemsKey: 'id',
+	selectionType: 'multiple',
+	showBulkActionsManagementBar: true,
+	showBulkActionsManagementBarActions: true,
+	showManagementBar: true,
+	showPagination: true,
+	showSearch: true,
+	sorts: [],
+	style: 'default',
+};
+
+export default FrontendDataSet;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext.tsx
@@ -5,24 +5,38 @@
 
 import React from 'react';
 
-import {IInlineEditingSettings, IItemsActions, ISchema} from '.';
+import {IInlineEditingSettings, IItemsActions, IModalConfig, ISchema} from '.';
 
 export interface IFrontendDataSetContext {
 	actionParameterName?: string | null;
 	apiURL?: string;
 	appURL?: string;
-	applyItemInlineUpdates: Function;
-	createInlineItem: Function;
+	applyItemInlineUpdates: (itemKey: number) => Promise<any> | void;
+	createInlineItem: () => Promise<void> | void;
 	customDataRenderers?: Array<any>;
 	customRenderers?: {
 		tableCell?: Array<TRenderer>;
 		views?: Array<TRenderer>;
 	};
-	executeAsyncItemAction: Function;
+	executeAsyncItemAction: ({
+		errorMessage,
+		method,
+		requestBody,
+		setActionItemLoading,
+		successMessage,
+		url,
+	}: {
+		errorMessage: string;
+		method: string;
+		requestBody?: string;
+		setActionItemLoading?: Function;
+		successMessage?: string;
+		url: string;
+	}) => Promise<void> | void;
 	formId?: string;
 	formName?: string;
-	highlightItems: Function;
-	highlightedItemsValue?: string;
+	highlightItems: (value: any) => void;
+	highlightedItemsValue?: Array<string>;
 	id?: string;
 	inlineAddingSettings?: {
 		apiURL?: string;
@@ -30,8 +44,8 @@ export interface IFrontendDataSetContext {
 	};
 	inlineEditingSettings?: IInlineEditingSettings;
 	itemsActions?: Array<IItemsActions>;
-	itemsChanges?: Array<any>;
-	loadData: Function;
+	itemsChanges?: any;
+	loadData: () => Promise<any> | void;
 	modalId?: string;
 	namespace?: string;
 	nestedItemsKey?: string;
@@ -42,28 +56,49 @@ export interface IFrontendDataSetContext {
 		itemKey,
 		items,
 	}: {
-		itemKey?: string;
+		itemKey: string;
 		items: Array<any>;
 	}) => void;
 	onSearch: ({query}: {query: string}) => void;
-	onSelect: Function;
-	openFolder: Function;
-	openModal: Function;
-	openSidePanel: Function;
+	onSelect?: ({selectedItems}: {selectedItems: Array<any>}) => void;
+	openFolder: ({item}: {item: any}) => void;
+	openModal: (config: IModalConfig) => void;
+	openSidePanel: (config: IModalConfig) => void;
 	portletId?: string;
 	searchParam?: string;
-	selectItems: Function;
+	selectItems: (value: any) => void;
 	selectable?: boolean;
 	selectedItemsKey?: string;
 	selectedItemsValue?: Array<any>;
 	selectionType?: string;
+	showBulkActionsManagementBar?: boolean;
+	showBulkActionsManagementBarActions?: boolean;
 	sidePanelId?: string;
 	sorts?: Array<TRenderer>;
 	style?: string;
-	toggleItemInlineEdit: Function;
+	toggleItemInlineEdit: (itemKey: number) => void;
 	uniformActionsDisplay?: boolean;
-	updateDataSetItems: Function;
-	updateItem: Function;
+	updateDataSetItems: ({
+		items,
+		lastPage,
+		page,
+		pageSize,
+		totalCount,
+	}: IDataSetData) => void;
+	updateItem: (
+		itemKey: string,
+		property: string,
+		valuePath: string,
+		value: any
+	) => void;
+}
+
+export interface IDataSetData {
+	items: Array<any>;
+	lastPage: number;
+	page: number;
+	pageSize?: number;
+	totalCount: number;
 }
 
 export interface IHTMLElementBuilder {
@@ -91,7 +126,7 @@ export interface IInternalRenderer {
 
 export type TRenderer = IClientExtensionRenderer | IInternalRenderer;
 
-const FrontendDataSetContext = React.createContext({
+const FrontendDataSetContext = React.createContext<IFrontendDataSetContext>({
 	applyItemInlineUpdates: () => {},
 	createInlineItem: () => {},
 	executeAsyncItemAction: () => {},
@@ -111,6 +146,6 @@ const FrontendDataSetContext = React.createContext({
 	toggleItemInlineEdit: () => {},
 	updateDataSetItems: () => {},
 	updateItem: () => {},
-} as IFrontendDataSetContext);
+});
 
 export default FrontendDataSetContext;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext.tsx
@@ -47,6 +47,7 @@ export interface IFrontendDataSetContext {
 	}) => void;
 	onSearch: ({query}: {query: string}) => void;
 	onSelect: Function;
+	openFolder: Function;
 	openModal: Function;
 	openSidePanel: Function;
 	portletId?: string;
@@ -101,6 +102,7 @@ const FrontendDataSetContext = React.createContext({
 	onItemsChange: () => {},
 	onSearch: () => {},
 	onSelect: () => {},
+	openFolder: () => {},
 	openModal: () => {},
 	openSidePanel: () => {},
 	selectItems: () => {},

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
@@ -88,7 +88,7 @@ export const INTERNAL_CELL_RENDERERS: Array<IInternalRenderer> = [
 	},
 	{
 		component: NavigationLinkRenderer,
-		label: Liferay.Language.get('link'),
+		label: Liferay.Language.get('navigation-link'),
 		name: 'navigationLink',
 		type: 'internal',
 	},

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
@@ -27,8 +27,8 @@ import LabelRenderer from './LabelRenderer';
 // @ts-ignore
 
 import LinkRenderer from './LinkRenderer';
-
 import NavigationLinkRenderer from './NavigationLinkRenderer';
+
 // @ts-ignore
 
 import QuantitySelectorRenderer from './QuantitySelectorRenderer';

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/InternalCellRenderer.ts
@@ -28,6 +28,7 @@ import LabelRenderer from './LabelRenderer';
 
 import LinkRenderer from './LinkRenderer';
 
+import NavigationLinkRenderer from './NavigationLinkRenderer';
 // @ts-ignore
 
 import QuantitySelectorRenderer from './QuantitySelectorRenderer';
@@ -83,6 +84,12 @@ export const INTERNAL_CELL_RENDERERS: Array<IInternalRenderer> = [
 		component: LinkRenderer,
 		label: Liferay.Language.get('link'),
 		name: 'link',
+		type: 'internal',
+	},
+	{
+		component: NavigationLinkRenderer,
+		label: Liferay.Language.get('link'),
+		name: 'navigationLink',
 		type: 'internal',
 	},
 	{

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/NavigationLinkRenderer.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/NavigationLinkRenderer.tsx
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 20256 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLink from '@clayui/link';
+import React, {useContext} from 'react';
+
+// @ts-ignore
+
+import DefaultContent from './DefaultRenderer';
+import FrontendDataSetContext from '../FrontendDataSetContext';
+import ClayIcon from '@clayui/icon';
+
+const NavigationLinkRenderer = ({
+	itemData,
+	itemId,
+	options,
+	value
+}: {
+	itemData: any;
+	itemId: number;
+	options: any;
+	value: string;
+}) => {
+	const {openFolder} = useContext(FrontendDataSetContext);
+	const isFolder = itemData?.entryClassName.includes('Folder');
+	return (
+		<div className="table-list-title">
+			<ClayLink
+				href='#'
+				onClick={(event) =>{
+					event.preventDefault();
+
+					openFolder({item: itemData});
+				}}
+				style={{cursor: 'pointer'}}
+			>
+				{isFolder && <span className='c-pr-2'>
+					<ClayIcon symbol='folder' />
+					</span>}
+				{value}
+			</ClayLink>
+		</div>
+	);
+};
+
+export default NavigationLinkRenderer;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/NavigationLinkRenderer.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/NavigationLinkRenderer.tsx
@@ -1,46 +1,50 @@
 /**
- * SPDX-FileCopyrightText: (c) 20256 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
-import React, {useContext} from 'react';
-
-// @ts-ignore
+import React from 'react';
 
 import DefaultContent from './DefaultRenderer';
-import FrontendDataSetContext from '../FrontendDataSetContext';
-import ClayIcon from '@clayui/icon';
 
 const NavigationLinkRenderer = ({
 	itemData,
-	itemId,
-	options,
-	value
+	openFolder,
+	options = {},
+	value,
 }: {
 	itemData: any;
-	itemId: number;
+	openFolder: ({item}: {item: any}) => void;
 	options: any;
 	value: string;
 }) => {
-	const {openFolder} = useContext(FrontendDataSetContext);
 	const isFolder = itemData?.entryClassName.includes('Folder');
+
 	return (
 		<div className="table-list-title">
-			<ClayLink
-				href='#'
-				onClick={(event) =>{
-					event.preventDefault();
+			{isFolder ? (
+				<ClayLink
+					href="#"
+					onClick={(event) => {
+						event.preventDefault();
 
-					openFolder({item: itemData});
-				}}
-				style={{cursor: 'pointer'}}
-			>
-				{isFolder && <span className='c-pr-2'>
-					<ClayIcon symbol='folder' />
-					</span>}
-				{value}
-			</ClayLink>
+						openFolder({item: itemData});
+					}}
+					style={{cursor: 'pointer'}}
+				>
+					{isFolder && (
+						<span className="c-pr-2">
+							<ClayIcon symbol="folder" />
+						</span>
+					)}
+
+					{value}
+				</ClayLink>
+			) : (
+				<DefaultContent options={options} value={value} />
+			)}
 		</div>
 	);
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -6,6 +6,7 @@
 import {ModalStatus} from 'frontend-js-components-web';
 
 import {TRenderer} from './FrontendDataSetContext';
+import {ICreationActionItem} from './management_bar/controls/CreationMenu';
 
 export declare function FrontendDataSet({
 	actionParameterName,
@@ -167,30 +168,36 @@ export interface ICardSchema {
 
 export type ISchema = ITableSchema | ICardSchema;
 
-type TViews = {
+export type TViews = {
 	component?: any;
 	contentRenderer?: string;
 	contentRendererClientExtension?: boolean;
 	contentRendererModuleURL?: string;
+	default?: boolean;
 	label?: string;
 	name?: string;
 	schema?: ISchema;
 	thumbnail?: string;
+	views?: Array<any>;
 };
 
 export interface IFrontendDataSetProps {
 	actionParameterName?: string;
 	activeViewSettings?: string;
+	additionalAPIURLParameters?: string;
 	apiURL?: string;
 	appURL?: string;
 	bulkActions?: any[];
 	creationMenu?: {
-		primaryItems?: any[];
-		secondaryItems?: any[];
+		primaryItems: Array<ICreationActionItem>;
+		secondaryItems?: Array<ICreationActionItem>;
 	};
 	currentURL?: string;
 	customDataRenderers?: any;
-	customRenderers?: {tableCell: Array<TRenderer>};
+	customRenderers?: {
+		tableCell?: Array<TRenderer>;
+		views?: Array<TRenderer>;
+	};
 	customViews?: string;
 	customViewsEnabled?: boolean;
 	emptyState?: {
@@ -201,7 +208,7 @@ export interface IFrontendDataSetProps {
 	enableInlineAddModeSetting?: {
 		defaultBodyContent?: object;
 	};
-	filters?: any;
+	filters?: Array<any>;
 	formId?: string;
 	formName?: string;
 	header?: {
@@ -211,6 +218,7 @@ export interface IFrontendDataSetProps {
 	inlineAddingSettings?: {
 		apiURL: string;
 		defaultBodyContent: object;
+		method?: string;
 	};
 	inlineEditingSettings?: IInlineEditingSettings;
 	items?: any[];
@@ -221,6 +229,7 @@ export interface IFrontendDataSetProps {
 	onActionDropdownItemClick?: any;
 	onBulkActionItemClick?: any;
 	onSelect?: ({selectedItems}: {selectedItems: Array<any>}) => void;
+	onSelectedItemsChange?: (selectedItems: Array<any>) => void;
 	overrideEmptyResultView?: boolean;
 	pagination?: {
 		deltas?: TDelta[];
@@ -231,14 +240,35 @@ export interface IFrontendDataSetProps {
 	selectedItems?: any[];
 	selectedItemsKey?: string;
 	selectionType?: 'single' | 'multiple';
+	showBulkActionsManagementBar?: boolean;
+	showBulkActionsManagementBarActions?: boolean;
 	showManagementBar?: boolean;
 	showPagination?: boolean;
 	showSearch?: boolean;
 	sidePanelId?: string;
 	sorts?: TSort[];
 	style?: 'default' | 'fluid' | 'stacked';
+	uniformActionsDisplay?: boolean;
 	views: TViews[];
 	viewsTitle?: string;
+}
+
+export interface IModalConfig {
+	disableHeader: boolean;
+	size: string;
+	title: string;
+	url: string;
+}
+
+export interface IRequestOptions {
+	body?: string;
+	headers: {[key: string]: string};
+	method?: string;
+}
+
+export interface ISuccessNotification {
+	message: string;
+	showSuccessNotification?: boolean;
 }
 
 export {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/eventsDefinitions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/eventsDefinitions.ts
@@ -26,6 +26,7 @@ const EVENTS = {
 	DISPLAY_UPDATED: 'fds-display-updated',
 	IFRAME_LOADED,
 	IS_LOADING_MODAL,
+	OPEN_FOLDER: 'fds-open-folder',
 	OPEN_MODAL,
 	OPEN_MODAL_FROM_IFRAME,
 	OPEN_SIDE_PANEL,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/loadData.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/loadData.ts
@@ -46,9 +46,9 @@ export async function loadData({
 	additionalAPIURLParameters?: string;
 	apiURL: string;
 	currentURL?: string;
-	delta: number;
+	delta?: number;
 	odataFiltersStrings?: Array<string>;
-	page: number;
+	page?: number;
 	searchParam?: string;
 	sorts?: TSort[];
 }) {
@@ -80,7 +80,7 @@ export async function loadData({
 	}
 
 	url.searchParams.append('page', page.toString());
-	url.searchParams.append('pageSize', delta.toString());
+	delta && url.searchParams.append('pageSize', delta.toString());
 
 	if (searchParam) {
 		url.searchParams.append('search', searchParam);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -116,15 +116,16 @@ const Cards = ({items, schema}: {items: Array<any>; schema: ICardSchema}) => {
 			<div className="row">
 				{items.map((item, index) => {
 					return (
-						<div
-							className="col-md-3"
-							key={index}
-						>
-							<Card item={item} schema={schema} key={
-								selectedItemsKey
-									? item[selectedItemsKey]
-									: getRandomId()
-							}/>
+						<div className="col-md-3" key={index}>
+							<Card
+								item={item}
+								key={
+									selectedItemsKey
+										? item[selectedItemsKey]
+										: getRandomId()
+								}
+								schema={schema}
+							/>
 						</div>
 					);
 				})}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -114,17 +114,17 @@ const Cards = ({items, schema}: {items: Array<any>; schema: ICardSchema}) => {
 			)}
 		>
 			<div className="row">
-				{items.map((item) => {
+				{items.map((item, index) => {
 					return (
 						<div
 							className="col-md-3"
-							key={
+							key={index}
+						>
+							<Card item={item} schema={schema} key={
 								selectedItemsKey
 									? item[selectedItemsKey]
 									: getRandomId()
-							}
-						>
-							<Card item={item} schema={schema} />
+							}/>
 						</div>
 					);
 				})}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -610,6 +610,7 @@ function CellRenderer({
 		customRenderers,
 		loadData,
 		onItemsChange,
+		openFolder,
 		openSidePanel,
 	}: IFrontendDataSetContext = useContext(FrontendDataSetContext);
 	const [{modifiedFields}] = useContext(ViewsContext) as any;
@@ -667,6 +668,7 @@ function CellRenderer({
 						itemId={itemId}
 						loadData={loadData}
 						onItemsChange={onItemsChange}
+						openFolder={openFolder}
 						openSidePanel={openSidePanel}
 						options={field}
 						rootPropertyName={rootPropertyName}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/AllSectionTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/AllSectionTableFDSView.java
@@ -32,7 +32,12 @@ public class AllSectionTableFDSView extends BaseTableFDSView {
 			_fdsTableSchemaBuilderFactory.create();
 
 		return fdsTableSchemaBuilder.add(
-			"title", "title"
+			"title", "title",
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"navigationLink"
+			).setSortable(
+				true
+			)
 		).add(
 			"description", "description"
 		).add(

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ContentsSectionTableFDSView.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/view/table/ContentsSectionTableFDSView.java
@@ -34,7 +34,7 @@ public class ContentsSectionTableFDSView extends BaseTableFDSView {
 		return fdsTableSchemaBuilder.add(
 			"title", "title",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
-				"title"
+				"navigationLink"
 			).setSortable(
 				true
 			)


### PR DESCRIPTION
## Scope
In this PoC we want to test how to implement a way to navigate within folders inside a FDS, showing its contents. To achieve this, we may want to update the `apiURL` prop that it is used to retrieve the data for a given FDS.
Also, we need to identify which content is a folder


## Concerns
- We have a weak way to identify what it is a folder. Currently checking the `entryClassName` of an item to check if it contains `*Folder`. While this is valid for some Liferay content (Web Content : `com.liferay.journal.model.JournalFolder`, KnowledgeBase: `com.liferay.knowledge.base.model.KBFolder` ) it does not work with Objects out of the box.
- Folder navigation is able to update the `apiURL` and retrieve new data, but we cannot ensure that the actual table schema matches the upcoming data.
- Related to the previous one, creation menu could differ from the current to upcoming data.

## UI
https://github.com/user-attachments/assets/7a4cf3f4-8b63-4631-8b50-42457072a671

