### PR TITLE
LPD-61085 Increase pageSize to 100

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
@@ -29,6 +29,7 @@ import {
 	DEFAULT_FETCH_HEADERS,
 	FUZZY_OPTIONS,
 	OBJECT_RELATIONSHIP,
+	PAGE_SIZE,
 } from '../../../utils/constants';
 import openDefaultFailureToast from '../../../utils/openDefaultFailureToast';
 import openDefaultSuccessToast from '../../../utils/openDefaultSuccessToast';
@@ -372,7 +373,7 @@ function Table(props: IDataSetSectionProps & {title?: string}) {
 
 	const getFDSFields = async () => {
 		const response = await fetch(
-			`${API_URL.TABLE_SECTIONS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_TABLE_SECTIONS_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_TABLE_SECTIONS}&sort=dateCreated:asc`,
+			`${API_URL.TABLE_SECTIONS}?filter=(${OBJECT_RELATIONSHIP.DATA_SET_TABLE_SECTIONS_ID} eq '${dataSet.id}')&nestedFields=${OBJECT_RELATIONSHIP.DATA_SET_TABLE_SECTIONS}&pageSize=${PAGE_SIZE}&sort=dateCreated:asc`,
 			{
 				headers: DEFAULT_FETCH_HEADERS,
 			}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/constants.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/constants.ts
@@ -81,6 +81,8 @@ const DEFAULT_VISUALIZATION_MODES: Array<IBaseVisualizationMode<any>> = [
 
 const ALLOWED_ENDPOINTS_PARAMETERS = ['scopeKey', 'siteId', 'userId'];
 
+const PAGE_SIZE = '100';
+
 export {
 	API_URL,
 	DEFAULT_VISUALIZATION_MODES,
@@ -89,4 +91,5 @@ export {
 	DEFAULT_FETCH_HEADERS,
 	OBJECT_RELATIONSHIP,
 	ALLOWED_ENDPOINTS_PARAMETERS,
+	PAGE_SIZE,
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts
@@ -5,7 +5,7 @@
 
 import {fetch} from 'frontend-js-web';
 
-import {DEFAULT_FETCH_HEADERS} from './constants';
+import {DEFAULT_FETCH_HEADERS, PAGE_SIZE} from './constants';
 import openDefaultFailureToast from './openDefaultFailureToast';
 import {IPickList} from './types';
 
@@ -14,7 +14,7 @@ export default async function getAllPicklists(
 	items: IPickList[] = []
 ) {
 	const response = await fetch(
-		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=100&page=${page}`,
+		`/o/headless-admin-list-type/v1.0/list-type-definitions?pageSize=${PAGE_SIZE}&page=${page}`,
 		{
 			headers: DEFAULT_FETCH_HEADERS,
 		}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-admin/visualizationModes.spec.ts
@@ -1441,4 +1441,128 @@ test.describe('Visualization Modes in Data Set Manager', () => {
 			});
 		}
 	);
+
+	test('Check more than 20 fields can be added @LPD-61085', async ({
+		page,
+		visualizationModesPage,
+	}) => {
+		await test.step('Add 21 fields', async () => {
+			await visualizationModesPage.goto({
+				dataSetLabel,
+			});
+
+			await visualizationModesPage.selectTab('Table');
+
+			await page.getByText('Add Fields', {exact: true}).click();
+
+			await page
+				.getByRole('menuitem', {name: 'Assign from Data Source'})
+				.click();
+
+			await page
+				.getByRole('treeitem', {name: 'auditEvents'})
+				.getByRole('checkbox')
+				.click();
+
+			await page
+				.getByRole('treeitem', {name: 'creator'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'dateCreated'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'dateModified'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'defaultLanguageId'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'displayDate'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'expirationDate'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {
+					exact: true,
+					name: 'externalReferenceCode',
+				})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'friendlyUrlPath'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {exact: true, name: 'id'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'keywords'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {
+					name: 'objectEntryFolderExternalReferenceCode',
+				})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'objectEntryFolderId'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'permissions'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'reviewDate'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'scopeId'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'status'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'taxonomyCategoryBriefs'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'taxonomyCategoryIds'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'active'})
+				.getByRole('checkbox')
+				.click();
+			await page
+				.getByRole('treeitem', {name: 'fieldName'})
+				.getByRole('checkbox')
+				.click();
+
+			await page.getByRole('button', {name: 'Save'}).click();
+
+			const toastContainer = page.locator('.alert-container');
+
+			await expect(toastContainer.getByText('Success')).toBeInViewport();
+
+			await page.getByTitle('New').click();
+
+			await page
+				.getByRole('menuitem', {name: 'Assign from Data Source'})
+				.click();
+
+			await expect(page.getByText('Items Selected')).toContainText('21');
+		});
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-61085
https://liferay.atlassian.net/browse/LPP-59689

The data set fields are limited and users cannot add more than 20 fields.

To resolve this, I added pageSize to 100, which matches the pageSize of [pickLists](https://github.com/liferay-frontend/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getAllPicklists.ts#L17).

I also tested with 100 fields and was not able to notice any slow down when data set is on a page.

Please let me know if there are any questions or comments about this.
Thank you!