### PR TITLE
LPD-52687 Fix use of CKEditor 5 in preview feature of Form builder

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormAdminDisplayContext.java
@@ -77,6 +77,7 @@ import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -413,8 +414,9 @@ public class DDMFormAdminDisplayContext {
 					EditorConfiguration editorConfiguration =
 						EditorConfigurationFactoryUtil.getEditorConfiguration(
 							StringPool.BLANK, ddmFormFieldType.getName(),
-							"ckeditor_classic", new HashMap<String, Object>(),
-							themeDisplay,
+							FeatureFlagManagerUtil.isEnabled("LPD-11235") ?
+								"ckeditor5_classic" : "ckeditor_classic",
+							new HashMap<String, Object>(), themeDisplay,
 							RequestBackedPortletURLFactoryUtil.create(
 								httpServletRequest));
 

--- a/modules/test/playwright/tests/dynamic-data-mapping-form-web/richText.spec.ts
+++ b/modules/test/playwright/tests/dynamic-data-mapping-form-web/richText.spec.ts
@@ -11,29 +11,55 @@ import {loginTest} from '../../fixtures/loginTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import {deleteItems} from './utils/deleteItems';
 
-export const xssBypassTest = mergeTests(
+const baseTest = mergeTests(formsPagesTest, loginTest());
+
+const ckeditor5Test = mergeTests(
+	baseTest,
+	featureFlagsTest({
+		'LPD-11235': {enabled: true},
+	})
+);
+
+const xssBypassTest = mergeTests(
+	baseTest,
 	featureFlagsTest({
 		'LPD-31212': {enabled: true},
-	}),
-	loginTest(),
-	formsPagesTest
+	})
 );
 
-export const xssDisabledTest = mergeTests(
+const xssDisabledTest = mergeTests(
+	baseTest,
 	featureFlagsTest({
 		'LPD-31212': {enabled: false},
-	}),
-	loginTest(),
-	formsPagesTest
+	})
 );
 
-[xssBypassTest, xssDisabledTest].forEach((testSuite) => {
+[ckeditor5Test, xssBypassTest, xssDisabledTest].forEach((testSuite) => {
 	testSuite.afterEach(async ({formsPage}) => {
 		await formsPage.goTo();
 
 		await deleteItems(formsPage);
 	});
 });
+
+ckeditor5Test(
+	'Added "Rich Text" field includes preview of editor',
+	{
+		tag: ['@LPD-11235'],
+	},
+	async ({formBuilderPage, formBuilderSidePanelPage}) => {
+		await formBuilderPage.goToNew();
+
+		await expect(formBuilderPage.newFormHeading).toBeVisible();
+
+		await formBuilderSidePanelPage.addFieldByDoubleClick('Rich Text');
+
+		const editable = formBuilderSidePanelPage.page.getByRole('textbox', {
+			name: 'Rich Text Editor',
+		});
+		await expect(editable).toBeVisible();
+	}
+);
 
 const content = '<script>alert("Hello! I am an alert box!");</script>';
 const sanitizedContent = '<script>;</script>';


### PR DESCRIPTION
### References

- Parent Task: [LPD-52587 Fix use of CKEditor 5 in preview feature of Form builder](https://issues.liferay.com/browse/LPD-52587)
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/4819

### What is the goal of this PR?

We are fixing the issue noticed by @igor-franca in https://github.com/liferay-frontend/liferay-portal/pull/4819#pullrequestreview-2743038785

### What does it look like?


https://github.com/user-attachments/assets/944739c4-9475-4328-aef9-bec190bc658e

![image](https://github.com/user-attachments/assets/328ecec4-b6ac-40a2-9b89-b8b8ed069dc7)



