### PR TITLE
LPD-59511 Make FDS DnD compatible with other backend instances in the same page

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/FDSDndProvider.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/FDSDndProvider.tsx
@@ -12,7 +12,9 @@ const FDSDndProvider = ({children}: {children: ReactNode}) => {
 
 		// @ts-ignore
 
-		<DndProvider backend={HTML5Backend}>{children}</DndProvider>
+		<DndProvider backend={HTML5Backend} context={window}>
+			{children}
+		</DndProvider>
 	);
 };
 


### PR DESCRIPTION
Reference:

- https://liferay.atlassian.net/browse/LPD-59511

In this PR we are attaching the FDS `<DnDProvider>` to the browser's window object context. In doing so, we allow other instances of the `HTML5backend` to coexist in the same page.

Manual testing asserts this fix preserves existing behavior in terms of FDS file drop feature recently added.

Let's see what CI has to say though