### PR TITLE
LPD-60696 CKEditor fails to load when adding a Rich Text field

### DIFF
--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v2_0/util/DataDefinitionFieldUtil.java
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/java/com/liferay/data/engine/rest/internal/dto/v2_0/util/DataDefinitionFieldUtil.java
@@ -26,6 +26,7 @@ import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.editor.configuration.EditorConfiguration;
 import com.liferay.portal.kernel.editor.configuration.EditorConfigurationFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -96,7 +97,9 @@ public class DataDefinitionFieldUtil {
 
 		EditorConfiguration editorConfiguration =
 			EditorConfigurationFactoryUtil.getEditorConfiguration(
-				StringPool.BLANK, ddmFormFieldType, "ckeditor_classic",
+				StringPool.BLANK, ddmFormFieldType,
+				FeatureFlagManagerUtil.isEnabled("LPD-11235") ?
+					"ckeditor5_classic" : "ckeditor_classic",
 				new HashMap<>(), themeDisplay,
 				RequestBackedPortletURLFactoryUtil.create(httpServletRequest));
 


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-60696

<h1>CKEditor fails to load when adding a Rich Text field</h1>

This PR fixes a bug that Rich Text fields crash the first time they are added to a fragment

<img width="842" height="157" alt="Screenshot 2025-07-15 at 09 39 32" src="https://github.com/user-attachments/assets/8ac87217-e92f-4bd5-a8a2-c3db1a75a660" />
