### PR TITLE
LPD-61055 Images selected from document library might bring some query parameters

### DIFF
--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
@@ -161,7 +161,7 @@ test(
 		});
 
 		await expect(ckeditor4Page.contextMenu.getByLabel('URL')).toHaveValue(
-			(new RegExp('^/documents/d/guest/satellite-png'))
+			new RegExp('^/documents/d/guest/satellite-png')
 		);
 
 		await ckeditor4Page.contextMenu.getByText('OK').click();

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor4/classic.spec.ts
@@ -161,14 +161,14 @@ test(
 		});
 
 		await expect(ckeditor4Page.contextMenu.getByLabel('URL')).toHaveValue(
-			'/documents/d/guest/satellite-png'
+			(new RegExp('^/documents/d/guest/satellite-png'))
 		);
 
 		await ckeditor4Page.contextMenu.getByText('OK').click();
 
 		await expect(
 			ckeditor4Page.editableFrame.locator(
-				'img[src="/documents/d/guest/satellite-png"]'
+				'img[src^="/documents/d/guest/satellite-png"]'
 			)
 		).toBeVisible();
 	}


### PR DESCRIPTION
Hi,

This test started failing after LPD-59008 which is adding `previewCTCollectionId` parameter to document's url.

Thanks.

Regards.