### PR TITLE
LPD-52751 DataSet Fragment selection of Data Set can select more than 1 Data Set

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.js
@@ -373,6 +373,12 @@ const FrontendDataSet = ({
 	}
 
 	function selectItems(value) {
+		if (selectionType === 'single') {
+			return setSelectedItemsValue(
+				Array.isArray(value) ? value : [value]
+			);
+		}
+
 		if (Array.isArray(value)) {
 			const newItems = value.filter(
 				(item) => !selectedItemsValue.includes(item)

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -96,6 +96,15 @@ test(
 		dataSetERCs.push(dataSetERC1);
 		dataSetERCs.push(dataSetERC2);
 
+		const dataSetInput1 =
+			dataSetFragmentPage.selectDataSetModalFrame.locator(
+				`li:has-text("${dataSetLabel1}") input.custom-control-input`
+			);
+		const dataSetInput2 =
+			dataSetFragmentPage.selectDataSetModalFrame.locator(
+				`li:has-text("${dataSetLabel2}") input.custom-control-input`
+			);
+
 		await test.step('Create data sets', async () => {
 			await dataSetManagerApiHelpers.createDataSet({
 				erc: dataSetERC1,
@@ -133,24 +142,13 @@ test(
 		});
 
 		await test.step('Check that only one data set can be selected', async () => {
-			const dataSetInput1 =
-				dataSetFragmentPage.selectDataSetModalFrame.locator(
-					`li:has-text("${dataSetLabel1}") input.custom-control-input`
-				);
-			const dataSetInput2 =
-				dataSetFragmentPage.selectDataSetModalFrame.locator(
-					`li:has-text("${dataSetLabel2}") input.custom-control-input`
-				);
-
 			await dataSetFragmentPage.selectDataSetButton.click();
 
 			await page.getByRole('dialog').isVisible();
 
 			await page.getByRole('heading', {name: 'Select'}).isVisible();
 
-			await dataSetFragmentPage.selectDataSetModalFrame
-				.locator('.fds-admin-item-selector')
-				.waitFor({state: 'visible'});
+			await dataSetFragmentPage.selectionListContainer.waitFor();
 
 			await dataSetInput1.setChecked(true);
 
@@ -176,21 +174,9 @@ test(
 		await test.step('Change assignment to second data set', async () => {
 			await dataSetFragmentPage.changeDataSetButton.click();
 
-			const selectionListContainer =
-				dataSetFragmentPage.selectDataSetModalFrame.locator(
-					'.fds-admin-item-selector'
-				);
+			await dataSetFragmentPage.selectionListContainer.waitFor();
 
-			await expect(selectionListContainer).toBeVisible();
-
-			await expect(
-				selectionListContainer
-					.locator('.selectable.list-group-item')
-					.filter({
-						has: page.getByText(dataSetLabel1, {exact: true}),
-					})
-					.getByRole('radio')
-			).toBeChecked();
+			await expect(dataSetInput1).toBeChecked();
 
 			await dataSetFragmentPage.selectDataSet(dataSetLabel2);
 		});
@@ -266,9 +252,7 @@ test('Data set selection modal shows a "No results found" message when there are
 	});
 
 	await test.step('Assert that there are no Data Sets available to select', async () => {
-		await dataSetFragmentPage.selectDataSetModalFrame
-			.locator('.fds-admin-item-selector')
-			.waitFor({state: 'visible'});
+		await dataSetFragmentPage.selectionListContainer.waitFor();
 
 		await expect(
 			dataSetFragmentPage.selectDataSetModalFrame.locator(
@@ -435,12 +419,7 @@ test(
 
 			await dataSetFragmentPage.changeDataSetButton.click();
 
-			const selectionListContainer =
-				dataSetFragmentPage.selectDataSetModalFrame.locator(
-					'.fds-admin-item-selector'
-				);
-
-			await expect(selectionListContainer).toBeVisible();
+			await dataSetFragmentPage.selectionListContainer.waitFor();
 
 			await dataSetFragmentPage.selectDataSetModalFrame
 				.locator('li')
@@ -493,12 +472,7 @@ test(
 
 			await dataSetFragmentPage.changeDataSetButton.click();
 
-			const selectionListContainer =
-				dataSetFragmentPage.selectDataSetModalFrame.locator(
-					'.fds-admin-item-selector'
-				);
-
-			await expect(selectionListContainer).toBeVisible();
+			await dataSetFragmentPage.selectionListContainer.waitFor();
 
 			await page
 				.frameLocator('iframe[title="Select"]')

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/dataSets.spec.ts
@@ -132,6 +132,41 @@ test(
 			await dataSetFragmentPage.addDataSetFragment(layout);
 		});
 
+		await test.step('Check that only one data set can be selected', async () => {
+			const dataSetInput1 =
+				dataSetFragmentPage.selectDataSetModalFrame.locator(
+					`li:has-text("${dataSetLabel1}") input.custom-control-input`
+				);
+			const dataSetInput2 =
+				dataSetFragmentPage.selectDataSetModalFrame.locator(
+					`li:has-text("${dataSetLabel2}") input.custom-control-input`
+				);
+
+			await dataSetFragmentPage.selectDataSetButton.click();
+
+			await page.getByRole('dialog').isVisible();
+
+			await page.getByRole('heading', {name: 'Select'}).isVisible();
+
+			await dataSetFragmentPage.selectDataSetModalFrame
+				.locator('.fds-admin-item-selector')
+				.waitFor({state: 'visible'});
+
+			await dataSetInput1.setChecked(true);
+
+			await expect(dataSetInput1).toBeChecked();
+
+			await dataSetInput2.setChecked(true);
+
+			await expect(dataSetInput2).toBeChecked();
+
+			await expect(dataSetInput1).not.toBeChecked();
+
+			await dataSetFragmentPage.selectDataSetModalFrame
+				.getByRole('button', {name: 'Cancel'})
+				.click();
+		});
+
 		await test.step('Assign first data set to fragment', async () => {
 			await dataSetFragmentPage.selectDataSetButton.click();
 

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/pages/DataSetFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/pages/DataSetFragmentPage.ts
@@ -33,6 +33,7 @@ export class DataSetFragmentPage {
 	readonly selectDataSetModalFrame: FrameLocator;
 	readonly selectDataSetButton: Locator;
 	readonly selectedDataSetInput: Locator;
+	readonly selectionListContainer: Locator;
 	readonly sidePanel: Locator;
 	readonly sidePanelFrame: FrameLocator;
 	readonly table: {
@@ -88,6 +89,10 @@ export class DataSetFragmentPage {
 		this.selectedDataSetInput = page
 			.getByLabel('Configuration Panel')
 			.getByLabel('Data Set View', {exact: true});
+
+		this.selectionListContainer = this.selectDataSetModalFrame.locator(
+			'.fds-admin-item-selector'
+		);
 
 		this.sidePanel = page.locator('.fds-side-panel');
 		this.sidePanelFrame = this.sidePanel.frameLocator('iframe');


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-52751

<h1>DataSet Fragment selection of Data Set can select more than 1 Data Set</h1>

The goal of this PR is to fix a bug where more than one data set could be selected in data set fragments.

![image](https://github.com/user-attachments/assets/74e0c589-45a6-42de-a410-f23a74c060ee)
