### PR TITLE
LPD-55693 Change password using CSRF bypass related to `p_l_back_url`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
@@ -85,9 +85,7 @@ const initSPA = function (config) {
 
 						const lifecycle = uri.searchParams.get('p_p_lifecycle');
 
-						match =
-							(lifecycle === '0' || !lifecycle) &&
-							checkExcludedTargetPortlets(uri);
+						match = lifecycle === '0' || !lifecycle;
 					}
 				}
 

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {getPortletNamespace} from 'frontend-js-web';
+
 import App from './app/LiferayApp';
 import ActionURLScreen from './screen/ActionURLScreen';
 import RenderURLScreen from './screen/RenderURLScreen';
@@ -26,6 +28,17 @@ const initSPA = function (config) {
 
 		if (config.excludedTargetPortlets.includes(id)) {
 			return false;
+		}
+		else {
+			const redirect = uri.searchParams.get(
+				getPortletNamespace(id) + 'redirect'
+			);
+
+			if (redirect) {
+				return checkExcludedTargetPortlets(
+					new URL(redirect, window.location.origin)
+				);
+			}
 		}
 
 		return true;

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/init.js
@@ -17,6 +17,20 @@ import {getUrlPath} from './util/utils';
 const initSPA = function (config) {
 	const app = new App(config);
 
+	const checkExcludedTargetPortlets = (uri) => {
+		const id = uri.searchParams.get('p_p_id');
+
+		if (!id || !config.excludedTargetPortlets) {
+			return true;
+		}
+
+		if (config.excludedTargetPortlets.includes(id)) {
+			return false;
+		}
+
+		return true;
+	};
+
 	app.addRoutes([
 		{
 			handler: ActionURLScreen,
@@ -33,15 +47,9 @@ const initSPA = function (config) {
 				const host = loginRedirectURL.host || window.location.host;
 
 				if (app.isLinkSameOrigin_(host)) {
-					match = uri.searchParams.get('p_p_lifecycle') === '1';
-
-					if (match) {
-						const id = uri.searchParams.get('p_p_id');
-
-						if (id && config.excludedTargetPortlets) {
-							match = !config.excludedTargetPortlets.includes(id);
-						}
-					}
+					match =
+						uri.searchParams.get('p_p_lifecycle') === '1' &&
+						checkExcludedTargetPortlets(uri);
 				}
 
 				return match;
@@ -64,7 +72,9 @@ const initSPA = function (config) {
 
 						const lifecycle = uri.searchParams.get('p_p_lifecycle');
 
-						match = lifecycle === '0' || !lifecycle;
+						match =
+							(lifecycle === '0' || !lifecycle) &&
+							checkExcludedTargetPortlets(uri);
 					}
 				}
 


### PR DESCRIPTION
Hi,

Sec vulnerabilities trhough `back` button when SPA is enabled were originally fixed by LPD-19368, however it stopped working when we removed feature flag LPS-180328 because it partially rewrites URL while editing content pages, so we need to create this new solution where we stop navigating with SPA any request including a redirect to an excluded portlet.

Thanks.

Regards.