### PR TITLE
LPD-56780 Update helpMessage in aui:input taglib to be read only once by screen-reader

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
+++ b/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
@@ -38,7 +38,7 @@
 		<span class="taglib-text-icon"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
 	</c:when>
 	<c:otherwise>
-		<c:if test="<%= Validator.isNotNull(message) %>">
+		<c:if test="<%= !toolTip && Validator.isNotNull(message) %>">
 			<span class="taglib-text <%= label ? StringPool.BLANK : "hide-accessible sr-only" %>"><%= localizeMessage ? LanguageUtil.get(resourceBundle, message) : message %></span>
 		</c:if>
 	</c:otherwise>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-56780 - Update helpMessage in aui:input taglib to be read only once by screen-reader

Design has noticed that the help message is read 2-3 times in the inputs created with `aui:input` because the tooltip has additional `sr-only` text. 

<img width="1429" height="665" alt="image" src="https://github.com/user-attachments/assets/98ac8d92-6c6d-41b0-a7d9-e9e8b2e8a354" />

<img width="357" height="471" alt="Screenshot 2025-08-14 at 3 03 13 PM" src="https://github.com/user-attachments/assets/f1c99141-c63a-4944-80c1-2976fedebbda" />

This change would be to check the presence of a tooltip before including that additional taglib text, which cuts down on being read several times ([design is fine with this idea](https://liferay.atlassian.net/browse/LPD-56780?focusedCommentId=2997175)).

Let me know if there's any other suggestions, if this looks ok! Thank you.
