### PR TITLE
LPD-52924 - XSS with Style Book theme name

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -625,7 +625,7 @@ public class VerticalCardTag extends BaseCardTag {
 			jspWriter.write("<p class=\"card-subtitle\"><span class=\"");
 			jspWriter.write("text-truncate-inline\"><span class=\"");
 			jspWriter.write("text-truncate\">");
-			jspWriter.write(subtitle);
+			jspWriter.write(HtmlUtil.escape(subtitle));
 			jspWriter.write("</span></span></p>");
 		}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-52924

getSubtitle should be escaped since it is already being escaped in the React component, but just not on the first load. There are some usages of the ClayVerticalCard that are already escaping the value of the subtitle that is being passed in. This could result to double escape UI issues, but this wouldn't be a new problem since it would already be double escaped when the React component is hydrated.