### PR TITLE
LPD-57867 Rename to prevent vulnerability

### DIFF
--- a/modules/test/playwright/tests/portal-web/main/html/common/themes/bottom_js_script.spec.ts
+++ b/modules/test/playwright/tests/portal-web/main/html/common/themes/bottom_js_script.spec.ts
@@ -108,3 +108,21 @@ test(
 		expect(jsSnippetIIFE).toEqual(true);
 	}
 );
+
+test(
+	'Check URL does not allow XSS injection',
+	{tag: '@LPD-57867'},
+	async ({page}) => {
+		let capturedLogMessage = '';
+
+		page.on('console', (msg) => {
+			if (msg.type() === 'log') {
+				capturedLogMessage = msg.text();
+			}
+		});
+
+		await page.goto(`/?snippet=console.log("${getRandomString()}")`);
+
+		expect(capturedLogMessage).toBe('');
+	}
+);

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -208,17 +208,27 @@ if (layout != null) {
 	UnicodeProperties layoutSetSettingsUnicodeProperties = layoutSet.getSettingsProperties();
 
 	UnicodeProperties layoutTypeSettingsUnicodeProperties = layout.getTypeSettingsProperties();
+
+	String snippet = GetterUtil.getString(layoutSetSettingsUnicodeProperties.getProperty("javascript"));
 	%>
 
-	<liferay-util:include page="/html/common/themes/bottom_js_script.jsp">
-		<liferay-util:param name="snippet" value='<%= GetterUtil.getString(layoutSetSettingsUnicodeProperties.getProperty("javascript")) %>' />
-	</liferay-util:include>
+	<c:if test="<%= Validator.isNotNull(snippet) %>">
+		<%@ include file="/html/common/themes/bottom_js_script.jspf" %>
+	</c:if>
 
-	<liferay-util:include page="/html/common/themes/bottom_js_script.jsp">
-		<liferay-util:param name="snippet" value='<%= GetterUtil.getString(masterLayoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>' />
-	</liferay-util:include>
+	<%
+	snippet = GetterUtil.getString(masterLayoutTypeSettingsUnicodeProperties.getProperty("javascript"));
+	%>
 
-	<liferay-util:include page="/html/common/themes/bottom_js_script.jsp">
-		<liferay-util:param name="snippet" value='<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>' />
-	</liferay-util:include>
+	<c:if test="<%= Validator.isNotNull(snippet) %>">
+		<%@ include file="/html/common/themes/bottom_js_script.jspf" %>
+	</c:if>
+
+	<%
+	snippet = GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("javascript"));
+	%>
+
+	<c:if test="<%= Validator.isNotNull(snippet) %>">
+		<%@ include file="/html/common/themes/bottom_js_script.jspf" %>
+	</c:if>
 </c:if>

--- a/portal-web/docroot/html/common/themes/bottom_js_script.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js_script.jspf
@@ -5,12 +5,6 @@
  */
 --%>
 
-<%@ include file="/html/common/init.jsp" %>
-
-<%
-String snippet = ParamUtil.getString(request, "snippet");
-%>
-
 <c:if test="<%= Validator.isNotNull(snippet) %>">
 	<aui:script type="text/javascript">
 		// <![CDATA[


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57867
https://liferay.atlassian.net/browse/LPP-59235

@dsanz, I was not able to get this working with the recommendation of BChan in this comment. Let me know if we still want to try this way.

For this fix, I changed the name to prevent vulnerability. Using `snippet\x26` breaks the URL if the user tries it.
Please let me know if there are questions or comments about this.

Thank you!