### PR TITLE
LPD-53880 Regression in CKEditor: image update does not update path v2

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
+++ b/modules/apps/adaptive-media/adaptive-media-image-js-web/src/main/resources/META-INF/resources/ckeditor/plugins/adaptivemedia/plugin.js
@@ -33,8 +33,18 @@ function sourceTagTemplate({media, srcset}) {
 
 					event.cancel();
 
-					const onSelectedImageChangeFn =
-						instance._onSelectedImageChange.bind(instance, editor);
+					let onSelectedImageChangeFn;
+
+					if (event.data.commandData) {
+						onSelectedImageChangeFn = event.data.commandData;
+					}
+					else {
+						onSelectedImageChangeFn =
+							instance._onSelectedImageChange.bind(
+								instance,
+								editor
+							);
+					}
 
 					editor.execCommand(
 						'imageselector',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/ClassicEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/ClassicEditorConfigContributor.java
@@ -36,8 +36,10 @@ public class ClassicEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
+		String extraPlugins = jsonObject.getString("extraPlugins");
+
 		jsonObject.put(
-			"extraPlugins", "itemselector, maximize, stylescombo"
+			"extraPlugins", extraPlugins += ",maximize"
 		).put(
 			"toolbar_liferay",
 			JSONUtil.putAll(
@@ -45,7 +47,8 @@ public class ClassicEditorConfigContributor
 				toJSONArray("['Styles', 'Bold', 'Italic', 'Underline']"),
 				toJSONArray("['NumberedList', 'BulletedList']"),
 				toJSONArray("['Maximize']"), toJSONArray("['Link', Unlink]"),
-				toJSONArray("['Table', 'ImageSelector']"))
+				toJSONArray("['Table', 'ImageSelector']"),
+				toJSONArray("['Source', 'Expand']"))
 		);
 	}
 

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor4/partials/classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor4/partials/classic.jsp
@@ -62,4 +62,5 @@
 	editorName="ckeditor_classic"
 	name="sampleClassicEditor"
 	placeholder="content"
