### PR TITLE
FDS delegated mode and selection without bulkActions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/ReactFrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/ReactFrontendDataSet.tsx
@@ -3,8 +3,11 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import Button from '@clayui/button';
+import Icon from '@clayui/icon';
 import {
 	DisplayType,
+	FDS_EVENT,
 	FrontendDataSet,
 	IFrontendDataSetProps,
 } from '@liferay/frontend-data-set-web';
@@ -61,7 +64,24 @@ const ReactFrontendDataSet = (props: IFrontendDataSetProps) => {
 
 	props.views.push(listView);
 
-	return <FrontendDataSet {...props} />;
+	return (
+		<>
+			<Button
+				displayType="danger"
+				onClick={() => {
+					Liferay.fire(FDS_EVENT.CLEAR_SELECTION);
+				}}
+				size="sm"
+			>
+				<span className="inline-item inline-item-before">
+					<Icon symbol="trash" />
+				</span>
+				Clear selection
+			</Button>
+
+			<FrontendDataSet {...props} />
+		</>
+	);
 };
 
 export default ReactFrontendDataSet;

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/react.jsp
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/partials/react.jsp
@@ -20,6 +20,12 @@ ReactFDSDisplayContext reactFDSDisplayContext = new ReactFDSDisplayContext(reque
 			).put(
 				"id", FDSSampleFDSNames.REACT
 			).put(
+				"mode", "delegated"
+			).put(
+				"selectedItemsKey", "id"
+			).put(
+				"selectionType", "multiple"
+			).put(
 				"style", "fluid"
 			).put(
 				"views", reactFDSDisplayContext.getViews()

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -126,7 +126,7 @@ const FrontendDataSetContent = ({
 	portletId,
 	selectedItems: initialSelectedItemsValues,
 	selectedItemsKey = 'id',
-	selectionType = 'multiple',
+	selectionType = 'none',
 	showBulkActionsManagementBar = true,
 	showBulkActionsManagementBarActions = true,
 	showManagementBar = true,
@@ -1158,9 +1158,8 @@ const FrontendDataSetContent = ({
 		}
 	};
 
-	const selectable = Boolean(
-		selectedItemsKey && (bulkActions?.length || selectionType === 'single')
-	);
+	const selectable =
+		selectionType === 'multiple' || selectionType === 'single';
 
 	const {className} = useFDSDrop({
 		targetDropRef: dataSetWrapperRef,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -114,6 +114,7 @@ const FrontendDataSetContent = ({
 	inlineEditingSettings,
 	items: itemsProp,
 	itemsActions,
+	mode = 'normal',
 	namespace,
 	nestedItemsKey,
 	nestedItemsReferenceKey,
@@ -477,17 +478,20 @@ const FrontendDataSetContent = ({
 		}
 	}, [itemsProp]);
 
-	function deselectItems(value: any) {
-		if (Array.isArray(value)) {
-			return setSelectedItemsValue(
-				selectedItemsValue.filter((item) => !value.includes(item))
-			);
-		}
+	const deselectItems = useCallback(
+		(value: any) => {
+			if (Array.isArray(value)) {
+				return setSelectedItemsValue(
+					selectedItemsValue.filter((item) => !value.includes(item))
+				);
+			}
 
-		setSelectedItemsValue(
-			selectedItemsValue.filter((item) => item !== value)
-		);
-	}
+			setSelectedItemsValue(
+				selectedItemsValue.filter((item) => item !== value)
+			);
+		},
+		[selectedItemsValue]
+	);
 
 	function selectItems({
 		trigger,
@@ -756,6 +760,12 @@ const FrontendDataSetContent = ({
 		};
 	}, [id, refreshData]);
 
+	useEffect(() => {
+		Liferay.on(EVENTS.CLEAR_SELECTION, () =>
+			deselectItems(selectedItemsValue)
+		);
+	}, [deselectItems, selectedItemsValue]);
+
 	const managementBar = showManagementBar ? (
 		<div className="management-bar-wrapper">
 			<ManagementBar
@@ -770,6 +780,7 @@ const FrontendDataSetContent = ({
 				}}
 				fluid={style === 'fluid'}
 				items={items}
+				mode={mode}
 				onBulkActionsClear={() => {
 					deselectItems(selectedItemsValue);
 
@@ -1190,6 +1201,7 @@ const FrontendDataSetContent = ({
 				itemsChanges,
 				loadData: refreshData,
 				modalId: dataSetSupportModalIdRef.current,
+				mode,
 				namespace,
 				nestedItemsKey,
 				nestedItemsReferenceKey,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSetContext.tsx
@@ -50,6 +50,7 @@ export interface IFrontendDataSetContext {
 	itemsChanges?: {[key: string]: any};
 	loadData: Function;
 	modalId?: string;
+	mode?: string;
 	namespace?: string;
 	nestedItemsKey?: string;
 	nestedItemsReferenceKey?: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -16,6 +16,7 @@ function ManagementBar({
 	deselectItems,
 	fluid,
 	items,
+	mode,
 	onBulkActionsClear,
 	onSelectAll,
 	selectItems,
@@ -43,7 +44,7 @@ function ManagementBar({
 
 	return (
 		<>
-			{selectionType === 'multiple' && (
+			{mode === 'normal' && selectionType === 'multiple' && (
 				<BulkActions
 					bulkActions={bulkActions}
 					deselectItems={deselectItems}
@@ -62,11 +63,14 @@ function ManagementBar({
 				/>
 			)}
 
-			{(!selectedItemsValue.length || selectionType === 'single') && (
+			{(mode === 'delegated' ||
+				!selectedItemsValue.length ||
+				selectionType === 'single') && (
 				<NavBar
 					creationMenu={creationMenu}
 					handleCheckboxClick={handleCheckboxClick}
 					items={items}
+					pageSelectedItemsValue={pageSelectedItemsValue}
 					showSearch={showSearch}
 				/>
 			)}
@@ -93,6 +97,7 @@ ManagementBar.propTypes = {
 	deselectItems: PropTypes.func.isRequired,
 	fluid: PropTypes.bool,
 	items: PropTypes.array.isRequired,
+	mode: PropTypes.string,
 	onBulkActionsClear: PropTypes.func.isRequired,
 	onSelectAll: PropTypes.func.isRequired,
 	pageSelectedItemsValue: PropTypes.array,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -100,7 +100,7 @@ ManagementBar.propTypes = {
 	selectedItems: PropTypes.array,
 	selectedItemsKey: PropTypes.string,
 	selectedItemsValue: PropTypes.array,
-	selectionType: PropTypes.oneOf(['single', 'multiple']),
+	selectionType: PropTypes.oneOf(['single', 'multiple', 'none']),
 	showSearch: PropTypes.bool,
 	showSelectAll: PropTypes.bool,
 	total: PropTypes.number,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js
@@ -75,7 +75,7 @@ function ManagementBar({
 				/>
 			)}
 
-			<ActiveFiltersBar disabled={!!selectedItemsValue.length} />
+			<ActiveFiltersBar disabled={!!selectedItemsValue.length && mode === 'normal'} />
 		</>
 	);
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/NavBar.js
@@ -20,7 +20,13 @@ import SelectionCheckbox from './SelectionCheckbox';
 import SortDropdown from './SortDropdown';
 import FiltersDropdown from './filters/FiltersDropdown';
 
-function NavBar({creationMenu, handleCheckboxClick, items, showSearch}) {
+function NavBar({
+	creationMenu,
+	handleCheckboxClick,
+	items,
+	pageSelectedItemsValue,
+	showSearch,
+}) {
 	const {selectable, selectionType, showInfoPanel} = useContext(
 		FrontendDataSetContext
 	);
@@ -43,7 +49,7 @@ function NavBar({creationMenu, handleCheckboxClick, items, showSearch}) {
 							<SelectionCheckbox
 								handleCheckboxClick={handleCheckboxClick}
 								items={items}
-								selectedItemsValue={[]}
+								selectedItemsValue={pageSelectedItemsValue}
 							/>
 						</ManagementToolbar.Item>
 					)}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/eventsDefinitions.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/eventsDefinitions.ts
@@ -4,6 +4,7 @@
  */
 
 export const AUTOCOMPLETE_VALUE_UPDATED = 'autocomplete-updated';
+export const CLEAR_SELECTION = 'fds-clear-selection';
 export const CLOSE_MODAL = 'close-modal';
 export const CLOSE_SIDE_PANEL = 'close-side-panel';
 export const CURRENT_PRODUCT_STATUS_CHANGED = 'current-product-status-changed';
@@ -19,6 +20,7 @@ export const SIDE_PANEL_CLOSED = 'side-panel-closed';
 const EVENTS = {
 	ACTION_PERFORMED: 'fds-action-performed',
 	AUTOCOMPLETE_VALUE_UPDATED,
+	CLEAR_SELECTION,
 	CLOSE_MODAL,
 	CLOSE_SIDE_PANEL,
 	CURRENT_PRODUCT_STATUS_CHANGED,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -294,6 +294,7 @@ export interface IFrontendDataSetProps {
 	inlineEditingSettings?: IInlineEditingSettings;
 	items?: any[];
 	itemsActions?: IItemsActions[];
+	mode?: 'delegated' | 'normal';
 	namespace?: string;
 	nestedItemsKey?: string;
 	nestedItemsReferenceKey?: string;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -310,7 +310,7 @@ export interface IFrontendDataSetProps {
 	portletId?: string;
 	selectedItems?: any[];
 	selectedItemsKey?: string;
-	selectionType?: 'single' | 'multiple';
+	selectionType?: 'single' | 'multiple' | 'none';
 	showBulkActionsManagementBar?: boolean;
 	showBulkActionsManagementBarActions?: boolean;
 	showManagementBar?: boolean;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -173,7 +173,8 @@ const Card = forwardRef<HTMLDivElement, any>(
 					}
 				: undefined,
 			onSelectChange: selectable ? () => undefined : undefined,
-			selectableType: selectionType === 'single' ? 'radio' : 'checkbox',
+			selectableType:
+				selectable && selectionType === 'single' ? 'radio' : 'checkbox',
 			selected:
 				selectable &&
 				!!selectedItemsValue?.find(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.tsx
@@ -84,7 +84,7 @@ const ListItem = forwardRef<HTMLLIElement, any>(
 			schema;
 
 		const SelectionInput =
-			selectionType === 'single' ? ClayRadio : ClayCheckbox;
+			selectable && selectionType === 'single' ? ClayRadio : ClayCheckbox;
 
 		const itemId = item[selectedItemsKey || 'id'];
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -161,12 +161,12 @@ const Row = ({
 	onItemSelectionChange: Function;
 	selectionType?: string;
 }) => {
-	const {itemsChanges, selectedItemsKey, updateItem} = useContext(
+	const {itemsChanges, selectable, selectedItemsKey, updateItem} = useContext(
 		FrontendDataSetContext
 	);
 
 	const SelectionComponent =
-		selectionType === 'multiple' ? ClayCheckbox : ClayRadio;
+		selectable && selectionType === 'multiple' ? ClayCheckbox : ClayRadio;
 
 	const id = item[selectedItemsKey ?? 'id'];
 
@@ -218,7 +218,7 @@ const Row = ({
 								key={`${id}:select`}
 								textValue={Liferay.Language.get('select-item')}
 							>
-								{!item.editable && (
+								{!item.editable && SelectionComponent && (
 									<SelectionComponent
 										checked={active}
 										onChange={() =>


### PR DESCRIPTION
## Related
[Item Selector - Multiple Selection](https://liferay.atlassian.net/browse/LPD-40536)


## Context
The new Item Selector that uses the FDS component has specific requirements that do not match the actual behavior and design of the actual default component. Those are:
- allow selecting items (actual behavior needs `selectionType="multiple"` and a collection of `bulkActions` to be defined
- allow clearing the selected items from a different place (footer of the modal that contains the FDS instead of the bulkActions bar)
- allow users filtering, ordering or searching while keeping the current selection (actual behavior/design prevents users from changing items in the current view by hiding management bar controls)

<img width="953" height="588" alt="Screenshot from 2025-07-23 13-44-37" src="https://github.com/user-attachments/assets/daee7ef1-7d8e-4d7f-8399-feea023f63ad" />

## Multiple selection without bulkActions
After considering different options ([see Slack thread](https://liferay.slack.com/archives/C3JBR21HA/p1752840815767579)) I've decided to use the current `selectionType` to let the component know when to show selection controls (checkbox, radio or none) as it makes it easy to have the calculated `selectable` variable across the component.

## Clear of selection from external control
To achieve this requirement my proposal is to set a `mode` prop in the FDS component that defaults to `normal` and will work as we know as of today and a `delegated` when we want to have (at least for now) the clear option available from outside of the main FDS component.
The implementation of this control is through an `event` that will trigger the `deselectItems` method available in the FDS component. The drawback of this option is the need of another `useEffect` that I know Marko will hate :smile: .

## UI
https://github.com/user-attachments/assets/6c6c37c1-7287-4d52-8df4-1c5d46c6fef1


## Selection & filtering 

https://github.com/user-attachments/assets/00e82c39-8edd-49eb-aa6b-66a62d65434a



