### PR TITLE
LPD-61790 FDS cards do not show the action icons

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -153,6 +153,7 @@ const Card = forwardRef<HTMLDivElement, any>(
 						toggleItemInlineEdit,
 					});
 				},
+				symbolLeft: action.icon,
 			})),
 			description: getLocalizedValue(item, schema.description)?.value,
 			href: (schema.link && item[schema.link]) || null,

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/tests/data-set-fragment/itemActions.spec.ts
@@ -783,7 +783,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 			});
 		});
 
-		await test.step('Checkt that the Item Actions is present in table row', async () => {
+		await test.step('Check that the Item Actions is present in table row', async () => {
 			const itemActionsCell =
 				dataSetFragmentPage.table.itemActionsCells.first();
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -22,6 +22,7 @@ export class FDSSamplePage {
 	readonly cards: {
 		container: Locator;
 		items: Locator;
+		itemActionButtons: Locator;
 	};
 	readonly customViewsActionsButton: Locator;
 	readonly customViewsDeleteAlert: Locator;
@@ -34,6 +35,7 @@ export class FDSSamplePage {
 	readonly itemActionsButtons: Locator;
 	readonly list: {
 		container: Locator;
+		itemActionButtons: Locator;
 		items: Locator;
 	};
 	readonly managementToolbar: {
@@ -70,11 +72,15 @@ export class FDSSamplePage {
 				.getByLabel('Actions'),
 			container: page.locator('.bulk-actions'),
 		};
+
 		const cardsContainer = page.locator('.cards-container');
+
+		const cardItems = cardsContainer.locator('.card');
 
 		this.cards = {
 			container: cardsContainer,
-			items: cardsContainer.locator('.card'),
+			itemActionButtons: cardItems.getByLabel('More actions'),
+			items: cardItems,
 		};
 		this.customViewsActionsButton = page.getByLabel('Show View Actions', {
 			exact: true,
@@ -100,9 +106,15 @@ export class FDSSamplePage {
 
 		const listContainer = page.locator('.fds .list-sheet');
 
+		const listItems = listContainer.locator('.list-group-item');
+
 		this.list = {
 			container: listContainer,
-			items: listContainer.locator('.list-group-item'),
+			itemActionButtons: listItems.getByRole('button', {
+				exact: true,
+				name: 'Actions',
+			}),
+			items: listItems,
 		};
 
 		this.managementToolbar = {
@@ -189,6 +201,24 @@ export class FDSSamplePage {
 				name: action,
 			})
 			.click();
+	}
+
+	async checkDropdownMenuIconsAreVisible(itemActionButton: Locator) {
+		await itemActionButton.click();
+
+		const dropdownId = await itemActionButton.getAttribute('aria-controls');
+
+		const dropdownMenu = this.page.locator(`#${dropdownId}`);
+
+		await dropdownMenu.filter({has: this.page.getByRole('menu')}).waitFor();
+
+		const menuItems = dropdownMenu.getByRole('menuitem');
+
+		for (const menuItem of await menuItems.all()) {
+			await expect.soft(menuItem.locator('.lexicon-icon')).toBeVisible();
+		}
+
+		await this.page.keyboard.press('Escape');
 	}
 
 	selectItemActionsByRow(text: string) {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -21,8 +21,8 @@ export class FDSSamplePage {
 	};
 	readonly cards: {
 		container: Locator;
-		items: Locator;
 		itemActionButtons: Locator;
+		items: Locator;
 	};
 	readonly customViewsActionsButton: Locator;
 	readonly customViewsDeleteAlert: Locator;
@@ -57,7 +57,7 @@ export class FDSSamplePage {
 		container: Locator;
 		firstColumnHeader: Locator;
 		headerCells: Locator;
-		itemActionsCells: Locator;
+		itemActionButtons: Locator;
 		manageColumnsVisibilityButton: Locator;
 	};
 	readonly toggleInfoPanelButton: Locator;
@@ -150,7 +150,12 @@ export class FDSSamplePage {
 			container: tableContainer,
 			firstColumnHeader: headerCells.nth(1),
 			headerCells,
-			itemActionsCells: tableContainer.locator('.cell-item-actions'),
+			itemActionButtons: tableContainer
+				.locator('.cell-item-actions')
+				.getByRole('button', {
+					exact: true,
+					name: 'Actions',
+				}),
 			manageColumnsVisibilityButton: tableContainer.getByTitle(
 				'Manage Columns Visibility'
 			),

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -73,24 +73,9 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 
 	await test.step('Check that the Item Actions dropdown displays icons for Table, List, and Cards views', async () => {
 		await test.step('Check Table view actions dropdown items has icons', async () => {
-			const dropdownId =
-				await itemActionButton.getAttribute('aria-controls');
-
-			await itemActionButton.click();
-
-			const dropdownMenu = page.locator(`#${dropdownId}`);
-
-			await dropdownMenu.filter({has: page.getByRole('menu')}).waitFor();
-
-			const menuItems = dropdownMenu.getByRole('menuitem');
-
-			for (const menuItem of await menuItems.all()) {
-				await expect
-					.soft(menuItem.locator('.lexicon-icon'))
-					.toBeVisible();
-			}
-
-			await page.keyboard.press('Escape');
+			await fdsSamplePage.checkDropdownMenuIconsAreVisible(
+				itemActionButton
+			);
 		});
 
 		await test.step('Check List view actions dropdown items has icons', async () => {
@@ -99,30 +84,14 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 				visualizationMode: EFDSVisualizationMode.LIST,
 			});
 
-			const listItemActionButton = fdsSamplePage.list.items
-				.first()
-				.getByRole('button', {
-					exact: true,
-					name: 'Actions',
-				});
+			const listItemActionButton =
+				fdsSamplePage.list.itemActionButtons.first();
 
-			await listItemActionButton.click();
+			await expect(listItemActionButton).toBeVisible();
 
-			const dropdownMenu = page.locator(
-				`#${await listItemActionButton.getAttribute('aria-controls')}`
+			await fdsSamplePage.checkDropdownMenuIconsAreVisible(
+				listItemActionButton
 			);
-
-			await dropdownMenu.filter({has: page.getByRole('menu')}).waitFor();
-
-			const menuItems = dropdownMenu.getByRole('menuitem');
-
-			for (const menuItem of await menuItems.all()) {
-				await expect
-					.soft(menuItem.locator('.lexicon-icon'))
-					.toBeVisible();
-			}
-
-			await page.keyboard.press('Escape');
 		});
 
 		await test.step('Check Cards view action dropdown items has icons', async () => {
@@ -131,30 +100,14 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 				visualizationMode: EFDSVisualizationMode.CARDS,
 			});
 
-			const cardItemActionButton = fdsSamplePage.cards.items
-				.first()
-				.getByLabel('More actions');
+			const cardItemActionButton =
+				fdsSamplePage.cards.itemActionButtons.first();
 
 			await expect(cardItemActionButton).toBeVisible();
 
-			await cardItemActionButton.click();
-
-			const dropdownId =
-				await cardItemActionButton.getAttribute('aria-controls');
-
-			const dropdownMenu = page.locator(`#${dropdownId}`);
-
-			await dropdownMenu.filter({has: page.getByRole('menu')}).waitFor();
-
-			const menuItems = dropdownMenu.getByRole('menuitem');
-
-			for (const menuItem of await menuItems.all()) {
-				await expect
-					.soft(menuItem.locator('.lexicon-icon'))
-					.toBeVisible();
-			}
-
-			await page.keyboard.press('Escape');
+			await fdsSamplePage.checkDropdownMenuIconsAreVisible(
+				cardItemActionButton
+			);
 		});
 
 		await test.step('Switch back to Table view', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -85,7 +85,9 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 			const menuItems = dropdownMenu.getByRole('menuitem');
 
 			for (const menuItem of await menuItems.all()) {
-				await expect(menuItem.locator('.lexicon-icon')).toBeVisible();
+				await expect
+					.soft(menuItem.locator('.lexicon-icon'))
+					.toBeVisible();
 			}
 
 			await page.keyboard.press('Escape');
@@ -115,7 +117,9 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 			const menuItems = dropdownMenu.getByRole('menuitem');
 
 			for (const menuItem of await menuItems.all()) {
-				await expect(menuItem.locator('.lexicon-icon')).toBeVisible();
+				await expect
+					.soft(menuItem.locator('.lexicon-icon'))
+					.toBeVisible();
 			}
 
 			await page.keyboard.press('Escape');
@@ -145,7 +149,9 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 			const menuItems = dropdownMenu.getByRole('menuitem');
 
 			for (const menuItem of await menuItems.all()) {
-				await expect(menuItem.locator('.lexicon-icon')).toBeVisible();
+				await expect
+					.soft(menuItem.locator('.lexicon-icon'))
+					.toBeVisible();
 			}
 
 			await page.keyboard.press('Escape');

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -71,6 +71,94 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 		await page.keyboard.press('Escape');
 	});
 
+	await test.step('Check that the Item Actions dropdown displays icons for Table, List, and Cards views', async () => {
+		await test.step('Check Table view actions dropdown items has icons', async () => {
+			const dropdownId =
+				await itemActionButton.getAttribute('aria-controls');
+
+			await itemActionButton.click();
+
+			const dropdownMenu = page.locator(`#${dropdownId}`);
+
+			await dropdownMenu.filter({has: page.getByRole('menu')}).waitFor();
+
+			const menuItems = dropdownMenu.getByRole('menuitem');
+
+			for (const menuItem of await menuItems.all()) {
+				await expect(menuItem.locator('.lexicon-icon')).toBeVisible();
+			}
+
+			await page.keyboard.press('Escape');
+		});
+
+		await test.step('Check List view actions dropdown items has icons', async () => {
+			await fdsSamplePage.changeVisualizationMode({
+				page,
+				visualizationMode: EFDSVisualizationMode.LIST,
+			});
+
+			const listItemActionButton = fdsSamplePage.list.items
+				.first()
+				.getByRole('button', {
+					exact: true,
+					name: 'Actions',
+				});
+
+			await listItemActionButton.click();
+
+			const dropdownMenu = page.locator(
+				`#${await listItemActionButton.getAttribute('aria-controls')}`
+			);
+
+			await dropdownMenu.filter({has: page.getByRole('menu')}).waitFor();
+
+			const menuItems = dropdownMenu.getByRole('menuitem');
+
+			for (const menuItem of await menuItems.all()) {
+				await expect(menuItem.locator('.lexicon-icon')).toBeVisible();
+			}
+
+			await page.keyboard.press('Escape');
+		});
+
+		await test.step('Check Cards view action dropdown items has icons', async () => {
+			await fdsSamplePage.changeVisualizationMode({
+				page,
+				visualizationMode: EFDSVisualizationMode.CARDS,
+			});
+
+			const cardItemActionButton = fdsSamplePage.cards.items
+				.first()
+				.getByLabel('More actions');
+
+			await expect(cardItemActionButton).toBeVisible();
+
+			await cardItemActionButton.click();
+
+			const dropdownId =
+				await cardItemActionButton.getAttribute('aria-controls');
+
+			const dropdownMenu = page.locator(`#${dropdownId}`);
+
+			await dropdownMenu.filter({has: page.getByRole('menu')}).waitFor();
+
+			const menuItems = dropdownMenu.getByRole('menuitem');
+
+			for (const menuItem of await menuItems.all()) {
+				await expect(menuItem.locator('.lexicon-icon')).toBeVisible();
+			}
+
+			await page.keyboard.press('Escape');
+		});
+
+		await test.step('Switch back to Table view', async () => {
+			await fdsSamplePage.changeVisualizationMode({
+				page,
+				visualizationMode: EFDSVisualizationMode.TABLE,
+			});
+		});
+	});
+
 	await test.step('Side Panel action opens a side panel with content title', async () => {
 		await fdsSamplePage.clickItemAction(
 			sidePanelActionLabelWithContentTitle

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -45,19 +45,16 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 	const sidePanelActionTitle = 'Side Panel Title Provided by Action';
 	const sidePanelContentTitle = 'Side Panel Title Provided by Page';
 
-	const itemActionsCell = fdsSamplePage.table.itemActionsCells.first();
-
-	const itemActionButton = itemActionsCell.getByRole('button', {
-		exact: true,
-		name: 'Actions',
-	});
-
 	await test.step('Check that the Item Actions dropdown is present in table row', async () => {
-		await expect(itemActionButton).toBeVisible();
+		const tableItemActionButton =
+			fdsSamplePage.table.itemActionButtons.first();
 
-		const dropdownId = await itemActionButton.getAttribute('aria-controls');
+		await expect(tableItemActionButton).toBeVisible();
 
-		await itemActionButton.click();
+		const dropdownId =
+			await tableItemActionButton.getAttribute('aria-controls');
+
+		await tableItemActionButton.click();
 
 		await page
 			.locator(`#${dropdownId}`)
@@ -73,8 +70,13 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 
 	await test.step('Check that the Item Actions dropdown displays icons for Table, List, and Cards views', async () => {
 		await test.step('Check Table view actions dropdown items has icons', async () => {
+			const tableItemActionButton =
+				fdsSamplePage.table.itemActionButtons.first();
+
+			await expect(tableItemActionButton).toBeVisible();
+
 			await fdsSamplePage.checkDropdownMenuIconsAreVisible(
-				itemActionButton
+				tableItemActionButton
 			);
 		});
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/item_selection.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/item_selection.spec.ts
@@ -224,19 +224,10 @@ test(
 	'Check behavior of quick actions',
 	{tag: '@LPS-153220'},
 	async ({fdsSamplePage, page}) => {
-		const firstRowItemActionButton = fdsSamplePage.table.itemActionsCells
-			.first()
-			.getByRole('button', {
-				exact: true,
-				name: 'Actions',
-			});
-
-		const thirdRowItemActionButton = fdsSamplePage.table.itemActionsCells
-			.nth(2)
-			.getByRole('button', {
-				exact: true,
-				name: 'Actions',
-			});
+		const firstRowItemActionButton =
+			fdsSamplePage.table.itemActionButtons.first();
+		const thirdRowItemActionButton =
+			fdsSamplePage.table.itemActionButtons.nth(2);
 
 		const firstRowSampleEditQuickActionLink = fdsSamplePage.table.bodyRows
 			.first()

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/classic/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/classic/actions.spec.ts
@@ -79,12 +79,7 @@ test('Check behavior of conditional item actions', async ({
 			await fdsSamplePage.table.bodyRows.count()
 		).toBeGreaterThanOrEqual(3);
 
-		const itemActionsCell = fdsSamplePage.table.itemActionsCells.first();
-
-		const itemActionButton = itemActionsCell.getByRole('button', {
-			exact: true,
-			name: 'Actions',
-		});
+		const itemActionButton = fdsSamplePage.table.itemActionButtons.first();
 
 		await expect(itemActionButton).toBeVisible();
 


### PR DESCRIPTION
Bug Ticket: https://liferay.atlassian.net/browse/LPD-61790

---

## The issue

The issue is that the Cards view uses `ClayCardWithInfo` which uses `ClayDropDownWithItems` to render the actions. The `items` prop expects the icon to be defined with `symbolLeft` https://github.com/liferay/clay/blob/7759bb752a8805c627a8c77adaf063381ed89f56/packages/clay-drop-down/src/Item.tsx#L50-L53

In comparison, List and Table views use the frontend-data-set-web `Actions` component which builds the dropdown itself in the `ActionsDropdown` component.

## The solution

Pass in the icon using the `symbolLeft` prop.

## Screenshot With Solution Applied

<img width="1243" height="979" alt="Screenshot 2025-08-12 at 2 53 36 PM" src="https://github.com/user-attachments/assets/59e7f751-0227-43d3-9923-047daa54a376" />

## Other solutions explored

- Use `Actions` in Cards view as well
    - Not possible unless Cards refactors into using composed components.
    - Cards view currently uses a high-level component `ClayCardWithInfo` so all of the props are passed into the component. The action dropdown component being used can’t be changed.