### PR TITLE
LPD-47209 Ensure CK Editor 5 uses Clay icons

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -2,6 +2,7 @@
 
 :root {
 	--ck-font-family: $font-family-base;
+	--ck-icon-font-size: 0.67em;
 }
 
 .lfr-ck .ck {

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/IconsModifier.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/IconsModifier.tsx
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AlignmentCommand, Plugin} from 'ckeditor5';
+
+import getIcon from '../utils/getIcon';
+
+/**
+ * Mapping between names of CKEditor components and Clay icon symbols
+ */
+const COMPONENT_SYMBOL: Record<string, string | null> = {
+	accessibilityHelp: 'accessibility',
+	alignment: 'align-left',
+	blockQuote: 'quote-left',
+	bold: 'bold',
+	bulletedList: 'list-ul',
+	fontBackgroundColor: 'textbox',
+	fontColor: 'text-color',
+	fontFamily: 'font-family',
+	fontSize: 'font-size',
+	horizontalLine: 'hr',
+	indent: 'indent-more',
+	insertTable: 'table2',
+	italic: 'italic',
+	link: 'link',
+	numberedList: 'list-ol',
+	outdent: 'indent-less',
+	redo: 'redo',
+	removeFormat: 'remove-style',
+	sourceEditing: 'code',
+	strikethrough: 'strikethrough',
+	undo: 'undo',
+};
+
+class IconsModifier extends Plugin {
+	init() {
+		const editor = this.editor;
+
+		const componentFactory = editor.ui.componentFactory;
+
+		const componentNames = Array.from(componentFactory.names());
+
+		componentNames.forEach((componentName: string) => {
+			const symbol = COMPONENT_SYMBOL[componentName];
+
+			if (!symbol) {
+				return;
+			}
+
+			// @ts-ignore
+
+			const component = componentFactory._components.get(
+				componentName.toLowerCase()
+			);
+
+			if (!component) {
+				return;
+			}
+
+			componentFactory.add(componentName, (locale) => {
+				const componentInstance = component.callback(locale);
+
+				const componentType = componentInstance.constructor.name;
+
+				if (componentName === 'alignment') {
+					const command: AlignmentCommand =
+						editor.commands.get('alignment')!;
+
+					const alignIcons: Record<string, string> = {
+						center: getIcon({symbol: 'align-center'}),
+						justify: getIcon({symbol: 'align-justify'}),
+						left: getIcon({symbol: 'align-left'}),
+						right: getIcon({symbol: 'align-right'}),
+					};
+
+					componentInstance.buttonView.unbind('icon');
+
+					componentInstance.buttonView
+						.bind('icon')
+						.to(
+							command,
+							'value',
+							(value: string) =>
+								alignIcons[value] ||
+								getIcon({symbol: 'align-left'})
+						);
+
+					componentInstance.on('change:isOpen', () => {
+						const buttons =
+							componentInstance.panelView.children.first.items
+								._items;
+
+						const alignmentOptions =
+							editor.config.get('alignment.options')!;
+
+						for (let i = 0; i < alignmentOptions.length; i++) {
+							buttons[i].set({
+								icon: alignIcons[alignmentOptions[i] as string],
+							});
+						}
+					});
+				}
+				else if (componentType === 'ButtonView') {
+					componentInstance.set({
+						icon: getIcon({symbol}),
+					});
+				}
+				else if (componentType === '_DropdownView') {
+					componentInstance.buttonView.set({
+						icon: getIcon({symbol}),
+					});
+
+					componentInstance.buttonView.arrowView.set({
+						content: getIcon({symbol: 'angle-down'}),
+					});
+				}
+
+				return componentInstance;
+			});
+
+			componentFactory.create(componentName);
+		});
+	}
+}
+
+export default IconsModifier;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/plugins/ItemSelector.tsx
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {ButtonView, Command, Config, Plugin, icons} from 'ckeditor5';
+import {ButtonView, Command, Config, Plugin} from 'ckeditor5';
 import {openSelectionModal} from 'frontend-js-components-web';
 
