### PR TITLE
LPD-56877 Develop clear search query functionality

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/MainSearch.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/MainSearch.tsx
@@ -29,6 +29,10 @@ function MainSearch({onClear}: {onClear: () => void}) {
 					onChange={(event) => {
 						setInputValue(event.target.value);
 
+						if (!event.target.value) {
+							onClear();
+						}
+
 						if (!apiURL && !appURL) {
 							onSearch({query: event.target.value});
 						}
@@ -41,33 +45,11 @@ function MainSearch({onClear}: {onClear: () => void}) {
 						}
 					}}
 					placeholder={Liferay.Language.get('search')}
+					type="search"
 					value={inputValue}
 				/>
 
 				<ClayInput.GroupInsetItem after tag="div">
-					<ClayButtonWithIcon
-						aria-label={Liferay.Language.get('clear')}
-						className="navbar-breakpoint-d-none"
-						disabled={!inputValue?.length}
-						displayType="unstyled"
-						monospaced={false}
-						onClick={(event) => {
-							event.preventDefault();
-
-							setInputValue('');
-
-							onClear();
-							onSearch({query: ''});
-						}}
-						style={{
-							opacity: !inputValue?.length ? 0 : 1,
-							pointerEvents: !inputValue?.length
-								? 'none'
-								: 'auto',
-						}}
-						symbol="times-circle"
-					/>
-
 					<ClayButtonWithIcon
 						aria-label={Liferay.Language.get('search')}
 						displayType="unstyled"

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_main_search.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/_main_search.scss
@@ -1,0 +1,4 @@
+input[type='search']::-webkit-search-decoration:hover,
+input[type='search']::-webkit-search-cancel-button:hover {
+	cursor: pointer;
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/main.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/main.scss
@@ -2,6 +2,7 @@
 
 @import 'data_renderers/tooltip_summary';
 @import 'drag_drop';
+@import 'main_search';
 @import 'modal';
 @import 'side_panel';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -111,7 +111,7 @@ const Head = ({
 		<ClayTableHead
 			items={selectable ? [{fieldName: 'select'}, ...fields] : fields}
 		>
-			{(field) => {
+			{(field: Field) => {
 				if (field.fieldName === 'select') {
 					if (!!items.length && selectionType !== 'multiple') {
 						return (
@@ -358,7 +358,7 @@ const Body = ({
 					inlineAddingSettings ? [...items, defaultAddItem] : items
 				}
 			>
-				{(item) => {
+				{(item: any) => {
 					return (
 						<Row
 							active={
@@ -757,7 +757,7 @@ const Table = ({
 	);
 
 	const getSorting = (): Sorting | null => {
-		const activeSort = sorts.find((sort) => sort.active);
+		const activeSort = sorts.find((sort: any) => sort.active);
 
 		if (!activeSort) {
 			return null;
@@ -773,7 +773,7 @@ const Table = ({
 	const onSortChange = (sorting: Sorting | null) => {
 		let updatedSorts: TSort[] = [];
 
-		updatedSorts = sorts.map((sort) =>
+		updatedSorts = sorts.map((sort: any) =>
 			sort.key === sorting?.column
 				? {
 						...sort,
@@ -788,7 +788,7 @@ const Table = ({
 		);
 
 		const newSort: boolean = Boolean(
-			!sorts.find((sort) => sort.key === sorting?.column)
+			!sorts.find((sort: any) => sort.key === sorting?.column)
 		);
 
 		if (newSort) {
@@ -829,7 +829,7 @@ const Table = ({
 				}}
 				nestedKey={nestedItemsReferenceKey}
 				onSortChange={onSortChange}
-				onVisibleColumnsChange={(visibleColumns) => {
+				onVisibleColumnsChange={(visibleColumns: any) => {
 					const visibleFieldNames: VisibleFieldNames = {};
 
 					schema.fields.forEach(({fieldName}) => {
@@ -838,7 +838,7 @@ const Table = ({
 						}
 					});
 
-					visibleColumns.forEach((value, key) => {
+					visibleColumns.forEach((value: any, key: any) => {
 						visibleFieldNames[key] = true;
 					});
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -35,7 +35,10 @@ export class FDSSamplePage {
 		container: Locator;
 		items: Locator;
 	};
-	readonly managementToolbar: Locator;
+	readonly managementToolbar: {
+		container: Locator;
+		searchInput: Locator;
+	};
 	readonly page: Page;
 	readonly showViewOptionsButton: Locator;
 	readonly sidePanel: Locator;
@@ -100,7 +103,13 @@ export class FDSSamplePage {
 			items: listContainer.locator('.list-group-item'),
 		};
 
-		this.managementToolbar = page.getByTestId('managementToolbar');
+		this.managementToolbar = {
+			container: page.getByTestId('managementToolbar'),
+			searchInput: page
+				.getByTestId('managementToolbar')
+				.locator('input[type="search"]'),
+		};
+
 		this.page = page;
 		this.selectAllCheckbox = page.getByText('Select All');
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -100,7 +100,7 @@ test(
 
 		await test.step('Check searching the available filters in filter dropdown', async () => {
 			await test.step('Open filter dropdown', async () => {
-				await fdsSamplePage.managementToolbar
+				await fdsSamplePage.managementToolbar.container
 					.getByRole('button', {name: 'Filter'})
 					.click();
 			});
@@ -162,7 +162,7 @@ test(
 			});
 
 			await test.step('Open filter dropdown', async () => {
-				await fdsSamplePage.managementToolbar
+				await fdsSamplePage.managementToolbar.container
 					.getByRole('button', {name: 'Filter'})
 					.click();
 			});
@@ -192,7 +192,7 @@ test(
 			});
 
 			await test.step('Select "Red" color in the filters dropdown', async () => {
-				await fdsSamplePage.managementToolbar
+				await fdsSamplePage.managementToolbar.container
 					.getByRole('button', {name: 'Filter'})
 					.click();
 
@@ -236,7 +236,7 @@ test(
 			});
 
 			await test.step('Check exclude switch for "Blue", "Green", "Yellow" colors', async () => {
-				await fdsSamplePage.managementToolbar
+				await fdsSamplePage.managementToolbar.container
 					.getByRole('button', {name: 'Filter'})
 					.click();
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../fixtures/loginTest';
+import getRandomString from '../../../../../utils/getRandomString';
+import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	fdsSamplePageTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test.beforeEach(async ({fdsSamplePage, page, site}) => {
+	await fdsSamplePage.setupFDSSampleWidget({site});
+
+	await fdsSamplePage.selectTab('Advanced');
+
+	await expect(
+		page.getByText('This is a description for sample 1.')
+	).toBeVisible();
+});
+
+test('Check Search clear button', async ({fdsSamplePage}) => {
+	const searchInput = fdsSamplePage.managementToolbar.searchInput;
+	const searchValue = getRandomString();
+
+	await test.step('Fill search input', async () => {
+		await searchInput.fill(searchValue);
+
+		await expect(searchInput).toHaveValue(searchValue);
+	});
+
+	await test.step('Clean search text by the input clear button', async () => {
+		const searchInputBox = await searchInput.boundingBox();
+
+		await searchInput.click({
+			position: {
+				x: searchInputBox.width - 10,
+				y: searchInputBox.height / 2,
+			},
+		});
+	});
+
+	await test.step('Check that input is empty', async () => {
+		await expect(searchInput).toHaveValue('');
+	});
+});


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-56877

<h1>Clear search query button</h1>

The goal of this PR is to provide a way for the user to clear easily their search term in FDS search input.

![image](https://github.com/user-attachments/assets/50dcfd16-ca67-4d35-b14d-2aceb737e34c)


:warning: Please, notice that the clear button is provided natively by the browser, so there will be differences between browsers. For example, Safari and Chrome shows a visually different ones, and Firefox doesn't shows it at all.