### PR TITLE
LPD-51456 Set XXXL size for the Management Toolbar

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Container.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/management_toolbar/Container.tsx
@@ -25,7 +25,7 @@ export default function Container({
 				}
 			)}
 		>
-			<ClayLayout.ContainerFluid size={false}>
+			<ClayLayout.ContainerFluid size="xxxl">
 				{children}
 			</ClayLayout.ContainerFluid>
 		</nav>


### PR DESCRIPTION
[Link to issue](https://liferay.atlassian.net/browse/LPD-51456)

Hey @liferay-frontend team! 
While reviewing our components and adjusting styles related to the fluid layout, we read in https://liferay.atlassian.net/wiki/spaces/PEDS/pages/2450227524/Guidelines+on+How+to+Generate+Fluid+Designs+in+DXP that: 

> Management toolbar and Navbars will be max-width XXXL (1872px).

So, I'm changing the size for the Mangament Toolbar, and we will also fix the navigation bars in our components (this will go to our repos) 