### PR TITLE
LPD-55498 - Fix translation manager rendering unnecessarily

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf
@@ -53,12 +53,103 @@ if (Validator.isNotNull(script)) {
 
 	<liferay-ui:section>
 		<div id="<portlet:namespace />formBuilderTab">
-			<liferay-frontend:translation-manager
-				availableLocales="<%= availableLocales %>"
-				changeableDefaultLanguage="<%= changeableDefaultLanguage %>"
-				defaultLanguageId="<%= defaultLanguageId %>"
-				id="translationManager"
-			/>
+			<div class="lfr-translation-manager" id="<portlet:namespace />translationManager">
+				<div class="lfr-translation-manager-content">
+					<label class="lfr-translation-manager-default-locale-label" for="<portlet:namespace />defaultLanguageId"><liferay-ui:message key="default-language" />:</label>
+
+					<span class="label label-default label-lg lfr-translation-manager-default-locale-text lfr-translation-manager-translation lfr-translation-manager-translation-editing">
+
+						<%
+						Locale defaultLocale = LocaleUtil.fromLanguageId(defaultLanguageId);
+						%>
+
+						<img alt="<%= HtmlUtil.escapeAttribute(defaultLocale.getDisplayName(locale)) %>" src="<%= HtmlUtil.escapeAttribute(themeDisplay.getPathThemeImages() + "/language/" + defaultLanguageId + ".png") %>" />
+
+						<%= defaultLocale.getDisplayName(locale) %>
+					</span>
+
+					<select class="form-control hide lfr-translation-manager-default-locale">
+
+						<%
+						Set<Locale> locales = LanguageUtil.getAvailableLocales(themeDisplay.getSiteGroupId());
+
+						for (Locale curLocale : locales) {
+						%>
+
+							<aui:option label="<%= curLocale.getDisplayName(locale) %>" selected="<%= defaultLanguageId.equals(LocaleUtil.toLanguageId(curLocale)) %>" value="<%= LocaleUtil.toLanguageId(curLocale) %>" />
+
+						<%
+						}
+						%>
+
+					</select>
+
+					<c:if test="<%= changeableDefaultLanguage %>">
+						<a class="label label-default label-lg lfr-translation-manager-change-default-locale" href="javascript:void(0);"><liferay-ui:message key="change" /></a>
+					</c:if>
+
+					<liferay-ui:icon-menu
+						cssClass="lfr-translation-manager-icon-menu"
+						direction="down"
+						icon="../aui/plus"
+						message='<%= LanguageUtil.get(resourceBundle, "add-translation") %>'
+						showArrow="<%= true %>"
+						showWhenSingleIcon="<%= true %>"
+					>
+
+						<%
+						for (Locale curLocale : locales) {
+						%>
+
+							<liferay-ui:icon
+								cssClass="lfr-translation-manager-translation-item"
+								id="<%= LocaleUtil.toLanguageId(curLocale) %>"
+								image='<%= "../language/" + LocaleUtil.toLanguageId(curLocale) %>'
+								lang="<%= LocaleUtil.toLanguageId(curLocale) %>"
+								message="<%= curLocale.getDisplayName(locale) %>"
+								url="javascript:void(0);"
+							/>
+
+						<%
+						}
+						%>
+
+					</liferay-ui:icon-menu>
+
+					<div class="alert alert-info hide lfr-translation-manager-translations-message" id="<portlet:namespace />translationsMessage">
+						<liferay-ui:message key="the-changes-in-your-translations-will-be-available-once-the-content-is-published" />
+					</div>
+
+					<c:if test="<%= availableLocales.length > 1 %>">
+						<div class="lfr-translation-manager-available-translations">
+							<label><liferay-ui:message key="available-translations" /></label>
+
+							<span class="lfr-translation-manager-available-translations-links">
+
+								<%
+								for (int i = 0; i < availableLocales.length; i++) {
+									if (defaultLanguageId.equals(LocaleUtil.toLanguageId(availableLocales[i]))) {
+										continue;
+									}
+								%>
+
+									<span class="label label-default label-lg lfr-translation-manager-translation" locale="<%= availableLocales[i] %>">
+										<img alt="<%= HtmlUtil.escapeAttribute(availableLocales[i].getDisplayName(locale)) %>" src="<%= themeDisplay.getPathThemeImages() %>/language/<%= LocaleUtil.toLanguageId(availableLocales[i]) %>.png" />
+
+										<%= availableLocales[i].getDisplayName(locale) %>
+
+										<aui:icon cssClass="lfr-translation-manager-delete-translation" image="remove" />
+									</span>
+
+								<%
+								}
+								%>
+
+							</span>
+						</div>
+					</c:if>
+				</div>
+			</div>
 
 			<div class="diagram-builder form-builder" id="<portlet:namespace />formBuilder">
 				<div class="diagram-builder-content" id="<portlet:namespace />formBuilderContent">

--- a/modules/apps/dynamic-data-mapping/source-formatter-suppressions.xml
+++ b/modules/apps/dynamic-data-mapping/source-formatter-suppressions.xml
@@ -21,6 +21,7 @@
 		<suppress checks="FTLEmptyLinesCheck" files="dynamic-data-mapping-test/src/testIntegration/resources/com/liferay/dynamic/data/mapping/dependencies/upgrade.v5_3_3/expected-ddm-template-browser-sniffer-content\.ftl" />
 		<suppress checks="FTLWhitespaceCheck" files="dynamic-data-mapping-test/src/testIntegration/resources/com/liferay/dynamic/data/mapping/dependencies/upgrade.v5_3_3/expected-ddm-template-browser-sniffer-content\.ftl" />
 		<suppress checks="HTMLWhitespaceCheck" files="dynamic-data-mapping-test/src/testIntegration/resources/com/liferay/dynamic/data/mapping/dependencies/upgrade.v5_3_3/expected-fragment-entry-browser-sniffer-content\.html" />
+		<suppress checks="IllegalTaglibsCheck" files="dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf" />
 		<suppress checks="JavaForLoopCheck" files="dynamic-data-mapping-form-values-query/src/main/java/com/liferay/dynamic/data/mapping/form/values/query/internal/model/DDMFormValuesFilterImpl\.java" />
 		<suppress checks="JavaUpgradeIndexCheck" files="dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v4_3_0/DLFileEntryTypeDataDefinitionIdUpgradeProcess\.java" />
 	</source-check>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-55498

I had previously replaced the translation manager with the new one, but the markup was really different and we couldn't easily just port the UI over. So we want to just copy over the old markup from the removed aui tag