### PR TITLE
LPD-59005 Add Card border on :hover and :active states

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_cards.scss
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/styles/views/_cards.scss
@@ -18,6 +18,7 @@
 
 		&:hover .card {
 			background-color: $light;
+			border: 1px solid $primary-color;
 		}
 
 		&.active {
@@ -27,6 +28,7 @@
 
 			.card {
 				background-color: $primary-l3;
+				border: 1px solid $primary-color;
 			}
 		}
 	}


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-58652

<h1>Add Card border on :hover and :active states</h1>

The goal of this PR is to add a border on Cards to match design:

<img width="1097" height="404" alt="image" src="https://github.com/user-attachments/assets/16a2c5d3-d39a-4e11-a472-173bf6d8ceb5" />
