### PR TITLE
LPD-52523 AdditionalAPIURLParameters are not applied in the fragment

### DIFF
--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PendingCommerceOrderItemsSystemFDSEntry.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PendingCommerceOrderItemsSystemFDSEntry.java
@@ -20,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 public class PendingCommerceOrderItemsSystemFDSEntry implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return null;
-	}
-
-	@Override
 	public String getDescription() {
 		return null;
 	}

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PendingCommerceOrdersSystemFDSEntry.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PendingCommerceOrdersSystemFDSEntry.java
@@ -20,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 public class PendingCommerceOrdersSystemFDSEntry implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return null;
-	}
-
-	@Override
 	public String getDescription() {
 		return null;
 	}

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrderItemsSystemFDSEntry.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrderItemsSystemFDSEntry.java
@@ -20,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 public class PlacedCommerceOrderItemsSystemFDSEntry implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return null;
-	}
-
-	@Override
 	public String getDescription() {
 		return null;
 	}

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrderReturnsSystemFDSEntry.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrderReturnsSystemFDSEntry.java
@@ -22,11 +22,6 @@ public class PlacedCommerceOrderReturnsSystemFDSEntry
 	implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return null;
-	}
-
-	@Override
 	public String getDescription() {
 		return null;
 	}

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrderShipmentsSystemFDSEntry.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrderShipmentsSystemFDSEntry.java
@@ -21,11 +21,6 @@ public class PlacedCommerceOrderShipmentsSystemFDSEntry
 	implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return null;
-	}
-
-	@Override
 	public String getDescription() {
 		return null;
 	}

