### PR TITLE
LPD-62410 Adapt AlloyEditor's full screen mode to Liferay.Util.openModal

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/css/main.scss
@@ -165,3 +165,7 @@
 		}
 	}
 }
+
+.lfr-fullscreen-source-editor-dialog .modal-dialog {
+	max-width: 90%;
+}

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/legacy/alloyeditor_source.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/legacy/alloyeditor_source.js
@@ -123,77 +123,60 @@ AUI.add(
 					const host = instance.get(STR_HOST);
 					const strings = instance.get(STRINGS);
 
-					let fullScreenDialog = instance._fullScreenDialog;
 					let fullScreenEditor = instance._fullScreenEditor;
 
-					if (fullScreenDialog) {
-						fullScreenEditor.set('value', host.getHTML());
-
-						fullScreenDialog.show();
-					}
-					else {
-						Liferay.Util.openModal({
-							buttons: [
-								{
-									label: strings.cancel,
-									onClick: () => {
-										fullScreenDialog.hide();
-									},
+					Liferay.Util.openModal({
+						bodyHTML: '<div id="fullScreenEditorBody"></div>',
+						buttons: [
+							{
+								label: strings.cancel,
+								onClick: ({processClose}) => {
+									processClose();
 								},
-								{
-									displayType: 'primary',
-									label: strings.done,
-									onClick: () => {
-										fullScreenDialog.hide();
-										instance._switchMode({
-											content:
-												fullScreenEditor.get('value'),
-										});
-									},
-								},
-							],
-							className:
-								'lfr-fulscreen-source-editor-dialog modal-full-screen',
-							containerProps: {},
-							onOpen: ({container}) => {
-								fullScreenDialog = container;
-
-								Liferay.Util.getTop()
-									.AUI()
-									.use(
-										'liferay-fullscreen-source-editor',
-										(A) => {
-											fullScreenEditor =
-												new A.LiferayFullScreenSourceEditor(
-													{
-														boundingBox: container
-															.getStdModNode(
-																A.WidgetStdMod
-																	.BODY
-															)
-															.appendChild(
-																'<div></div>'
-															),
-														dataProcessor:
-															host.getNativeEditor()
-																.dataProcessor,
-														previewCssClass:
-															'alloy-editor alloy-editor-placeholder',
-														value: host.getHTML(),
-													}
-												).render();
-
-											instance._fullScreenDialog =
-												fullScreenDialog;
-
-											instance._fullScreenEditor =
-												fullScreenEditor;
-										}
-									);
 							},
-							title: strings.editContent,
-						});
-					}
+							{
+								displayType: 'primary',
+								label: strings.done,
+								onClick: ({processClose}) => {
+									processClose();
+									instance._switchMode({
+										content: fullScreenEditor.get('value'),
+									});
+								},
+							},
+						],
+						className:
+							'lfr-fullscreen-source-editor-dialog modal-full-screen',
+						containerProps: {},
+						onOpen: () => {
+							Liferay.Util.getTop()
+								.AUI()
+								.use(
+									'liferay-fullscreen-source-editor',
+									(A) => {
+										fullScreenEditor =
+											new A.LiferayFullScreenSourceEditor(
+												{
+													boundingBox:
+														document.getElementById(
+															'fullScreenEditorBody'
+														),
+													dataProcessor:
+														host.getNativeEditor()
+															.dataProcessor,
+													previewCssClass:
+														'alloy-editor alloy-editor-placeholder',
+													value: host.getHTML(),
+												}
+											).render();
+
+										instance._fullScreenEditor =
+											fullScreenEditor;
+									}
+								);
+						},
+						title: strings.editContent,
+					});
 				},
 
 				_onSwitchBlur() {
@@ -279,12 +262,14 @@ AUI.add(
 				_toggleEditorModeUI() {
 					const instance = this;
 
+					const editorContent = instance._editorContent;
 					const editorFullscreen = instance._editorFullscreen;
 					const editorSwitch = instance._editorSwitch;
 					const editorSwitchContainer = editorSwitch.ancestor();
 					const editorSwitchTheme = instance._editorSwitchTheme;
 					const editorWrapper = instance._editorWrapper;
 
+					editorContent.toggleClass('hide');
 					editorWrapper.toggleClass(CSS_SHOW_SOURCE);
 					editorSwitchContainer.toggleClass(CSS_SHOW_SOURCE);
 					editorFullscreen.toggleClass('hide');
@@ -340,12 +325,6 @@ AUI.add(
 						fullScreenEditor.destroy();
 					}
 
-					const fullScreenDialog = instance._fullScreenDialog;
-
-					if (fullScreenDialog) {
-						fullScreenDialog.destroy();
-					}
-
 					new A.EventHandle(instance._eventHandles).detach();
 				},
 
@@ -354,6 +333,7 @@ AUI.add(
 
 					const host = instance.get(STR_HOST);
 
+					instance._editorContent = host._srcNode;
 					instance._editorFullscreen = host.one('#Fullscreen');
 					instance._editorSource = host.one('#Source');
 					instance._editorSwitch = host.one('#Switch');

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/legacy/fullscreen_source_editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/js/legacy/fullscreen_source_editor.js
@@ -238,7 +238,6 @@ AUI.add(
 						boundingBox.one('#switchTheme');
 
 					instance._editor = new A.LiferaySourceEditor({
-						aceOptions: instance.get('aceOptions'),
 						boundingBox: boundingBox.one('.source-html'),
 						height: '100%',
 						mode: 'html',

--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/test.properties
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/test.properties
@@ -1,0 +1,32 @@
+modified.files.includes[relevant][frontend-editor-alloyeditor-web-functional-rule]=**
+
+modified.files.includes[relevant][frontend-editor-alloyeditor-web-java-rule]=\
+    **/*.java,\
+    **/test/**,\
+    **/testIntegration/**
+
+modified.files.includes[relevant][frontend-editor-alloyeditor-web-playwright-rule]=**
+modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][frontend-editor-alloyeditor-web-java-rule]=
+modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][frontend-editor-alloyeditor-web-java-rule]=
+
+playwright.projects.includes[playwright-js-tomcat101-mysql57][relevant][frontend-editor-alloyeditor-web-playwright-rule]=\
+    frontend-editor-alloyeditor-web.main
+
+relevant.rule.names=\
+    frontend-editor-alloyeditor-web-functional-rule,\
+    frontend-editor-alloyeditor-web-java-rule,\
+    frontend-editor-alloyeditor-web-playwright-rule
+
+test.batch.names[relevant][frontend-editor-alloyeditor-web-functional-rule]=\
+    functional-tomcat90-mysql57
+
+test.batch.names[relevant][frontend-editor-alloyeditor-web-java-rule]=\
+    modules-integration-postgresql163,\
+    modules-unit
+
+test.batch.names[relevant][frontend-editor-alloyeditor-web-playwright-rule]=\
+    playwright-js-tomcat101-mysql57
+
+test.batch.run.property.query[frontend-editor-alloyeditor-web-functional-rule][relevant][functional-tomcat90-mysql57]=
+
+testray.main.component.name=Frontend Editor

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -62,6 +62,7 @@ import {config as friendlyURLConfig} from './tests/friendly-url-web/main/config'
 import {config as frontendCssCadminWebConfig} from './tests/frontend-css-cadmin-web/main/config';
 import {config as frontendDataSetAdminWebConfig} from './tests/frontend-data-set-admin-web/main/config';
 import {config as frontendDataSetWebConfig} from './tests/frontend-data-set-web/main/config';
+import {config as frontendEditorAlloyEditorWebConfig} from './tests/frontend-editor-alloyeditor-web/main/config';
 import {config as frontendEditorCKEditorWebConfig} from './tests/frontend-editor-ckeditor-web/main/config';
 import {config as frontendJsBootstrapSupportWebConfig} from './tests/frontend-js-bootstrap-support-web/main/config';
 import {config as frontendJsComponentsWebConfig} from './tests/frontend-js-components-web/main/config';
@@ -225,6 +226,7 @@ export default defineConfig({
 		frontendCssCadminWebConfig,
 		frontendDataSetAdminWebConfig,
 		frontendDataSetWebConfig,
+		frontendEditorAlloyEditorWebConfig,
 		frontendEditorCKEditorWebConfig,
 		frontendJsBootstrapSupportWebConfig,
 		frontendJsComponentsWebConfig,

--- a/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/config.ts
+++ b/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'frontend-editor-alloyeditor-web.main',
+	testDir: 'tests/frontend-editor-alloyeditor-web/main',
+};

--- a/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/env/osgi-modules.list
+++ b/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/env/osgi-modules.list
@@ -1,0 +1,1 @@
+frontend-editor-ckeditor-sample-web

--- a/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/sourceEditor.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/sourceEditor.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {EEditorType, waitForEditor} from '../../../utils/waitFor';
+import {ckeditorSamplePageTest} from '../../frontend-editor-ckeditor-web/main/fixtures/ckeditorSamplePageTest';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	ckeditorSamplePageTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest()
+);
+
+test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
+	await ckeditorSamplePage.createAndGotoSitePage({site});
+
+	await ckeditorSamplePage.selectTab('CKEditor 4');
+	await ckeditorSamplePage.selectTab('Alloy');
+
+	await waitForEditor({editorType: EEditorType.ALLOYEDITOR, page});
+});
+
+test('Content is rendered in source editor when using full screen mode',
+	{tag: ['@LPD-62410']}, 
+    async ({page}) => {
+	await test.step('Go to source mode and edit in full screen mode', async () => {
+        await page.locator('.ae-editable').click();
+
+        const switchModeButton = page.locator('[id$="AlloyEditorSwitch"]');
+
+        await switchModeButton.waitFor({state: 'visible', timeout: 10000});
+
+        switchModeButton.click();
+
+        const fullScreenButton = page.locator('[id$="AlloyEditorFullscreen"]');
+
+        await fullScreenButton.waitFor({state: 'visible', timeout: 10000});
+
+        fullScreenButton.click();
+
+        const fullScreenModal = page.locator('.lfr-fulscreen-source-editor-dialog');
+
+        await fullScreenModal.waitFor({state: 'visible', timeout: 10000});
+
+        await expect(fullScreenModal).toHaveText('Lorem ipsum');
+	});
+});

--- a/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/sourceEditor.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/sourceEditor.spec.ts
@@ -49,10 +49,10 @@ test('Content is rendered in source editor when using full screen mode',
 
         fullScreenButton.click();
 
-        const fullScreenModal = page.locator('.lfr-fulscreen-source-editor-dialog');
+        const fullScreenModal = page.locator('.lfr-fullscreen-source-editor-dialog');
 
         await fullScreenModal.waitFor({state: 'visible', timeout: 10000});
 
-        await expect(fullScreenModal).toHaveText('Lorem ipsum');
+        await expect(fullScreenModal).toContainText('Lorem ipsum');
 	});
 });

--- a/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/sourceEditor.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/sourceEditor.spec.ts
@@ -31,28 +31,34 @@ test.beforeEach(async ({ckeditorSamplePage, page, site}) => {
 	await waitForEditor({editorType: EEditorType.ALLOYEDITOR, page});
 });
 
-test('Content is rendered in source editor when using full screen mode',
-	{tag: ['@LPD-62410']}, 
-    async ({page}) => {
-	await test.step('Go to source mode and edit in full screen mode', async () => {
-        await page.locator('.ae-editable').click();
+test(
+	'Content is rendered in source editor when using full screen mode',
+	{tag: ['@LPD-62410']},
+	async ({page}) => {
+		await test.step('Go to source mode and edit in full screen mode', async () => {
+			await page.locator('.ae-editable').click();
 
-        const switchModeButton = page.locator('[id$="AlloyEditorSwitch"]');
+			const switchModeButton = page.locator('[id$="AlloyEditorSwitch"]');
 
-        await switchModeButton.waitFor({state: 'visible', timeout: 10000});
+			await switchModeButton.waitFor({state: 'visible', timeout: 10000});
 
-        switchModeButton.click();
+			switchModeButton.click();
 
-        const fullScreenButton = page.locator('[id$="AlloyEditorFullscreen"]');
+			const fullScreenButton = page.locator(
+				'[id$="AlloyEditorFullscreen"]'
+			);
 
-        await fullScreenButton.waitFor({state: 'visible', timeout: 10000});
+			await fullScreenButton.waitFor({state: 'visible', timeout: 10000});
 
-        fullScreenButton.click();
+			fullScreenButton.click();
 
-        const fullScreenModal = page.locator('.lfr-fullscreen-source-editor-dialog');
+			const fullScreenModal = page.locator(
+				'.lfr-fullscreen-source-editor-dialog'
+			);
 
-        await fullScreenModal.waitFor({state: 'visible', timeout: 10000});
+			await fullScreenModal.waitFor({state: 'visible', timeout: 10000});
 
-        await expect(fullScreenModal).toContainText('Lorem ipsum');
-	});
-});
+			await expect(fullScreenModal).toContainText('Lorem ipsum');
+		});
+	}
+);

--- a/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/test.properties
+++ b/modules/test/playwright/tests/frontend-editor-alloyeditor-web/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Frontend Editor

--- a/modules/test/playwright/utils/waitFor.ts
+++ b/modules/test/playwright/utils/waitFor.ts
@@ -32,12 +32,12 @@ export async function waitForEditor({
 			.frameLocator('iframe')
 			.locator('.cke_editable')
 			.waitFor({state: 'visible'});
-	} else {
-		const container = containerProp ?? page.locator('.alloy-editor-container');
+	}
+	else {
+		const container =
+			containerProp ?? page.locator('.alloy-editor-container');
 
-		await container
-			.locator('.ae-editable')
-			.waitFor({state: 'visible'});
+		await container.locator('.ae-editable').waitFor({state: 'visible'});
 	}
 }
 

--- a/modules/test/playwright/utils/waitFor.ts
+++ b/modules/test/playwright/utils/waitFor.ts
@@ -6,6 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 export enum EEditorType {
+	ALLOYEDITOR = 'alloyeditor',
 	CKEDITOR4 = 'ckeditor4',
 	CKEDITOR5 = 'ckeditor5',
 }
@@ -24,12 +25,18 @@ export async function waitForEditor({
 
 		await container.locator('.ck-content').waitFor({state: 'visible'});
 	}
-	else {
+	else if (editorType === EEditorType.CKEDITOR4) {
 		const container = containerProp ?? page.locator('.cke');
 
 		await container
 			.frameLocator('iframe')
 			.locator('.cke_editable')
+			.waitFor({state: 'visible'});
+	} else {
+		const container = containerProp ?? page.locator('.alloy-editor-container');
+
+		await container
+			.locator('.ae-editable')
 			.waitFor({state: 'visible'});
 	}
 }


### PR DESCRIPTION
Hi,

In [LPD-53792](https://liferay.atlassian.net/browse/LPD-53792) we replaced the usages of `Liferay.Util.openWindow` by `Liferay.Util.openModal`, however we didn't make required changes to adapt this case to new API. So Alloyeditor's source mode in full screen was not working after that change (there was nothing rendered on modal's body, button were doing nothing, modal size was too small to be able to edit anything, ....).

This pull request is basically making needed changes to be able to use `Liferay.Util.openModal` in AlloyEditor.

Thanks.

Regards.