### PR TITLE
LPD-44871 Add Highlighted Bulk Actions in the Info Bar

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/display/context/FDSSampleDisplayContext.java
@@ -157,6 +157,10 @@ public class FDSSampleDisplayContext {
 		).build();
 	}
 
+	public String[] getHighlightedBulkActionDropdownItemIds() {
+		return new String[] {"sampleBulkAction"};
+	}
+
 	private final FDSRequestHelper _fdsRequestHelper;
 	private final RenderResponse _renderResponse;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/advanced.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/advanced.jsp
@@ -23,6 +23,7 @@ FDSSampleDisplayContext fdsSampleDisplayContext = (FDSSampleDisplayContext)reque
 	fdsActionDropdownItems="<%= fdsSampleDisplayContext.getFDSActionDropdownItems() %>"
 	fdsSortItemList="<%= fdsSampleDisplayContext.getFDSSortItemList() %>"
 	formId="fm"
+	highlightedBulkActionDropdownItemIds="<%= fdsSampleDisplayContext.getHighlightedBulkActionDropdownItemIds() %>"
 	id="<%= FDSSampleFDSNames.ADVANCED %>"
 	itemsPerPage="<%= 10 %>"
 	propsTransformer="{AdvancedPropsTransformer} from frontend-data-set-sample-web"

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set Taglib
 Bundle-SymbolicName: com.liferay.frontend.data.set.taglib
-Bundle-Version: 1.2.1
+Bundle-Version: 1.3.0
 Export-Package: com.liferay.frontend.data.set.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/package.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/package.json
@@ -7,5 +7,5 @@
 		"checkFormat": "node-scripts format --check",
 		"format": "node-scripts format"
 	},
-	"version": "1.2.1"
+	"version": "1.3.0"
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -136,6 +136,10 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		return _formName;
 	}
 
+	public String[] getHighlightedBulkActionDropdownItemIds() {
+		return _highlightedBulkActionDropdownItemIds;
+	}
+
 	public String getNestedItemsKey() {
 		return _nestedItemsKey;
 	}
