### PR TITLE
LPD-58622 Fix Manage Translation option missing

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -941,7 +941,9 @@ AUI.add(
 
 					const inputLanguageValue = instance.getValue(languageId);
 
-					instance._flags = A.one('.palette-container');
+					const boundingBox = instance.get('boundingBox');
+
+					instance._flags = boundingBox.one('.palette-container');
 
 					instance._animate(inputPlaceholder, shouldFocus);
 					instance._clearFormValidator(inputPlaceholder);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-58622

- This fixes a bug where the manage translations option would go missing

The issue occurs when there are multiple input localized on the page. Since the selector was not scoped (`A.one('.palette-container')`), the description input's `instance._flags` would point to the name inputs's menu dropdown instead (`.palette-container`) and overwrite the contents of it. The fix was to scope with bounding box, which the rest of the `input_localized.js` does already too.