### PR TITLE
LPD-54139 frontend-taglib-clay: Format the label in clay button taglib

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ButtonTag.java
@@ -9,6 +9,7 @@ import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.util.TagResourceBundleUtil;
@@ -275,8 +276,10 @@ public class ButtonTag extends BaseContainerTag {
 
 	protected void writeLabel(JspWriter jspWriter) throws IOException {
 		jspWriter.write(
-			LanguageUtil.get(
-				TagResourceBundleUtil.getResourceBundle(pageContext), _label));
+			HtmlUtil.escape(
+				LanguageUtil.get(
+					TagResourceBundleUtil.getResourceBundle(pageContext),
+					_label)));
 	}
 
 	private static final String _ATTRIBUTE_NAMESPACE = "clay:button:";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-54139 - Clay Button taglib should escape label

This was something noticed when trying to adopt Clay Dropdown Menu taglib for the Sort widget. Since the label can be user-input, it would help to format the label (thanks @thektan for the advice!).

Included some steps to test on the ticket as well:
1. Create a custom sort widget template with snippet below
2. Add a sort widget to the search page
3. Open sort widget’s configurations and select the custom sort widget
4. In configurations, replace the first display label to `test"><script>alert(123);</script>`
5. Save configurations and refresh page
6. An alert should not pop up on the page

```
<@clay["button"]
	cssClass="form-control form-control-select"
	displayType="secondary"
	label="${entries[0].getLabel()}"
/>
```

Let me know if this is okay, thanks for taking a look!