### PR TITLE
LPD-52944 CKEditor 5 image and video buttons remain enabled when viewing source tab

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor4/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor4/view.jsp
@@ -50,9 +50,7 @@ String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classi
 	%>'
 />
 
-<clay:container-fluid
-	cssClass="mt-3"
->
+<div class="mt-3">
 	<c:choose>
 		<c:when test='<%= StringUtil.equals(innerNavigation, "classic") %>'>
 			<liferay-util:include page="/ckeditor4/partials/classic.jsp" servletContext="<%= application %>" />
@@ -70,4 +68,4 @@ String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classi
 			<liferay-util:include page="/ckeditor4/partials/balloon.jsp" servletContext="<%= application %>" />
 		</c:otherwise>
 	</c:choose>
-</clay:container-fluid>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/view.jsp
@@ -32,9 +32,7 @@ String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classi
 	%>'
 />
 
-<clay:container-fluid
-	cssClass="mt-3"
->
+<div class="mt-3">
 	<c:choose>
 		<c:when test='<%= StringUtil.equals(innerNavigation, "classic") %>'>
 			<liferay-util:include page="/ckeditor5/partials/classic.jsp" servletContext="<%= application %>" />
@@ -43,4 +41,4 @@ String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classi
 			<liferay-util:include page="/ckeditor5/partials/react.jsp" servletContext="<%= application %>" />
 		</c:otherwise>
 	</c:choose>
-</clay:container-fluid>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -11,32 +11,34 @@
 String navigation = ParamUtil.getString(request, "navigation", "ckeditor5");
 %>
 
-<clay:navigation-bar
-	navigationItems='<%=
-		new JSPNavigationItemList(pageContext) {
-			{
-				add(
-					navigationItem -> {
-						navigationItem.setActive(navigation.equals("ckeditor5"));
-						navigationItem.setHref(renderResponse.createRenderURL());
-						navigationItem.setLabel("CKEditor 5");
-					});
-				add(
-					navigationItem -> {
-						navigationItem.setActive(navigation.equals("ckeditor4"));
-						navigationItem.setHref(renderResponse.createRenderURL(), "navigation", "ckeditor4");
-						navigationItem.setLabel("CKEditor 4");
-					});
+<clay:container-fluid>
+	<clay:navigation-bar
+		navigationItems='<%=
+			new JSPNavigationItemList(pageContext) {
+				{
+					add(
+						navigationItem -> {
+							navigationItem.setActive(navigation.equals("ckeditor5"));
+							navigationItem.setHref(renderResponse.createRenderURL());
+							navigationItem.setLabel("CKEditor 5");
+						});
+					add(
+						navigationItem -> {
+							navigationItem.setActive(navigation.equals("ckeditor4"));
+							navigationItem.setHref(renderResponse.createRenderURL(), "navigation", "ckeditor4");
+							navigationItem.setLabel("CKEditor 4");
+						});
+				}
 			}
-		}
-	%>'
-/>
+		%>'
+	/>
 
-<c:choose>
-	<c:when test='<%= StringUtil.equals(navigation, "ckeditor5") %>'>
-		<liferay-util:include page="/ckeditor5/view.jsp" servletContext="<%= application %>" />
-	</c:when>
-	<c:otherwise>
-		<liferay-util:include page="/ckeditor4/view.jsp" servletContext="<%= application %>" />
-	</c:otherwise>
-</c:choose>
+	<c:choose>
+		<c:when test='<%= StringUtil.equals(navigation, "ckeditor5") %>'>
+			<liferay-util:include page="/ckeditor5/view.jsp" servletContext="<%= application %>" />
+		</c:when>
+		<c:otherwise>
+			<liferay-util:include page="/ckeditor4/view.jsp" servletContext="<%= application %>" />
+		</c:otherwise>
+	</c:choose>
+</clay:container-fluid>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
@@ -17,6 +17,7 @@ module.exports = {
 			'Bold',
 			'ButtonView',
 			'ClassicEditor',
+			'Command',
 			'EditorConfig',
 			'Essentials',
 			'Font',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ButtonView, Config, Plugin, icons} from 'ckeditor5';
+import {ButtonView, Command, Config, Plugin, icons} from 'ckeditor5';
 import {openSelectionModal} from 'frontend-js-components-web';
 
 import {ClassicEditorConfig} from '../utils/types';
@@ -11,6 +11,12 @@ import {ClassicEditorConfig} from '../utils/types';
 class ItemSelector extends Plugin {
 	init() {
 		const editor = this.editor;
+
+		const commandName = 'itemSelectorCommand';
+
+		editor.commands.add(commandName, new Command(editor));
+
+		const command = editor.commands.get(commandName)!;
 
 		const config: Config<ClassicEditorConfig> = editor.config;
 
@@ -27,6 +33,8 @@ class ItemSelector extends Plugin {
 					label: Liferay.Language.get('image'),
 					tooltip: true,
 				});
+
+				buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 				buttonView.on('execute', () => {
 					openSelectionModal({
@@ -82,6 +90,8 @@ class ItemSelector extends Plugin {
 					label: Liferay.Language.get('video'),
 					tooltip: true,
 				});
+
+				buttonView.bind('isEnabled').to(command, 'isEnabled');
 
 				buttonView.on('execute', () => {
 					openSelectionModal({

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -429,6 +429,7 @@ module.exports = {
 			'Bold',
 			'ButtonView',
 			'ClassicEditor',
+			'Command',
 			'EditorConfig',
 			'Essentials',
 			'Font',

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: '92e4b338ff970654eeeb0cd5d4397820d618d1e4395f259db69346b6fce9c936',
+	hash: 'e9b4ba0019a819fc18a0e58f38bc8e8c4461fe4e9e9cdb0b3086506bc453d182',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/classic.spec.ts
@@ -161,3 +161,29 @@ test(
 		).toBeVisible();
 	}
 );
+
+test(
+	'Opening source editing disables all custom controls',
+	{tag: '@LPD-11235'},
+	async ({classicPage}) => {
+		const imageButton = classicPage.toolbar.getByRole('button', {
+			name: 'Image',
+		});
+		const sourceButton = classicPage.toolbar.getByRole('button', {
+			name: 'Source',
+		});
+		const videoButton = classicPage.toolbar.getByRole('button', {
+			name: 'Video',
+		});
+
+		await sourceButton.click();
+
+		await expect(imageButton).toBeDisabled();
+		await expect(videoButton).toBeDisabled();
+
+		await sourceButton.click();
+
+		await expect(imageButton).toBeEnabled();
+		await expect(videoButton).toBeEnabled();
+	}
+);


### PR DESCRIPTION
### References

- JIRA: [LPD-52944 CKEditor 5 image and video buttons remain enabled when viewing source tab](https://issues.liferay.com/browse/LPD-52944)

### What is the goal of this PR?

A bugfix. More precisely, we are improving implementation of item selector custom plugin.

Technical details inline.

### What does it look like?

![image](https://github.com/user-attachments/assets/aef592d3-c1fa-4169-aba0-9938d7487af2)

![image](https://github.com/user-attachments/assets/d43b1c92-c3bc-4e87-95c1-cb7bae7edd01)

