### PR TITLE
LPD-53985 - Form is displayed to guest users with a disabled style

### DIFF
--- a/portal-web/docroot/html/common/themes/session_timeout.jspf
+++ b/portal-web/docroot/html/common/themes/session_timeout.jspf
@@ -9,7 +9,7 @@
 String rememberMe = CookiesManagerUtil.getCookieValue(CookiesConstants.NAME_REMEMBER_ME, request);
 %>
 
-<c:if test="<%= themeDisplay.isSignedIn() && (PropsValues.SESSION_TIMEOUT_WARNING > 0) %>">
+<c:if test="<%= !themeDisplay.isSignedIn() || Validator.isNull(rememberMe) %>">
 	<aui:script type="module">
 		import {Session} from '<%= ESMURLUtil.buildURL(themeDisplay, "frontend-js-web", "legacy") %>';
 


### PR DESCRIPTION
Fixing when the Session is added should fix this. This is essentially reverting back to the previous logic we had, which should work with our rememberMe prop