### PR TITLE
LPD-54629 Quick actions should not be displayed if the row is checked

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -39,7 +39,7 @@ function Actions({
 		toggleItemInlineEdit,
 	}: IFrontendDataSetContext = useContext(FrontendDataSetContext);
 
-	const isRowChecked =
+	const isRowSelected =
 		allItemsSelectedActive ||
 		selectedItemsValue?.some(
 			(selectedItemValue) => String(selectedItemValue) === String(itemId)
@@ -99,7 +99,7 @@ function Actions({
 		<>
 			{quickActionsEnabled &&
 				formattedActions.length > 1 &&
-				!isRowChecked && (
+				!isRowSelected && (
 					<QuickActions
 						actions={formattedActions.slice(
 							0,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -39,12 +39,6 @@ function Actions({
 		toggleItemInlineEdit,
 	}: IFrontendDataSetContext = useContext(FrontendDataSetContext);
 
-	const isRowSelected =
-		allItemsSelectedActive ||
-		selectedItemsValue?.some(
-			(selectedItemValue) => String(selectedItemValue) === String(itemId)
-		);
-
 	const [
 		{
 			activeView: {quickActionsEnabled},
@@ -54,8 +48,15 @@ function Actions({
 	const [loading, setLoading] = useState(false);
 	const [menuActive, setMenuActive] = useState(false);
 
+	const isRowSelected =
+		allItemsSelectedActive ||
+		selectedItemsValue?.some(
+			(selectedItemValue) => String(selectedItemValue) === String(itemId)
+		);
+
 	const inlineEditingAvailable =
 		inlineEditingSettings && itemData.actions?.update;
+
 	const inlineEditingAlwaysOn =
 		inlineEditingAvailable && inlineEditingSettings.alwaysOn;
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -41,10 +41,9 @@ function Actions({
 
 	const isRowChecked =
 		allItemsSelectedActive ||
-		(selectedItemsValue &&
-			!!selectedItemsValue.find(
-				(element: any) => String(element) === String(itemId)
-			));
+		selectedItemsValue?.some(
+			(selectedItemValue) => String(selectedItemValue) === String(itemId)
+		);
 
 	const [
 		{

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -27,6 +27,7 @@ function Actions({
 	itemId: string | number;
 }) {
 	const {
+		allItemsSelectedActive,
 		executeAsyncItemAction,
 		highlightItems,
 		inlineEditingSettings,
@@ -34,8 +35,16 @@ function Actions({
 		onActionDropdownItemClick,
 		openModal,
 		openSidePanel,
+		selectedItemsValue,
 		toggleItemInlineEdit,
 	}: IFrontendDataSetContext = useContext(FrontendDataSetContext);
+
+	const isRowChecked =
+		allItemsSelectedActive ||
+		(selectedItemsValue &&
+			!!selectedItemsValue.find(
+				(element: any) => String(element) === String(itemId)
+			));
 
 	const [
 		{
@@ -89,17 +98,20 @@ function Actions({
 
 	return (
 		<>
-			{quickActionsEnabled && formattedActions.length > 1 && (
-				<QuickActions
-					actions={formattedActions.slice(
-						0,
-						QUICK_ACTIONS_MAX_NUMBER
-					)}
-					itemData={itemData}
-					itemId={itemId}
-					onClick={handleClick}
-				/>
-			)}
+			{quickActionsEnabled &&
+				formattedActions.length > 1 &&
+				!isRowChecked && (
+					<QuickActions
+						actions={formattedActions.slice(
+							0,
+							QUICK_ACTIONS_MAX_NUMBER
+						)}
+						itemData={itemData}
+						itemId={itemId}
+						onClick={handleClick}
+					/>
+				)}
+
 			<ActionsDropdown
 				actions={formattedActions}
 				itemData={itemData}


### PR DESCRIPTION
Bug: https://liferay.atlassian.net/browse/LPD-54629

---

Follow-up from https://github.com/liferay-frontend/liferay-portal/pull/4892

- Simplified logic for readability
- Renamed `isRowChecked` to `isRowSelected` for consistency of the word "selected"
- Sorted variables