### PR TITLE
LPD-60748 CKEditor toolbar options are not accessible via keyboard navigation

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/AdvancedClassicCKEditor5EditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/AdvancedClassicCKEditor5EditorConfigContributor.java
@@ -21,12 +21,12 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"editor.config.key=sampleCKEditor5ClassicEditor",
+		"editor.config.key=advancedClassicCKEditor5Editor",
 		"jakarta.portlet.name=" + CKEditorSamplePortletKeys.CKEDITOR_SAMPLE
 	},
 	service = EditorConfigContributor.class
 )
-public class CKEditor5ClassicEditorConfigContributor
+public class AdvancedClassicCKEditor5EditorConfigContributor
 	extends BaseEditorConfigContributor {
 
 	@Override
@@ -37,10 +37,7 @@ public class CKEditor5ClassicEditorConfigContributor
 
 		jsonObject.put(
 			"placeholder",
-			"This placeholder is set from EditorConfigContributor."
-		).put(
-			"removePlugins", toJSONArray("['Underline']")
-		);
+			"This placeholder is set from EditorConfigContributor.");
 	}
 
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/BasicClassicCKEditor5EditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/java/com/liferay/frontend/editor/ckeditor/sample/web/internal/editor/configuration/BasicClassicCKEditor5EditorConfigContributor.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.frontend.editor.ckeditor.sample.web.internal.editor.configuration;
+
+import com.liferay.frontend.editor.ckeditor.sample.web.internal.constants.CKEditorSamplePortletKeys;
+import com.liferay.portal.kernel.editor.configuration.BaseEditorConfigContributor;
+import com.liferay.portal.kernel.editor.configuration.EditorConfigContributor;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Marko Cikos
+ */
+@Component(
+	property = {
+		"editor.config.key=basicClassicCKEditor5Editor",
+		"jakarta.portlet.name=" + CKEditorSamplePortletKeys.CKEDITOR_SAMPLE
+	},
+	service = EditorConfigContributor.class
+)
+public class BasicClassicCKEditor5EditorConfigContributor
+	extends BaseEditorConfigContributor {
+
+	@Override
+	public void populateConfigJSONObject(
+		JSONObject jsonObject, Map<String, Object> inputEditorTaglibAttributes,
+		ThemeDisplay themeDisplay,
+		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
+
+		jsonObject.put("preset", "basic");
+	}
+
+}

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/partials/advanced_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/partials/advanced_classic.jsp
@@ -1,0 +1,27 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<liferay-util:buffer
+	var="contents"
+>
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.
+	</p>
+
+	<p>
+		<a href="/sample-relative-url">Diam quis enim lobortis scelerisque fermentum dui faucibus.</a>
+	</p>
+</liferay-util:buffer>
+
+<liferay-editor:editor
+	contents="<%= contents %>"
+	editorName="ckeditor5_classic"
+	name="advancedClassicCKEditor5Editor"
+	placeholder="content"
+/>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/partials/basic_classic.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/partials/basic_classic.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>
@@ -13,15 +13,11 @@
 	<p>
 		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam.
 	</p>
-
-	<p>
-		<a href="/sample-relative-url">Diam quis enim lobortis scelerisque fermentum dui faucibus.</a>
-	</p>
 </liferay-util:buffer>
 
 <liferay-editor:editor
 	contents="<%= contents %>"
 	editorName="ckeditor5_classic"
-	name="sampleCKEditor5ClassicEditor"
+	name="basicClassicCKEditor5Editor"
 	placeholder="content"
 />

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/view.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/ckeditor5/view.jsp
@@ -8,7 +8,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classic");
+String innerNavigation = ParamUtil.getString(request, "innerNavigation", "advanced_classic");
 %>
 
 <clay:navigation-bar
