### PR TITLE
LPD-60234 Add accessible text to FDS empty table header

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -122,7 +122,9 @@ const Head = ({
 								textValue="select-item"
 								width="51px"
 							>
-								{null}
+								<span className="sr-only">
+									{Liferay.Language.get('item-selection')}
+								</span>
 							</ClayTableCell>
 						);
 					}
@@ -136,7 +138,13 @@ const Head = ({
 						sortable={(field as any).sortable}
 						textValue="select"
 					>
-						{(field as any).label}
+						{field.label || (
+							<span className="sr-only">
+								{field.fieldName === 'select'
+									? Liferay.Language.get('item-selection')
+									: field.fieldName}
+							</span>
+						)}
 					</HeadCellResizer>
 				);
 			}}
@@ -829,6 +837,9 @@ const Table = ({
 					columnsVisibility: Liferay.Language.get(
 						'manage-columns-visibility'
 					),
+					columnsVisibilityCell: itemsActions?.length
+						? Liferay.Language.get('item-actions')
+						: undefined,
 					columnsVisibilityDescription: Liferay.Language.get(
 						'at-least-one-column-must-remain-visible'
 					),

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -135,8 +135,8 @@ const Head = ({
 						className={getCellColumnClassName(field.fieldName)}
 						columnName={field.fieldName}
 						key={field.fieldName}
-						sortable={(field as any).sortable}
-						textValue="select"
+						sortable={field.sortable}
+						textValue={field.fieldName}
 					>
 						{field.label || (
 							<span className="sr-only">

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/customDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/customDataSets.spec.ts
@@ -121,7 +121,7 @@ async function assertTableColumnLabels(customDataSetsPage: CustomDataSetsPage) {
 		'REST Schema',
 		'REST Endpoint',
 		'Modified Date',
-		'Manage Columns Visibility',
+		'Item Actions',
 	];
 
 	expect(tableColumnLabels).toEqual(expectedLabels);

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/dataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/dataSets.spec.ts
@@ -519,7 +519,7 @@ test(
 					.first()
 					.locator('td')
 					.allInnerTexts()
-			).toEqual(['Topic', '0', 'Manage Columns Visibility']);
+			).toEqual(['Topic', '0', '']);
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/classic/localization.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/classic/localization.spec.ts
@@ -65,7 +65,7 @@ test(
 				'Nombre',
 				'Apellido',
 				'Dirección de correo',
-				'Administrar la visibilidad de las columnas',
+				'Acciones del elemento',
 			]);
 		});
 	}


### PR DESCRIPTION
**Bug:** https://liferay.atlassian.net/browse/LPD-59500
**Subtask:** https://liferay.atlassian.net/browse/LPD-60234

---

This adds `sr-only` text to the FDS table headers "Item Selection" and "Item Actions."

A change was sent to the Clay repo which adds a new `columnsVisibilityCell` message to add customized text where the column visibility header cell aligned with the row table actions. By default the `columnsVisibility` message is used for the `sr-only` header cell.
- **PR:** https://github.com/liferay/clay/pull/6103
- **Release version:** https://github.com/liferay/clay/releases/tag/v3.141.0

<img width="1225" height="330" alt="Screenshot 2025-07-10 at 4 44 35 PM" src="https://github.com/user-attachments/assets/52c4757c-d15c-47a8-a9b8-1fec260bed7f" />

⚠️ `ci:test:sf` Fails because of the missing `columnsVisibilityCell` not yet on master. If this needs to be forwarded sooner I can add a `@ts-ignore` in the meantime and create a task to remove it once it's on master.