### PR TITLE
LPD-53924 Removes overlay from DOM once menu is closed

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -122,7 +122,9 @@ AUI.add(
 					);
 
 					if (overlay) {
-						overlay.hide();
+						overlay.destroy();
+
+						instance._overlayMap.clear();
 					}
 
 					instance._activeMenu = null;

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/java/com/liferay/frontend/taglib/sample/web/internal/display/context/SampleDisplayContext.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/java/com/liferay/frontend/taglib/sample/web/internal/display/context/SampleDisplayContext.java
@@ -42,6 +42,13 @@ public class SampleDisplayContext {
 				"Fieldset"
 			).build(),
 			NavigationItemBuilder.setActive(
+				navigation.equals("icon-menu")
+			).setHref(
+				_renderResponse.createRenderURL(), "navigation", "icon-menu"
+			).setLabel(
+				"Icon Menu"
+			).build(),
+			NavigationItemBuilder.setActive(
 				navigation.equals("input-localized")
 			).setHref(
 				_renderResponse.createRenderURL(), "navigation",

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/icon_menu.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/icon_menu.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/icon_menu.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/icon_menu.jsp
@@ -1,0 +1,24 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-ui:icon-menu
+	direction="right-side"
+	extended="<%= false %>"
+	icon="plus"
+	id="iconMenu"
+	markupView="lexicon"
+	message="Sample Add"
+	scroll="<%= false %>"
+	showArrow="<%= false %>"
+	showWhenSingleIcon="<%= true %>"
+>
+	<liferay-ui:icon
+		message="First Menu Option"
+	/>
+</liferay-ui:icon-menu>

--- a/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib-sample-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,6 +23,9 @@ String navigation = ParamUtil.getString(request, "navigation", "fieldset");
 	<c:when test='<%= navigation.equals("fieldset") %>'>
 		<liferay-util:include page="/partials/fieldset.jsp" servletContext="<%= application %>" />
 	</c:when>
+	<c:when test='<%= navigation.equals("icon-menu") %>'>
+		<liferay-util:include page="/partials/icon_menu.jsp" servletContext="<%= application %>" />
+	</c:when>
 	<c:when test='<%= navigation.equals("input-localized") %>'>
 		<liferay-util:include page="/partials/input_localized.jsp" servletContext="<%= application %>" />
 	</c:when>

--- a/modules/apps/frontend-taglib/source-formatter-suppressions.xml
+++ b/modules/apps/frontend-taglib/source-formatter-suppressions.xml
@@ -4,4 +4,7 @@
 	<checkstyle>
 		<suppress checks="MapBuilderCheck" files="frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/TranslationManagerTag\.java" />
 	</checkstyle>
+	<source-check>
+		<suppress checks="IllegalTaglibsCheck" files="frontend-taglib-sample-web/src/main/resources/META-INF/resources/partials/icon_menu.jsp" />
+	</source-check>
 </suppressions>

--- a/modules/test/playwright/tests/portal-web/main/html/taglib/ui/iconMenu.spec.ts
+++ b/modules/test/playwright/tests/portal-web/main/html/taglib/ui/iconMenu.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../../fixtures/loginTest';
+import {samplePageTest} from '../../../../../frontend-taglib/main/fixtures/samplePageTest';
+
+export const test = mergeTests(
+	isolatedSiteTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	loginTest(),
+	samplePageTest
+);
+
+const linkName = 'Icon Menu';
+
+test(
+	'Overlay is removed from DOM after menu is closed',
+	{
+		tag: '@LPD-53924',
+	},
+	async ({page, samplePage, site}) => {
+		const overlay = page.locator('.overlay');
+
+		await test.step('Add taglib sample to page', async () => {
+			await samplePage.setupSampleWidget({
+				site,
+			});
+
+			await samplePage.selectLink(linkName);
+		});
+
+		await test.step('Set viewport for mobile resolution', async () => {
+			page.setViewportSize({height: 720, width: 360});
+		});
+
+		await test.step('Open and close menu', async () => {
+			await page.getByRole('button', {name: 'Sample Add'}).click();
+
+			// Setup the handler to manage overlay
+
+			await page.addLocatorHandler(
+				page.getByText('First Menu Option'),
+				async () => {
+					await expect(overlay).toHaveCount(1);
+
+					// Close menu by clicking anywhere in the overlay
+
+					await page.locator('.yui3-widget-mask').click();
+				}
+			);
+		});
+
+		await test.step('Check overlay has been removed from DOM', async () => {
+			await expect(overlay).toHaveCount(0);
+		});
+	}
+);


### PR DESCRIPTION
Hi,

You can get information about this case in [LPP-58577](https://liferay.atlassian.net/browse/LPP-58557) and [PTR-6482](https://liferay.atlassian.net/browse/PTR-6482).

YUI is making wrongly some calculations about the position of the menu widget when it is open and closed and few times. I was afraid of making any change so deep inside YUI since it could have some side-effects when positioning other widgets, so I'm simply removing the overly once the menu it's closed, what resets the position calculation although overlay is created/removed in DOM every time the menu is opened/closed.

Thanks.

Regards.