### PR TITLE
LPD-54316 Fix CSSCompressor @container queries breakage

### DIFF
--- a/portal-impl/src/com/liferay/portal/minifier/CSSCompressor.java
+++ b/portal-impl/src/com/liferay/portal/minifier/CSSCompressor.java
@@ -63,6 +63,8 @@ public class CSSCompressor {
 
 		css = _removeUnneededLeadingSpaces(css);
 
+		css = _restoreContainerQuerySpaces(css);
+
 		css = _retainSpaceForSpecialIE6Cases(css);
 
 		css = _removeWhitespaceAfterPreservedComments(css);
@@ -631,6 +633,26 @@ public class CSSCompressor {
 		return sb.toString();
 	}
 
+	private String _restoreContainerQuerySpaces(String css) {
+		StringBuffer sb = new StringBuffer();
+
+		Matcher matcher = _restoreContainerQuerySpacesPattern.matcher(css);
+
+		while (matcher.find()) {
+			String group = matcher.group();
+
+			group = group.substring(0, group.length() - 1);
+
+			group += " (";
+
+			matcher.appendReplacement(sb, group);
+		}
+
+		matcher.appendTail(sb);
+
+		return sb.toString();
+	}
+
 	private String _restorePreservedTokens(
 		String css, List<String> preservedTokens) {
 
@@ -855,6 +877,8 @@ public class CSSCompressor {
 	private static final Pattern _replaceBorderNonePattern = Pattern.compile(
 		"(?i)(border|border-top|border-right|border-bottom|border-left|" +
 			"outline|background):none(;|})");
+	private static final Pattern _restoreContainerQuerySpacesPattern =
+		Pattern.compile("@container\\s+([^\\s(]+\\()");
 	private static final Pattern _restoreSomeMultipleZeroesPattern =
 		Pattern.compile(
 			StringBundler.concat(

--- a/portal-impl/test/unit/com/liferay/portal/minifier/MinifierUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/minifier/MinifierUtilTest.java
@@ -43,6 +43,21 @@ public class MinifierUtilTest {
 	}
 
 	@Test
+	public void testProcessMinifiedCssWithContainerQuery() {
+		String minifiedCss = MinifierUtil.minifyCss(
+			"@container c-card-page (min-width: 540px)");
+
+		Assert.assertEquals(
+			"@container c-card-page (min-width:540px)", minifiedCss);
+
+		minifiedCss = MinifierUtil.minifyCss(
+			"@container     c-card-page    (min-width: 540px)   ;");
+
+		Assert.assertEquals(
+			"@container c-card-page (min-width:540px);", minifiedCss);
+	}
+
+	@Test
 	public void testProcessMinifiedCssWithDataImageUrl() {
 		String minifiedCss = MinifierUtil.minifyCss(
 			StringBundler.concat(


### PR DESCRIPTION
Given how unintelligible the `CSSCompressor` is to me I've added a new method to restore the removed whitespace.

The CSSCompressor uses another technique to do this (replacing protected texts by magic tokens) but we cannot apply it here because the content is variable.

Also, by encapsulating the fix in a new method we make it easier to roll it back or modify it in case it is necessary :see_no_evil: .