### PR TITLE
LPD-52523 AdditionalAPIURLParameters are not applied in the fragment

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 19.0.1
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.frontend.data.set,\
 	com.liferay.frontend.data.set.action,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/serializer/FDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/serializer/FDSSerializer.java
@@ -32,6 +32,9 @@ public interface FDSSerializer {
 	public boolean isAvailable(
 		String fdsName, HttpServletRequest httpServletRequest);
 
+	public String serializeAdditionalAPIURLParameters(
+		String fdsName, HttpServletRequest httpServletRequest);
+
 	public String serializeAPIURL(
 		String fdsName, HttpServletRequest httpServletRequest);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/serializer/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/serializer/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/renderer/FDSRendererImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/renderer/FDSRendererImpl.java
@@ -70,6 +70,19 @@ public class FDSRendererImpl implements FDSRenderer {
 		else {
 			props.putAll(
 				HashMapBuilder.<String, Object>put(
+					"additionalAPIURLParameters",
+					() -> {
+						String additionalAPIURLParameters =
+							fdsSerializer.serializeAdditionalAPIURLParameters(
+								fdsName, httpServletRequest);
+
+						if (Validator.isNull(additionalAPIURLParameters)) {
+							return null;
+						}
+
+						return additionalAPIURLParameters;
+					}
+				).put(
 					"apiURL",
 					() -> {
 						String apiURL = fdsSerializer.serializeAPIURL(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -107,6 +107,16 @@ public class CustomFDSSerializer
 	}
 
 	@Override
+	public String serializeAdditionalAPIURLParameters(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		Map<String, Object> properties = getDataSetObjectEntryProperties(
+			fdsName, httpServletRequest);
+
+		return String.valueOf(properties.get("additionalAPIURLParameters"));
+	}
+
+	@Override
 	public String serializeAPIURL(
 		String fdsName, HttpServletRequest httpServletRequest) {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
@@ -71,6 +71,20 @@ public class SystemFDSSerializer
 	}
 
 	@Override
+	public String serializeAdditionalAPIURLParameters(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		SystemFDSEntry systemFDSEntry =
+			systemFDSEntryRegistry.getSystemFDSEntry(fdsName);
+
+		if (systemFDSEntry == null) {
+			return null;
+		}
+
+		return String.valueOf(systemFDSEntry.getAdditionalAPIURLParameters());
+	}
+
+	@Override
 	public String serializeAPIURL(
 		String fdsName, HttpServletRequest httpServletRequest) {
 
@@ -84,8 +98,6 @@ public class SystemFDSSerializer
 		return createFDSAPIURLBuilder(
 			httpServletRequest, systemFDSEntry.getRESTApplication(),
 			systemFDSEntry.getRESTEndpoint(), systemFDSEntry.getRESTSchema()
-		).addQueryString(
-			systemFDSEntry.getAdditionalAPIURLParameters()
 		).build();
 	}
 


### PR DESCRIPTION
Bug: https://liferay.atlassian.net/browse/LPD-52523

---

- This is fixed by passing the `additionalAPIURLParameters` into the `FrontendDataSet` react component
- Originally only the system data sets were applying the `additionalAPIURLParameters` with the `apiURL` but the react component needs it separate so it can apply the appropriate parameter merging (see: https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/loadData.ts#L109-L190)

**Another possible solution I'm exploring:** 
Instead of needing to pass `additionalAPIURLParameters` into the react component, we can grab all the query parameters (everything after the `?`) in the `apiURL`, then apply the appropriate merging. This could be even more advantageous if an `apiURL` already was adding their own query parameters _not_ through the `additionalAPIURLParameters` field.

Submitting as-is since this current solution does work though, but might update this if that other solution works out cleaner.