### PR TITLE
LPD-55692 Investigate/fix test "Check behavior of custom views"

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-web/main/advanced.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/advanced.spec.ts
@@ -367,6 +367,8 @@ test(
 
 			actionsDropdown = page.locator(`#${actionsDropdownId}`);
 
+			page.keyboard.press('Escape');
+
 			await fdsSamplePage.customViewsSelectorButton.click();
 
 			const customViewsDropdownId =
@@ -375,6 +377,8 @@ test(
 				);
 
 			customViewsDropdown = page.locator(`#${customViewsDropdownId}`);
+
+			page.keyboard.press('Escape');
 
 			await fdsSamplePage.table.manageColumnsVisibilityButton.click();
 
@@ -386,6 +390,8 @@ test(
 			columnsVisibilityDropdown = page.locator(
 				`#${columnsVisibilityDropdownId}`
 			);
+
+			page.keyboard.press('Escape');
 		});
 
 		await test.step('Create a custom views and set it as the default one', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/advanced.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/advanced.spec.ts
@@ -458,11 +458,9 @@ test(
 				.getByRole('menuitem', {name: 'Description'})
 				.click();
 
-			await expect(fdsSamplePage.table.headerCells).toHaveCount(9);
-
-			await fdsSamplePage.customViewsActionsButton.click();
-
 			page.keyboard.press('Escape');
+
+			await expect(fdsSamplePage.table.headerCells).toHaveCount(9);
 		});
 
 		await test.step('Confirm that changes in a custom view does not affect Default View', async () => {


### PR DESCRIPTION
**Task:** https://liferay.atlassian.net/browse/LPD-53435
**Subtask:** https://liferay.atlassian.net/browse/LPD-55692

---

"Check behavior of custom views" is failing in CI and it seems like it might be how the dropdown is blocking the button. There are screenshots of the failures in the subtask ticket https://liferay.atlassian.net/browse/LPD-55692.

~Currently setting this as a draft so I can run it in CI since only locally I'm getting database errors and the test is failing elsewhere where the columns aren't properly updating. I'm hoping it's just because of this error and that I just need to locally re-build (but clearing my database didn't work 😕).~ Saving a view still isn't locally working for me but hopefully it's just a local database/elasticsearch issue since on CI the test seems to pass.
```
2025-05-15 21:18:48.180 ERROR [http-nio-8080-exec-5][BatchingBatch:134] HHH000315: Exception executing batch [java.sql.BatchUpdateException: Duplicate entry '35117-FDS£_com_liferay_frontend_data_set_sample_web_internal_po' for key 'portalpreferencevalue.IX_D5E35599'], SQL: insert into PortalPreferenceValue (mvccVersion, companyId, portalPreferencesId, index_, key_, largeValue, namespace, smallValue, portalPreferenceValueId) values (?, ?, ?, ?, ?, ?, ?, ?, ?)
2025-05-15 21:18:48.188 ERROR [http-nio-8080-exec-5][SqlExceptionHelper:142] Duplicate entry '35117-FDS£_com_liferay_frontend_data_set_sample_web_internal_po' for key 'portalpreferencevalue.IX_D5E35599'
2025-05-15 21:18:48.226 ERROR [http-nio-8080-exec-5][FDSApplication:271] null
java.util.ConcurrentModificationException: null
	at com.liferay.portlet.PortalPreferencesImpl._retryableStore(PortalPreferencesImpl.java:518) ~[portal-impl.jar:?]
	at com.liferay.portlet.PortalPreferencesImpl.setValue(PortalPreferencesImpl.java:304) ~[portal-impl.jar:?]
	at com.liferay.frontend.data.set.taglib.internal.jaxrs.application.FDSApplication.saveActiveFDSViewSettings(FDSApplication.java:261) [bundleFile:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
```

---

**Update (Thu, May 22):** "Check behavior of custom views" test seems to consistently pass (ran `ci:test:frontend` 2 times, `ci:test:playwright` 1 time) 