### PR TITLE
LPD-39002 Add link to documentation for the Data Set static parameters

### DIFF
--- a/learn-resources/data/frontend-data-set-admin-web.json
+++ b/learn-resources/data/frontend-data-set-admin-web.json
@@ -1,7 +1,8 @@
 {
 	"rest-parameters": {
 		"en_US": {
-			"message": "Learn more about REST parameters."
+			"message": "Learn more about REST parameters.",
+			"url": "https://learn.liferay.com/w/dxp/liferay-development/data-sets/managing-data-sets#adding-advanced-parameters-to-a-data-set"
 		}
 	}
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/details/Details.tsx
@@ -329,6 +329,7 @@ const Details = ({
 					</ClayForm.Group>
 
 					<LearnMessage
+						className="single-link text-3"
 						resource="frontend-data-set-admin-web"
 						resourceKey="rest-parameters"
 					/>


### PR DESCRIPTION
**Story:** https://liferay.atlassian.net/browse/LPD-37271
**Subtask:** https://liferay.atlassian.net/browse/LPD-39002

---

Adds learn url for the Details tab's "Advanced Optional Parameters", which links to https://learn.liferay.com/w/dxp/liferay-development/data-sets/managing-data-sets#adding-advanced-parameters-to-a-data-set

Tested using the preview learn links server https://github.com/liferay/liferay-portal/tree/master/learn-resources#previewing-liferay-learn-resource-links

## Demo

<img width="1005" alt="Screenshot 2025-04-03 at 3 28 45 PM" src="https://github.com/user-attachments/assets/d73980c4-4df0-4c71-9c95-d37f8178b5de" />