+import getIcon from '../utils/getIcon';
 import {LiferayEditorConfig} from '../utils/types';
 
 class ItemSelector extends Plugin {
@@ -29,7 +30,7 @@ class ItemSelector extends Plugin {
 				const buttonView = new ButtonView();
 
 				buttonView.set({
-					icon: icons.image,
+					icon: getIcon({symbol: 'picture'}),
 					label: Liferay.Language.get('image'),
 					tooltip: true,
 				});
@@ -80,13 +81,8 @@ class ItemSelector extends Plugin {
 			editor.ui.componentFactory.add('videoSelector', () => {
 				const buttonView = new ButtonView();
 
-				const videoIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 20">
-					<path d="M1.587 1.5c-.612 0-.601-.029-.601.551v14.84c0 .59-.01.559.591.559h18.846c.602 0 .591.03.591-.56V2.052c0-.58.01-.55-.591-.55H1.587Zm.701.971h1.003v1H2.288v-1Zm16.448 0h1.003v1h-1.003v-1Zm-14.24 1h13.008v12H4.467l.029-12Zm-2.208 1h1.003v1H2.288v-1Zm16.448 0h1.003v1h-1.003v-1Zm-16.448 2h1.003v1H2.288v-1Zm16.448 0h1.003v1h-1.003v-1Zm-16.448 2h1.003v1H2.288v-1Zm16.448 0h1.003v1h-1.003v-1Zm-16.448 2h1.003v1H2.288v-1Zm16.448 0h1.003v1h-1.003v-1Zm-16.448 2h1.003l-.029 1h-.974v-1Zm16.448 0h1.003v1h-1.003v-1Zm-16.448 2h.974v1h-.974v-1Zm16.448 0h1.003v1h-1.003v-1Z"></path>
-					<path d="M8.374 6.648a.399.399 0 0 1 .395-.4.402.402 0 0 1 .2.049l5.148 2.824a.4.4 0 0 1 0 .7l-5.148 2.824a.403.403 0 0 1-.595-.35V6.648Z"></path>
-				</svg>`;
-
 				buttonView.set({
-					icon: videoIcon,
+					icon: getIcon({symbol: 'video'}),
 					label: Liferay.Language.get('video'),
 					tooltip: true,
 				});

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -39,6 +39,7 @@ import {
 } from 'ckeditor5';
 import {sub} from 'frontend-js-web';
 
+import IconsModifier from '../plugins/IconsModifier';
 import ItemSelector from '../plugins/ItemSelector';
 import {EEditorConfigPreset, EEditorVariant} from './types';
 
@@ -70,7 +71,7 @@ const getDefaultEditorConfig = ({
 
 	if (preset === EEditorConfigPreset.BASIC) {
 		const basicEditorConfig: EditorConfig = {
-			plugins: basicPlugins,
+			plugins: [...basicPlugins, IconsModifier],
 			toolbar: {
 				items: [
 					'undo',
@@ -124,6 +125,11 @@ const getDefaultEditorConfig = ({
 	if (editorVariant === EEditorVariant.CLASSIC) {
 		advancedPlugins.push(SourceEditing);
 	}
+
+	// Add IconsModifier as the last plugin in array. That way it will
+	// initialize last, and be able to modify all other plugin instances.
+
+	advancedPlugins.push(IconsModifier);
 
 	const toolbarItems = [
 		'undo',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getIcon.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getIcon.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const getIcon = ({symbol}: {symbol: string}): string => {
+	return `<svg xmlns="http://www.w3.org/2000/svg">
+		<use href="${Liferay.Icons.spritemap}#${symbol}" />
+	</svg>`;
+};
+
+export default getIcon;

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/classic.spec.ts
@@ -96,6 +96,12 @@ test(
 				classicPage.toolbar.buttonLabels.getByLabel('Underline')
 			).toBeHidden();
 		});
+
+		await test.step('Toolbar buttons have Clay icons', async () => {
+			await expect(
+				classicPage.toolbar.container.locator('svg use[href*="/clay/"]')
+			).toHaveCount(23);
+		});
 	}
 );
 


### PR DESCRIPTION
### References

- Parent Story: https://liferay.atlassian.net/browse/LPD-47207

### What is the goal of this PR?

Replacing default CKE5 icons with Clay icons.

See technical notes inline.

### What does it look like?

#### Before PR
<img width="1267" height="307" alt="before" src="https://github.com/user-attachments/assets/dc49efd1-fdbd-4bff-ae5c-7751e0ca36ae" />

#### After PR
<img width="1266" height="308" alt="after" src="https://github.com/user-attachments/assets/67884fde-35b6-40b2-b1e6-8d8a9489c0cf" />
