### PR TITLE
LPD-57698 Auto Fields should consider id and name attributes are not always the same

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -407,7 +407,7 @@ AUI.add(
 							const inputNodeName = item.attr('nodeName');
 							const inputType = item.attr('type');
 
-							let oldId = item.attr('id');
+							const oldId = item.attr('id');
 							let oldName = item.attr('name') || oldId;
 
 							const newId = oldId.replace(

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -432,7 +432,7 @@ AUI.add(
 								inputNodeName === 'div' ||
 								inputNodeName === 'span'
 							) {
-								if (oldName) {
+								if (oldId) {
 									item.attr('id', newId);
 								}
 							}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/auto_fields.js
@@ -407,7 +407,13 @@ AUI.add(
 							const inputNodeName = item.attr('nodeName');
 							const inputType = item.attr('type');
 
-							let oldName = item.attr('id') || item.attr('name');
+							let oldId = item.attr('id');
+							let oldName = item.attr('name') || oldId;
+
+							const newId = oldId.replace(
+								/([0-9]+)([_A-Za-z]*)$/,
+								guid + '$2'
+							);
 
 							const newName = oldName.replace(
 								/([0-9]+)([_A-Za-z]*)$/,
@@ -419,7 +425,7 @@ AUI.add(
 
 								item.attr('checked', '');
 								item.attr('name', newName);
-								item.attr('id', newName);
+								item.attr('id', newId);
 							}
 							else if (
 								inputNodeName === 'button' ||
@@ -427,12 +433,12 @@ AUI.add(
 								inputNodeName === 'span'
 							) {
 								if (oldName) {
-									item.attr('id', newName);
+									item.attr('id', newId);
 								}
 							}
 							else {
 								item.attr('name', newName);
-								item.attr('id', newName);
+								item.attr('id', newId);
 							}
 
 							if (fieldStrings && fieldStrings[oldName]) {
@@ -450,9 +456,9 @@ AUI.add(
 								);
 							}
 
-							node.all('label[for=' + oldName + ']').attr(
+							node.all('label[for=' + oldId + ']').attr(
 								'for',
-								newName
+								newId
 							);
 						}
 					);

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -941,6 +941,8 @@ AUI.add(
 
 					const inputLanguageValue = instance.getValue(languageId);
 
+					instance._flags = A.one('.palette-container');
+
 					instance._animate(inputPlaceholder, shouldFocus);
 					instance._clearFormValidator(inputPlaceholder);
 


### PR DESCRIPTION
Hi,

This issue came up after LPD-53924, because `AutoFields` component is not handling separately `id` and `name` attribute and it's assuming they are always the same, but that is not necessary true.

Second commit is just about a residual error I saw while testing the first one and also related to LPD-53924, so I committed here.

Thanks.

Regards.