### PR TITLE
LPD-58389 Remove Poshi tests with Priority 3 and lower from acceptance - Frontend Infra

### DIFF
--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/FrontendJSCustomDialog.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/FrontendJSCustomDialog.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-frontend-infrastructure"
 definition {
 
-	property portal.acceptance = "true";
+	property portal.acceptance = "false";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property testray.main.component.name = "Frontend JS";

--- a/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
+++ b/modules/apps/frontend-js/frontend-js-test/src/testFunctional/tests/WalkthroughPopover.testcase
@@ -156,6 +156,7 @@ definition {
 	@priority = 3
 	test CanHaveADarkBackgroundOverlay {
 		property custom.properties = "feature.flag.LPD-44091=true";
+		property portal.acceptance = "false";
 
 		task ("When click hotspot element") {
 			Click(locator1 = "Walkthrough#SAMPLE_PORTLET_HOTSPOT");
@@ -175,6 +176,7 @@ definition {
 	@priority = 2
 	test CanHaveAShadowAroundElement {
 		property custom.properties = "feature.flag.LPD-44091=true";
+		property portal.acceptance = "false";
 
 		task ("When click hotspot element until Step 4") {
 			Click(locator1 = "Walkthrough#SAMPLE_PORTLET_HOTSPOT");
@@ -199,6 +201,7 @@ definition {
 	@priority = 3
 	test CanReturnToPreviousStepIfElementDoesNotExist {
 		property custom.properties = "feature.flag.LPD-44091=true";
+		property portal.acceptance = "false";
 
 		task ("Given JSON file includes an element that does not exist on the page/sample portlet") {
 			Navigator.gotoNavTab(navTab = "Test Walkable");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionThemeSvg.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/remotewebapps/ClientExtensionThemeSvg.testcase
@@ -39,7 +39,7 @@ definition {
 	@description = "LPS-166479. Verify that new SVG spritemap is applied on the page"
 	@priority = 3
 	test CanExtendSvgFileFromDM {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		var portalURL = PropsUtil.get("portal.url");
 
@@ -81,7 +81,7 @@ definition {
 	@description = "LPS-173318. Verify that new SVG spritemap file from external site is applied on the page"
 	@priority = 3
 	test CanExtendSvgFileFromExternalSite {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("A created Theme svg extensions using the external URL") {
 			ClientExtensionGeneral.goToRemoteAppsPortlet();


### PR DESCRIPTION
Hi team, Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on acceptance.
If you believe any of these tests should not be removed from acceptance, please let us know so we can update the priority and keep the test running on acceptance.
Thank you!