### PR TITLE
LPD-40364 LPD-63141 frontend-data-set-web: Add option for onFileDrop callback

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
@@ -43,43 +43,50 @@ const useFileUploader = ({
 			return;
 		}
 
-		const ModalBody = () => {
+		if (fileDropSettings.onFileDrop) {
+			fileDropSettings.onFileDrop(droppedFiles, dropTarget);
+		}
+		else {
+			const ModalBody = () => {
 
-			// @ts-ignore
+				// @ts-ignore
 
-			const label = (file) =>
-				`'${file.name}' of size '${file.size}' and type '${file.type}'`;
+				const label = (file) =>
+					`'${file.name}' of size '${file.size}' and type '${file.type}'`;
 
-			return (
-				<div>
-					{droppedFiles.map((file) => (
+				return (
+					<div>
+						{droppedFiles.map((file) => (
 
-						// @ts-ignore
+							// @ts-ignore
 
-						<li key={file.name}>{label(file)}</li>
-					))}
+							<li key={file.name}>{label(file)}</li>
+						))}
 
-					{dropTarget ? (
-						<span>
-							Dropped on item{' '}
+						{dropTarget ? (
+							<span>
+								Dropped on item{' '}
 
-							{getSelectedItemValue({
-								item: dropTarget,
-								path: selectedItemsKey,
-							})}
-						</span>
-					) : (
-						<span>Dropped on the FDS, no specific drop target</span>
-					)}
-				</div>
-			);
-		};
+								{getSelectedItemValue({
+									item: dropTarget,
+									path: selectedItemsKey,
+								})}
+							</span>
+						) : (
+							<span>
+								Dropped on the FDS, no specific drop target
+							</span>
+						)}
+					</div>
+				);
+			};
 
-		openModal({
-			bodyComponent: ModalBody,
-			size: 'lg',
-			title: Liferay.Language.get('files'),
-		});
+			openModal({
+				bodyComponent: ModalBody,
+				size: 'lg',
+				title: Liferay.Language.get('files'),
+			});
+		}
 	}, [droppedFiles, dropTarget, fileDropSettings, selectedItemsKey]);
 
 	return {onFileDrop};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -249,6 +249,7 @@ export interface IView {
 export interface IFileDropSettings {
 	enabled: boolean;
 	isDropTarget: ({item}: {item: any}) => boolean;
+	onFileDrop?: (droppedItem: any, dropTarget?: any) => void;
 }
 
 export interface IFrontendDataSetProps {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63141 - Update FDS to accept a callback when dropping in files

From trying out frontend-data-set's new drag and drop feature, it looks like the default action opens this modal:
<img width="800" alt="Screenshot 2025-08-18 at 5 11 31 PM" src="https://github.com/user-attachments/assets/12292462-941a-442d-994c-617ab8af7fe8" />

I added a few changes to allow the option to pass in a custom callback `onFileDrop`. If it is available, that gets called instead in order to facilitate the action.

Let me know if this makes sense to do? I had not seen another way to define a file drop action, and this feature is so new I don't think I saw any documentation.

Thank you!