### PR TITLE
LPD-52943 CKEditor 5 deleting from source does not remove upon saving

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/RichText/RichText.es.js
@@ -231,6 +231,39 @@ const RichText = ({
 		}
 	};
 
+	const onReady = (editor) => {
+		const sourceEditingPlugin = editor.plugins.get('SourceEditing');
+
+		if (!sourceEditingPlugin) {
+			return;
+		}
+
+		sourceEditingPlugin.on('change:isSourceEditingMode', () => {
+			if (!sourceEditingPlugin.isSourceEditingMode) {
+				return;
+			}
+
+			for (const [rootName] of editor.editing.view.domRoots) {
+				const replacedRoot =
+					sourceEditingPlugin._replacedRoots?.get(rootName);
+
+				if (!replacedRoot) {
+					continue;
+				}
+
+				const textarea = replacedRoot.querySelector('textarea');
+
+				if (!textarea) {
+					continue;
+				}
+
+				textarea.addEventListener('input', () => {
+					handleContentChange(editor.getData());
+				});
+			}
+		});
+	};
+
 	function sanitezeHTML(html) {
 		if (Liferay.FeatureFlags['LPD-31212']) {
 			return html;
@@ -315,6 +348,7 @@ const RichText = ({
 							onChange={(event, editor) =>
 								handleContentChange(editor.getData())
 							}
+							onReady={onReady}
 						/>
 					) : (
 						<ClassicEditor

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -1731,6 +1731,7 @@ ckeditor5Test(
 
 		const articleContentAR = getRandomString();
 		const articleContentEN = getRandomString();
+		const articleContentSource = getRandomString();
 		const articleTitleAR = getRandomString();
 		const articleTitleEN = getRandomString();
 
@@ -1788,6 +1789,43 @@ ckeditor5Test(
 
 				await expect(
 					editable.getByText(articleContentAR)
+				).toBeVisible();
+			}
+		);
+
+		await ckeditor5Test.step('Reset to English', async () => {
+			await journalEditArticlePage.changeLanguage('en_US');
+		});
+
+		await ckeditor5Test.step(
+			'Change article in source editing',
+			async () => {
+				const toolbar =
+					journalEditArticlePage.page.getByLabel('Editor toolbar');
+
+				await toolbar.getByRole('button', {name: 'Source'}).click();
+
+				const textarea = journalEditArticlePage.page.getByLabel(
+					'Source code editing area'
+				);
+
+				await textarea.fill(articleContentSource);
+			}
+		);
+
+		await ckeditor5Test.step('Publish article again', async () => {
+			await journalEditArticlePage.publishArticle(true);
+
+			await expect(page.locator('.alert-success')).toBeVisible();
+		});
+
+		await ckeditor5Test.step(
+			'Open saved article and assert content is correct',
+			async () => {
+				await page.getByTitle(articleTitleEN).click();
+
+				await expect(
+					editable.getByText(articleContentSource)
 				).toBeVisible();
 			}
 		);

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -323,8 +323,6 @@ export class JournalEditArticlePage {
 				trigger: this.publishDropdown,
 			});
 
-			await this.page.locator('.alert-success').waitFor({timeout: 2000});
-
 			return;
 		}
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/fragments.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/fragments.spec.ts
@@ -531,6 +531,8 @@ test.describe('Related Asset Fragment', () => {
 
 			await journalEditArticlePage.publishArticle(true);
 
+			await expect(page.locator('.alert-success')).toBeVisible();
+
 			// Create a display page template for Basic Web Content
 
 			await displayPageTemplatesPage.goto(


### PR DESCRIPTION
### References

- [JIRA: LPD-52943 CKEditor 5 deleting from source does not remove upon saving](https://liferay.atlassian.net/browse/LPD-52943)

### What is the goal of this PR?

A bugfix. Changes during source editing are now saved when publishing.

Well, strictly speaking, this is not a bugfix. Editor intentionally does not emit change events when you change content in source mode editing. This is from their [CKE4 docs](https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_editor.html#event-change). The behavior is the same in CKE5.

> Due to performance reasons, it is not verified if the content really changed. The editor instead watches several editing actions that usually result in changes. This event may thus in some cases be fired when no changes happen or may even get fired twice.
> If it is important not to get the change event fired too often, you should compare the previous and the current editor content inside the event listener. It is not recommended to do that on every change event.

We made an override of this behavior in CKE4, and in this PR, we are making similar override in CKE5.

An alternative for this solution would be to disable publishing while source editing is active.

See technical notes inline.

### What does it look like?

https://github.com/user-attachments/assets/7de45a1f-9d1d-416a-8ff6-be540caddff2



