### PR TITLE
LPD-50587 - Adapt FrontendDataSet component in DSM and CX pages

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/view.jsp
+++ b/modules/apps/client-extension/client-extension-web/src/main/resources/META-INF/resources/admin/view.jsp
@@ -15,6 +15,7 @@ ClientExtensionAdminDisplayContext clientExtensionAdminDisplayContext = (ClientE
 	actionParameterName="externalReferenceCode"
 	creationMenu="<%= clientExtensionAdminDisplayContext.getCreationMenu() %>"
 	dataProviderKey="<%= ClientExtensionAdminFDSNames.CLIENT_EXTENSION_TYPES %>"
+	fluidSize="xxl"
 	id="<%= ClientExtensionAdminFDSNames.CLIENT_EXTENSION_TYPES %>"
 	itemsPerPage="<%= 10 %>"
 	selectedItemsKey="externalReferenceCode"

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
@@ -677,6 +677,7 @@ const CustomDataSets = ({
 					image: '/states/empty_state.svg',
 					title: Liferay.Language.get('no-data-sets-created'),
 				}}
+				fluidSize="xxl"
 				id={`${namespace}CustomDataSets`}
 				itemsActions={[
 					{

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -467,6 +467,7 @@ const SystemDataSets = ({
 					image: '/states/empty_state.svg',
 					title: Liferay.Language.get('no-system-data-sets-created'),
 				}}
+				fluidSize="xxl"
 				id="CreatedSystemDataSets"
 				itemsActions={[
 					{

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
@@ -126,189 +126,206 @@ const Details = ({
 	const {restApplication, restEndpoint, restSchema} = dataSet;
 
 	return (
-		<ClayLayout.Sheet className="mt-3" size="lg">
-			<ClayLayout.SheetHeader>
-				<h2 className="sheet-title">
-					{Liferay.Language.get('details')}
-				</h2>
-			</ClayLayout.SheetHeader>
+		<ClayLayout.ContainerFluid
+			className="mt-3 visualization-modes"
+			size="lg"
+		>
+			<ClayLayout.Sheet>
+				<ClayLayout.SheetHeader>
+					<h2 className="sheet-title">
+						{Liferay.Language.get('details')}
+					</h2>
+				</ClayLayout.SheetHeader>
 
-			<ClayLayout.SheetSection>
-				<ClayForm.Group
-					className={classNames({
-						'has-error': labelValidationError,
-					})}
-				>
-					<label htmlFor={`${namespace}dataSetLabelInput`}>
-						{Liferay.Language.get('name')}
-
-						<RequiredMark />
-					</label>
-
-					<ClayInput
-						defaultValue={dataSet.label}
-						id={`${namespace}dataSetLabelInput`}
-						onBlur={() =>
-							setLabelValidationError(!labelRef.current?.value)
-						}
-						ref={labelRef}
-						type="text"
-					/>
-
-					{labelValidationError && (
-						<ClayForm.FeedbackGroup>
-							<ClayForm.FeedbackItem>
-								<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
-								{Liferay.Language.get('this-field-is-required')}
-							</ClayForm.FeedbackItem>
-						</ClayForm.FeedbackGroup>
-					)}
-				</ClayForm.Group>
-
-				<ClayForm.Group>
-					<label htmlFor={`${namespace}dataSetDesctiptionInput`}>
-						{Liferay.Language.get('description')}
-					</label>
-
-					<ClayInput
-						defaultValue={dataSet.description}
-						id={`${namespace}dataSetDesctiptionInput`}
-						ref={descriptionRef}
-						type="text"
-					/>
-				</ClayForm.Group>
-			</ClayLayout.SheetSection>
-
-			<ClayLayout.SheetSection className="mb-4">
-				<h3 className="sheet-subtitle">
-					{Liferay.Language.get('rest-information')}
-				</h3>
-
-				<ClayList className="flex-row flex-wrap">
-					<ClayList.Item className="border-0 col-12 col-sm-6" flex>
-						<ClayList.ItemField className="justify-content-center">
-							<ClayIcon symbol="api-web" />
-						</ClayList.ItemField>
-
-						<ClayList.ItemField expand>
-							<ClayList.ItemTitle>
-								{Liferay.Language.get('application')}
-							</ClayList.ItemTitle>
-
-							<ClayList.ItemText>
-								{restApplication}
-							</ClayList.ItemText>
-						</ClayList.ItemField>
-					</ClayList.Item>
-
-					<ClayList.Item className="border-0 col-12 col-sm-6" flex>
-						<ClayList.ItemField className="justify-content-center">
-							<ClayIcon symbol="diagram" />
-						</ClayList.ItemField>
-
-						<ClayList.ItemField>
-							<ClayList.ItemTitle>
-								{Liferay.Language.get('schema')}
-							</ClayList.ItemTitle>
-
-							<ClayList.ItemText>{restSchema}</ClayList.ItemText>
-						</ClayList.ItemField>
-					</ClayList.Item>
-
-					<ClayList.Item className="border-0 col-12" flex>
-						<ClayList.ItemField className="justify-content-center">
-							<ClayIcon symbol="nodes" />
-						</ClayList.ItemField>
-
-						<ClayList.ItemField>
-							<ClayList.ItemTitle>
-								{Liferay.Language.get('endpoint')}
-							</ClayList.ItemTitle>
-
-							<ClayList.ItemText>
-								{restEndpoint}
-							</ClayList.ItemText>
-						</ClayList.ItemField>
-					</ClayList.Item>
-				</ClayList>
-			</ClayLayout.SheetSection>
-
-			<ClayLayout.SheetSection className="mb-4">
-				<h3 className="sheet-subtitle">
-					{Liferay.Language.get('advanced-optional-parameters')}
-				</h3>
-
-				<ClayForm.Group>
-					<label htmlFor={`${namespace}dataSetParametersInput`}>
-						{Liferay.Language.get('parameters')}
-
-						<span
-							className="label-icon lfr-portal-tooltip ml-2"
-							title={Liferay.Language.get(
-								'data-set-parameters-help'
-							)}
-						>
-							<ClayIcon symbol="question-circle-full" />
-						</span>
-					</label>
-
-					<ClayInput
-						component="textarea"
-						defaultValue={dataSet.additionalAPIURLParameters}
-						id={`${namespace}dataSetParametersInput`}
-						onChange={handleKeyUpParameters}
-						placeholder={sub(
-							Liferay.Language.get(
-								'data-set-parameters-placeholder'
-							),
-							'filter=dateCreated le 2012-05-29T00:00:00.000Z&flatten=true&sort=name'
-						)}
-						ref={parametersRef}
-						type="text"
-					/>
-				</ClayForm.Group>
-
-				<ClayForm.Group>
-					<label htmlFor={`${namespace}dataSetURLPreviewInput`}>
-						{Liferay.Language.get('url-preview')}
-
-						<span
-							className="label-icon lfr-portal-tooltip ml-2"
-							title={Liferay.Language.get('url-preview-help')}
-						>
-							<ClayIcon symbol="question-circle-full" />
-						</span>
-					</label>
-
-					<ClayInput
-						id={`${namespace}dataSetURLPreviewInput`}
-						readOnly
-						value={urlPreview}
-					/>
-				</ClayForm.Group>
-
-				<LearnMessage
-					resource="frontend-data-set-admin-web"
-					resourceKey="rest-parameters"
-				/>
-			</ClayLayout.SheetSection>
-
-			<ClayLayout.SheetFooter>
-				<ClayButton.Group spaced>
-					<ClayButton onClick={updateFDSView}>
-						{Liferay.Language.get('save')}
-					</ClayButton>
-
-					<ClayButton
-						displayType="secondary"
-						onClick={() => navigate(backURL)}
+				<ClayLayout.SheetSection>
+					<ClayForm.Group
+						className={classNames({
+							'has-error': labelValidationError,
+						})}
 					>
-						{Liferay.Language.get('cancel')}
-					</ClayButton>
-				</ClayButton.Group>
-			</ClayLayout.SheetFooter>
-		</ClayLayout.Sheet>
+						<label htmlFor={`${namespace}dataSetLabelInput`}>
+							{Liferay.Language.get('name')}
+
+							<RequiredMark />
+						</label>
+
+						<ClayInput
+							defaultValue={dataSet.label}
+							id={`${namespace}dataSetLabelInput`}
+							onBlur={() =>
+								setLabelValidationError(
+									!labelRef.current?.value
+								)
+							}
+							ref={labelRef}
+							type="text"
+						/>
+
+						{labelValidationError && (
+							<ClayForm.FeedbackGroup>
+								<ClayForm.FeedbackItem>
+									<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+
+									{Liferay.Language.get(
+										'this-field-is-required'
+									)}
+								</ClayForm.FeedbackItem>
+							</ClayForm.FeedbackGroup>
+						)}
+					</ClayForm.Group>
+
+					<ClayForm.Group>
+						<label htmlFor={`${namespace}dataSetDesctiptionInput`}>
+							{Liferay.Language.get('description')}
+						</label>
+
+						<ClayInput
+							defaultValue={dataSet.description}
+							id={`${namespace}dataSetDesctiptionInput`}
+							ref={descriptionRef}
+							type="text"
+						/>
+					</ClayForm.Group>
+				</ClayLayout.SheetSection>
+
+				<ClayLayout.SheetSection className="mb-4">
+					<h3 className="sheet-subtitle">
+						{Liferay.Language.get('rest-information')}
+					</h3>
+
+					<ClayList className="flex-row flex-wrap">
+						<ClayList.Item
+							className="border-0 col-12 col-sm-6"
+							flex
+						>
+							<ClayList.ItemField className="justify-content-center">
+								<ClayIcon symbol="api-web" />
+							</ClayList.ItemField>
+
+							<ClayList.ItemField expand>
+								<ClayList.ItemTitle>
+									{Liferay.Language.get('application')}
+								</ClayList.ItemTitle>
+
+								<ClayList.ItemText>
+									{restApplication}
+								</ClayList.ItemText>
+							</ClayList.ItemField>
+						</ClayList.Item>
+
+						<ClayList.Item
+							className="border-0 col-12 col-sm-6"
+							flex
+						>
+							<ClayList.ItemField className="justify-content-center">
+								<ClayIcon symbol="diagram" />
+							</ClayList.ItemField>
+
+							<ClayList.ItemField>
+								<ClayList.ItemTitle>
+									{Liferay.Language.get('schema')}
+								</ClayList.ItemTitle>
+
+								<ClayList.ItemText>
+									{restSchema}
+								</ClayList.ItemText>
+							</ClayList.ItemField>
+						</ClayList.Item>
+
+						<ClayList.Item className="border-0 col-12" flex>
+							<ClayList.ItemField className="justify-content-center">
+								<ClayIcon symbol="nodes" />
+							</ClayList.ItemField>
+
+							<ClayList.ItemField>
+								<ClayList.ItemTitle>
+									{Liferay.Language.get('endpoint')}
+								</ClayList.ItemTitle>
+
+								<ClayList.ItemText>
+									{restEndpoint}
+								</ClayList.ItemText>
+							</ClayList.ItemField>
+						</ClayList.Item>
+					</ClayList>
+				</ClayLayout.SheetSection>
+
+				<ClayLayout.SheetSection className="mb-4">
+					<h3 className="sheet-subtitle">
+						{Liferay.Language.get('advanced-optional-parameters')}
+					</h3>
+
+					<ClayForm.Group>
+						<label htmlFor={`${namespace}dataSetParametersInput`}>
+							{Liferay.Language.get('parameters')}
+
+							<span
+								className="label-icon lfr-portal-tooltip ml-2"
+								title={Liferay.Language.get(
+									'data-set-parameters-help'
+								)}
+							>
+								<ClayIcon symbol="question-circle-full" />
+							</span>
+						</label>
+
+						<ClayInput
+							component="textarea"
+							defaultValue={dataSet.additionalAPIURLParameters}
+							id={`${namespace}dataSetParametersInput`}
+							onChange={handleKeyUpParameters}
+							placeholder={sub(
+								Liferay.Language.get(
+									'data-set-parameters-placeholder'
+								),
+								'filter=dateCreated le 2012-05-29T00:00:00.000Z&flatten=true&sort=name'
+							)}
+							ref={parametersRef}
+							type="text"
+						/>
+					</ClayForm.Group>
+
+					<ClayForm.Group>
+						<label htmlFor={`${namespace}dataSetURLPreviewInput`}>
+							{Liferay.Language.get('url-preview')}
+
+							<span
+								className="label-icon lfr-portal-tooltip ml-2"
+								title={Liferay.Language.get('url-preview-help')}
+							>
+								<ClayIcon symbol="question-circle-full" />
+							</span>
+						</label>
+
+						<ClayInput
+							id={`${namespace}dataSetURLPreviewInput`}
+							readOnly
+							value={urlPreview}
+						/>
+					</ClayForm.Group>
+
+					<LearnMessage
+						resource="frontend-data-set-admin-web"
+						resourceKey="rest-parameters"
+					/>
+				</ClayLayout.SheetSection>
+
+				<ClayLayout.SheetFooter>
+					<ClayButton.Group spaced>
+						<ClayButton onClick={updateFDSView}>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => navigate(backURL)}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayButton.Group>
+				</ClayLayout.SheetFooter>
+			</ClayLayout.Sheet>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/pagination/Pagination.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/pagination/Pagination.tsx
@@ -141,156 +141,163 @@ function Pagination({
 		requiredDefaultItemsPerPageValidationError;
 
 	return (
-		<ClayLayout.Sheet className="mt-3" size="lg">
-			<ClayLayout.SheetHeader>
-				<h2 className="sheet-title">
-					{Liferay.Language.get('pagination')}
-				</h2>
+		<ClayLayout.ContainerFluid className="mt-3" size="lg">
+			<ClayLayout.Sheet>
+				<ClayLayout.SheetHeader>
+					<h2 className="sheet-title">
+						{Liferay.Language.get('pagination')}
+					</h2>
 
-				<div className="sheet-text">
-					{Liferay.Language.get(
-						'data-set-view-pagination-description'
-					)}
-				</div>
-			</ClayLayout.SheetHeader>
+					<div className="sheet-text">
+						{Liferay.Language.get(
+							'data-set-view-pagination-description'
+						)}
+					</div>
+				</ClayLayout.SheetHeader>
 
-			<ClayLayout.SheetSection>
-				<ClayForm.Group
-					className={classnames(
-						listOfItemsPerPageValidationError && 'has-error'
-					)}
-				>
-					<label
-						htmlFor={`${namespace}dataSetListOfItemsPerPageTextarea`}
+				<ClayLayout.SheetSection>
+					<ClayForm.Group
+						className={classnames(
+							listOfItemsPerPageValidationError && 'has-error'
+						)}
 					>
-						{Liferay.Language.get('list-of-items-per-page')}
+						<label
+							htmlFor={`${namespace}dataSetListOfItemsPerPageTextarea`}
+						>
+							{Liferay.Language.get('list-of-items-per-page')}
 
-						<RequiredMark />
-					</label>
+							<RequiredMark />
+						</label>
 
-					<ClayInput
-						component="textarea"
-						id={`${namespace}dataSetListOfItemsPerPageTextarea`}
-						onBlur={() => {
-							const itemsPerPageArray = getItemsPerPageArray();
+						<ClayInput
+							component="textarea"
+							id={`${namespace}dataSetListOfItemsPerPageTextarea`}
+							onBlur={() => {
+								const itemsPerPageArray =
+									getItemsPerPageArray();
 
-							listOfItemsPerPageFieldValidation(
-								itemsPerPageArray
-							);
+								listOfItemsPerPageFieldValidation(
+									itemsPerPageArray
+								);
 
-							compatibilityValidation(itemsPerPageArray);
+								compatibilityValidation(itemsPerPageArray);
 
-							setRequiredListOfItemsPerPageValidationError(
-								!listOfItemsPerPageRef.current?.value
-							);
-						}}
-						onChange={(event) =>
-							setListOfItemsPerPage(event.target.value)
-						}
-						ref={listOfItemsPerPageRef}
-						required
-						type="text"
-						value={listOfItemsPerPage}
-					/>
+								setRequiredListOfItemsPerPageValidationError(
+									!listOfItemsPerPageRef.current?.value
+								);
+							}}
+							onChange={(event) =>
+								setListOfItemsPerPage(event.target.value)
+							}
+							ref={listOfItemsPerPageRef}
+							required
+							type="text"
+							value={listOfItemsPerPage}
+						/>
 
-					{listOfItemsPerPageValidationError && (
-						<ClayForm.FeedbackGroup>
-							<ClayForm.FeedbackItem>
-								<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+						{listOfItemsPerPageValidationError && (
+							<ClayForm.FeedbackGroup>
+								<ClayForm.FeedbackItem>
+									<ClayForm.FeedbackIndicator symbol="exclamation-full" />
 
-								{requiredListOfItemsPerPageValidationError
-									? Liferay.Language.get(
-											'this-field-is-required'
-										)
-									: invalidNumberInListOfItemsPerPageValidationError
+									{requiredListOfItemsPerPageValidationError
 										? Liferay.Language.get(
-												'this-field-contains-an-invalid-number'
+												'this-field-is-required'
+											)
+										: invalidNumberInListOfItemsPerPageValidationError
+											? Liferay.Language.get(
+													'this-field-contains-an-invalid-number'
+												)
+											: Liferay.Language.get(
+													'this-field-contains-more-than-25-elements'
+												)}
+								</ClayForm.FeedbackItem>
+							</ClayForm.FeedbackGroup>
+						)}
+
+						<ClayForm.Text>
+							{Liferay.Language.get(
+								'list-of-items-per-page-help'
+							)}
+						</ClayForm.Text>
+					</ClayForm.Group>
+
+					<ClayForm.Group
+						className={classnames(
+							defaultItemsPerPageValidationError && 'has-error'
+						)}
+					>
+						<label
+							htmlFor={`${namespace}dataSetDefaultItemsPerPageInput`}
+						>
+							{Liferay.Language.get('default-items-per-page')}
+
+							<RequiredMark />
+						</label>
+
+						<ClayInput
+							id={`${namespace}dataSetDefaultItemsPerPageInput`}
+							onBlur={() => {
+								compatibilityValidation(getItemsPerPageArray());
+
+								setRequiredDefaultItemsPerPageValidationError(
+									!defaultItemsPerPageRef.current?.value
+								);
+							}}
+							onChange={(event) =>
+								setDefaultItemsPerPage(event.target.value)
+							}
+							ref={defaultItemsPerPageRef}
+							type="number"
+							value={defaultItemsPerPage}
+						/>
+
+						{defaultItemsPerPageValidationError && (
+							<ClayForm.FeedbackGroup>
+								<ClayForm.FeedbackItem>
+									<ClayForm.FeedbackIndicator symbol="exclamation-full" />
+
+									{requiredDefaultItemsPerPageValidationError
+										? Liferay.Language.get(
+												'this-field-is-required'
 											)
 										: Liferay.Language.get(
-												'this-field-contains-more-than-25-elements'
+												'the-default-value-must-exist-in-the-list-of-items-per-page'
 											)}
-							</ClayForm.FeedbackItem>
-						</ClayForm.FeedbackGroup>
-					)}
+								</ClayForm.FeedbackItem>
+							</ClayForm.FeedbackGroup>
+						)}
 
-					<ClayForm.Text>
-						{Liferay.Language.get('list-of-items-per-page-help')}
-					</ClayForm.Text>
-				</ClayForm.Group>
+						<ClayForm.Text>
+							{Liferay.Language.get(
+								'default-items-per-page-help'
+							)}
+						</ClayForm.Text>
+					</ClayForm.Group>
+				</ClayLayout.SheetSection>
 
-				<ClayForm.Group
-					className={classnames(
-						defaultItemsPerPageValidationError && 'has-error'
-					)}
-				>
-					<label
-						htmlFor={`${namespace}dataSetDefaultItemsPerPageInput`}
-					>
-						{Liferay.Language.get('default-items-per-page')}
+				<ClayLayout.SheetFooter>
+					<ClayButton.Group spaced>
+						<ClayButton
+							disabled={
+								listOfItemsPerPageValidationError ||
+								defaultItemsPerPageValidationError
+							}
+							onClick={handleSaveClick}
+						>
+							{Liferay.Language.get('save')}
+						</ClayButton>
 
-						<RequiredMark />
-					</label>
-
-					<ClayInput
-						id={`${namespace}dataSetDefaultItemsPerPageInput`}
-						onBlur={() => {
-							compatibilityValidation(getItemsPerPageArray());
-
-							setRequiredDefaultItemsPerPageValidationError(
-								!defaultItemsPerPageRef.current?.value
-							);
-						}}
-						onChange={(event) =>
-							setDefaultItemsPerPage(event.target.value)
-						}
-						ref={defaultItemsPerPageRef}
-						type="number"
-						value={defaultItemsPerPage}
-					/>
-
-					{defaultItemsPerPageValidationError && (
-						<ClayForm.FeedbackGroup>
-							<ClayForm.FeedbackItem>
-								<ClayForm.FeedbackIndicator symbol="exclamation-full" />
-
-								{requiredDefaultItemsPerPageValidationError
-									? Liferay.Language.get(
-											'this-field-is-required'
-										)
-									: Liferay.Language.get(
-											'the-default-value-must-exist-in-the-list-of-items-per-page'
-										)}
-							</ClayForm.FeedbackItem>
-						</ClayForm.FeedbackGroup>
-					)}
-
-					<ClayForm.Text>
-						{Liferay.Language.get('default-items-per-page-help')}
-					</ClayForm.Text>
-				</ClayForm.Group>
-			</ClayLayout.SheetSection>
-
-			<ClayLayout.SheetFooter>
-				<ClayButton.Group spaced>
-					<ClayButton
-						disabled={
-							listOfItemsPerPageValidationError ||
-							defaultItemsPerPageValidationError
-						}
-						onClick={handleSaveClick}
-					>
-						{Liferay.Language.get('save')}
-					</ClayButton>
-
-					<ClayButton
-						displayType="secondary"
-						onClick={() => navigate(backURL)}
-					>
-						{Liferay.Language.get('cancel')}
-					</ClayButton>
-				</ClayButton.Group>
-			</ClayLayout.SheetFooter>
-		</ClayLayout.Sheet>
+						<ClayButton
+							displayType="secondary"
+							onClick={() => navigate(backURL)}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayButton.Group>
+				</ClayLayout.SheetFooter>
+			</ClayLayout.Sheet>
+		</ClayLayout.ContainerFluid>
 	);
 }
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/settings/Settings.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/settings/Settings.tsx
@@ -153,152 +153,160 @@ const Settings = ({
 	}, []);
 
 	return (
-		<ClayLayout.Sheet className="mt-3" size="lg">
-			<ClayLayout.SheetHeader className="mb-4">
-				<h2 className="sheet-title">
-					{Liferay.Language.get('settings')}
-				</h2>
-			</ClayLayout.SheetHeader>
+		<ClayLayout.ContainerFluid className="mt-3" size="lg">
+			<ClayLayout.Sheet>
+				<ClayLayout.SheetHeader className="mb-4">
+					<h2 className="sheet-title">
+						{Liferay.Language.get('settings')}
+					</h2>
+				</ClayLayout.SheetHeader>
 
-			<ClayLayout.SheetSection>
-				<h3 className="sheet-subtitle">
-					{Liferay.Language.get('fragment-defaults')}
-				</h3>
+				<ClayLayout.SheetSection>
+					<h3 className="sheet-subtitle">
+						{Liferay.Language.get('fragment-defaults')}
+					</h3>
 
-				<ClayLayout.Row className="align-items-center justify-content-between">
-					<ClayLayout.Col size={8}>
-						<div>
-							<label htmlFor="view-mode-picker" id="view-mode">
-								{Liferay.Language.get(
-									'default-visualization-mode'
-								)}
-							</label>
-
-							<ClayTooltipProvider>
-								<span
-									className="ml-1 text-secondary"
-									data-tooltip-align="top"
-									title={Liferay.Language.get(
-										'default-visualization-mode-tooltip'
-									)}
+					<ClayLayout.Row className="align-items-center justify-content-between">
+						<ClayLayout.Col size={8}>
+							<div>
+								<label
+									htmlFor="view-mode-picker"
+									id="view-mode"
 								>
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="question-circle-full"
-									/>
-								</span>
-							</ClayTooltipProvider>
-						</div>
+									{Liferay.Language.get(
+										'default-visualization-mode'
+									)}
+								</label>
 
-						<div>
-							{Liferay.Language.get(
-								'default-visualization-mode-help'
-							)}
-						</div>
-					</ClayLayout.Col>
-
-					<ClayLayout.Col size={4}>
-						{!loading && (
-							<Picker
-								aria-labelledby="view-mode"
-								className="mb-2"
-								disabled={!visualizationModes.length}
-								id="view-mode-picker"
-								items={visualizationModes}
-								onSelectionChange={(option: React.Key) => {
-									if (
-										option !==
-										NOT_CONFIGURED_VISUALIZATION_MODE.type
-									) {
-										setDefaultVisualizationMode(
-											option as string
-										);
-									}
-								}}
-								placeholder={
-									NOT_CONFIGURED_VISUALIZATION_MODE.type
-								}
-								selectedKey={defaultVisualizationMode}
-							>
-								{visualizationModes.length ? (
-									({label, mode, thumbnail}) => (
-										<Option key={mode} textValue={label}>
-											<ClayIcon
-												className="mr-3"
-												symbol={thumbnail}
-											/>
-
-											{label}
-										</Option>
-									)
-								) : (
-									<DropDown.Group
-										header={Liferay.Language.get(
-											'not-configured'
+								<ClayTooltipProvider>
+									<span
+										className="ml-1 text-secondary"
+										data-tooltip-align="top"
+										title={Liferay.Language.get(
+											'default-visualization-mode-tooltip'
 										)}
 									>
-										<Option
-											key={
-												NOT_CONFIGURED_VISUALIZATION_MODE.type
-											}
-											textValue={
-												NOT_CONFIGURED_VISUALIZATION_MODE.type
-											}
-										>
-											<ClayLayout.Row>
-												<ClayLayout.Col>
-													<Text size={3}>
-														{
-															NOT_CONFIGURED_VISUALIZATION_MODE.label
-														}
-													</Text>
-												</ClayLayout.Col>
-											</ClayLayout.Row>
-										</Option>
-									</DropDown.Group>
-								)}
-							</Picker>
-						)}
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="question-circle-full"
+										/>
+									</span>
+								</ClayTooltipProvider>
+							</div>
 
-						{!loading && !visualizationModes.length && (
-							<ClayLink
-								borderless
-								onClick={() => onActiveSectionChange(1)}
-								onKeyPress={() => onActiveSectionChange(1)}
-								tabIndex={0}
-								weight="semi-bold"
-							>
-								<span className="inline-item inline-item-before">
-									<ClayIcon
-										spritemap={spritemap}
-										symbol="shortcut"
-									/>
-								</span>
-
+							<div>
 								{Liferay.Language.get(
-									'go-to-visualization-modes'
+									'default-visualization-mode-help'
 								)}
-							</ClayLink>
-						)}
-					</ClayLayout.Col>
-				</ClayLayout.Row>
-			</ClayLayout.SheetSection>
+							</div>
+						</ClayLayout.Col>
 
-			<ClayLayout.SheetFooter>
-				<ClayButton.Group spaced>
-					<ClayButton onClick={updateFDSViewSettings}>
-						{Liferay.Language.get('save')}
-					</ClayButton>
+						<ClayLayout.Col size={4}>
+							{!loading && (
+								<Picker
+									aria-labelledby="view-mode"
+									className="mb-2"
+									disabled={!visualizationModes.length}
+									id="view-mode-picker"
+									items={visualizationModes}
+									onSelectionChange={(option: React.Key) => {
+										if (
+											option !==
+											NOT_CONFIGURED_VISUALIZATION_MODE.type
+										) {
+											setDefaultVisualizationMode(
+												option as string
+											);
+										}
+									}}
+									placeholder={
+										NOT_CONFIGURED_VISUALIZATION_MODE.type
+									}
+									selectedKey={defaultVisualizationMode}
+								>
+									{visualizationModes.length ? (
+										({label, mode, thumbnail}) => (
+											<Option
+												key={mode}
+												textValue={label}
+											>
+												<ClayIcon
+													className="mr-3"
+													symbol={thumbnail}
+												/>
 
-					<ClayButton
-						displayType="secondary"
-						onClick={() => navigate(backURL)}
-					>
-						{Liferay.Language.get('cancel')}
-					</ClayButton>
-				</ClayButton.Group>
-			</ClayLayout.SheetFooter>
-		</ClayLayout.Sheet>
+												{label}
+											</Option>
+										)
+									) : (
+										<DropDown.Group
+											header={Liferay.Language.get(
+												'not-configured'
+											)}
+										>
+											<Option
+												key={
+													NOT_CONFIGURED_VISUALIZATION_MODE.type
+												}
+												textValue={
+													NOT_CONFIGURED_VISUALIZATION_MODE.type
+												}
+											>
+												<ClayLayout.Row>
+													<ClayLayout.Col>
+														<Text size={3}>
+															{
+																NOT_CONFIGURED_VISUALIZATION_MODE.label
+															}
+														</Text>
+													</ClayLayout.Col>
+												</ClayLayout.Row>
+											</Option>
+										</DropDown.Group>
+									)}
+								</Picker>
+							)}
+
+							{!loading && !visualizationModes.length && (
+								<ClayLink
+									borderless
+									onClick={() => onActiveSectionChange(1)}
+									onKeyPress={() => onActiveSectionChange(1)}
+									tabIndex={0}
+									weight="semi-bold"
+								>
+									<span className="inline-item inline-item-before">
+										<ClayIcon
+											spritemap={spritemap}
+											symbol="shortcut"
+										/>
+									</span>
+
+									{Liferay.Language.get(
+										'go-to-visualization-modes'
+									)}
+								</ClayLink>
+							)}
+						</ClayLayout.Col>
+					</ClayLayout.Row>
+				</ClayLayout.SheetSection>
+
+				<ClayLayout.SheetFooter>
+					<ClayButton.Group spaced>
+						<ClayButton onClick={updateFDSViewSettings}>
+							{Liferay.Language.get('save')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="secondary"
+							onClick={() => navigate(backURL)}
+						>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+					</ClayButton.Group>
+				</ClayLayout.SheetFooter>
+			</ClayLayout.Sheet>
+		</ClayLayout.ContainerFluid>
 	);
 };
 

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -128,6 +128,10 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		return _fdsSortItemList;
 	}
 
+	public String getFluidSize() {
+		return _fluidSize;
+	}
+
 	public String getFormId() {
 		return _formId;
 	}
@@ -206,6 +210,10 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_fdsSortItemList = fdsSortItemList;
 	}
 
+	public void setFluidSize(String fluidSize) {
+		_fluidSize = fluidSize;
+	}
+
 	public void setFormId(String formId) {
 		_formId = formId;
 	}
@@ -280,6 +288,7 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_dataProviderKey = null;
 		_deltaParam = null;
 		_fdsSortItemList = new FDSSortItemList();
+		_fluidSize = null;
 		_formId = null;
 		_formName = null;
 		_nestedItemsKey = null;
@@ -316,6 +325,8 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 				"currentURL", PortalUtil.getCurrentURL(getRequest())
 			).put(
 				"dataProviderKey", _dataProviderKey
+			).put(
+				"fluidSize", _toNullOrObject(_fluidSize)
 			).put(
 				"formId", _toNullOrObject(_formId)
 			).put(
@@ -385,6 +396,7 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 	private String _dataProviderKey;
 	private String _deltaParam;
 	private FDSSortItemList _fdsSortItemList = new FDSSortItemList();
+	private String _fluidSize;
 	private String _formId;
 	private String _formName;
 	private String _nestedItemsKey;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -91,6 +91,10 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		return _fdsSortItemList;
 	}
 
+	public String getFluidSize() {
+		return _fluidSize;
+	}
+
 	public String getFormId() {
 		return _formId;
 	}
@@ -177,6 +181,10 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_fdsSortItemList = fdsSortItemList;
 	}
 
+	public void setFluidSize(String fluidSize) {
+		_fluidSize = fluidSize;
+	}
+
 	public void setFormId(String formId) {
 		_formId = formId;
 	}
@@ -252,6 +260,7 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_fdsFilters = new ArrayList<>();
 		_fdsSortItemList = new FDSSortItemList();
 		_filtersJSONArray = null;
+		_fluidSize = null;
 		_formId = null;
 		_formName = null;
 		_nestedItemsKey = null;
@@ -290,6 +299,8 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 				"customViewsEnabled", _customViewsEnabled
 			).put(
 				"filters", _filtersJSONArray
+			).put(
+				"fluidSize", _validateDataAttribute(_fluidSize)
 			).put(
 				"formId", _validateDataAttribute(_formId)
 			).put(
@@ -368,6 +379,7 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private List<FDSFilter> _fdsFilters = new ArrayList<>();
 	private FDSSortItemList _fdsSortItemList = new FDSSortItemList();
 	private JSONArray _filtersJSONArray;
+	private String _fluidSize;
 	private String _formId;
 	private String _formName;
 	private String _nestedItemsKey;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -65,6 +65,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>fluidSize</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>formId</name>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
@@ -229,6 +234,11 @@
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 			<type>java.util.List</type>
+		</attribute>
+		<attribute>
+			<name>fluidSize</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
 			<name>formId</name>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -54,6 +54,7 @@ const FrontendDataSet = ({
 	customViewsEnabled,
 	emptyState,
 	filters: initialFilters,
+	fluidSize,
 	formId,
 	formName,
 	header,
@@ -613,6 +614,7 @@ const FrontendDataSet = ({
 				creationMenu={creationMenu}
 				deselectItems={(items) => deselectItems(items)}
 				fluid={style === 'fluid'}
+				fluidSize={fluidSize}
 				items={items}
 				selectItems={(items) => selectItems(items)}
 				selectedItems={selectedItems}
@@ -1029,7 +1031,14 @@ const FrontendDataSet = ({
 							<div className="data-set data-set-fluid">
 								{managementBar}
 
-								<div className="container-fluid mt-3">
+								<div
+									className={`mt-3 ${
+										!fluidSize
+											? ''
+											: 'container-fluid container-fluid-max-' +
+												fluidSize
+									}`}
+								>
 									{view}
 
 									{paginationComponent}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -20,6 +20,7 @@ export declare function FrontendDataSet({
 	customViewsEnabled,
 	emptyState,
 	filters,
+	fluidSize,
 	formId,
 	formName,
 	header,
@@ -202,6 +203,7 @@ export interface IFrontendDataSetProps {
 		defaultBodyContent?: object;
 	};
 	filters?: any;
+	fluidSize?: 'md' | 'lg' | 'sm' | 'xl' | 'xxl' | 'xxxl' | undefined;
 	formId?: string;
 	formName?: string;
 	header?: {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -15,6 +15,7 @@ function ManagementBar({
 	creationMenu,
 	deselectItems,
 	fluid,
+	fluidSize,
 	items,
 	selectItems,
 	selectedItems,
@@ -39,7 +40,13 @@ function ManagementBar({
 	}
 
 	return (
-		<>
+		<div
+			className={
+				fluid && fluidSize
+					? `container-fluid container-fluid-max-${fluidSize}`
+					: ''
+			}
+		>
 			{selectionType === 'multiple' && (
 				<BulkActions
 					bulkActions={bulkActions}
@@ -65,7 +72,7 @@ function ManagementBar({
 			)}
 
 			<ActiveFiltersBar disabled={!!selectedItemsValue.length} />
-		</>
+		</div>
 	);
 }
 
@@ -84,6 +91,7 @@ ManagementBar.propTypes = {
 		secondaryItems: PropTypes.array,
 	}),
 	fluid: PropTypes.bool,
+	fluidSize: PropTypes.string,
 	items: PropTypes.array.isRequired,
 	selectItems: PropTypes.func.isRequired,
 	selectedItems: PropTypes.array,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_management_bar.scss
@@ -1,4 +1,5 @@
 .management-bar-wrapper {
+	background-color: #fff;
 	border-bottom: 1px solid $border-color;
 
 	& > .management-bar + .management-bar {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/main.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/main.scss
@@ -4,6 +4,7 @@
 
 @import 'modal';
 @import 'side_panel';
+@import 'views/cards';
 @import 'views/list';
 
 .fds {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_cards.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_cards.scss
@@ -1,0 +1,21 @@
+.cards-container {
+	// stylelint-disable-next-line property-no-unknown
+	container: card-view / inline-size;
+	padding: 1rem;
+}
+
+.cards-section {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: 1fr;
+}
+
+.cards-section > * {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+._card-wrapper {
+	max-width: 100%;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -118,7 +118,7 @@ const Cards = ({items, schema}: {items: Array<any>; schema: ICardSchema}) => {
 				{items.map((item) => {
 					return (
 						<div
-							className="col-md-3"
+							className="col-md-4 col-sm-6 col-xl-3 col-xxxl-2"
 							key={
 								selectedItemsKey
 									? item[selectedItemsKey]

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -114,11 +114,19 @@ const Cards = ({items, schema}: {items: Array<any>; schema: ICardSchema}) => {
 				style === 'default' && 'px-3 pt-4'
 			)}
 		>
-			<div className="row">
+			<style>{`
+				@container card-view (min-width: 280px) {
+					.cards-section {
+						grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+					}
+				}
+			`}</style>
+
+			<div className="cards-section">
 				{items.map((item) => {
 					return (
 						<div
-							className="col-md-4 col-sm-6 col-xl-3 col-xxxl-2"
+							className="card-wrapper"
 							key={
 								selectedItemsKey
 									? item[selectedItemsKey]


### PR DESCRIPTION
## Story / Task
[LPD-50561](https://liferay.atlassian.net/browse/LPD-50561) / [LPD-50587](https://liferay.atlassian.net/browse/LPD-50587)

## Goal
- Use containers with defined max-width to limit the width of the Frontend Data Set in DSM and CX pages
- Adapt the width of DSM sections

## Concerns
- Need to update classic & headless taglib to allow passing a new parameter.
- Clay `@media` queries consider min-width of the viewport. Need to investigate support of [`@container queries.](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) 

## UI (with @container queries)
Changes layout depending on the width of the container

https://github.com/user-attachments/assets/76524539-70bc-43e3-bc3c-814e6524cdb2

## UI (with @media queries)
Changes layout depending on the width of the viewport, no matter how wide is the space that contains the FDS

https://github.com/user-attachments/assets/fe5cea11-a2e4-44f9-b56f-e610775b7fa5



