### PR TITLE
LPD-41490 Provide Link to API Explorer from each Data Set

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
@@ -6,7 +6,10 @@
 import ClayButton from '@clayui/button';
 import ClayDropDown from '@clayui/drop-down';
 import ClayForm, {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
 import ClayModal from '@clayui/modal';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import {FrontendDataSet} from '@liferay/frontend-data-set-web';
 import classNames from 'classnames';
 import {openModal} from 'frontend-js-components-web';
@@ -596,6 +599,37 @@ const CustomDataSets = ({
 		});
 	};
 
+	const restApplicationRenderer = function ({
+		itemData,
+	}: {
+		itemData: IDataSet;
+	}) {
+		const apiExplorerURL = `${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${itemData.restApplication}/openapi.json`;
+
+		return (
+			<ClayTooltipProvider>
+				<ClayLink
+					data-tooltip-align="top"
+					decoration="underline"
+					displayType="tertiary"
+					href={apiExplorerURL}
+					rel="noopener noreferrer"
+					target="_blank"
+					title={apiExplorerURL}
+				>
+					<span className="inline-item inline-item-before">
+						<ClayIcon
+							className="mr-1 text-2 text-secondary"
+							symbol="shortcut"
+						/>
+					</span>
+
+					{itemData.restApplication}
+				</ClayLink>
+			</ClayTooltipProvider>
+		);
+	};
+
 	const creationMenu = {
 		primaryItems: [
 			{
@@ -635,6 +669,7 @@ const CustomDataSets = ({
 						sortable: true,
 					},
 					{
+						contentRenderer: 'restApplicationRenderer',
 						fieldName: 'restApplication',
 						label: Liferay.Language.get('rest-application'),
 						sortable: true,
@@ -670,6 +705,7 @@ const CustomDataSets = ({
 						? creationMenu
 						: undefined
 				}
+				customDataRenderers={{restApplicationRenderer}}
 				emptyState={{
 					description: Liferay.Language.get(
 						'start-creating-one-to-show-your-data'

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/CustomDataSets.tsx
@@ -29,6 +29,7 @@ import {
 	DEFAULT_FETCH_HEADERS,
 	FDS_DEFAULT_PROPS,
 } from './utils/constants';
+import getAPIExplorerURL from './utils/getAPIExplorerURL';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 import openDefaultSuccessToast from './utils/openDefaultSuccessToast';
 import {IDataSet, ISystemDataSet} from './utils/types';
@@ -604,7 +605,7 @@ const CustomDataSets = ({
 	}: {
 		itemData: IDataSet;
 	}) {
-		const apiExplorerURL = `${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${itemData.restApplication}/openapi.json`;
+		const apiExplorerURL = getAPIExplorerURL(itemData.restApplication);
 
 		return (
 			<ClayTooltipProvider>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -12,9 +12,11 @@ import ClayButton from '@clayui/button';
 import {ClayRadio} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
+import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
 import ClayModal from '@clayui/modal';
 import ClaySticker from '@clayui/sticker';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import {openModal} from 'frontend-js-components-web';
 import {fetch, navigate} from 'frontend-js-web';
@@ -379,6 +381,37 @@ const SystemDataSets = ({
 		],
 	};
 
+	const restApplicationRenderer = function ({
+		itemData,
+	}: {
+		itemData: IDataSet;
+	}) {
+		const apiExplorerURL = `${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${itemData.restApplication}/openapi.json`;
+
+		return (
+			<ClayTooltipProvider>
+				<ClayLink
+					data-tooltip-align="top"
+					decoration="underline"
+					displayType="tertiary"
+					href={apiExplorerURL}
+					rel="noopener noreferrer"
+					target="_blank"
+					title={apiExplorerURL}
+				>
+					<span className="inline-item inline-item-before">
+						<ClayIcon
+							className="mr-1 text-2 text-secondary"
+							symbol="shortcut"
+						/>
+					</span>
+
+					{itemData.restApplication}
+				</ClayLink>
+			</ClayTooltipProvider>
+		);
+	};
+
 	const toggleRenderer = function ({
 		itemData,
 		onItemsChange,
@@ -417,6 +450,7 @@ const SystemDataSets = ({
 						sortable: true,
 					},
 					{
+						contentRenderer: 'restApplicationRenderer',
 						fieldName: 'restApplication',
 						label: Liferay.Language.get('rest-application'),
 						sortable: true,
@@ -459,7 +493,7 @@ const SystemDataSets = ({
 				{...FDS_DEFAULT_PROPS}
 				apiURL={getAPIURL()}
 				creationMenu={creationMenu}
-				customDataRenderers={{toggleRenderer}}
+				customDataRenderers={{restApplicationRenderer, toggleRenderer}}
 				emptyState={{
 					description: Liferay.Language.get(
 						'start-creating-one-to-show-your-data'

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/SystemDataSets.tsx
@@ -27,6 +27,7 @@ import {
 	DEFAULT_FETCH_HEADERS,
 	FDS_DEFAULT_PROPS,
 } from './utils/constants';
+import getAPIExplorerURL from './utils/getAPIExplorerURL';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
 import openDefaultSuccessToast from './utils/openDefaultSuccessToast';
 import {IDataSet, ISystemDataSet} from './utils/types';
@@ -386,7 +387,7 @@ const SystemDataSets = ({
 	}: {
 		itemData: IDataSet;
 	}) {
-		const apiExplorerURL = `${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${itemData.restApplication}/openapi.json`;
+		const apiExplorerURL = getAPIExplorerURL(itemData.restApplication);
 
 		return (
 			<ClayTooltipProvider>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
@@ -7,7 +7,9 @@ import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
 import ClayList from '@clayui/list';
+import {ClayTooltipProvider} from '@clayui/tooltip';
 import classNames from 'classnames';
 import {LearnMessage} from 'frontend-js-components-web';
 import {fetch, navigate, sub} from 'frontend-js-web';
@@ -208,7 +210,26 @@ const Details = ({
 								</ClayList.ItemTitle>
 
 								<ClayList.ItemText>
-									{restApplication}
+									<ClayTooltipProvider>
+										<ClayLink
+											data-tooltip-align="top"
+											decoration="underline"
+											displayType="tertiary"
+											href={`${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${restApplication}/openapi.json`}
+											rel="noopener noreferrer"
+											target="_blank"
+											title={`${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${restApplication}/openapi.json`}
+										>
+											{restApplication}
+
+											<span className="inline-item inline-item-after">
+												<ClayIcon
+													className="text-2 text-secondary"
+													symbol="shortcut"
+												/>
+											</span>
+										</ClayLink>
+									</ClayTooltipProvider>
 								</ClayList.ItemText>
 							</ClayList.ItemField>
 						</ClayList.Item>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
@@ -18,6 +18,7 @@ import React, {useRef, useState} from 'react';
 import {IDataSet} from '../..//utils/types';
 import RequiredMark from '../../components/RequiredMark';
 import {API_URL, DEFAULT_FETCH_HEADERS} from '../../utils/constants';
+import getAPIExplorerURL from '../../utils/getAPIExplorerURL';
 import openDefaultFailureToast from '../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../utils/openDefaultSuccessToast';
 import {IDataSetSectionProps} from '../DataSet';
@@ -127,6 +128,8 @@ const Details = ({
 
 	const {restApplication, restEndpoint, restSchema} = dataSet;
 
+	const apiExplorerURL = getAPIExplorerURL(restApplication);
+
 	return (
 		<ClayLayout.ContainerFluid
 			className="mt-3 visualization-modes"
@@ -215,10 +218,10 @@ const Details = ({
 											data-tooltip-align="top"
 											decoration="underline"
 											displayType="tertiary"
-											href={`${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${restApplication}/openapi.json`}
+											href={apiExplorerURL}
 											rel="noopener noreferrer"
 											target="_blank"
-											title={`${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${restApplication}/openapi.json`}
+											title={apiExplorerURL}
 										>
 											{restApplication}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAPIExplorerURL.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAPIExplorerURL.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function getAPIExplorerURL(restApplication: string) {
+	return `${Liferay.ThemeDisplay.getPortalURL()}/o/api?endpoint=${Liferay.ThemeDisplay.getPortalURL()}/o${restApplication}/openapi.json`;
+}


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPD-40075
**Subtask:** https://liferay.atlassian.net/browse/LPD-41490

---

**What changed:**
- Adds links to the "REST Application" cells and Details tab "Application" text to the API Explorer page
- Opens the API Explorer in a new browser tab

**Questionable changes:**
- In the API Explorer URL, the `/o/api` and `openapi.json` is hardcoded, which I'm not sure if it's possible these could be different? I can look more into this, but if someone is already aware this could be different please let me know.

---

## Demo Screenshots
![Screenshot 2025-03-26 at 8 00 47 PM](https://github.com/user-attachments/assets/6eba853e-a28b-4663-b518-20ad12d74c95)
![Screenshot 2025-03-26 at 8 00 56 PM](https://github.com/user-attachments/assets/9068341b-a34b-4d0c-8403-58d22419673a)
![Screenshot 2025-03-26 at 8 00 31 PM](https://github.com/user-attachments/assets/c4527fef-0fdf-44ba-9bea-d410b964812b)
![Screenshot 2025-03-26 at 8 09 07 PM](https://github.com/user-attachments/assets/66c782d3-7065-4301-a29e-36349a9293aa)