--- a/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrdersSystemFDSEntry.java
+++ b/modules/apps/commerce/commerce-order-content-web/src/main/java/com/liferay/commerce/order/content/web/internal/frontend/data/set/PlacedCommerceOrdersSystemFDSEntry.java
@@ -20,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 public class PlacedCommerceOrdersSystemFDSEntry implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return null;
-	}
-
-	@Override
 	public String getDescription() {
 		return null;
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Frontend Data Set API
 Bundle-SymbolicName: com.liferay.frontend.data.set.api
-Bundle-Version: 19.0.1
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.frontend.data.set,\
 	com.liferay.frontend.data.set.action,\

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/SystemFDSEntry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/SystemFDSEntry.java
@@ -12,7 +12,9 @@ import com.liferay.portal.util.PropsValues;
  */
 public interface SystemFDSEntry {
 
-	public String getAdditionalAPIURLParameters();
+	public default String getAdditionalAPIURLParameters() {
+		return null;
+	}
 
 	public default int getDefaultItemsPerPage() {
 		return PropsValues.SEARCH_CONTAINER_PAGE_DEFAULT_DELTA;

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/serializer/FDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/serializer/FDSSerializer.java
@@ -32,6 +32,9 @@ public interface FDSSerializer {
 	public boolean isAvailable(
 		String fdsName, HttpServletRequest httpServletRequest);
 
+	public String serializeAdditionalAPIURLParameters(
+		String fdsName, HttpServletRequest httpServletRequest);
+
 	public String serializeAPIURL(
 		String fdsName, HttpServletRequest httpServletRequest);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/serializer/packageinfo
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/resources/com/liferay/frontend/data/set/serializer/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/renderer/FDSRendererImpl.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/renderer/FDSRendererImpl.java
@@ -70,6 +70,19 @@ public class FDSRendererImpl implements FDSRenderer {
 		else {
 			props.putAll(
 				HashMapBuilder.<String, Object>put(
+					"additionalAPIURLParameters",
+					() -> {
+						String additionalAPIURLParameters =
+							fdsSerializer.serializeAdditionalAPIURLParameters(
+								fdsName, httpServletRequest);
+
+						if (Validator.isNull(additionalAPIURLParameters)) {
+							return null;
+						}
+
+						return additionalAPIURLParameters;
+					}
+				).put(
 					"apiURL",
 					() -> {
 						String apiURL = fdsSerializer.serializeAPIURL(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -107,6 +107,16 @@ public class CustomFDSSerializer
 	}
 
 	@Override
+	public String serializeAdditionalAPIURLParameters(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		Map<String, Object> properties = getDataSetObjectEntryProperties(
+			fdsName, httpServletRequest);
+
+		return String.valueOf(properties.get("additionalAPIURLParameters"));
+	}
+
+	@Override
 	public String serializeAPIURL(
 		String fdsName, HttpServletRequest httpServletRequest) {
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
@@ -81,7 +81,7 @@ public class SystemFDSSerializer
 			return null;
 		}
 
-		return String.valueOf(systemFDSEntry.getAdditionalAPIURLParameters());
+		return systemFDSEntry.getAdditionalAPIURLParameters();
 	}
 
 	@Override
@@ -372,11 +372,6 @@ public class SystemFDSSerializer
 	}
 
 	private static final SystemFDSEntry _systemFDSEntry = new SystemFDSEntry() {
-
-		@Override
-		public String getAdditionalAPIURLParameters() {
-			return "";
-		}
 
 		public int getDefaultItemsPerPage() {
 			return SystemFDSEntry.super.getDefaultItemsPerPage();

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializer.java
@@ -71,6 +71,20 @@ public class SystemFDSSerializer
 	}
 
 	@Override
+	public String serializeAdditionalAPIURLParameters(
+		String fdsName, HttpServletRequest httpServletRequest) {
+
+		SystemFDSEntry systemFDSEntry =
+			systemFDSEntryRegistry.getSystemFDSEntry(fdsName);
+
+		if (systemFDSEntry == null) {
+			return null;
+		}
+
+		return String.valueOf(systemFDSEntry.getAdditionalAPIURLParameters());
+	}
+
+	@Override
 	public String serializeAPIURL(
 		String fdsName, HttpServletRequest httpServletRequest) {
 
@@ -84,8 +98,6 @@ public class SystemFDSSerializer
 		return createFDSAPIURLBuilder(
 			httpServletRequest, systemFDSEntry.getRESTApplication(),
 			systemFDSEntry.getRESTEndpoint(), systemFDSEntry.getRESTSchema()
-		).addQueryString(
-			systemFDSEntry.getAdditionalAPIURLParameters()
 		).build();
 	}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/url/FDSAPIURLBuilder.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/url/FDSAPIURLBuilder.java
@@ -48,14 +48,6 @@ public class FDSAPIURLBuilder {
 		return this;
 	}
 
-	public FDSAPIURLBuilder addQueryString(String queryString) {
-		if (Validator.isNotNull(queryString)) {
-			_queryStringItems.add(queryString);
-		}
-
-		return this;
-	}
-
 	public String build() {
 		StringBundler sb = new StringBundler(
 			3 + (_queryStringItems.size() * 2));

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializerTestCase.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializerTestCase.java
@@ -188,6 +188,9 @@ public abstract class BaseFDSSerializerTestCase {
 			resourceBundleLoader);
 	}
 
+	protected static final String API_URL_PARAMETER =
+		RandomTestUtil.randomString();
+
 	protected static final String[] CONTENT_RENDERERS =
 		RandomTestUtil.randomStrings(2);
 

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -95,6 +95,33 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 	}
 
 	@Test
+	public void testSerializeAdditionalAPIURLParameters() throws Exception {
+
+		// No parameters
+
+		_resetFDSSerializer();
+
+		_mockSerializeAdditionalAPIURLParameters(FDS_NAMES[0], "");
+
+		Assert.assertEquals(
+			StringPool.BLANK,
+			_customFDSSerializer.serializeAdditionalAPIURLParameters(
+				FDS_NAMES[0], httpServletRequest));
+
+		// Parameter
+
+		_resetFDSSerializer();
+
+		_mockSerializeAdditionalAPIURLParameters(
+			FDS_NAMES[0], API_URL_PARAMETER);
+
+		Assert.assertEquals(
+			API_URL_PARAMETER,
+			_customFDSSerializer.serializeAdditionalAPIURLParameters(
+				FDS_NAMES[0], httpServletRequest));
+	}
+
+	@Test
 	public void testSerializeAPIURL() {
 
 		// Nested fields: creator.name
@@ -1196,6 +1223,24 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 			"primaryItems");
 
 		return dropdownItems.size();
+	}
+
+	private void _mockSerializeAdditionalAPIURLParameters(
+		String fdsName, String additionalAPIURLParameters) {
+
+		Mockito.when(
+			_customFDSSerializer.getDataSetObjectEntryProperties(
+				fdsName, httpServletRequest)
+		).thenReturn(
+			HashMapBuilder.<String, Object>put(
+				"additionalAPIURLParameters", additionalAPIURLParameters
+			).build()
+		);
+
+		Mockito.when(
+			_customFDSSerializer.serializeAdditionalAPIURLParameters(
+				fdsName, httpServletRequest)
+		).thenCallRealMethod();
 	}
 
 	private void _mockSerializeAPIURL(String fdsName, String[] fieldNames) {

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/SystemFDSSerializerTest.java
@@ -90,9 +90,9 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testSerializeAPIURL() throws Exception {
+	public void testSerializeAdditionalAPIURLParameters() throws Exception {
 
-		// Nested fields: creator
+		// No parameters
 
 		ServiceTrackerMap
 			<String,
@@ -114,6 +114,70 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 			themeDisplay
 		);
 
+		_registerServices(_registerSystemFDSEntry(FDS_NAMES[0]));
+
+		Assert.assertNull(
+			systemFDSSerializer.serializeAdditionalAPIURLParameters(
+				FDS_NAMES[0], httpServletRequest));
+
+		_unregisterServices();
+
+		// Parameter
+
+		_registerServices(
+			_registerSystemFDSEntry(
+				SystemFDSEntryFactory.create(
+					FDS_NAMES[0]
+				).withAdditionalURLParameters(
+					API_URL_PARAMETER
+				)));
+
+		Assert.assertEquals(
+			API_URL_PARAMETER,
+			systemFDSSerializer.serializeAdditionalAPIURLParameters(
+				FDS_NAMES[0], httpServletRequest));
+
+		_unregisterServices();
+
+		serviceTrackerMap.close();
+	}
+
+	@Test
+	public void testSerializeAPIURL() throws Exception {
+
+		// No parameters
+
+		ServiceTrackerMap
+			<String,
+			 ServiceTrackerCustomizerFactory.ServiceWrapper<FDSAPIURLResolver>>
+				serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+					bundleContext, FDSAPIURLResolver.class,
+					"fds.rest.application.key",
+					ServiceTrackerCustomizerFactory.
+						<FDSAPIURLResolver>serviceWrapper(bundleContext));
+
+		systemFDSSerializer.fdsAPIURLResolverRegistry =
+			new FDSAPIURLResolverRegistryImpl(serviceTrackerMap);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY)
+		).thenReturn(
+			themeDisplay
+		);
+
+		_registerServices(_registerSystemFDSEntry(FDS_NAMES[0]));
+
+		Assert.assertEquals(
+			"/o/app/endpoint",
+			systemFDSSerializer.serializeAPIURL(
+				FDS_NAMES[0], httpServletRequest));
+
+		_unregisterServices();
+
+		// Parameters
+
 		_registerServices(
 			_registerSystemFDSEntry(
 				SystemFDSEntryFactory.create(
@@ -121,52 +185,6 @@ public class SystemFDSSerializerTest extends BaseFDSSerializerTestCase {
 				).withAdditionalURLParameters(
 					"nestedFields=creator"
 				)));
-
-		Assert.assertEquals(
-			"/o/app/endpoint?nestedFields=creator",
-			systemFDSSerializer.serializeAPIURL(
-				FDS_NAMES[0], httpServletRequest));
-
-		_unregisterServices();
-
-		// Nested fields: creator and status
-
-		_registerServices(
-			_registerSystemFDSEntry(
-				SystemFDSEntryFactory.create(
-					FDS_NAMES[0]
-				).withAdditionalURLParameters(
-					"nestedFields=creator,status"
-				)));
-
-		Assert.assertEquals(
-			"/o/app/endpoint?nestedFields=creator,status",
-			systemFDSSerializer.serializeAPIURL(
-				FDS_NAMES[0], httpServletRequest));
-
-		_unregisterServices();
-
-		// Nested fields depth
-
-		_registerServices(
-			_registerSystemFDSEntry(
-				SystemFDSEntryFactory.create(
-					FDS_NAMES[0]
-				).withAdditionalURLParameters(
-					"nestedFields=creator,status,relation&nestedFieldsDepth=2"
-				)));
-
-		Assert.assertEquals(
-			"/o/app/endpoint?nestedFields=creator,status,relation&" +
-				"nestedFieldsDepth=2",
-			systemFDSSerializer.serializeAPIURL(
-				FDS_NAMES[0], httpServletRequest));
-
-		_unregisterServices();
-
-		// No parameters
-
-		_registerServices(_registerSystemFDSEntry(FDS_NAMES[0]));
 
 		Assert.assertEquals(
 			"/o/app/endpoint",

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/url/FDSAPIURLBuilderTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/url/FDSAPIURLBuilderTest.java
@@ -104,29 +104,6 @@ public class FDSAPIURLBuilderTest {
 			).addParameter(
 				"param2", "value2"
 			).build());
-		Assert.assertEquals(
-			"/o/app/endpoint?param1=value1&param2=value2",
-			new FDSAPIURLBuilder(
-				_fdsAPIURLResolverRegistry, _httpServletRequest, "/app",
-				"/endpoint", "schema"
-			).addQueryString(
-				"param1=value1&param2=value2"
-			).build());
-		Assert.assertEquals(
-			"/o/app/endpoint?param1=value1&param2=value2&param3=value3&" +
-				"param4=value4&param5=value5",
-			new FDSAPIURLBuilder(
-				_fdsAPIURLResolverRegistry, _httpServletRequest, "/app",
-				"/endpoint", "schema"
-			).addParameter(
-				"param1", "value1"
-			).addQueryString(
-				"param2=value2&param3=value3"
-			).addParameter(
-				"param4", "value4"
-			).addQueryString(
-				"param5=value5"
-			).build());
 
 		// One resolver, one token
 

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/AdvancedSystemFDSEntry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/AdvancedSystemFDSEntry.java
@@ -20,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 public class AdvancedSystemFDSEntry implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return "";
-	}
-
-	@Override
 	public String getDescription() {
 		return "This is the \"Advanced\" sample of a frontend data set.";
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/CustomInternalViewSystemFDSEntry.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/CustomInternalViewSystemFDSEntry.java
@@ -20,11 +20,6 @@ import org.osgi.service.component.annotations.Component;
 public class CustomInternalViewSystemFDSEntry implements SystemFDSEntry {
 
 	@Override
-	public String getAdditionalAPIURLParameters() {
-		return "";
-	}
-
-	@Override
 	public String getDescription() {
 		return "This is the custom internal view sample of a frontend data " +
 			"set.";


### PR DESCRIPTION
Continuation of https://github.com/liferay-frontend/liferay-portal/pull/4837 where:

- A default implementation of `getAdditionalAPIURLParameters()` is provided in the `FDSSerializer` interface, freeing implementros from providing empty implementations when java-based data sets don't need additional api url parameters
- Updated unit tests, in particular, 
  - Specific methods to test this new serialization have been provided
  - System serialization tests now assert additional url parameters are not added to the URL when serializing it
- Removed unneeded method to add api url parameters in `FDSAPIURLBuilder` class

@thektan, I leveraged most of your proposal. Good job!