@@ -212,6 +216,13 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 
 	public void setFormName(String formName) {
 		_formName = formName;
+	}
+
+	public void setHighlightedBulkActionDropdownItemIds(
+		String[] highlightedBulkActionDropdownItemIds) {
+
+		_highlightedBulkActionDropdownItemIds =
+			highlightedBulkActionDropdownItemIds;
 	}
 
 	public void setNestedItemsKey(String nestedItemsKey) {
@@ -321,6 +332,9 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 			).put(
 				"formName", _toNullOrObject(_formName)
 			).put(
+				"highlightedBulkActionIds",
+				_highlightedBulkActionDropdownItemIds
+			).put(
 				"id", getId()
 			).put(
 				"nestedItemsKey", _toNullOrObject(_nestedItemsKey)
@@ -387,6 +401,7 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 	private FDSSortItemList _fdsSortItemList = new FDSSortItemList();
 	private String _formId;
 	private String _formName;
+	private String[] _highlightedBulkActionDropdownItemIds;
 	private String _nestedItemsKey;
 	private String _nestedItemsReferenceKey;
 	private String _selectedItemsKey;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/ClassicDisplayTag.java
@@ -293,6 +293,7 @@ public class ClassicDisplayTag extends BaseDisplayTag {
 		_fdsSortItemList = new FDSSortItemList();
 		_formId = null;
 		_formName = null;
+		_highlightedBulkActionDropdownItemIds = null;
 		_nestedItemsKey = null;
 		_nestedItemsReferenceKey = null;
 		_selectedItemsKey = null;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -265,6 +265,7 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		_filtersJSONArray = null;
 		_formId = null;
 		_formName = null;
+		_highlightedBulkActionDropdownItemIds = null;
 		_nestedItemsKey = null;
 		_nestedItemsReferenceKey = null;
 		_selectedItemsKey = null;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/java/com/liferay/frontend/data/set/taglib/servlet/taglib/HeadlessDisplayTag.java
@@ -99,6 +99,10 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 		return _formName;
 	}
 
+	public String[] getHighlightedBulkActionDropdownItemIds() {
+		return _highlightedBulkActionDropdownItemIds;
+	}
+
 	public String getNestedItemsKey() {
 		return _nestedItemsKey;
 	}
@@ -183,6 +187,13 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 
 	public void setFormName(String formName) {
 		_formName = formName;
+	}
+
+	public void setHighlightedBulkActionDropdownItemIds(
+		String[] highlightedBulkActionDropdownItemIds) {
+
+		_highlightedBulkActionDropdownItemIds =
+			highlightedBulkActionDropdownItemIds;
 	}
 
 	public void setNestedItemsKey(String nestedItemsKey) {
@@ -295,6 +306,9 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 			).put(
 				"formName", _validateDataAttribute(_formName)
 			).put(
+				"highlightedBulkActionIds",
+				_highlightedBulkActionDropdownItemIds
+			).put(
 				"id", getId()
 			).put(
 				"itemsActions", _fdsActionDropdownItems
@@ -370,6 +384,7 @@ public class HeadlessDisplayTag extends BaseDisplayTag {
 	private JSONArray _filtersJSONArray;
 	private String _formId;
 	private String _formName;
+	private String[] _highlightedBulkActionDropdownItemIds;
 	private String _nestedItemsKey;
 	private String _nestedItemsReferenceKey;
 	private String _selectedItemsKey;

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/META-INF/frontend-data-set.tld
@@ -73,6 +73,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>highlightedBulkActionDropdownItemIds</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>id</name>
 			<required>true</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -237,6 +242,11 @@
 		</attribute>
 		<attribute>
 			<name>formName</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>highlightedBulkActionDropdownItemIds</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/com/liferay/frontend/data/set/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-taglib/src/main/resources/com/liferay/frontend/data/set/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -57,6 +57,7 @@ const FrontendDataSet = ({
 	formId,
 	formName,
 	header,
+	highlightedBulkActionIds,
 	id,
 	inlineAddingSettings,
 	inlineEditingSettings,
@@ -613,6 +614,7 @@ const FrontendDataSet = ({
 				creationMenu={creationMenu}
 				deselectItems={(items) => deselectItems(items)}
 				fluid={style === 'fluid'}
+				highlightedBulkActionIds={highlightedBulkActionIds}
 				items={items}
 				onBulkActionsClear={() => deselectItems(selectedItemsValue)}
 				selectItems={(items) => selectItems(items)}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import BulkActions from './controls/BulkActions';
+import BulkActionsDeprecated from './controls/BulkActionsDeprecated';
 import NavBar from './controls/NavBar';
 import ActiveFiltersBar from './controls/filters/ActiveFiltersBar';
 
@@ -41,21 +42,36 @@ function ManagementBar({
 
 	return (
 		<>
-			{selectionType === 'multiple' && (
-				<BulkActions
-					bulkActions={bulkActions}
-					fluid={fluid}
-					handleCheckboxClick={handleCheckboxClick}
-					items={items}
-					onClear={onBulkActionsClear}
-					pageSelectedItemsValue={pageSelectedItemsValue}
-					selectItems={selectItems}
-					selectedItems={selectedItems}
-					selectedItemsKey={selectedItemsKey}
-					selectedItemsValue={selectedItemsValue}
-					total={total}
-				/>
-			)}
+			{selectionType === 'multiple' &&
+				(Liferay.FeatureFlags['LPD-42570'] ? (
+					<BulkActions
+						bulkActions={bulkActions}
+						fluid={fluid}
+						handleCheckboxClick={handleCheckboxClick}
+						items={items}
+						onClear={onBulkActionsClear}
+						pageSelectedItemsValue={pageSelectedItemsValue}
+						selectItems={selectItems}
+						selectedItems={selectedItems}
+						selectedItemsKey={selectedItemsKey}
+						selectedItemsValue={selectedItemsValue}
+						total={total}
+					/>
+				) : (
+					<BulkActionsDeprecated
+						bulkActions={bulkActions}
+						fluid={fluid}
+						handleCheckboxClick={handleCheckboxClick}
+						items={items}
+						onClear={onBulkActionsClear}
+						pageSelectedItemsValue={pageSelectedItemsValue}
+						selectItems={selectItems}
+						selectedItems={selectedItems}
+						selectedItemsKey={selectedItemsKey}
+						selectedItemsValue={selectedItemsValue}
+						total={total}
+					/>
+				))}
 
 			{(!selectedItemsValue.length || selectionType === 'single') && (
 				<NavBar

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -16,6 +16,7 @@ function ManagementBar({
 	creationMenu,
 	deselectItems,
 	fluid,
+	highlightedBulkActionIds,
 	items,
 	onBulkActionsClear,
 	selectItems,
@@ -48,6 +49,7 @@ function ManagementBar({
 						bulkActions={bulkActions}
 						fluid={fluid}
 						handleCheckboxClick={handleCheckboxClick}
+						highlightedBulkActionIds={highlightedBulkActionIds}
 						items={items}
 						onClear={onBulkActionsClear}
 						pageSelectedItemsValue={pageSelectedItemsValue}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
+import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
 import DropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
@@ -152,10 +152,10 @@ function BulkActions({
 				selectable,
 				sidePanelId,
 			}) => (
-				<nav className="management-bar management-bar-primary navbar navbar-expand-md pb-2 pt-2 subnav-tbar">
+				<nav className="management-bar management-bar-primary navbar navbar-expand-md">
 					<div
 						className={classNames(
-							'container-fluid py-1',
+							'container-fluid',
 							!fluid && 'px-0'
 						)}
 					>
@@ -225,16 +225,14 @@ function BulkActions({
 
 						{showBulkActionsManagementBarActions && (
 							<ul className="bulk-actions navbar-nav">
-								{bulkActions.map((actionDefinition, i) => (
+								{bulkActions.map((actionDefinition) => (
 									<li
 										className="nav-item"
 										key={actionDefinition.label}
 									>
-										<button
-											className={classNames(
-												'btn btn-monospaced btn-link',
-												i > 0 && 'ml-1'
-											)}
+										<ClayButton
+											className="nav-link"
+											displayType="unstyled"
 											onClick={() =>
 												handleActionClick(
 													actionDefinition,
@@ -245,12 +243,17 @@ function BulkActions({
 													sidePanelId
 												)
 											}
-											type="button"
 										>
-											<ClayIcon
-												symbol={actionDefinition.icon}
-											/>
-										</button>
+											<span className="inline-item inline-item-before">
+												<ClayIcon
+													symbol={
+														actionDefinition.icon
+													}
+												/>
+											</span>
+
+											{actionDefinition.label}
+										</ClayButton>
 									</li>
 								))}
 
@@ -263,8 +266,8 @@ function BulkActions({
 													aria-label={Liferay.Language.get(
 														'actions'
 													)}
+													className="nav-link nav-link-monospaced"
 													displayType="unstyled"
-													small
 													symbol="ellipsis-v"
 													title={Liferay.Language.get(
 														'actions'

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -237,11 +237,11 @@ function BulkActions({
 
 										return (
 											<li
-												className="nav-item"
+												className="d-none d-sm-flex nav-item"
 												key={actionDefinition.data.id}
 											>
 												<ClayButton
-													className="nav-link"
+													className="d-lg-inline d-none nav-link"
 													displayType="unstyled"
 													onClick={() =>
 														handleActionClick(
@@ -264,6 +264,30 @@ function BulkActions({
 
 													{actionDefinition.label}
 												</ClayButton>
+
+												<ClayButtonWithIcon
+													aria-label={
+														actionDefinition.label
+													}
+													className="d-lg-none nav-link nav-link-monospaced"
+													displayType="unstyled"
+													onClick={() =>
+														handleActionClick(
+															actionDefinition,
+															formId,
+															formName,
+															loadData,
+															namespace,
+															sidePanelId
+														)
+													}
+													symbol={
+														actionDefinition.icon
+													}
+													title={
+														actionDefinition.label
+													}
+												/>
 											</li>
 										);
 									}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -34,6 +34,7 @@ function BulkActions({
 	bulkActions,
 	fluid,
 	handleCheckboxClick,
+	highlightedBulkActionIds,
 	items,
 	onClear,
 	pageSelectedItemsValue,
@@ -225,37 +226,48 @@ function BulkActions({
 
 						{showBulkActionsManagementBarActions && (
 							<ul className="bulk-actions navbar-nav">
-								{bulkActions.map((actionDefinition) => (
-									<li
-										className="nav-item"
-										key={actionDefinition.label}
-									>
-										<ClayButton
-											className="nav-link"
-											displayType="unstyled"
-											onClick={() =>
-												handleActionClick(
-													actionDefinition,
-													formId,
-													formName,
-													loadData,
-													namespace,
-													sidePanelId
-												)
-											}
-										>
-											<span className="inline-item inline-item-before">
-												<ClayIcon
-													symbol={
-														actionDefinition.icon
-													}
-												/>
-											</span>
+								{highlightedBulkActionIds.map(
+									(highlightedBulkActionId) => {
+										const actionDefinition =
+											bulkActions.find(
+												(bulkAction) =>
+													bulkAction.data.id ===
+													highlightedBulkActionId
+											);
 
-											{actionDefinition.label}
-										</ClayButton>
-									</li>
-								))}
+										return (
+											<li
+												className="nav-item"
+												key={actionDefinition.data.id}
+											>
+												<ClayButton
+													className="nav-link"
+													displayType="unstyled"
+													onClick={() =>
+														handleActionClick(
+															actionDefinition,
+															formId,
+															formName,
+															loadData,
+															namespace,
+															sidePanelId
+														)
+													}
+												>
+													<span className="inline-item inline-item-before">
+														<ClayIcon
+															symbol={
+																actionDefinition.icon
+															}
+														/>
+													</span>
+
+													{actionDefinition.label}
+												</ClayButton>
+											</li>
+										);
+									}
+								)}
 
 								{!!bulkActions.length && (
 									<li className="nav-item">

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -194,18 +194,16 @@ function BulkActions({
 											)}
 								</span>
 
-								{Liferay.FeatureFlags['LPD-42570'] && (
-									<ClayLink
-										className="ml-3"
-										href="#"
-										onClick={(event) => {
-											event.preventDefault();
-											onClear();
-										}}
-									>
-										{Liferay.Language.get('clear')}
-									</ClayLink>
-								)}
+								<ClayLink
+									className="ml-3"
+									href="#"
+									onClick={(event) => {
+										event.preventDefault();
+										onClear();
+									}}
+								>
+									{Liferay.Language.get('clear')}
+								</ClayLink>
 
 								<ClayLink
 									className="ml-3"

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActionsDeprecated.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActionsDeprecated.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ClayButtonWithIcon} from '@clayui/button';
-import DropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
@@ -15,7 +13,6 @@ import React, {useContext, useEffect, useState} from 'react';
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import {OPEN_SIDE_PANEL} from '../../utils/eventsDefinitions';
 import {getOpenedSidePanel} from '../../utils/sidePanels';
-import SelectionCheckbox from './SelectionCheckbox';
 
 function getQueryString(key, values = []) {
 	return `?${key}=${values.join(',')}`;
@@ -33,10 +30,7 @@ function getRichPayload(payload, key, values = []) {
 function BulkActions({
 	bulkActions,
 	fluid,
-	handleCheckboxClick,
 	items,
-	onClear,
-	pageSelectedItemsValue,
 	selectItems,
 	selectedItems,
 	selectedItemsKey,
@@ -161,17 +155,7 @@ function BulkActions({
 					>
 						<ul className="navbar-nav">
 							{!!total && selectable && (
-								<li className="nav-item">
-									<SelectionCheckbox
-										handleCheckboxClick={
-											handleCheckboxClick
-										}
-										items={items}
-										selectedItemsValue={
-											pageSelectedItemsValue
-										}
-									/>
-								</li>
+								<li className="ml-3 nav-item"></li>
 							)}
 
 							<li className="nav-item">
@@ -193,19 +177,6 @@ function BulkActions({
 											)}
 								</span>
 
-								{Liferay.FeatureFlags['LPD-42570'] && (
-									<ClayLink
-										className="ml-3"
-										href="#"
-										onClick={(event) => {
-											event.preventDefault();
-											onClear();
-										}}
-									>
-										{Liferay.Language.get('clear')}
-									</ClayLink>
-								)}
-
 								<ClayLink
 									className="ml-3"
 									href="#"
@@ -224,86 +195,32 @@ function BulkActions({
 						</ul>
 
 						{showBulkActionsManagementBarActions && (
-							<ul className="bulk-actions navbar-nav">
+							<div className="bulk-actions">
 								{bulkActions.map((actionDefinition, i) => (
-									<li
-										className="nav-item"
+									<button
+										className={classNames(
+											'btn btn-monospaced btn-link',
+											i > 0 && 'ml-1'
+										)}
 										key={actionDefinition.label}
+										onClick={() =>
+											handleActionClick(
+												actionDefinition,
+												formId,
+												formName,
+												loadData,
+												namespace,
+												sidePanelId
+											)
+										}
+										type="button"
 									>
-										<button
-											className={classNames(
-												'btn btn-monospaced btn-link',
-												i > 0 && 'ml-1'
-											)}
-											onClick={() =>
-												handleActionClick(
-													actionDefinition,
-													formId,
-													formName,
-													loadData,
-													namespace,
-													sidePanelId
-												)
-											}
-											type="button"
-										>
-											<ClayIcon
-												symbol={actionDefinition.icon}
-											/>
-										</button>
-									</li>
+										<ClayIcon
+											symbol={actionDefinition.icon}
+										/>
+									</button>
 								))}
-
-								{!!bulkActions.length && (
-									<li className="nav-item">
-										<DropDown
-											hasLeftSymbols
-											trigger={
-												<ClayButtonWithIcon
-													aria-label={Liferay.Language.get(
-														'actions'
-													)}
-													displayType="unstyled"
-													small
-													symbol="ellipsis-v"
-													title={Liferay.Language.get(
-														'actions'
-													)}
-												/>
-											}
-										>
-											<DropDown.ItemList>
-												{bulkActions.map(
-													(actionDefinition) => (
-														<DropDown.Item
-															key={
-																actionDefinition.label
-															}
-															onClick={() =>
-																handleActionClick(
-																	actionDefinition,
-																	formId,
-																	formName,
-																	loadData,
-																	namespace,
-																	sidePanelId
-																)
-															}
-															symbolLeft={
-																actionDefinition.icon
-															}
-														>
-															{
-																actionDefinition.label
-															}
-														</DropDown.Item>
-													)
-												)}
-											</DropDown.ItemList>
-										</DropDown>
-									</li>
-								)}
-							</ul>
+							</div>
 						)}
 					</div>
 				</nav>
@@ -324,7 +241,6 @@ BulkActions.propTypes = {
 	),
 	handleCheckboxClick: PropTypes.func.isRequired,
 	items: PropTypes.array.isRequired,
-	onClear: PropTypes.func.isRequired,
 	selectedItemsKey: PropTypes.string.isRequired,
 	selectedItemsValue: PropTypes.array.isRequired,
 	total: PropTypes.number,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActionsDeprecated.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActionsDeprecated.js
@@ -132,6 +132,7 @@ function BulkActions({
 			}
 		},
 
+		// eslint-disable-next-line react-compiler/react-compiler
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[selectedItemsValue]
 	);

--- a/modules/test/playwright/tests/frontend-data-set-web/advanced.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/advanced.spec.ts
@@ -750,12 +750,49 @@ test('Check behavior of selection', async ({fdsSamplePage, page}) => {
 			.first()
 			.getByRole('checkbox');
 
-		await test.step('Select one of the items in the table', async () => {
+		await test.step('Select the first item in the table', async () => {
 			await firstItemCheckbox.check();
 		});
 
+		await test.step('Check the highlighted bulk action "Label" is visible', async () => {
+			await expect(
+				fdsSamplePage.bulkActions.container.getByRole('button', {
+					name: 'Label',
+				})
+			).toHaveText('Label');
+		});
+
+		await test.step('Check in medium-width windows the text is hidden', async () => {
+			await page.setViewportSize({height: 1024, width: 800});
+
+			const visibleLabelButton = await fdsSamplePage.getVisibleLocator(
+				fdsSamplePage.bulkActions.container.getByRole('button', {
+					name: 'Label',
+				})
+			);
+
+			await expect(visibleLabelButton).not.toHaveText('Label');
+			await expect(
+				visibleLabelButton.locator('.lexicon-icon')
+			).toBeVisible();
+		});
+
+		await test.step('Check in small-width windows the text and icon are hidden', async () => {
+			await page.setViewportSize({height: 720, width: 360});
+
+			await expect(
+				fdsSamplePage.bulkActions.container.getByRole('button', {
+					name: 'Label',
+				})
+			).toBeHidden();
+		});
+
+		await test.step('Reset the window size', async () => {
+			await page.setViewportSize({height: 720, width: 1280});
+		});
+
 		await test.step('Open ellipsis actions menu', async () => {
-			await page.locator('.bulk-actions').getByLabel('Actions').click();
+			await fdsSamplePage.bulkActions.actionsDropdownButton.click();
 		});
 
 		await test.step('Check the bulk actions are listed', async () => {
@@ -765,7 +802,7 @@ test('Check behavior of selection', async ({fdsSamplePage, page}) => {
 		});
 
 		await test.step('Close ellipsis actions menu', async () => {
-			await page.locator('.bulk-actions').getByLabel('Actions').click();
+			await fdsSamplePage.bulkActions.actionsDropdownButton.click();
 
 			await expect(page.locator('.dropdown-menu.show')).toBeHidden();
 		});

--- a/modules/test/playwright/tests/frontend-data-set-web/advanced.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/advanced.spec.ts
@@ -822,6 +822,11 @@ test('Check behavior of selection', async ({fdsSamplePage, page}) => {
 
 			await page.getByRole('option', {name: '60 Items'}).click();
 
+			await page
+				.getByText('This is a description for sample')
+				.first()
+				.waitFor();
+
 			await expect(
 				page.getByText('Showing 1 to 60 of 75 entries.')
 			).toBeVisible();
@@ -838,6 +843,11 @@ test('Check behavior of selection', async ({fdsSamplePage, page}) => {
 		await test.step('Select all items', async () => {
 			await page.getByLabel('Go to page, 2').click();
 
+			await page
+				.getByText('This is a description for sample')
+				.first()
+				.waitFor();
+
 			for (let i = 1; i <= 15; i++) {
 				await page
 					.locator(
@@ -853,6 +863,11 @@ test('Check behavior of selection', async ({fdsSamplePage, page}) => {
 
 		await test.step('Check that selection are preserved through page navigation', async () => {
 			await page.getByLabel('Go to page, 1').click();
+
+			await page
+				.getByText('This is a description for sample')
+				.first()
+				.waitFor();
 
 			await expect(
 				page.getByText('All Selected (75 of 75 Items)')

--- a/modules/test/playwright/tests/frontend-data-set-web/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/pages/FDSSamplePage.ts
@@ -13,6 +13,10 @@ import getWidgetDefinition from '../../layout-content-page-editor-web/utils/getW
 
 export class FDSSamplePage {
 	private readonly apiHelpers: ApiHelpers;
+	readonly bulkActions: {
+		actionsDropdownButton: Locator;
+		container: Locator;
+	};
 	readonly customViewsActionsButton: Locator;
 	readonly customViewsDeleteAlert: Locator;
 	readonly customViewsSaveModal: Locator;
@@ -33,6 +37,12 @@ export class FDSSamplePage {
 
 	constructor(page: Page) {
 		this.apiHelpers = new ApiHelpers(page);
+		this.bulkActions = {
+			actionsDropdownButton: page
+				.locator('.bulk-actions')
+				.getByLabel('Actions'),
+			container: page.locator('.bulk-actions'),
+		};
 		this.customViewsActionsButton = page.getByLabel('Show View Actions', {
 			exact: true,
 		});
@@ -62,6 +72,7 @@ export class FDSSamplePage {
 				'Manage Columns Visibility'
 			),
 		};
+
 		const itemActionsCell = this.table.itemActionsCells.first();
 
 		this.itemActionButton = itemActionsCell.getByRole('button', {
@@ -88,6 +99,20 @@ export class FDSSamplePage {
 				name: itemAction,
 			})
 			.click();
+	}
+
+	async getVisibleLocator(locator: Locator): Promise<Locator> {
+		const locators = await locator.all();
+
+		let visibleLocator: Locator;
+
+		for (const locator of locators) {
+			if (await locator.isVisible()) {
+				visibleLocator = locator;
+			}
+		}
+
+		return visibleLocator;
 	}
 
 	selectItemActionsByRow(text: string) {


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPD-42584
**Subtask:** https://liferay.atlassian.net/browse/LPD-44871

---

**Main changes:**
- Adds support for configuring highlighted bulk actions through a new prop `highlightedBulkActionIds` on the `FrontendDataSet.js` component. This a list of IDs referencing the IDs in `bulkActions` which seemed the most flexible to allow any amount of highlighted actions to be added in any order.
- For the taglib, `highlightedBulkActionDropdownItemIds` was the name chosen to relate with `bulkActionDropdownItems`.
- For responsiveness, the change from icon only and hidden is done through the `d-*` css classes so it changes based off of window width. I attempted using javascript calculation to check actual overflowing but couldn't get anything working well because of situations like the icon only button needing to be displayed to check for overflowing before hiding which would cause layout shifting around.

**Additional refactoring notes:**
- Created a new file `BulkActionsDeprecated.js` to cleanly separate the feature flag since the css classes needed to be adjusted for the entire management bar. 

---

## Demo
### Default
<img width="1305" alt="Screenshot 2025-03-21 at 11 05 24 PM" src="https://github.com/user-attachments/assets/d19cfa6f-41d1-432a-bce6-201c7a4b7edb" />

### Icon Only
<img width="774" alt="Screenshot 2025-03-21 at 11 05 38 PM" src="https://github.com/user-attachments/assets/0693a5a9-9770-4763-ac23-71fd90832d99" />

### Fully Hidden
<img width="494" alt="Screenshot 2025-03-21 at 11 05 59 PM" src="https://github.com/user-attachments/assets/a3978f88-298f-473b-a39b-bea14e52cccf" />
