### PR TITLE
LPD-52896 Selection filter does not show the correct type after creation or edition

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -50,7 +50,7 @@ const FILTER_TYPES: Record<EFilterType, IFilterTypeProps> = {
 	[EFilterType.CLIENT_EXTENSION]: {
 		Component: ClientExtensionFilterFormContent,
 		availableFieldsFilter: (item: IField) => !!item,
-		displayType: Liferay.Language.get('client-extension-filter'),
+		displayType: () => Liferay.Language.get('client-extension-filter'),
 		fdsViewRelationship:
 			OBJECT_RELATIONSHIP.DATA_SET_CLIENT_EXTENSION_FILTERS,
 		fdsViewRelationshipId:
@@ -63,7 +63,7 @@ const FILTER_TYPES: Record<EFilterType, IFilterTypeProps> = {
 		availableFieldsFilter: (item: IField) =>
 			item.format === EFieldFormat.DATE ||
 			item.format === EFieldFormat.DATE_TIME,
-		displayType: Liferay.Language.get('date-filter'),
+		displayType: () => Liferay.Language.get('date-filter'),
 		fdsViewRelationship: OBJECT_RELATIONSHIP.DATA_SET_DATE_FILTERS,
 		fdsViewRelationshipId: OBJECT_RELATIONSHIP.DATA_SET_DATE_FILTERS_ID,
 		label: Liferay.Language.get('date-range'),
@@ -74,8 +74,8 @@ const FILTER_TYPES: Record<EFilterType, IFilterTypeProps> = {
 		availableFieldsFilter: (item: IField) =>
 			(item.type === EFieldType.STRING && !item.format) ||
 			item.type === EFieldType.INTEGER,
-		displayType: (filter: IFilter) => {
-			if (filter.sourceType === ESelectionFilterSourceType.ITEM_PROXY) {
+		displayType: (filter: IFilter | undefined) => {
+			if (filter?.sourceType === ESelectionFilterSourceType.ITEM_PROXY) {
 				return Liferay.Language.get('system-filter');
 			}
 
@@ -151,7 +151,7 @@ function FilterFormComponent({
 
 		openDefaultSuccessToast();
 
-		onSave({...responseJSON, displayType, filterType});
+		onSave({...responseJSON, displayType: displayType(filter), filterType});
 	};
 
 	return (
@@ -226,19 +226,9 @@ function Filters({
 					responseJSON[filterTypeProps.fdsViewRelationship];
 
 				filtersArray.forEach((filter: any) => {
-					let displayType: string = '';
-
-					if (typeof filterTypeProps.displayType === 'string') {
-						displayType = filterTypeProps.displayType;
-					}
-
-					if (typeof filterTypeProps.displayType === 'function') {
-						displayType = filterTypeProps.displayType(filter);
-					}
-
 					filtersOrdered.push({
 						...filter,
-						displayType,
+						displayType: filterTypeProps.displayType(filter),
 						filterType: type as EFilterType,
 					});
 				});

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -136,7 +136,7 @@ export interface IFilterTypeProps {
 		Header: JSXElementConstructor<any>;
 	};
 	availableFieldsFilter: (field: IField) => boolean;
-	displayType: string | ((filter: IFilter) => string);
+	displayType: (filter?: IFilter) => string;
 	fdsViewRelationship: string;
 	fdsViewRelationshipId: string;
 	label: string;

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/clientExtensionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/clientExtensionFilters.spec.ts
@@ -26,6 +26,7 @@ const test = mergeTests(
 let dataSetERC: string;
 let dataSetLabel: string;
 const clientExtensionName = 'Liferay Sample FDS Filter';
+const CLIENT_EXTENSION_FILTER_DISPLAY_TYPE = 'Client Extension Filter';
 const DATE_FIELD_NAME = 'dateCreated';
 const NAME_FIELD_NAME = 'fieldName';
 
@@ -123,11 +124,18 @@ test('Can create a Client Extension Filter in DSM', async ({
 		await filtersPage.saveAddFilterForm();
 	});
 
-	await test.step('Check that the client extension filter is in the list', async () => {
+	await test.step('Check that the client extension filter is in the list with correct fields', async () => {
 		await expect(
 			page.getByRole('cell', {
 				exact: true,
 				name: DATE_FIELD_NAME,
+			})
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {
+				exact: true,
+				name: CLIENT_EXTENSION_FILTER_DISPLAY_TYPE,
 			})
 		).toBeVisible();
 	});

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dateRangeFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dateRangeFilters.spec.ts
@@ -28,7 +28,9 @@ const dataSetERCs = [];
 let dataSetERC: string;
 let dataSetLabel: string;
 const DATE_FIELD_NAME = 'dateCreated';
+const DATE_FILTER_DISPLAY_TYPE = 'Date Filter';
 const DATE_FILTER_NAME = 'Creation Date';
+const DISPLAY_TYPE_COLUMN_INDEX = 3;
 const NAME_COLUMN_INDEX = 1;
 
 test.beforeEach(async ({dataSetManagerApiHelpers, filtersPage}) => {
@@ -193,13 +195,20 @@ test('Ability to save and edit DSM date filters @LPS-181281', async ({
 		await filtersPage.saveAddFilterForm();
 	});
 
-	await test.step('Assert filter with new name is saved @LPS-183056', async () => {
+	await test.step('Assert filter with correct fields is saved @LPS-183056', async () => {
 		await expect(
 			filtersPage
 				.getRowByText(filterNewName)
 				.locator('td')
 				.nth(NAME_COLUMN_INDEX)
 		).toHaveText(filterNewName);
+
+		await expect(
+			filtersPage
+				.getRowByText(filterNewName)
+				.locator('td')
+				.nth(DISPLAY_TYPE_COLUMN_INDEX)
+		).toHaveText(DATE_FILTER_DISPLAY_TYPE);
 
 		await filtersPage.assertFiltersTableRowCount(1);
 	});

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
@@ -18,6 +18,7 @@ import {dataSetManagerSetupTest} from './fixtures/dataSetManagerSetupTest';
 import {filtersPageTest} from './fixtures/filtersPageTest';
 
 const SELECTION_API_HEADLESS_FILTER_NAME = 'Selection API Headless filter';
+const SELECTION_DISPLAY_TYPE = 'Selection Filter';
 const SELECTION_PICKLIST_FILTER_NAME = 'Selection Picklist filter';
 const SELECTION_PICKLIST_NO_PRESELECTED_VALUES_FILTER_NAME =
 	'Selection Picklist filter without preselected values';
@@ -409,6 +410,13 @@ test(
 				page.getByRole('cell', {
 					exact: true,
 					name: SELECTION_API_HEADLESS_FILTER_NAME,
+				})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('cell', {
+					exact: true,
+					name: SELECTION_DISPLAY_TYPE,
 				})
 			).toBeVisible();
 		});


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-52522

<h1>Selection filter does not show the correct type after creation or edition</h1>

In the Data Set Manager, after creating or editing a Selection filter the Type field returns the expression used to calculate the type instead of returning the translated type itself.

The problem does not occurs after navigating to other tabs or reloading the page.

![image](https://github.com/user-attachments/assets/135f853f-dae6-4d64-be09-a5dc3c6cb03b)
