### PR TITLE
LPD-53211 Add support for filters on Multiselect Picklist fields

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -815,6 +815,10 @@ public class CustomFDSSerializer
 		return (Boolean)properties.get("active");
 	}
 
+	private Boolean _isCollection(String fieldName) {
+		return fieldName.contains(StringPool.OPEN_BRACKET);
+	}
+
 	private JSONObject _serializeFilter(
 			HttpServletRequest httpServletRequest, ObjectEntry objectEntry)
 		throws Exception {
@@ -963,7 +967,16 @@ public class CustomFDSSerializer
 		JSONObject jsonObject = JSONUtil.put(
 			"autocompleteEnabled", true
 		).put(
-			"entityFieldType", FDSEntityFieldTypes.STRING
+			"entityFieldType",
+			() -> {
+				if (_isCollection(
+						String.valueOf(properties.get("fieldName")))) {
+
+					return FDSEntityFieldTypes.COLLECTION;
+				}
+
+				return FDSEntityFieldTypes.STRING;
+			}
 		).put(
 			"id",
 			() -> {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -19,6 +19,9 @@ import {dataSetFragmentPageTest} from './fixtures/dataSetFragmentPageTest';
 const picklistBooleanOptionLabel = 'Boolean';
 const picklistDefaultOptionLabel = 'Default';
 
+const picklistBooleanOptionKey = picklistBooleanOptionLabel.toLocaleLowerCase();
+const picklistDefaultOptionKey = picklistDefaultOptionLabel.toLocaleLowerCase();
+
 const apiHeadlessName = 'FieldType';
 const apiHeadlessURL = `c/${apiHeadlessName.toLocaleLowerCase()}s`;
 const dataSetERCs: string[] = [];
@@ -27,6 +30,7 @@ let dataSetLabel: string;
 let objectDefinition: any;
 let picklistBooleanOption: any;
 let picklistDefaultOption: any;
+let picklistERC: any;
 let picklistName: string;
 
 export const test = mergeTests(
@@ -55,18 +59,20 @@ test.beforeEach(
 		});
 
 		await test.step('Create and populate a picklist', async () => {
-			await picklistApiHelpers.createPicklist({
+			const picklist = await picklistApiHelpers.createPicklist({
 				name: picklistName,
 			});
 
+			picklistERC = picklist.externalReferenceCode;
+
 			picklistDefaultOption = await picklistApiHelpers.editPicklist({
-				key: picklistDefaultOptionLabel.toLocaleLowerCase(),
+				key: picklistDefaultOptionKey,
 				name: picklistName,
 				value: picklistDefaultOptionLabel,
 			});
 
 			picklistBooleanOption = await picklistApiHelpers.editPicklist({
-				key: picklistBooleanOptionLabel.toLocaleLowerCase(),
+				key: picklistBooleanOptionKey,
 				name: picklistName,
 				value: picklistBooleanOptionLabel,
 			});
@@ -98,6 +104,21 @@ test.beforeEach(
 							required: false,
 							state: false,
 						},
+						{
+							DBType: 'String',
+							businessType: 'MultiselectPicklist',
+							indexed: true,
+							indexedAsKeyword: true,
+							label: {
+								en_US: 'picklist',
+							},
+							listTypeDefinitionExternalReferenceCode:
+								picklistERC,
+							localized: false,
+							name: 'picklist',
+							required: false,
+							state: false,
+						},
 					],
 					pluralLabel: {en_US: `${apiHeadlessName}s`},
 					scope: 'company',
@@ -121,11 +142,27 @@ test.beforeEach(
 				apiHeadlessURL
 			);
 			await apiHelpers.objectEntry.postObjectEntry(
-				{type: 'object'},
+				{
+					picklist: [
+						{
+							key: picklistBooleanOptionKey,
+							name: picklistBooleanOptionLabel,
+						},
+					],
+					type: 'object',
+				},
 				apiHeadlessURL
 			);
 			await apiHelpers.objectEntry.postObjectEntry(
-				{type: 'string'},
+				{
+					picklist: [
+						{
+							key: picklistDefaultOptionKey,
+							name: picklistDefaultOptionLabel,
+						},
+					],
+					type: 'string',
+				},
 				apiHeadlessURL
 			);
 		});
@@ -439,6 +476,99 @@ test('Selection filter of type "Object Picklist" can be configured to include or
 				'Showing 1 to 2 of 2 entries.'
 			)
 		).toBeVisible();
+	});
+});
+
+test('Selection filter of type "Object Picklist" using a "Multiselect Picklist" type field', async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	picklistApiHelpers,
+}) => {
+	const filterLabel = 'picklist';
+	const picklistDataSetERC = getRandomString();
+	const picklistDataSetLabel = getRandomString();
+
+	await test.step('Create a new data set for FieldType', async () => {
+		dataSetERCs.push(picklistDataSetERC);
+
+		await dataSetManagerApiHelpers.createDataSet({
+			erc: picklistDataSetERC,
+			label: picklistDataSetLabel,
+			restApplication: `/${apiHeadlessURL}`,
+			restSchema: apiHeadlessName,
+		});
+	});
+
+	await test.step('Add fields, so FDS has something to show', async () => {
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC: picklistDataSetERC,
+			fieldName: 'picklist',
+			label_i18n: {en_US: 'Picklist'},
+		});
+	});
+
+	await test.step('Create a selection filter with the picklist', async () => {
+		const picklist = await picklistApiHelpers.getPicklist(picklistName);
+
+		await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+			dataSetERC: picklistDataSetERC,
+			fieldName: 'picklist[]name',
+			label_i18n: {en_US: filterLabel},
+			multiple: true,
+			source: picklist.externalReferenceCode,
+			sourceType: 'OBJECT_PICKLIST',
+		});
+	});
+
+	await test.step('Configure Data Set fragment', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel: picklistDataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step(`Select ${filterLabel} filter`, async () => {
+		await dataSetFragmentPage.selectFilter(filterLabel);
+	});
+
+	await test.step('Configure and apply filter', async () => {
+		await expect(
+			dataSetFragmentPage.filterItem.getByRole('checkbox', {
+				name: picklistDefaultOptionLabel,
+			})
+		).toBeVisible();
+		await expect(
+			dataSetFragmentPage.filterItem.getByRole('checkbox', {
+				name: picklistDefaultOptionLabel,
+			})
+		).toBeVisible();
+
+		await dataSetFragmentPage.filterItem
+			.getByRole('checkbox', {name: picklistDefaultOptionLabel})
+			.check();
+
+		await dataSetFragmentPage.addFilterButton.click();
+	});
+
+	await test.step('Check that the filter works', async () => {
+		await dataSetFragmentPage.filterResumeButton.waitFor({
+			state: 'visible',
+		});
+
+		await expect(
+			dataSetFragmentPage.page.getByRole('button', {
+				name: `${filterLabel}: ${picklistDefaultOptionLabel}`,
+			})
+		).toBeVisible();
+
+		const rows = await dataSetFragmentPage.table.bodyRows.all();
+
+		for (const row of rows) {
+			await expect(row.locator('td:first-child')).toHaveText(
+				'[{"key":"default","name":"Default"}]'
+			);
+		}
 	});
 });
 


### PR DESCRIPTION
Follow up to https://github.com/liferay-frontend/liferay-portal/pull/4840 to add playwright tests. 

---

Original description:

> ## Story / Task
> [LPD-53174](https://liferay.atlassian.net/browse/LPD-53174) / [LPD-53211](https://liferay.atlassian.net/browse/LPD-53211)
> 
> ## Goal
> When an Object has fields defined as Multiselect Picklist, `oData` query string to retrieve data differs from a normal field. Even though FDS supports both kinds of queries, we were not providing the correct mechanism to differentiate them.
> 
> We've think on different approaches:
> 
> * use always 'collection' for every query (does not work)
> * check the `fieldName` looking for the indicator of array fields `[]` in `type[]`  or `type[]*` (actual, it works)
> * persist a different value for simple versus complex picklist in the sourceType DB field. Right now we have `OBJECT_PICKLIST` and `API_REST_APPLICATION` . We can add `OBJECT_PICKLIST_SIMPLE` & `OBJECT_PICKLIST_COLLECTION`
> 
> ## UI
>  Screencast.from.2025-04-10.15-46-46.mp4

