### PR TITLE
LPD-62033 Error appears twice when a user views pages without permissions

### DIFF
--- a/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.servlet.TempAttributesServletRequest;
 import com.liferay.portal.kernel.struts.LastPath;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.LayoutTypeAccessPolicyTracker;
@@ -418,7 +417,7 @@ public class SecurityPortletContainerWrapper implements PortletContainer {
 				SecurityPortletContainerWrapper.class.getName(),
 				"#SKIP_SHOW_PORTLET_ACCESS_DENIED#", portlet.getPortletId());
 
-			if (ParamUtil.getBoolean(httpServletRequest, key)) {
+			if (Boolean.TRUE.equals(httpServletRequest.getAttribute(key))) {
 				return;
 			}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-62033

This is more as a follow-up to the additional formatting changes made by BChan in this PR: https://github.com/brianchandotcom/liferay-portal/pull/163935#issuecomment-3116226137

No need for additional review since this was the original change before the additional formatting.

Issue was that `ParamUtil.getBoolean` doesn't return the correct value. I reverted to using `httpServletRequest.getAttribute` to get the attribute that was previously set with `httpServletRequest.setAttribute`.

Just going to run tests here before forwarding to make sure this fixes it on the tests.