### PR TITLE
LPD-60025 Web Content Description field CK Editor 5 - Sticky header is not correctly placed

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionCKEditor5ConfigContributor.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionCKEditor5ConfigContributor.java
@@ -9,6 +9,7 @@ import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 
@@ -36,7 +37,11 @@ public class JournalArticleDescriptionCKEditor5ConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
-		jsonObject.put("preset", "basic");
+		jsonObject.put(
+			"preset", "basic"
+		).put(
+			"ui", JSONUtil.put("viewportOffset", JSONUtil.put("top", 120))
+		);
 	}
 
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -48,6 +48,10 @@ $productMenuWidth: 320px;
 	}
 
 	.edit-article-form {
+		.ck.ck-sticky-panel__content.ck-sticky-panel__content_sticky {
+			z-index: $toolbarZIndex - 1;
+		}
+
 		.component-tbar.tbar-article {
 			height: auto;
 			left: 0;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60025

- Fixes the position of the CKEditor5's sticky header so it gets placed under the page toolbar. 
- Also decreased the `z-index` otherwise it'd appear on top of the page toolbar when the sticky header would end after scrolling fully past the editor.

## Demo

https://github.com/user-attachments/assets/e26b6fbb-7fe4-49d5-823f-73cb802fcb0e

