### PR TITLE
LPD-59829 - Actions in FDS cards

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -209,7 +209,7 @@ const Card = forwardRef<HTMLDivElement, any>(
 								}
 							: undefined
 					}
-					onSelectChange={() => undefined}
+					onSelectChange={selectable ? () => undefined : undefined}
 					selectableType={
 						selectionType === 'single' ? 'radio' : 'checkbox'
 					}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -198,13 +198,14 @@ const Card = forwardRef<HTMLDivElement, any>(
 							? (event: any) => {
 									const target = getSelectionTrigger(event);
 
-									!!target &&
+									if (target) {
 										onItemSelectionChange?.({
 											item,
 											trigger: target,
 										});
 
-									event.preventDefault();
+										event.preventDefault();
+									}
 								}
 							: undefined
 					}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
@@ -393,14 +393,9 @@ test.describe('Item Actions in Data Set fragment', () => {
 
 			await itemAction.click();
 
-			await page.getByText('Page Not Found').isVisible();
+			await page.getByText('Not Found').isVisible();
 
-			const goBackLink = page.getByRole('link', {
-				exact: true,
-				name: 'Go Back',
-			});
-
-			await goBackLink.click();
+			await page.goto(layout.friendlyURL);
 		});
 
 		await test.step('Change visualization mode to List', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
@@ -395,7 +395,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 
 			await page.getByText('Not Found').isVisible();
 
-			await page.goto(layout.friendlyURL);
+			await dataSetFragmentPage.goToPage({layout});
 		});
 
 		await test.step('Change visualization mode to List', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
@@ -390,6 +390,17 @@ test.describe('Item Actions in Data Set fragment', () => {
 			await expect(
 				(await itemAction.getAttribute('href')).valueOf()
 			).toContain(`/detail/${itemId}`);
+
+			await itemAction.click();
+
+			await page.getByText('Page Not Found').isVisible();
+
+			const goBackLink = page.getByRole('link', {
+				exact: true,
+				name: 'Go Back',
+			});
+
+			await goBackLink.click();
 		});
 
 		await test.step('Change visualization mode to List', async () => {


### PR DESCRIPTION
## Task
https://liferay.atlassian.net/browse/LPD-59829

## Issue
With the introduction of the new selection behavior in the FDS, we were preventing the execution of actions. As we know the target of the event, we are going to prevent only events that match the selection criteria, allowing others to work in a default way.

[CardWithInfo](https://github.com/liferay/clay/blob/master/packages/clay-card/src/CardWithInfo.tsx#L236) uses the `onSelectChange` callback to render the `checkbox` or `radio` control. Current change returns an empty function when FDS is selectable or `undefined` otherwise. With this change we prevent the Cards from displaying the checkbox when the component doesn't allow selection.