+	showSource="<%= true %>"
 />

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -63,7 +63,7 @@
 					: editorContent;
 
 			const imgElement = editorContentDocument.querySelector(
-				`div[data-fileentryid="${imageSrc.fileEntryId}"]`
+				`img[src='${imageSrc.url}']`
 			);
 
 			if (imgElement) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -63,7 +63,7 @@
 					: editorContent;
 
 			const imgElement = editorContentDocument.querySelector(
-				`img[src='${imageSrc.url}']`
+				`img[src='${imageSrc}']`
 			);
 
 			if (imgElement) {
@@ -225,6 +225,9 @@
 			else if (itemSrc.value) {
 				itemSrc = itemSrc.value;
 			}
+			else if (itemSrc.url) {
+				itemSrc = itemSrc.url;
+			}
 
 			if (selectedItem.returnType === STR_FILE_ENTRY_RETURN_TYPE) {
 				try {
@@ -281,13 +284,7 @@
 						: document.getElementById(`cke_${editor.name}`);
 
 					if (typeof callback === 'function') {
-						callback(imageSrc.url, selectedItem);
-
-						instance._checkImageWidth(
-							editor,
-							editorContent,
-							imageSrc
-						);
+						callback(imageSrc);
 					}
 					else {
 						const editorContentHeight =
@@ -295,10 +292,7 @@
 
 						const imgElement = new Image();
 
-						imgElement.src =
-							typeof imageSrc === 'string'
-								? imageSrc
-								: imageSrc.url;
+						imgElement.src = imageSrc;
 
 						imgElement.onload = function () {
 							if (imgElement.height > editorContentHeight) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -295,7 +295,10 @@
 
 						const imgElement = new Image();
 
-						imgElement.src = imageSrc.url;
+						imgElement.src =
+							typeof imageSrc === 'string'
+								? imageSrc
+								: imageSrc.url;
 
 						imgElement.onload = function () {
 							if (imgElement.height > editorContentHeight) {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/itemselector/plugin.js
@@ -56,8 +56,6 @@
 				return;
 			}
 
-			const url = imageSrc.url ? imageSrc.url : imageSrc;
-
 			const editorContentDocument =
 				!editor.window.$.AlloyEditor &&
 				!editorContent.id.endsWith('BalloonEditor')
@@ -65,14 +63,16 @@
 					: editorContent;
 
 			const imgElement = editorContentDocument.querySelector(
-				`img[src='${url}']`
+				`div[data-fileentryid="${imageSrc.fileEntryId}"]`
 			);
 
-			imgElement.onload = function () {
-				if (this.width === 0) {
-					this.setAttribute('width', '150px');
-				}
-			};
+			if (imgElement) {
+				imgElement.onload = function () {
+					if (this.width === 0) {
+						this.setAttribute('width', '150px');
+					}
+				};
+			}
 		},
 
 		_commitAudioValue(value, node) {
@@ -281,7 +281,7 @@
 						: document.getElementById(`cke_${editor.name}`);
 
 					if (typeof callback === 'function') {
-						callback(imageSrc, selectedItem);
+						callback(imageSrc.url, selectedItem);
 
 						instance._checkImageWidth(
 							editor,
@@ -295,7 +295,7 @@
 
 						const imgElement = new Image();
 
-						imgElement.src = imageSrc;
+						imgElement.src = imageSrc.url;
 
 						imgElement.onload = function () {
 							if (imgElement.height > editorContentHeight) {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/fixtures/ckeditor4PageTest.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/fixtures/ckeditor4PageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {CKEditor4Page} from '../pages/CKEditor4Page';
+
+const ckeditor4PageTest = test.extend<{
+	ckeditor4Page: CKEditor4Page;
+}>({
+	ckeditor4Page: async ({page}, use) => {
+		await use(new CKEditor4Page(page));
+	},
+});
+
+export {ckeditor4PageTest};

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/pages/CKEditor4Page.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/pages/CKEditor4Page.ts
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrameLocator, Locator, Page, expect} from '@playwright/test';
+
+export class CKEditor4Page {
+	readonly contextMenu: Locator;
+	readonly editableFrame: FrameLocator;
+	private readonly itemSelectorFrame: FrameLocator;
+	readonly page: Page;
+	private readonly toolbar: Locator;
+
+	constructor(page: Page) {
+		this.contextMenu = page.locator('.cke_dialog_container');
+
+		this.editableFrame = page.frameLocator('iframe[title="editor"]');
+
+		this.itemSelectorFrame = page.frameLocator(
+			'iframe[title="Select Item"]'
+		);
+
+		this.page = page;
+
+		this.toolbar = page.locator('.cke_toolbox');
+	}
+
+	async insertHTML(html: string) {
+		const sourceButton = this.toolbar.getByRole('button', {name: 'Source'});
+
+		await sourceButton.click();
+
+		await this.page.evaluate((html) => {
+			const textarea: HTMLTextAreaElement =
+				document.querySelector('.cke_editable');
+
+			textarea.value = html;
+		}, html);
+
+		await sourceButton.click();
+	}
+
+	async selectImageWithItemSelector({cardTitle}: {cardTitle: string}) {
+		const siteAndLibrariesLink = this.itemSelectorFrame.getByRole('link', {
+			name: 'Sites and Libraries',
+		});
+
+		await siteAndLibrariesLink.click();
+
+		const liferayLink = this.itemSelectorFrame.getByRole('link', {
+			name: 'Liferay',
+		});
+
+		await liferayLink.click();
+
+		const liferayImagesLink = this.itemSelectorFrame.getByRole('link', {
+			name: 'Provided by Liferay',
+		});
+
+		await liferayImagesLink.click();
+
+		const imageCard = this.itemSelectorFrame.getByText(cardTitle);
+
+		await imageCard.click();
+
+		await expect(
+			this.itemSelectorFrame.getByText('Select Item')
+		).toBeHidden();
+	}
+}

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
@@ -9,10 +9,12 @@ import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
+import {ckeditor4PageTest} from '../../fixtures/ckeditor4PageTest';
 import {ckeditorSamplePageTest} from '../../fixtures/ckeditorSamplePageTest';
 
 export const test = mergeTests(
 	apiHelpersTest,
+	ckeditor4PageTest,
 	ckeditorSamplePageTest,
 	featureFlagsTest({
 		'LPS-178052': {enabled: true},
@@ -78,49 +80,24 @@ test(
 
 test(
 	'Able to drag and drop images with the right width',
-	{tag: ['@LPD-41443', '@LPD-42473']},
-	async ({page}) => {
+	{tag: ['@LPD-41443', '@LPD-42473', '@LPD-53880']},
+	async ({ckeditor4Page, page}) => {
+		const editableFrame = ckeditor4Page.editableFrame;
+
 		await test.step('Drag and drop image', async () => {
-			const ckeditorEditorBody = page
-				.frameLocator('iframe[title="editor"]')
-				.getByRole('heading', {name: 'Classic Editor'});
+			const ckeditorEditorBody = editableFrame.getByRole('heading', {
+				name: 'Classic Editor',
+			});
 
 			await ckeditorEditorBody.click();
 
 			await page.keyboard.press('Enter');
 
-			const imageButton = page.getByLabel('Image', {exact: true});
+			await page.getByLabel('Image', {exact: true}).click();
 
-			await imageButton.waitFor({state: 'visible'});
-			await imageButton.click();
-
-			const siteAndLibrariesLink = page
-				.frameLocator('iframe[title="Select Item"]')
-				.getByRole('link', {name: 'Sites and Libraries'});
-
-			await siteAndLibrariesLink.waitFor({state: 'visible'});
-			await siteAndLibrariesLink.click();
-
-			const liferayLink = page
-				.frameLocator('iframe[title="Select Item"]')
-				.getByRole('link', {name: 'Liferay'});
-
-			await liferayLink.waitFor({state: 'visible'});
-			await liferayLink.click();
-
-			const liferayImagesLink = page
-				.frameLocator('iframe[title="Select Item"]')
-				.getByRole('link', {name: 'Provided by Liferay'});
-
-			await liferayImagesLink.waitFor({state: 'visible'});
-			await liferayImagesLink.click();
-
-			const astronautImage = page
-				.frameLocator('iframe[title="Select Item"]')
-				.getByText('astronaut.png');
-
-			await astronautImage.waitFor({state: 'visible'});
-			await astronautImage.click();
+			await ckeditor4Page.selectImageWithItemSelector({
+				cardTitle: 'astronaut.png',
+			});
 
 			const astronautEditorImage = page
 				.getByRole('application', {name: 'Rich Text Editor'})
@@ -131,43 +108,69 @@ test(
 			await astronautEditorImage.waitFor({state: 'visible'});
 			await astronautEditorImage.hover();
 
-			const dragAndDropButton = page
-				.getByRole('application', {name: 'Rich Text Editor'})
-				.frameLocator('iframe[title="editor"]')
-				.getByTitle('Click and drag to move');
+			const dragAndDropButton = editableFrame.getByTitle(
+				'Click and drag to move'
+			);
 
 			await dragAndDropButton.dragTo(ckeditorEditorBody);
 
-			const astronautImageElement = page
-				.getByRole('application', {name: 'Rich Text Editor'})
-				.frameLocator('iframe[title="editor"]')
-				.locator('h1 > * > img.cke_widget_element');
+			const astronautImageElement = editableFrame.locator(
+				'h1 > * > img.cke_widget_element'
+			);
 
 			await expect(astronautImageElement).toBeVisible();
 		});
 
 		await test.step('Check image is not occupying the whole editor width', async () => {
-			const astronautImageElement = page
-				.getByRole('application', {name: 'Rich Text Editor'})
-				.frameLocator('iframe[title="editor"]')
-				.locator('h1 > * > img.cke_widget_element');
+			const imageElement = editableFrame.locator(
+				'h1 > * > img.cke_widget_element'
+			);
 
-			const astronautImageElementBoundingBox =
-				await astronautImageElement.boundingBox();
-			const astronautImageElementWidth =
-				astronautImageElementBoundingBox.width;
+			const imageElementBoundingBox = await imageElement.boundingBox();
+			const imageElementWidth = imageElementBoundingBox.width;
 
-			const imageContainer = page
-				.getByRole('application', {name: 'Rich Text Editor'})
-				.frameLocator('iframe[title="editor"]')
-				.locator('h1 > span.cke_widget_wrapper');
+			const imageContainer = editableFrame.locator(
+				'h1 > span.cke_widget_wrapper'
+			);
 
 			const imageContainerBoundingBox =
 				await imageContainer.boundingBox();
 			const imageContainerWidth = imageContainerBoundingBox.width;
 
-			await expect(astronautImageElementWidth).toBe(imageContainerWidth);
+			expect(imageElementWidth).toBe(imageContainerWidth);
 		});
+	}
+);
+
+test(
+	'Change image from context menu, in editor without "adaptivemedia" plugin',
+	{tag: ['@LPD-53880']},
+	async ({ckeditor4Page}) => {
+		await ckeditor4Page.insertHTML(
+			'<img src="/documents/d/guest/moon-png" />'
+		);
+
+		await ckeditor4Page.editableFrame
+			.locator('img[src="/documents/d/guest/moon-png"]')
+			.dblclick();
+
+		await ckeditor4Page.contextMenu.getByText('Browse Server').click();
+
+		await ckeditor4Page.selectImageWithItemSelector({
+			cardTitle: 'satellite.png',
+		});
+
+		await expect(ckeditor4Page.contextMenu.getByLabel('URL')).toHaveValue(
+			'/documents/d/guest/satellite-png'
+		);
+
+		await ckeditor4Page.contextMenu.getByText('OK').click();
+
+		await expect(
+			ckeditor4Page.editableFrame.locator(
+				'img[src="/documents/d/guest/satellite-png"]'
+			)
+		).toBeVisible();
 	}
 );
 

--- a/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/main/journalArticle.spec.ts
@@ -23,6 +23,7 @@ import {nextPage, setItemsPerPage} from '../../../utils/pagination';
 import addApprovedStructuredContent from '../../../utils/structured-content/addApprovedStructuredContent';
 import getBasicWebContentStructureId from '../../../utils/structured-content/getBasicWebContentStructureId';
 import {waitForAlert} from '../../../utils/waitForAlert';
+import {ckeditor4PageTest} from '../../frontend-editor-ckeditor-web/main/fixtures/ckeditor4PageTest';
 import {journalPagesTest} from './fixtures/journalPagesTest';
 import getDataStructureDefinition from './utils/getDataStructureDefinition';
 
@@ -75,6 +76,8 @@ const assetPublisherDeprecationTest = mergeTests(
 		'LPD-39304': {enabled: true},
 	})
 );
+
+const ckeditor4Test = mergeTests(baseTest, ckeditor4PageTest);
 
 const ckeditor5Test = mergeTests(
 	baseTest,
@@ -1717,6 +1720,44 @@ assetPublisherDeprecationTest(
 		await page.getByLabel('Go to page, 2').click();
 
 		await expect(page.getByText('page2')).toBeVisible();
+	}
+);
+
+ckeditor4Test(
+	'Change image from context menu, in editor with "adaptivemedia" plugin',
+	{tag: ['@LPD-53880']},
+	async ({ckeditor4Page, journalEditArticlePage, site}) => {
+		await ckeditor4Test.step('Open new Basic Web Content', async () => {
+			await journalEditArticlePage.goto({siteUrl: site.friendlyUrlPath});
+		});
+
+		await ckeditor4Page.insertHTML(
+			'<img src="/documents/d/guest/moon-png" />'
+		);
+
+		const editableFrame = journalEditArticlePage.page
+			.locator('.edit-article-panel')
+			.frameLocator('iframe[title="editor"]');
+
+		await editableFrame
+			.locator('img[src="/documents/d/guest/moon-png"]')
+			.dblclick();
+
+		await ckeditor4Page.contextMenu.getByText('Browse Server').click();
+
+		await ckeditor4Page.selectImageWithItemSelector({
+			cardTitle: 'satellite.png',
+		});
+
+		await expect(ckeditor4Page.contextMenu.getByLabel('URL')).toHaveValue(
+			'/documents/d/guest/satellite-png'
+		);
+
+		await ckeditor4Page.contextMenu.getByText('OK').click();
+
+		await expect(
+			editableFrame.locator('img[src="/documents/d/guest/satellite-png"]')
+		).toBeVisible();
 	}
 );
 


### PR DESCRIPTION
### References

- JIRA: https://liferay.atlassian.net/browse/LPD-53880, https://liferay.atlassian.net/browse/LPP-58009
- This is a followup on https://github.com/liferay-frontend/liferay-portal/pull/4852

### What is the goal of this PR?

Changes from previous version:
- Solution now works for the case when there is no `adaptivemedia` plugin
- Tests on both sample module (without `adaptivemedia`) and Web Content (with `adaptivemedia`)
- Extending sample module to apply standard CKE4 classic editor plugins
- Some simplifications in tests.

Technical notes inline.

### What does it look like?


https://github.com/user-attachments/assets/9df4d8d7-18a5-47a7-b009-332c195e87fe

![image](https://github.com/user-attachments/assets/bf5f210d-181b-476f-ae0f-df093f946c3f)

