### PR TITLE
LPD-59484 Fix: Click on a table row of a not selectable Data Set open bulk action context bar

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -39,6 +39,7 @@ function Actions({
 		onInfoPanelToggleButtonClick,
 		openModal,
 		openSidePanel,
+		selectable,
 		selectedItemsKey,
 		selectedItemsValue,
 		toggleItemInlineEdit,
@@ -69,6 +70,7 @@ function Actions({
 		actions,
 		infoPanelOpen,
 		itemData,
+		selectable,
 		selectedItemsKey,
 		selectedItemsValue,
 	});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterItemActions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterItemActions.ts
@@ -5,6 +5,7 @@
 
 import {getLocalizedValue} from '../getLocalizedValue';
 import {IItemActionsDataFilter, IItemsActions} from '../types';
+import {ACTION_ITEM_TARGETS} from './constants';
 
 const hasPermission = (action: IItemsActions, itemData: any): boolean => {
 	if (!action?.data?.permissionKey) {
@@ -49,7 +50,11 @@ const isDisabled = (
 		return action.isDisabled(itemData);
 	}
 
-	if (infoPanelOpen && action.target === 'infoPanel' && selectedItem) {
+	if (
+		infoPanelOpen &&
+		action.target === ACTION_ITEM_TARGETS.INFO_PANEL &&
+		selectedItem
+	) {
 		return true;
 	}
 
@@ -64,7 +69,7 @@ const isVisible = (
 	if (
 		!hasPermission(action, itemData) ||
 		!matchesVisibilityFilters(action, itemData) ||
-		(action.target === 'infoPanel' && !selectable)
+		(action.target === ACTION_ITEM_TARGETS.INFO_PANEL && !selectable)
 	) {
 		return false;
 	}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterItemActions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/filterItemActions.ts
@@ -56,10 +56,15 @@ const isDisabled = (
 	return false;
 };
 
-const isVisible = (action: IItemsActions, itemData: any): boolean => {
+const isVisible = (
+	action: IItemsActions,
+	itemData: any,
+	selectable: boolean = false
+): boolean => {
 	if (
 		!hasPermission(action, itemData) ||
-		!matchesVisibilityFilters(action, itemData)
+		!matchesVisibilityFilters(action, itemData) ||
+		(action.target === 'infoPanel' && !selectable)
 	) {
 		return false;
 	}
@@ -108,12 +113,14 @@ const filterItemActions = ({
 	actions,
 	infoPanelOpen = false,
 	itemData,
+	selectable,
 	selectedItemsKey,
 	selectedItemsValue,
 }: {
 	actions: Array<IItemsActions>;
 	infoPanelOpen?: boolean;
 	itemData: any;
+	selectable?: boolean;
 	selectedItemsKey: string;
 	selectedItemsValue?: Array<any>;
 }): Array<IItemsActions> => {
@@ -123,7 +130,9 @@ const filterItemActions = ({
 
 	return actions
 		? actions
-				.filter((action: IItemsActions) => isVisible(action, itemData))
+				.filter((action: IItemsActions) =>
+					isVisible(action, itemData, selectable)
+				)
 				.map((action: IItemsActions) =>
 					transformAction({
 						action,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -68,6 +68,7 @@ const Card = forwardRef<HTMLDivElement, any>(
 				actions,
 				infoPanelOpen,
 				itemData: item,
+				selectable,
 				selectedItemsKey,
 				selectedItemsValue,
 			}) as any);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -99,14 +99,14 @@ const getVisibleFields = ({
 const Head = ({
 	fields,
 	items,
-	selectable,
 	selectionType,
 }: {
 	fields: Array<Field>;
 	items: Array<any>;
-	selectable?: boolean;
 	selectionType?: string;
 }) => {
+	const {selectable} = useContext(FrontendDataSetContext);
+
 	return (
 		<ClayTableHead
 			items={selectable ? [{fieldName: 'select'}, ...fields] : fields}
@@ -327,7 +327,6 @@ const Body = ({
 	items,
 	itemsActions,
 	onItemSelectionChange,
-	selectable,
 	selectionType,
 }: {
 	fields: Array<Field>;
@@ -339,11 +338,14 @@ const Body = ({
 	items: Array<any>;
 	itemsActions: Array<IItemsActions>;
 	onItemSelectionChange: Function;
-	selectable?: boolean;
 	selectionType?: string;
 }) => {
-	const {allItemsSelectedActive, selectedItemsKey, selectedItemsValue} =
-		useContext(FrontendDataSetContext);
+	const {
+		allItemsSelectedActive,
+		selectable,
+		selectedItemsKey,
+		selectedItemsValue,
+	} = useContext(FrontendDataSetContext);
 
 	const columns: Array<Field> = [
 		...(selectable ? [{fieldName: 'select'}] : []),
@@ -395,6 +397,7 @@ function ClayTableRowOptionalDropTarget({
 	onItemSelectionChange: Function;
 }) {
 	const [viewsContext] = useContext(ViewsContext);
+	const {selectable} = useContext(FrontendDataSetContext);
 
 	const {className: dropClassName, dropRef} = useFDSDrop({item});
 
@@ -404,12 +407,15 @@ function ClayTableRowOptionalDropTarget({
 		...otherProps,
 		className: classNames(className, dropClassName),
 		items,
-		onClick: () => {
-			onItemSelectionChange({
-				item,
-				trigger: ESelectionTrigger.CONTAINER,
-			});
-		},
+		onClick: selectable
+			? () => {
+					onItemSelectionChange({
+						item,
+						trigger: ESelectionTrigger.CONTAINER,
+					});
+				}
+			: undefined,
+		ref: dropRef,
 	};
 
 	return (
@@ -418,7 +424,6 @@ function ClayTableRowOptionalDropTarget({
 				...props,
 				...(activeView.setItemComponentProps?.({item, props}) ?? {}),
 			}}
-			ref={dropRef}
 		>
 			{children}
 		</ClayTableRow>
@@ -859,7 +864,6 @@ const Table = ({
 				<Head
 					fields={schema.fields as Array<Field>}
 					items={items}
-					selectable={selectable}
 					selectionType={selectionType}
 				/>
 
@@ -870,7 +874,6 @@ const Table = ({
 					items={items}
 					itemsActions={itemsActions}
 					onItemSelectionChange={onItemSelectionChange}
-					selectable={selectable}
 					selectionType={selectionType}
 				/>
 			</ClayTable>

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/clientExtensionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/clientExtensionFilters.spec.ts
@@ -181,6 +181,8 @@ test(
 			});
 
 			await filtersPage.saveAddFilterForm();
+
+			await waitForAlert(page);
 		});
 
 		await test.step('Check that the client extension filter is in the list and it is "Active" by default', async () => {


### PR DESCRIPTION
Follow up from: https://github.com/liferay-frontend/liferay-portal/pull/5003

Issue: https://liferay.atlassian.net/browse/LPD-59484

<h1>Click on a table row of a not selectable Data Set open bulk action context bar</h1>

This PR is a fix for a bug that user could click on a not selectable Data Set.