### PR TITLE
LPD-53924 If we destroy menu from DOM we need to save it in Auto Fields components to create new rows

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -352,11 +352,15 @@ AUI.add(
 
 						const currentMenu = currentButton.getData('menu');
 
-						const currentMenuListContainer = currentButton.getData('menuListContainer');
+						const currentMenuListContainer =
+							currentButton.getData('menuListContainer');
 
 						trigger.setData('menu', currentMenu);
 
-						trigger.setData('menuListContainer', currentMenuListContainer);
+						trigger.setData(
+							'menuListContainer',
+							currentMenuListContainer
+						);
 
 						const list = A.Node.create(
 							'<ul class="dropdown-menu dropdown-menu-left-side"></ul>'


### PR DESCRIPTION
Hi,

When applying [original solution](https://github.com/brianchandotcom/liferay-portal/pull/161767) for LPD-53924 we didn't consider the case of AutoFields components, which relies on menu being present and hidden in DOM when cloning a new row.

With this extra commit  we are just providing the menu to that new cloned row.

Thanks.

Regards.