### PR TITLE
LPD-62552 Show selection filter screen every time we open 'Selection Filter' dropdown so we can guarantee we are showing updated results

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
@@ -42,7 +42,7 @@ const FiltersDropdown = () => {
 			onActiveChange={(active) => {
 				setActive(active);
 
-				if(active) {					
+				if (active) {
 					setActiveFilter(null);
 				}
 			}}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.js
@@ -39,7 +39,13 @@ const FiltersDropdown = () => {
 		<ClayDropDown
 			active={active}
 			className="filters-dropdown"
-			onActiveChange={setActive}
+			onActiveChange={(active) => {
+				setActive(active);
+
+				if(active) {					
+					setActiveFilter(null);
+				}
+			}}
 			trigger={
 				<Button
 					aria-expanded={active}

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -34,7 +34,7 @@ test.beforeEach(async ({fdsSamplePage, page, site}) => {
 test(
 	'Behavior of filters',
 	{
-		tag: ['@LPS-150047'],
+		tag: ['@LPS-150047', '@LPD-62552'],
 	},
 	async ({fdsSamplePage, page}) => {
 		const blueCells = page.getByRole('cell', {name: 'Blue'});
@@ -347,6 +347,62 @@ test(
 				expect.soft(await greenCells.count()).toBeGreaterThan(0);
 				expect.soft(await yellowCells.count()).toBeGreaterThan(0);
 				expect.soft(await redCells.count()).toBeGreaterThan(0);
+			});
+		});
+
+		await test.step('Check filter dropdown is updated after clearing results', async () => {
+			await test.step('Refresh the page', async () => {
+				await page.reload();
+
+				await page
+					.getByText('This is a description for sample 1.')
+					.waitFor();
+			});
+
+			await test.step('Open filter dropdown and check "Blue", "Green" and "Yellow" are selected', async () => {
+				await fdsSamplePage.managementToolbar.container
+					.getByRole('button', {name: 'Filter'})
+					.click();
+
+				await page
+					.locator('.dropdown-menu')
+					.getByRole('menuitem', {name: 'Color'})
+					.click();
+
+				expect(page.getByRole('checkbox', {name: 'Blue'})).toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Green'})).toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Yellow'})).toBeChecked;
+			});
+
+			await test.step('Click on clear filters button', async () => {
+				await fdsSamplePage.managementToolbar.container
+					.getByRole('button', {name: 'Filter'})
+					.click();
+
+				await fdsSamplePage.activeFiltersToolbar
+					.getByRole('button', {name: 'Clear'})
+					.click();
+
+				await page
+					.getByText('This is a description for sample 1.')
+					.waitFor();
+			});
+
+			await test.step('Open filter dropdown again and check nothing is selected', async () => {
+				await fdsSamplePage.managementToolbar.container
+					.getByRole('button', {name: 'Filter'})
+					.click();
+
+				await page
+					.locator('.dropdown-menu')
+					.getByRole('menuitem', {name: 'Color'})
+					.click();
+
+				expect(page.getByRole('checkbox', {name: 'Blue'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Green'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Yellow'})).not.toBeChecked;
 			});
 		});
 	}

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -371,8 +371,10 @@ test(
 
 				expect(page.getByRole('checkbox', {name: 'Blue'})).toBeChecked;
 				expect(page.getByRole('checkbox', {name: 'Green'})).toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Yellow'})).toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Red'})).not
+					.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Yellow'}))
+					.toBeChecked;
 			});
 
 			await test.step('Click on clear filters button', async () => {
@@ -399,10 +401,14 @@ test(
 					.getByRole('menuitem', {name: 'Color'})
 					.click();
 
-				expect(page.getByRole('checkbox', {name: 'Blue'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Green'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Red'})).not.toBeChecked;
-				expect(page.getByRole('checkbox', {name: 'Yellow'})).not.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Blue'})).not
+					.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Green'})).not
+					.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Red'})).not
+					.toBeChecked;
+				expect(page.getByRole('checkbox', {name: 'Yellow'})).not
+					.toBeChecked;
 			});
 		});
 	}


### PR DESCRIPTION
Hi,

The way to reproduce this issue is explained in [LPD-62552](https://liferay.atlassian.net/browse/LPD-62552). 

In `filter`s dropdown we have two screens:
* The first one to select which filter we want (i.e: color, size, ...)
* The second one to select the options in that filter (i.e: red, yellow, blue, ...)

The problem we have is when we open that dropdown and later we update filter's options externally (either through `clear` button or through `filter summary box`) when we then reopen the dropdown options have not been updated, what it might be misleading.

The first idea I had was to update that filter's status but since the React component is re-rendered , status is lost so I can't keep track of which filter is active. I could move it up or save it in the context but I thought that'd be overkilling for this small change, so I just decided to set  `activeFilter` to `null` everytime we open the dropdown in order to show always selection filter screen.

Thanks.

Regards