### PR TITLE
LPD-57549 - Remove flickering on FDS Cards after using download link

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -109,28 +109,39 @@ const Card = forwardRef<HTMLDivElement, any>(
 		return (
 			<div ref={ref}>
 				<ClayCardWithInfo
-					actions={formattedActions?.map((action: IItemsActions) => ({
-						...action,
-						href: isLink(action.target, null)
-							? formatActionURL(action.href, item, action.target)
-							: null,
-						onClick: (event: Event) => {
-							handleActionClick({
-								action,
-								event,
-								executeAsyncItemAction,
-								highlightItems,
-								itemData: item,
-								itemId: selectedItemKey,
-								loadData,
-								onActionDropdownItemClick,
-								onInfoPanelToggleButtonClick,
-								openModal,
-								openSidePanel,
-								toggleItemInlineEdit,
-							});
-						},
-					}))}
+					actions={formattedActions?.map((action: IItemsActions) => {
+						const actionItemProps = {
+							label: action.label,
+							symbolLeft: action.icon,
+						};
+
+						return {
+							...actionItemProps,
+							href: isLink(action.target, null)
+								? formatActionURL(
+										action.href,
+										item,
+										action.target
+									)
+								: null,
+							onClick: (event: Event) => {
+								handleActionClick({
+									action,
+									event,
+									executeAsyncItemAction,
+									highlightItems,
+									itemData: item,
+									itemId: selectedItemKey,
+									loadData,
+									onActionDropdownItemClick,
+									onInfoPanelToggleButtonClick,
+									openModal,
+									openSidePanel,
+									toggleItemInlineEdit,
+								});
+							},
+						};
+					})}
 					description={localizedDescription}
 					href={(schema.link && item[schema.link]) || null}
 					imgProps={imageProps}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-57549

Remove non HTML compliant attributes from action items in Cards:
- `isVisible` : remove React error complaining about the attribute camelCase notation
- `target`: FDS action target values do not match with HTML ones (reference https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target). Passing an invalid/valid target value causes the addition of `rel="noopener noreferer"` attribute
- `type`: FDS action type (`creation`, `item`, `bulk`) does not match with the expected MIME type value (reference https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#type)