@@ -17,9 +17,15 @@ String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classi
 			{
 				add(
 					navigationItem -> {
-						navigationItem.setActive(innerNavigation.equals("classic"));
+						navigationItem.setActive(innerNavigation.equals("advanced_classic"));
 						navigationItem.setHref(renderResponse.createRenderURL(), "navigation", "ckeditor5");
-						navigationItem.setLabel("Classic");
+						navigationItem.setLabel("Advanced Classic");
+					});
+				add(
+					navigationItem -> {
+						navigationItem.setActive(innerNavigation.equals("basic_classic"));
+						navigationItem.setHref(renderResponse.createRenderURL(), "navigation", "ckeditor5", "innerNavigation", "basic_classic");
+						navigationItem.setLabel("Basic Classic");
 					});
 				add(
 					navigationItem -> {
@@ -52,20 +58,23 @@ String innerNavigation = ParamUtil.getString(request, "innerNavigation", "classi
 
 <div class="mt-3">
 	<c:choose>
+		<c:when test='<%= StringUtil.equals(innerNavigation, "advanced_classic") %>'>
+			<liferay-util:include page="/ckeditor5/partials/advanced_classic.jsp" servletContext="<%= application %>" />
+		</c:when>
 		<c:when test='<%= StringUtil.equals(innerNavigation, "balloon") %>'>
 			<liferay-util:include page="/ckeditor5/partials/balloon.jsp" servletContext="<%= application %>" />
 		</c:when>
-		<c:when test='<%= StringUtil.equals(innerNavigation, "classic") %>'>
-			<liferay-util:include page="/ckeditor5/partials/classic.jsp" servletContext="<%= application %>" />
+		<c:when test='<%= StringUtil.equals(innerNavigation, "basic_classic") %>'>
+			<liferay-util:include page="/ckeditor5/partials/basic_classic.jsp" servletContext="<%= application %>" />
 		</c:when>
 		<c:when test='<%= StringUtil.equals(innerNavigation, "input_localized") %>'>
 			<liferay-util:include page="/ckeditor5/partials/input_localized.jsp" servletContext="<%= application %>" />
 		</c:when>
-		<c:when test='<%= StringUtil.equals(innerNavigation, "react_cet") %>'>
-			<liferay-util:include page="/ckeditor5/partials/react_cet.jsp" servletContext="<%= application %>" />
+		<c:when test='<%= StringUtil.equals(innerNavigation, "react") %>'>
+			<liferay-util:include page="/ckeditor5/partials/react.jsp" servletContext="<%= application %>" />
 		</c:when>
 		<c:otherwise>
-			<liferay-util:include page="/ckeditor5/partials/react.jsp" servletContext="<%= application %>" />
+			<liferay-util:include page="/ckeditor5/partials/react_cet.jsp" servletContext="<%= application %>" />
 		</c:otherwise>
 	</c:choose>
 </div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/CKEditor5ReactClassicEditor.tsx
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-sample-web/src/main/resources/META-INF/resources/js/CKEditor5ReactClassicEditor.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Bookmark} from 'ckeditor5';
+import {Bookmark, Underline} from 'ckeditor5';
 import {
 	CKEditor5ClassicEditor as ClassicEditor,
 	LiferayEditorConfig,
@@ -24,6 +24,7 @@ const CKEditor5ReactClassicEditor = ({
 		extraPlugins: [Bookmark, Timestamp],
 		initialData:
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Nunc id cursus metus aliquam eleifend mi in nulla. Quam adipiscing vitae proin sagittis nisl rhoncus. Suspendisse faucibus interdum posuere lorem. Nullam ac tortor vitae purus faucibus ornare. Ac felis donec et odio pellentesque diam. Nulla at volutpat diam ut. Posuere urna nec tincidunt praesent semper feugiat nibh. Gravida quis blandit turpis cursus. Proin libero nunc consequat interdum varius. Sollicitudin ac orci phasellus egestas tellus rutrum tellus pellentesque. Neque volutpat ac tincidunt vitae semper quis lectus nulla at. Odio euismod lacinia at quis risus sed vulputate odio ut. Augue lacus viverra vitae congue eu consequat ac. Elementum sagittis vitae et leo duis ut diam. Diam quis enim lobortis scelerisque fermentum dui faucibus.',
+		removePlugins: [Underline],
 		toolbar: {
 			items: [
 				'undo',
@@ -31,6 +32,7 @@ const CKEditor5ReactClassicEditor = ({
 				'|',
 				'bold',
 				'italic',
+				'underline',
 				'|',
 				'bookmark',
 				'timestamp',

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/js/ckeditor5/utils/getDefaultEditorConfig.ts
@@ -90,6 +90,8 @@ const getDefaultEditorConfig = ({
 			plugins: basicPlugins,
 			toolbar: {
 				items: [
+					'accessibilityHelp',
+					'|',
 					'undo',
 					'redo',
 					'|',
@@ -143,6 +145,8 @@ const getDefaultEditorConfig = ({
 	}
 
 	const toolbarItems = [
+		'accessibilityHelp',
+		'|',
 		'undo',
 		'redo',
 		'|',

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/pages/CKEditorSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/pages/CKEditorSamplePage.ts
@@ -38,6 +38,12 @@ export class CKEditorSamplePage {
 		await this.page.goto(
 			`${liferayConfig.environment.baseUrl}/web${site.friendlyUrlPath}/${title}`
 		);
+
+		const productMenuToggle = this.page.getByLabel('Close Product Menu');
+
+		if (await productMenuToggle.isVisible()) {
+			await productMenuToggle.click();
+		}
 	}
 
 	async selectTab(label: string) {

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/advanced_classic.spec.ts
@@ -5,7 +5,6 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
@@ -14,7 +13,6 @@ import {ckeditorSamplePageTest} from '../../fixtures/ckeditorSamplePageTest';
 import {classicPageTest} from './fixtures/classicPageTest';
 
 export const test = mergeTests(
-	apiHelpersTest,
 	ckeditorSamplePageTest,
 	classicPageTest,
 	featureFlagsTest({
@@ -28,15 +26,8 @@ export const test = mergeTests(
 test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
 	await ckeditorSamplePage.createAndGotoSitePage({site});
 
-	const productMenuToggle =
-		ckeditorSamplePage.page.getByLabel('Close Product Menu');
-
-	if (await productMenuToggle.isVisible()) {
-		await productMenuToggle.click();
-	}
-
 	await ckeditorSamplePage.selectTab('CKEditor 5');
-	await ckeditorSamplePage.selectTab('Classic');
+	await ckeditorSamplePage.selectTab('Advanced Classic');
 
 	await waitForEditor({page});
 });
@@ -61,12 +52,14 @@ test(
 
 		await test.step('Toolbar contains advanced preset controls', async () => {
 			const advancedPresetControls = [
+				'Accessibility help',
 				'Undo',
 				'Redo',
 				'Styles',
 				'Normal',
 				'Bold',
 				'Italic',
+				'Underline',
 				'Strikethrough',
 				'Font Color',
 				'Font Background Color',
@@ -89,12 +82,6 @@ test(
 				await classicPage.toolbar.buttonLabels.allInnerTexts();
 
 			expect(controls).toEqual(advancedPresetControls);
-		});
-
-		await test.step('Toolbar does not contain removed plugin', async () => {
-			await expect(
-				classicPage.toolbar.buttonLabels.getByLabel('Underline')
-			).toBeHidden();
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/balloon.spec.ts
@@ -28,13 +28,6 @@ export const test = mergeTests(
 test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
 	await ckeditorSamplePage.createAndGotoSitePage({site});
 
-	const productMenuToggle =
-		ckeditorSamplePage.page.getByLabel('Close Product Menu');
-
-	if (await productMenuToggle.isVisible()) {
-		await productMenuToggle.click();
-	}
-
 	await ckeditorSamplePage.selectTab('CKEditor 5');
 	await ckeditorSamplePage.selectTab('Balloon');
 
@@ -54,6 +47,7 @@ test(
 		await expect(balloonPage.toolbar).toBeVisible();
 
 		const advancedPresetControls = [
+			'Accessibility help',
 			'Undo',
 			'Redo',
 			'Styles',

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/basic_classic.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/basic_classic.spec.ts
@@ -5,16 +5,14 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
-import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
 import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
 import {waitForEditor} from '../../../../../utils/waitFor';
-import {ckeditorSamplePageTest} from './../../fixtures/ckeditorSamplePageTest';
+import {ckeditorSamplePageTest} from '../../fixtures/ckeditorSamplePageTest';
 import {classicPageTest} from './fixtures/classicPageTest';
 
 export const test = mergeTests(
-	apiHelpersTest,
 	ckeditorSamplePageTest,
 	classicPageTest,
 	featureFlagsTest({
@@ -29,7 +27,7 @@ test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
 	await ckeditorSamplePage.createAndGotoSitePage({site});
 
 	await ckeditorSamplePage.selectTab('CKEditor 5');
-	await ckeditorSamplePage.selectTab('React');
+	await ckeditorSamplePage.selectTab('Basic Classic');
 
 	await waitForEditor({page});
 });
@@ -37,33 +35,30 @@ test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
 test(
 	'Editor configuration is applied',
 	{tag: '@LPD-11235'},
-	async ({classicPage}) => {
+	async ({classicPage, page}) => {
 		await test.step('Initial data is set', async () => {
 			await expect(
-				classicPage.editable.getByText('Lorem ipsum dolor sit amet')
+				page.getByText('Lorem ipsum dolor sit amet')
 			).toBeVisible();
 		});
 
-		await test.step('Toolbar contains custom toobar configuration, including added custom and official plugins', async () => {
-			const expectedButtons = [
+		await test.step('Toolbar contains basic preset controls', async () => {
+			const basicPresetControlLabels = [
+				'Accessibility help',
 				'Undo',
 				'Redo',
 				'Bold',
 				'Italic',
-				'Bookmark',
-				'Timestamp',
+				'Underline',
+				'Numbered List',
+				'Bulleted List',
+				'Link',
 			];
 
-			const availableButtons =
+			const controlLabels =
 				await classicPage.toolbar.buttonLabels.allInnerTexts();
 
-			expect(availableButtons).toEqual(expectedButtons);
-		});
-
-		await test.step('Toolbar does not contain removed plugin', async () => {
-			await expect(
-				classicPage.toolbar.buttonLabels.getByLabel('Underline')
-			).toBeHidden();
+			expect(controlLabels).toEqual(basicPresetControlLabels);
 		});
 	}
 );


### PR DESCRIPTION
### References

- JIRA: https://liferay.atlassian.net/browse/LPD-60748

### What is the goal of this PR?

Adding a plugin to default presets. Reshuffling tests to showcase both advanced and basic presets.

### What does it look like?

<img width="1262" height="342" alt="image" src="https://github.com/user-attachments/assets/e89b8263-3e75-4ad1-87b2-04e6783c2966" />

<img width="1264" height="310" alt="image" src="https://github.com/user-attachments/assets/b1055217-7423-4b9f-a890-1bc7a24de388" />

<img width="1293" height="260" alt="image" src="https://github.com/user-attachments/assets/a6d0cf03-ff55-4ab2-8d00-8058b33987f0" />

<img width="350" height="195" alt="image" src="https://github.com/user-attachments/assets/6d17190f-1911-493e-92f4-6b24c83eece4" />

