### PR TITLE
LPD-56306 FDS is passing the "unfiltered" list of actions to the cell renderer, instead of the filtered one

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/action/AdvancedFDSItemsActions.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/frontend/data/set/action/AdvancedFDSItemsActions.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.PortalUtil;
 
@@ -96,6 +97,13 @@ public class AdvancedFDSItemsActions implements FDSItemsActions {
 		fdsActionDropdownItem3.putData("disableHeader", true);
 
 		return Arrays.asList(
+			new FDSActionDropdownItem(
+				"#test-visibility-filter", "sun",
+				"sampleVisibilityFilterMessage", "Sample Visibility Filter",
+				null, null, "link",
+				HashMapBuilder.<String, Object>put(
+					"color", "Yellow"
+				).build()),
 			new FDSActionDropdownItem(
 				null, "view", "infoPanel", "View Details", null, null,
 				"infoPanel"),

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/AdvancedTableFDSView.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/view/AdvancedTableFDSView.java
@@ -59,7 +59,11 @@ public class AdvancedTableFDSView extends BaseTableFDSView {
 			)
 		).add(
 			"title", "title",
-			fdsTableSchemaField -> fdsTableSchemaField.setSortable(true)
+			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(
+				"actionLink"
+			).setSortable(
+				true
+			)
 		).add(
 			"creator.name", "author",
 			fdsTableSchemaField -> fdsTableSchemaField.setContentRenderer(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/cell_renderers/ActionLinkRenderer.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import React, {useContext} from 'react';
 
 import FrontendDataSetContext from '../FrontendDataSetContext';
+import filterItemActions from '../utils/actionItems/filterItemActions';
 import formatActionURL from '../utils/actionItems/formatActionURL';
 import {openPermissionsModal} from '../utils/modals/openPermissionsModal';
 import DefaultContent from './DefaultRenderer';
@@ -19,36 +20,36 @@ function ActionLinkRenderer({actions, itemData, itemId, options, value}) {
 	const {
 		executeAsyncItemAction,
 		highlightItems,
+		infoPanelOpen,
 		onInfoPanelToggleButtonClick,
 		openModal,
 		openSidePanel,
+		selectable,
+		selectedItemsKey,
+		selectedItemsValue,
 	} = useContext(FrontendDataSetContext);
 
 	if (!actions || !actions.length) {
 		return value ? <DefaultContent value={value} /> : null;
 	}
 
-	let currentAction = options?.actionId
-		? actions.find((action) => action.data?.id === options.actionId)
-		: actions[0];
+	const formattedActions = filterItemActions({
+		actions,
+		infoPanelOpen,
+		itemData,
+		selectable,
+		selectedItemsKey,
+		selectedItemsValue,
+	});
+
+	const currentAction = options?.actionId
+		? formattedActions.find(
+				(action) => action.data?.id === options.actionId
+			)
+		: formattedActions[0];
 
 	if (!currentAction) {
-		return null;
-	}
-
-	if (currentAction.data?.permissionKey) {
-		if (itemData.actions[currentAction.data.permissionKey]) {
-			if (currentAction.target === 'headless') {
-				currentAction = {
-					...currentAction,
-					...itemData.actions[currentAction.data.id],
-					method: currentAction.method ?? currentAction.data?.method,
-				};
-			}
-		}
-		else {
-			return value ? <DefaultContent value={value} /> : null;
-		}
+		return value ? <DefaultContent value={value} /> : null;
 	}
 
 	const formattedHref =

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/content_renderers.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/content_renderers.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../../../fixtures/loginTest';
+import {EFDSVisualizationMode, waitForFDS} from '../../../../../utils/waitFor';
+import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
+
+const test = mergeTests(
+	apiHelpersTest,
+	fdsSamplePageTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test.beforeEach(async ({fdsSamplePage, page, site}) => {
+	await fdsSamplePage.setupFDSSampleWidget({site});
+
+	await fdsSamplePage.selectTab('Advanced');
+
+	await waitForFDS({page, visualizationMode: EFDSVisualizationMode.TABLE});
+});
+
+test(
+	'actionLink renderer',
+	{tag: ['@LPD-56306']},
+	async ({fdsSamplePage, page}) => {
+		await test.step('Check that if the configuration defines an actionId, that action URL is rendered', async () => {
+			await test.step('Check that the "ID" cell on the first 5 rows renders with the link "#test-pencil"', async () => {
+				for (let i = 0; i < 5; i++) {
+					const idCell = fdsSamplePage.table.bodyRows
+						.nth(i)
+						.locator('.cell-id');
+
+					await expect(idCell.locator('a')).toHaveAttribute(
+						'href',
+						'#test-pencil'
+					);
+				}
+			});
+		});
+
+		await test.step('Check that if the configuration does not define an actionId, the first visible link is rendered', async () => {
+			await test.step('Check that the "Title" cell with color "Blue" renders with the link "#"', async () => {
+				const blueRow = fdsSamplePage.table.bodyRows
+					.filter({
+						has: page.locator('td.cell-color', {hasText: 'Blue'}),
+					})
+					.first();
+
+				const titleCell = blueRow.locator('.cell-title');
+
+				await expect(titleCell.locator('a')).toHaveAttribute(
+					'href',
+					'#'
+				);
+			});
+
+			await test.step('Check that the "Title" cell with color "Yellow" renders with the link "#test-visibility-filter"', async () => {
+				const yellowRow = fdsSamplePage.table.bodyRows
+					.filter({
+						has: page.locator('td.cell-color', {
+							hasText: 'Yellow',
+						}),
+					})
+					.first();
+
+				const titleCell = yellowRow.locator('.cell-title');
+
+				await expect(titleCell.locator('a')).toHaveAttribute(
+					'href',
+					'#test-visibility-filter'
+				);
+			});
+		});
+	}
+);


### PR DESCRIPTION
**Bug Ticket:** https://liferay.atlassian.net/browse/LPD-56306

---

## Issue

When using the `actionLink` content renderer, if you don't define an `actionId` it uses the first action from the actions dropdown as the link. It currently correctly handles if the `permissionKey` but in this case, `visibilityFilters` is hiding the first action which the `actionLink` doesn't filter.

## Solution

Use the `filterItemActions` util function which is what is used by the [Actions dropdown](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx#L69-L76) so the action list it's referencing will be the same.

### Other notable changes

- Updated the FDS advanced sample:
  - **ID** column renders a link with a **defined** `actionId` _(this is unchanged)_
  - **Title** column renders a link using the first item when an `actionId` is **not defined** _(this is new)_
- I didn't see any tests around content renderers so I created a new file for it `content_renderers.spec.ts`

## Screenshots after fix

<img width="1472" height="366" alt="Screenshot 2025-07-31 at 3 46 28 PM" src="https://github.com/user-attachments/assets/124c6768-cd90-45e6-8deb-7993ee4bf39f" />
<img width="1467" height="467" alt="Screenshot 2025-07-31 at 3 47 18 PM" src="https://github.com/user-attachments/assets/67893638-80ec-4ced-81b2-2c5ef878937c" />
