### PR TITLE
LPD-54229 Selection filter using API REST Application and a nested field is not properly filtering

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -815,8 +815,9 @@ public class CustomFDSSerializer
 		return (Boolean)properties.get("active");
 	}
 
-	private Boolean _isCollection(String fieldName) {
-		return fieldName.contains(StringPool.OPEN_BRACKET);
+	private Boolean _isCollection(String fieldName, String sourceType) {
+		return fieldName.contains(StringPool.OPEN_BRACKET) &&
+			   Objects.equals(sourceType, "OBJECT_PICKLIST");
 	}
 
 	private JSONObject _serializeFilter(
@@ -970,7 +971,8 @@ public class CustomFDSSerializer
 			"entityFieldType",
 			() -> {
 				if (_isCollection(
-						String.valueOf(properties.get("fieldName")))) {
+						String.valueOf(properties.get("fieldName")),
+						sourceType)) {
 
 					return FDSEntityFieldTypes.COLLECTION;
 				}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -479,98 +479,102 @@ test('Selection filter of type "Object Picklist" can be configured to include or
 	});
 });
 
-test('Selection filter of type "Object Picklist" using a "Multiselect Picklist" type field', async ({
-	dataSetFragmentPage,
-	dataSetManagerApiHelpers,
-	layout,
-	picklistApiHelpers,
-}) => {
-	const filterLabel = 'picklist';
-	const picklistDataSetERC = getRandomString();
-	const picklistDataSetLabel = getRandomString();
+test(
+	'Selection filter of type "Object Picklist" using a "Multiselect Picklist" type field',
+	{tag: '@LPD-53174'},
+	async ({
+		dataSetFragmentPage,
+		dataSetManagerApiHelpers,
+		layout,
+		picklistApiHelpers,
+	}) => {
+		const filterLabel = 'picklist';
+		const picklistDataSetERC = getRandomString();
+		const picklistDataSetLabel = getRandomString();
 
-	await test.step('Create a new data set for FieldType', async () => {
-		dataSetERCs.push(picklistDataSetERC);
+		await test.step('Create a new data set for FieldType', async () => {
+			dataSetERCs.push(picklistDataSetERC);
 
-		await dataSetManagerApiHelpers.createDataSet({
-			erc: picklistDataSetERC,
-			label: picklistDataSetLabel,
-			restApplication: `/${apiHeadlessURL}`,
-			restSchema: apiHeadlessName,
-		});
-	});
-
-	await test.step('Add fields, so FDS has something to show', async () => {
-		await dataSetManagerApiHelpers.createDataSetTableSection({
-			dataSetERC: picklistDataSetERC,
-			fieldName: 'picklist',
-			label_i18n: {en_US: 'Picklist'},
-		});
-	});
-
-	await test.step('Create a selection filter with the picklist', async () => {
-		const picklist = await picklistApiHelpers.getPicklist(picklistName);
-
-		await dataSetManagerApiHelpers.createDataSetSelectionFilter({
-			dataSetERC: picklistDataSetERC,
-			fieldName: 'picklist[]name',
-			label_i18n: {en_US: filterLabel},
-			multiple: true,
-			source: picklist.externalReferenceCode,
-			sourceType: 'OBJECT_PICKLIST',
-		});
-	});
-
-	await test.step('Configure Data Set fragment', async () => {
-		await dataSetFragmentPage.configureDataSetFragment({
-			dataSetLabel: picklistDataSetLabel,
-			layout,
-		});
-	});
-
-	await test.step(`Select ${filterLabel} filter`, async () => {
-		await dataSetFragmentPage.selectFilter(filterLabel);
-	});
-
-	await test.step('Configure and apply filter', async () => {
-		await expect(
-			dataSetFragmentPage.filterItem.getByRole('checkbox', {
-				name: picklistDefaultOptionLabel,
-			})
-		).toBeVisible();
-		await expect(
-			dataSetFragmentPage.filterItem.getByRole('checkbox', {
-				name: picklistDefaultOptionLabel,
-			})
-		).toBeVisible();
-
-		await dataSetFragmentPage.filterItem
-			.getByRole('checkbox', {name: picklistDefaultOptionLabel})
-			.check();
-
-		await dataSetFragmentPage.addFilterButton.click();
-	});
-
-	await test.step('Check that the filter works', async () => {
-		await dataSetFragmentPage.filterResumeButton.waitFor({
-			state: 'visible',
+			await dataSetManagerApiHelpers.createDataSet({
+				erc: picklistDataSetERC,
+				label: picklistDataSetLabel,
+				restApplication: `/${apiHeadlessURL}`,
+				restSchema: apiHeadlessName,
+			});
 		});
 
-		await expect(
-			dataSetFragmentPage.page.getByRole('button', {
-				name: `${filterLabel}: ${picklistDefaultOptionLabel}`,
-			})
-		).toBeVisible();
+		await test.step('Add fields, so FDS has something to show', async () => {
+			await dataSetManagerApiHelpers.createDataSetTableSection({
+				dataSetERC: picklistDataSetERC,
+				fieldName: 'picklist',
+				label_i18n: {en_US: 'Picklist'},
+			});
+		});
 
-		const rows = await dataSetFragmentPage.table.bodyRows.all();
+		await test.step('Create a selection filter with the picklist', async () => {
+			const picklist = await picklistApiHelpers.getPicklist(picklistName);
 
-		for (const row of rows) {
-			await expect(row.locator('td:first-child')).toHaveText(
-				'[{"key":"default","name":"Default"}]'
-			);
-		}
-	});
-});
+			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+				dataSetERC: picklistDataSetERC,
+				fieldName: 'picklist[]name',
+				label_i18n: {en_US: filterLabel},
+				multiple: true,
+				source: picklist.externalReferenceCode,
+				sourceType: 'OBJECT_PICKLIST',
+			});
+		});
+
+		await test.step('Configure Data Set fragment', async () => {
+			await dataSetFragmentPage.configureDataSetFragment({
+				dataSetLabel: picklistDataSetLabel,
+				layout,
+			});
+		});
+
+		await test.step(`Select ${filterLabel} filter`, async () => {
+			await dataSetFragmentPage.selectFilter(filterLabel);
+		});
+
+		await test.step('Configure and apply filter', async () => {
+			await expect(
+				dataSetFragmentPage.filterItem.getByRole('checkbox', {
+					name: picklistDefaultOptionLabel,
+				})
+			).toBeVisible();
+			await expect(
+				dataSetFragmentPage.filterItem.getByRole('checkbox', {
+					name: picklistDefaultOptionLabel,
+				})
+			).toBeVisible();
+
+			await dataSetFragmentPage.filterItem
+				.getByRole('checkbox', {name: picklistDefaultOptionLabel})
+				.check();
+
+			await dataSetFragmentPage.addFilterButton.click();
+		});
+
+		await test.step('Check that the filter works', async () => {
+			await dataSetFragmentPage.filterResumeButton.waitFor({
+				state: 'visible',
+			});
+
+			await expect(
+				dataSetFragmentPage.page.getByRole('button', {
+					name: `${filterLabel}: ${picklistDefaultOptionLabel}`,
+				})
+			).toBeVisible();
+
+			const rows = await dataSetFragmentPage.table.bodyRows.all();
+
+			for (const row of rows) {
+				await expect(row.locator('td:first-child')).toHaveText(
+					'[{"key":"default","name":"Default"}]'
+				);
+			}
+		});
+	}
+);
 
 test('Selection filter of type "API REST Application" is displayed in fragment @LPD-10754', async ({
 	dataSetFragmentPage,
@@ -767,7 +771,7 @@ test('Selection filter of type "API REST Application" is displayed in fragment @
 
 test(
 	'Selection filter of type "API REST Application" with a composed field name is displayed in the fragment',
-	{tag: '@25905'},
+	{tag: '@LPD-25905'},
 	async ({dataSetFragmentPage, dataSetManagerApiHelpers, layout}) => {
 		const filterLabel = getRandomString();
 		const customDataSetLabel = getRandomString();

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/selectionFilters.spec.ts
@@ -233,7 +233,7 @@ test('Selection filter of type "Object Picklist" is displayed in fragment @LPD-1
 			fieldName: 'renderer',
 			label_i18n: {en_US: filterLabel},
 			source: picklist.externalReferenceCode,
-			sourceType: 'PICKLIST',
+			sourceType: 'OBJECT_PICKLIST',
 		});
 	});
 
@@ -332,7 +332,7 @@ test('Selection filter of type "Object Picklist" can be configured to use single
 				label_i18n: {en_US: filterLabel},
 				multiple: false,
 				source: picklist.externalReferenceCode,
-				sourceType: 'PICKLIST',
+				sourceType: 'OBJECT_PICKLIST',
 			});
 	});
 


### PR DESCRIPTION
**Bug Ticket:** https://liferay.atlassian.net/browse/LPD-54229

---

I don't have a great understanding of the FDS filters so I'm not sure if this is the appropriate fix, but I did notice after the Multiselect Picklist support changes in [LPD-53174](https://liferay.atlassian.net/browse/LPD-53174), the API REST Application filter with a nested field name `dataSetToDataSetCardsSections[]fieldName` was formatted like:

```
(dataSetToDataSetCardsSections/fieldName/any(x:(x eq 'label'))) ❌
```
Throwing an error: `Error 400:BAD_REQUEST, Expected token 'QualifiedName' not found.`

Without the changes from LPD-53174, the filter was in this format, which did work:

```
(dataSetToDataSetCardsSections/fieldName eq 'label') ✅
```
So my fix was the only apply the collection entityType to only `OBJECT_PICKLIST` `sourceType`.

---

### Additional Changes:
- Fixed some of the other playwright tests in the `selectionFilters.spec.ts` that needed to update the sourceType from `PICKLIST` to `OBJECT_PICKLIST`.

cc @juanjofgliferay since you worked on the original fix and might already see something why this fix isn't appropriate.