### PR TITLE
LPD-51667 FDS formatActionURL encoding

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/formatActionURL.ts
@@ -37,23 +37,17 @@ const formatActionURL = function (
 		return '';
 	}
 
-	const replacedURL = url
-		.replace(new RegExp('{(.*?)}', 'mg'), (matched) =>
-			encodeURIComponent(
-				getValueFromItem(
-					item,
-					matched.substring(1, matched.length - 1).split('.')
-				)
-			)
-		)
-		.replace(new RegExp('(%7B.*?%7D)', 'mg'), (matched) =>
-			encodeURIComponent(
-				getValueFromItem(
-					item,
-					matched.substring(3, matched.length - 3).split('.')
-				)
-			)
-		);
+	const replacedURL = url.replace(
+		/(?:%7B|{)(.*?)(?:%7D|})/g,
+		(match, key) => {
+			const value = getValueFromItem(item, key.split('.'));
+			const isFullyWrapped = match.length === url.length;
+
+			return isFullyWrapped
+				? encodeURI(value)
+				: encodeURIComponent(value);
+		}
+	);
 
 	if (target === 'link' && replacedURL.includes('?')) {
 		const redirectionURL = window.location.href;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/formatActionURL.ts
@@ -8,6 +8,7 @@ import formatActionURL from '../../../src/main/resources/META-INF/resources/util
 const testItem = {
 	id: 1235,
 	name: 'test_item_name',
+	url: 'https://www.liferay.com',
 };
 
 describe('formatActionURL helper', () => {
@@ -137,5 +138,23 @@ describe('formatActionURL helper', () => {
 		);
 
 		expect(anotherFormattedURL).toEqual('/test/page?p_p_id=random');
+	});
+
+	it('does not encode the value when the URL is fully wrapped with braces', () => {
+		const URLFullyWrapped = '{url}';
+		const target = 'link';
+		const formattedURL = formatActionURL(URLFullyWrapped, testItem, target);
+
+		expect(formattedURL).toEqual(testItem.url);
+	});
+
+	it('encodes only the value inside braces when part of the URL is wrapped with braces', () => {
+		const partialURL = '{id}/test/{url}';
+		const target = 'link';
+		const formattedURL = formatActionURL(partialURL, testItem, target);
+
+		expect(formattedURL).toEqual(
+			`${testItem.id}/test/${encodeURIComponent(testItem.url)}`
+		);
 	});
 });


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-51667

We need a mechanism to determine whether the URL should be escaped or not. 
More context in the issue itself https://liferay.atlassian.net/browse/LPD-51667.

# How am I fixing it?

Adding a mechanism to encode the URL or not. After this PR `{}` doesn't URL encode the URL by default and if you use double bracket `{{}}` the URL will be encoded.

# How can you verify that it works?

Go to `liferay-portal/modules/apps/frontend-data-set/frontend-data-set-web` and run the test

```sh
yarn test test/utils/actionItems/formatActionURL.ts
```

I added some test here 7f2769fc6f6f3cd834cbd334c3a569eb8f2e2f7f

![image](https://github.com/user-attachments/assets/0dd15392-fdec-4d0d-9a5c-90d80f587d3b)
