### PR TITLE
LPP-60124 Make CETEditorConfigContributor virtual instance aware

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/portlet/editor/config/contributor/CETEditorConfigContributor.java
@@ -26,9 +26,10 @@ public class CETEditorConfigContributor
 	implements EditorConfigContributor, Registrable {
 
 	public CETEditorConfigContributor(
-		String editorConfigKeys, String editorNames, String portletNames,
-		String url) {
+		long companyId, String editorConfigKeys, String editorNames,
+		String portletNames, String url) {
 
+		_companyId = companyId;
 		_editorConfigKeys = editorConfigKeys;
 		_editorNames = editorNames;
 		_portletNames = portletNames;
@@ -73,6 +74,10 @@ public class CETEditorConfigContributor
 		ThemeDisplay themeDisplay,
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
+		if (themeDisplay.getCompanyId() != _companyId) {
+			return;
+		}
+
 		JSONArray jsonArray = jsonObject.getJSONArray("editorTransformerURLs");
 
 		if (jsonArray == null) {
@@ -84,6 +89,7 @@ public class CETEditorConfigContributor
 		jsonArray.put(_url);
 	}
 
+	private final long _companyId;
 	private final String _editorConfigKeys;
 	private final String _editorNames;
 	private final String _portletNames;

--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/type/deployer/CETDeployerImpl.java
@@ -177,6 +177,7 @@ public class CETDeployerImpl implements CETDeployer {
 			_register(
 				EditorConfigContributor.class,
 				new CETEditorConfigContributor(
+					editorConfigContributorCET.getCompanyId(),
 					editorConfigContributorCET.getEditorConfigKeys(),
 					editorConfigContributorCET.getEditorNames(),
 					editorConfigContributorCET.getPortletNames(),


### PR DESCRIPTION
@fortunatomaldonado this shall be enough for LPP-60124.

Consider this a draft PR, not thought to be merged yet. I purposedly used the LPP number in the commit to signal this

Please:

- Test this manually using our sample on the default company and check that 
  - It does apply to the editor in the default company
  - It does not apply to other instances
- The other way round if you deploy another copy of the CX targting a non-default company
- Check what happens if CX has no companyID (it shall be applied to the default company only)
- If all the above holds, we have green light to create a hotfix
- Add tests for it
- Then we're ready to send this for master

@izaera can assist you in case there's some loose end here (there are other approaches for this, the one I'm proposing is the simplest one I could find)

Thank you

