### PR TITLE
LPD-60980 When pasting text to CKEditor 5 from Google Docs, text is always bold

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
@@ -17,6 +17,7 @@ module.exports = {
 			'BlockQuote',
 			'BlockToolbar',
 			'Bold',
+			'Bookmark',
 			'ButtonView',
 			'ClassicEditor',
 			'Command',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/node-scripts.config.js
@@ -40,6 +40,7 @@ module.exports = {
 			'List',
 			'MediaEmbed',
 			'Paragraph',
+			'PasteFromOffice',
 			'Plugin',
 			'RemoveFormat',
 			'SourceEditing',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -27,6 +27,7 @@ import {
 	List,
 	MediaEmbed,
 	Paragraph,
+	PasteFromOffice,
 	RemoveFormat,
 	SourceEditing,
 	Strikethrough,
@@ -59,6 +60,7 @@ const getDefaultEditorConfig = ({
 		Link,
 		List,
 		Paragraph,
+		PasteFromOffice,
 		Underline,
 	];
 

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -462,6 +462,7 @@ module.exports = {
 			'List',
 			'MediaEmbed',
 			'Paragraph',
+			'PasteFromOffice',
 			'Plugin',
 			'RemoveFormat',
 			'SourceEditing',

--- a/modules/node-scripts.config.js
+++ b/modules/node-scripts.config.js
@@ -10,7 +10,7 @@
  */
 
 module.exports = {
-	hash: 'e0c3b7ab45d91780f5628568407d67f0e5ad6e1ab7bd3b5f761790631084aa5e',
+	hash: '8d79980a735c8659e0682e35da75ebfc98591ae7d6b5dd9864f78351a4ab296a',
 	imports: {
 		'@liferay/accessibility-menu-web': [],
 		'@liferay/accessibility-settings-state-web': [],


### PR DESCRIPTION
### References

- JIRA: https://liferay.atlassian.net/browse/LPD-60980

### What is the goal of this PR?

The ticket is a bug, but the issue is really a missing "PasteFromOffice" plugin. We are enabling it in the PR.

Note that there is still some minor style differences, caused by inline styles like different font in GoogleDocs. But this I believe is expected behavior.

Test for this is not needed, as this is behavior of official plugin.

### What does it look like?

https://github.com/user-attachments/assets/b91f9430-584b-4b20-9881-502cc146d2cf



