### PR TITLE
LPD-53211 - Add support for filters on Multiselect Picklist fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -815,6 +815,10 @@ public class CustomFDSSerializer
 		return (Boolean)properties.get("active");
 	}
 
+	private Boolean _isCollection(String fieldName) {
+		return fieldName.contains(StringPool.OPEN_BRACKET);
+	}
+
 	private JSONObject _serializeFilter(
 			HttpServletRequest httpServletRequest, ObjectEntry objectEntry)
 		throws Exception {
@@ -963,7 +967,16 @@ public class CustomFDSSerializer
 		JSONObject jsonObject = JSONUtil.put(
 			"autocompleteEnabled", true
 		).put(
-			"entityFieldType", FDSEntityFieldTypes.STRING
+			"entityFieldType",
+			() -> {
+				if (_isCollection(
+						String.valueOf(properties.get("fieldName")))) {
+
+					return FDSEntityFieldTypes.COLLECTION;
+				}
+
+				return FDSEntityFieldTypes.STRING;
+			}
 		).put(
 			"id",
 			() -> {


### PR DESCRIPTION
## Story / Task
[LPD-53174](https://liferay.atlassian.net/browse/LPD-53174) / [LPD-53211](https://liferay.atlassian.net/browse/LPD-53211)

## Goal
When an Object has fields defined as Multiselect Picklist, `oData` query string to retrieve data differs from a normal field. Even though FDS supports both kinds of queries, we were not providing the correct mechanism to differentiate them.

We've think on different approaches:
- use always 'collection' for every query (does not work)
- check the `fieldName` looking for the indicator of array fields `[]` in `type[]`  or `type[]*` (actual, it works)
- persist a different value for simple versus complex picklist in the sourceType DB field. Right now we have `OBJECT_PICKLIST` and `API_REST_APPLICATION` . We can add `OBJECT_PICKLIST_SIMPLE` & `OBJECT_PICKLIST_COLLECTION`

## UI

https://github.com/user-attachments/assets/3133a0b8-20f7-4bff-92e7-3fd728aa7504



