### PR TITLE
LPD-56297 Enchance "Select all" by applying current filters and search query

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
@@ -129,7 +129,7 @@ export default function propsTransformer({
 		onBulkActionItemClick({
 			action,
 			loadData,
-			selectedData: {items, keyValues, selectAll},
+			selectedData: {filters, items, keyValues, searchQuery, selectAll},
 		}: any) {
 			if (action.data.id === 'sampleBulkAction') {
 				openModal({
@@ -163,7 +163,13 @@ export default function propsTransformer({
 
 			if (action.data.id === 'testBulkAction') {
 				fetch(action.href, {
-					body: JSON.stringify({items, keyValues, selectAll}),
+					body: JSON.stringify({
+						filters,
+						items,
+						keyValues,
+						searchQuery,
+						selectAll,
+					}),
 					headers: DEFAULT_FETCH_HEADERS,
 					method: action.data.method,
 				});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -61,17 +61,20 @@ function BulkActions({
 	const [currentSidePanelActionPayload, setCurrentSidePanelActionPayload] =
 		useState(null);
 
-	function getActiveFilters(filters) {
-		return filters
-			.filter((item) => item.active)
-			.map((item) => {
-				return {
-					id: item.id,
-					multiple: item.multiple,
-					odataFilterString: item.odataFilterString,
-					selectedItemsLabel: item.selectedItemsLabel,
-				};
-			});
+	function getAdditionalData(filters, searchParam) {
+		return {
+			filters: filters
+				.filter((item) => item.active)
+				.map((item) => {
+					return {
+						id: item.id,
+						multiple: item.multiple,
+						odataFilterString: item.odataFilterString,
+						selectedItemsLabel: item.selectedItemsLabel,
+					};
+				}),
+			searchQuery: searchParam,
+		};
 	}
 
 	function handleActionClick(
@@ -110,15 +113,11 @@ function BulkActions({
 				loadData,
 				namespace,
 				selectedData: {
-					...(allItemsSelectedActive && {
-						filters: getActiveFilters(filters),
-					}),
 					items: allItemsSelectedActive ? [] : selectedItems,
 					keyValues: allItemsSelectedActive ? [] : selectedItemsValue,
-					...(allItemsSelectedActive && {
-						searchQuery: searchParam,
-					}),
 					selectAll: allItemsSelectedActive,
+					...(allItemsSelectedActive &&
+						getAdditionalData(filters, searchParam)),
 				},
 			});
 		}
@@ -135,13 +134,9 @@ function BulkActions({
 							allItemsSelectedActive
 								? []
 								: selectedItemsValue.join(','),
-						...(allItemsSelectedActive && {
-							filters: getActiveFilters(filters),
-						}),
-						...(allItemsSelectedActive && {
-							searchQuery: searchParam,
-						}),
 						selectAll: allItemsSelectedActive,
+						...(allItemsSelectedActive &&
+							getAdditionalData(filters, searchParam)),
 					},
 					url: href || form.action,
 				});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/BulkActions.js
@@ -15,6 +15,7 @@ import React, {useContext, useEffect, useState} from 'react';
 import FrontendDataSetContext from '../../FrontendDataSetContext';
 import {OPEN_SIDE_PANEL} from '../../utils/eventsDefinitions';
 import {getOpenedSidePanel} from '../../utils/sidePanels';
+import ViewsContext from '../../views/ViewsContext';
 import InfoPanelToggleButton from './InfoPanelToggleButton';
 import SelectionCheckbox from './SelectionCheckbox';
 
@@ -49,13 +50,29 @@ function BulkActions({
 		actionParameterName,
 		allItemsSelectedActive,
 		onBulkActionItemClick,
+		searchParam,
 		showBulkActionsManagementBar,
 		showBulkActionsManagementBarActions,
 		showInfoPanel,
 	} = useContext(FrontendDataSetContext);
 
+	const [{filters}] = useContext(ViewsContext);
+
 	const [currentSidePanelActionPayload, setCurrentSidePanelActionPayload] =
 		useState(null);
+
+	function getActiveFilters(filters) {
+		return filters
+			.filter((item) => item.active)
+			.map((item) => {
+				return {
+					id: item.id,
+					multiple: item.multiple,
+					odataFilterString: item.odataFilterString,
+					selectedItemsLabel: item.selectedItemsLabel,
+				};
+			});
+	}
 
 	function handleActionClick(
 		actionDefinition,
@@ -93,8 +110,14 @@ function BulkActions({
 				loadData,
 				namespace,
 				selectedData: {
+					...(allItemsSelectedActive && {
+						filters: getActiveFilters(filters),
+					}),
 					items: allItemsSelectedActive ? [] : selectedItems,
 					keyValues: allItemsSelectedActive ? [] : selectedItemsValue,
+					...(allItemsSelectedActive && {
+						searchQuery: searchParam,
+					}),
 					selectAll: allItemsSelectedActive,
 				},
 			});
@@ -112,6 +135,12 @@ function BulkActions({
 							allItemsSelectedActive
 								? []
 								: selectedItemsValue.join(','),
+						...(allItemsSelectedActive && {
+							filters: getActiveFilters(filters),
+						}),
+						...(allItemsSelectedActive && {
+							searchQuery: searchParam,
+						}),
 						selectAll: allItemsSelectedActive,
 					},
 					url: href || form.action,

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/item_selection.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/item_selection.spec.ts
@@ -113,16 +113,20 @@ test(
 		const itemsSelectorCheckbox = page.locator(
 			'input[name="items-selector"]'
 		);
+		let sentFilters: Array<object>;
 		let sentItems: Array<number>;
 		let sentKeyValues: Array<number>;
+		let sentSearchQuery: string;
 		let sentSelectAll: boolean;
 
 		await page.route('/o/c/fdssamples/', async (route, request) => {
 			if (request.method() === 'POST') {
 				const postData = request.postDataJSON();
 
+				sentFilters = postData.filters;
 				sentItems = postData.items;
 				sentKeyValues = postData.keyValues;
+				sentSearchQuery = postData.searchQuery;
 				sentSelectAll = postData.selectAll;
 			}
 
@@ -165,8 +169,10 @@ test(
 				.getByRole('menuitem', {name: 'test'})
 				.click();
 
+			expect(sentFilters).toBeUndefined();
 			expect(sentItems).toHaveLength(19);
 			expect(sentKeyValues).toHaveLength(19);
+			expect(sentSearchQuery).toBeUndefined();
 			expect(sentSelectAll).toBe(false);
 
 			expect(
@@ -177,6 +183,18 @@ test(
 		});
 
 		await test.step('With Select All flag active, requests sent the flag instead of selected items', async () => {
+			await test.step('Enter a search term', async () => {
+				await fdsSamplePage.selectionToolbar.clearButton.click();
+
+				await fdsSamplePage.managementToolbar.searchInput.fill(
+					'Sample'
+				);
+
+				await fdsSamplePage.managementToolbar.container
+					.getByRole('button', {name: 'Search'})
+					.click();
+			});
+
 			await itemsSelectorCheckbox.click();
 
 			await fdsSamplePage.selectAllCheckbox.click();
@@ -188,8 +206,17 @@ test(
 				.getByRole('menuitem', {name: 'test'})
 				.click();
 
+			expect(sentFilters).toEqual([
+				{
+					id: 'color',
+					multiple: true,
+					odataFilterString: "color in ('Blue', 'Green', 'Yellow')",
+					selectedItemsLabel: 'Blue, Green, Yellow',
+				},
+			]);
 			expect(sentItems).toEqual([]);
 			expect(sentKeyValues).toEqual([]);
+			expect(sentSearchQuery).toEqual('Sample');
 			expect(sentSelectAll).toBe(true);
 
 			expect(


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-56297

<h1>Enchance "Select all" by applying current filters and search query</h1>

When "Select All" is enabled and active (showing "All Selected (X of Y Items Selected)"), and the user triggers a bulk action, the `selectAll` parameter is sent as true.

The goal of this PR is to add two new parameter is `selectAll` is true:

A `filters` parameter, containing the active filters currently applied in the Data Set:
	**id**: filter id
	**multiple**: single or multiple selection type
	**odataFilterString**: the pattern the filter uses to filter items
        **selectedItemsLabel**: items selected of the filter object

A `searchQuery` parameter, containing the active search query string currently applied in the Data Set.

Notice that it is the responsibility of the Bulk Action implementer to accept and correctly interpret these parameters to retrieve and process the relevant items within the backend.
