### PR TITLE
LPD-50120 Allow conditional actions (II)

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/model/FDSActionDropdownItem.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/model/FDSActionDropdownItem.java
@@ -7,7 +7,6 @@ package com.liferay.frontend.data.set.model;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -26,6 +25,21 @@ public class FDSActionDropdownItem extends DropdownItem {
 		setMethod(method);
 		setPermissionKey(permissionKey);
 		setTarget(target);
+	}
+
+	public FDSActionDropdownItem(
+		String href, String icon, String id, String label, String method,
+		String permissionKey, String target,
+		Map<String, Object> visibilityFilters) {
+
+		setHref(href);
+		setIcon(icon);
+		setId(id);
+		setLabel(label);
+		setMethod(method);
+		setPermissionKey(permissionKey);
+		setTarget(target);
+		setVisibilityFilters(visibilityFilters);
 	}
 
 	public FDSActionDropdownItem(
@@ -62,7 +76,7 @@ public class FDSActionDropdownItem extends DropdownItem {
 		String errorMessage, String href, String icon, String id, String label,
 		String method, String modalSize, String permissionKey,
 		String requestBody, String successMessage, String target, String title,
-		String type, String[] visibilityFilters) {
+		String type, Map<String, Object> visibilityFilters) {
 
 		this(
 			href, icon, id, label, method, permissionKey, target,
@@ -77,20 +91,6 @@ public class FDSActionDropdownItem extends DropdownItem {
 		setSuccessMessage(successMessage);
 		setTitle(title);
 		setType(type);
-	}
-
-	public FDSActionDropdownItem(
-		String href, String icon, String id, String label, String method,
-		String permissionKey, String target, String[] visibilityFilters) {
-
-		setHref(href);
-		setIcon(icon);
-		setId(id);
-		setLabel(label);
-		setMethod(method);
-		setPermissionKey(permissionKey);
-		setTarget(target);
-		setVisibilityFilters(visibilityFilters);
 	}
 
 	public void setConfirmationMessage(String confirmationMessage) {
@@ -137,21 +137,8 @@ public class FDSActionDropdownItem extends DropdownItem {
 		putData("type", type);
 	}
 
-	public void setVisibilityFilters(String... visibilityFilters) {
-		if ((visibilityFilters.length % 2) != 0) {
-			throw new IllegalArgumentException(
-				"Visibility filters length is not an even number");
-		}
-
-		Map<String, String> map = new HashMap<>();
-
-		for (int i = 0; i < visibilityFilters.length; i += 2) {
-			map.put(
-				String.valueOf(visibilityFilters[i]),
-				String.valueOf(visibilityFilters[i + 1]));
-		}
-
-		putData("visibilityFilters", map);
+	public void setVisibilityFilters(Map<String, Object> visibilityFilters) {
+		putData("visibilityFilters", visibilityFilters);
 	}
 
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/action/ClassicFDSItemsActions.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/action/ClassicFDSItemsActions.java
@@ -10,6 +10,7 @@ import com.liferay.frontend.data.set.action.FDSItemsActions;
 import com.liferay.frontend.data.set.model.FDSActionDropdownItem;
 import com.liferay.frontend.data.set.sample.web.internal.constants.FDSSampleFDSNames;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -45,20 +46,25 @@ public class ClassicFDSItemsActions implements FDSItemsActions {
 				null, null, null, "#", "cog", "deactivate",
 				_language.get(httpServletRequest, "deactivate"), null, null,
 				null, null, null, "link", null, "item",
-				new String[] {"active", Boolean.TRUE.toString()}),
+				HashMapBuilder.<String, Object>put(
+					"active", Boolean.TRUE
+				).build()),
 			new FDSActionDropdownItem(
 				null, null, null, "#", "cog", "activate",
 				_language.get(httpServletRequest, "activate"), null, null, null,
 				null, null, "link", null, "item",
-				new String[] {"active", Boolean.FALSE.toString()}),
+				HashMapBuilder.<String, Object>put(
+					"active", Boolean.FALSE
+				).build()),
 			new FDSActionDropdownItem(
 				null, null, null, "#", "cog", "activity",
 				_language.get(httpServletRequest, "activity"), null, null, null,
 				null, null, "link", null, "item",
-				new String[] {
-					"active", Boolean.TRUE.toString(), "emailAddress",
-					"manager.user@liferay.com"
-				}));
+				HashMapBuilder.<String, Object>put(
+					"active", Boolean.TRUE
+				).put(
+					"emailAddress", "manager.user@liferay.com"
+				).build()));
 	}
 
 	@Override

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -138,12 +138,11 @@ export interface IItemActionsData {
 	status?: ModalStatus;
 	successMessage?: string;
 	title?: string;
-	visibilityFilters?: IItemActionsDataFilter[];
+	visibilityFilters?: IItemActionsDataFilter;
 }
 
 export interface IItemActionsDataFilter {
-	key: string;
-	value: boolean | number | string;
+	[key: string]: boolean | number | string;
 }
 
 export interface IQuickActions extends IBaseActions {

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterItemActions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterItemActions.ts
@@ -30,9 +30,12 @@ const matchesVisibilityFilters = (
 		return true;
 	}
 
-	return action?.data?.visibilityFilters.every(
-		(filter: IItemActionsDataFilter) =>
-			getLocalizedValue(itemData, filter?.key)?.value === filter?.value
+	const visibilityFilters: IItemActionsDataFilter =
+		action?.data?.visibilityFilters;
+
+	return Object.keys(visibilityFilters).every(
+		(key: string) =>
+			getLocalizedValue(itemData, key)?.value === visibilityFilters[key]
 	);
 };
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/filterItemActions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/actionItems/filterItemActions.ts
@@ -146,11 +146,11 @@ describe('filterItemActions', () => {
 			const customItemActions = generateCustomItemActions([
 				{
 					permissionKey: 'UPDATE',
-					visibilityFilters: [{key: 'color', value: 'green'}],
+					visibilityFilters: {color: 'green'},
 				},
 				{
 					permissionKey: 'UPDATE',
-					visibilityFilters: [{key: 'color', value: 'blue'}],
+					visibilityFilters: {color: 'blue'},
 				},
 			]);
 
@@ -168,10 +168,10 @@ describe('filterItemActions', () => {
 		it('returns only the action that matches the action visibility filter criteria', () => {
 			const customItemActions = generateCustomItemActions([
 				{
-					visibilityFilters: [{key: 'color', value: 'green'}],
+					visibilityFilters: {color: 'green'},
 				},
 				{
-					visibilityFilters: [{key: 'color', value: 'blue'}],
+					visibilityFilters: {color: 'blue'},
 				},
 			]);
 
@@ -188,13 +188,13 @@ describe('filterItemActions', () => {
 		it('returns only the actions that matches all action visibility filters criteria', () => {
 			const customItemActions = generateCustomItemActions([
 				{
-					visibilityFilters: [{key: 'color', value: 'green'}],
+					visibilityFilters: {color: 'green'},
 				},
 				{
-					visibilityFilters: [
-						{key: 'color', value: 'blue'},
-						{key: 'type', value: 'boolean'},
-					],
+					visibilityFilters: {
+						color: 'blue',
+						type: 'boolean',
+					},
 				},
 			]);
 
@@ -209,13 +209,13 @@ describe('filterItemActions', () => {
 		it('returns actions if the filter criteria key includes a composed field name', () => {
 			const customItemActions = generateCustomItemActions([
 				{
-					visibilityFilters: [{key: 'color', value: 'green'}],
+					visibilityFilters: {color: 'green'},
 				},
 				{
-					visibilityFilters: [
-						{key: 'color', value: 'blue'},
-						{key: 'creator.name', value: 'Test Test'},
-					],
+					visibilityFilters: {
+						'color': 'blue',
+						'creator.name': 'Test Test',
+					},
 				},
 			]);
 
@@ -231,13 +231,13 @@ describe('filterItemActions', () => {
 		it('returns actions if the filter criteria is based on a boolean value', () => {
 			const customItemActions = generateCustomItemActions([
 				{
-					visibilityFilters: [{key: 'color', value: 'green'}],
+					visibilityFilters: {color: 'green'},
 				},
 				{
-					visibilityFilters: [
-						{key: 'color', value: 'blue'},
-						{key: 'sortable', value: true},
-					],
+					visibilityFilters: {
+						color: 'blue',
+						sortable: true,
+					},
 				},
 			]);
 


### PR DESCRIPTION
This is a followup after BChan's changes in the `FDSActionDropdownItem` API. ([reference](https://github.com/brianchandotcom/liferay-portal/pull/160199))

Basically this removes the need for a specific class to model filters on actions, substituting it with a real map that gets serialized and interpreted in the frontend accordingly.

No substantial changes other than the shape of the map and how it is exposed in the Java API.

Sent to check SF and tests