### PR TITLE
LPD-62993 Add items list in the action click handler

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
@@ -113,6 +113,7 @@ export default function propsTransformer({
 		onActionDropdownItemClick({
 			action,
 			itemData,
+			items,
 			loadData,
 			openSidePanel,
 		}: any) {
@@ -123,7 +124,16 @@ export default function propsTransformer({
 				loadData();
 			}
 			else if (action.data.id === 'sampleMessage') {
-				alert(`${greeting} ${itemData.title}!`);
+				const itemsIds = items
+					.map((item: any): string => item.id)
+					.join(',');
+
+				const currentItemPos =
+					items.findIndex((item: any) => item.id === itemData.id) + 1;
+
+				alert(
+					`${greeting} ${itemData.title}! You are ${itemData.id}, the element #${currentItemPos} in [${itemsIds}]`
+				);
 			}
 		},
 		onBulkActionItemClick({

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/actions/Actions.tsx
@@ -21,11 +21,13 @@ function Actions({
 	actions,
 	itemData,
 	itemId,
+	items,
 	onItemSelectionChange,
 }: {
 	actions: Array<IItemsActions>;
 	itemData: any;
 	itemId: string | number;
+	items: any[];
 	onItemSelectionChange?: Function;
 }) {
 	const {
@@ -102,6 +104,7 @@ function Actions({
 			infoPanelOpen,
 			itemData,
 			itemId,
+			items,
 			loadData,
 			onActionDropdownItemClick,
 			onInfoPanelToggleButtonClick,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/handleActionClick.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/actionItems/handleActionClick.ts
@@ -23,6 +23,7 @@ const handleActionClick = ({
 	infoPanelOpen,
 	itemData,
 	itemId,
+	items,
 	loadData,
 	onActionDropdownItemClick,
 	onInfoPanelToggleButtonClick,
@@ -40,6 +41,7 @@ const handleActionClick = ({
 	infoPanelOpen?: boolean;
 	itemData: any;
 	itemId: string | number;
+	items: any[];
 	loadData: Function;
 	onActionDropdownItemClick: Function;
 	onInfoPanelToggleButtonClick?: Function;
@@ -129,6 +131,7 @@ const handleActionClick = ({
 			action,
 			event,
 			itemData,
+			items,
 			loadData,
 			openSidePanel,
 		};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -130,7 +130,10 @@ const Card = forwardRef<HTMLDivElement, any>(
 				return ESelectionTrigger.INPUT;
 			}
 
-			if (target.closest('.dropdown-toggle')) {
+			if (
+				target.closest('.dropdown-toggle') ||
+				target.closest('.dropdown-item')
+			) {
 				return false;
 			}
 
@@ -149,12 +152,14 @@ const Card = forwardRef<HTMLDivElement, any>(
 						event,
 						executeAsyncItemAction,
 						highlightItems,
+						infoPanelOpen,
 						itemData: item,
 						itemId: selectedItemKey,
 						items,
 						loadData,
 						onActionDropdownItemClick,
 						onInfoPanelToggleButtonClick,
+						onItemSelectionChange,
 						openModal,
 						openSidePanel,
 						toggleItemInlineEdit,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/cards/Cards.tsx
@@ -34,9 +34,15 @@ const Card = forwardRef<HTMLDivElement, any>(
 	(
 		{
 			item,
+			items,
 			onItemSelectionChange,
 			schema,
-		}: {item: any; onItemSelectionChange: Function; schema: ICardSchema},
+		}: {
+			item: any;
+			items: any[];
+			onItemSelectionChange: Function;
+			schema: ICardSchema;
+		},
 		ref
 	) => {
 		const {
@@ -145,6 +151,7 @@ const Card = forwardRef<HTMLDivElement, any>(
 						highlightItems,
 						itemData: item,
 						itemId: selectedItemKey,
+						items,
 						loadData,
 						onActionDropdownItemClick,
 						onInfoPanelToggleButtonClick,
@@ -212,6 +219,7 @@ const Card = forwardRef<HTMLDivElement, any>(
 
 function ClayCardOptionalDropTarget({
 	item,
+	items,
 	onItemSelectionChange,
 	schema,
 }: React.ComponentProps<typeof Card>) {
@@ -230,6 +238,7 @@ function ClayCardOptionalDropTarget({
 		<div className="col-md-3">
 			<Card
 				item={item}
+				items={items}
 				onItemSelectionChange={onItemSelectionChange}
 				ref={cardRef}
 				schema={schema}
@@ -268,6 +277,7 @@ const Cards = ({
 						return (
 							<ClayCardOptionalDropTarget
 								item={item}
+								items={items}
 								key={
 									selectedItemsKey
 										? getSelectedItemValue({

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/emails_list/EmailsList.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/emails_list/EmailsList.js
@@ -20,6 +20,7 @@ function Email({
 	date,
 	frontendDataSetContext,
 	href,
+	items,
 	status,
 	subject,
 	summary,
@@ -103,7 +104,7 @@ function Email({
 
 				{actionDropdownItems.length ? (
 					<div className="col-auto d-flex flex-column justify-content-center">
-						<Actions actions={actionDropdownItems} />
+						<Actions actions={actionDropdownItems} items={items} />
 					</div>
 				) : null}
 			</div>
@@ -157,6 +158,7 @@ function EmailsList({dataLoading, frontendDataSetContext, items}) {
 					{...item}
 					borderBottom={i !== items.length - 1}
 					frontendDataSetContext={frontendDataSetContext}
+					items={items}
 				/>
 			))}
 		</ClayList>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/list/List.tsx
@@ -58,11 +58,13 @@ const ListItem = forwardRef<HTMLLIElement, any>(
 		{
 			className,
 			item,
+			items,
 			onItemSelectionChange,
 			schema,
 		}: {
 			className: string;
 			item: any;
+			items: any[];
 			onItemSelectionChange: Function;
 			schema: IListSchema;
 		},
@@ -181,6 +183,7 @@ const ListItem = forwardRef<HTMLLIElement, any>(
 							actions={itemsActions || item.actionDropdownItems}
 							itemData={item}
 							itemId={itemId}
+							items={items}
 							onItemSelectionChange={onItemSelectionChange}
 						/>
 					)}
@@ -192,10 +195,12 @@ const ListItem = forwardRef<HTMLLIElement, any>(
 
 const ListItemOptionalDropTarget = ({
 	item,
+	items,
 	onItemSelectionChange,
 	schema,
 }: {
 	item: any;
+	items: any[];
 	onItemSelectionChange: Function;
 	schema: IListSchema;
 }) => {
@@ -205,6 +210,7 @@ const ListItemOptionalDropTarget = ({
 		<ListItem
 			className={className}
 			item={item}
+			items={items}
 			onItemSelectionChange={onItemSelectionChange}
 			ref={dropRef}
 			schema={schema}
@@ -246,6 +252,7 @@ const List = ({
 					{items.map((item: any, index: number) => (
 						<ListItemOptionalDropTarget
 							item={item}
+							items={items}
 							key={
 								selectedItemsKey
 									? getSelectedItemValue({

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/views/table/Table.tsx
@@ -157,6 +157,7 @@ const Row = ({
 	columns,
 	item,
 	itemInlineChanges,
+	items,
 	itemsActions,
 	onItemSelectionChange,
 	selectionType,
@@ -166,6 +167,7 @@ const Row = ({
 	columns: Array<Field>;
 	item: any;
 	itemInlineChanges?: {[key: string]: any};
+	items: any[];
 	itemsActions: Array<IItemsActions>;
 	onItemSelectionChange: Function;
 	selectionType?: string;
@@ -211,6 +213,7 @@ const Row = ({
 											}
 											itemData={item}
 											itemId={id}
+											items={items}
 											onItemSelectionChange={
 												onItemSelectionChange
 											}
@@ -388,6 +391,7 @@ const Body = ({
 							columns={columns}
 							item={item}
 							itemInlineChanges={itemInlineChanges}
+							items={items}
 							itemsActions={itemsActions}
 							onItemSelectionChange={onItemSelectionChange}
 							selectionType={selectionType}

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceSitesModal.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceSitesModal.test.tsx
@@ -194,9 +194,9 @@ describe('SpaceSitesModal', () => {
 
 			await userEvent.click(screen.getByPlaceholderText('select-a-site'));
 
-			await screen
-				.getByRole('option', {name: mockUnconnectedSite.name})
-				.click();
+			await userEvent.click(
+				screen.getByRole('option', {name: mockUnconnectedSite.name})
+			);
 
 			await userEvent.click(
 				screen.getByRole('button', {name: 'connect'})
@@ -233,9 +233,9 @@ describe('SpaceSitesModal', () => {
 
 			await userEvent.click(screen.getByPlaceholderText('select-a-site'));
 
-			await screen
-				.getByRole('option', {name: mockUnconnectedSite.name})
-				.click();
+			await userEvent.click(
+				screen.getByRole('option', {name: mockUnconnectedSite.name})
+			);
 
 			await userEvent.click(
 				screen.getByRole('button', {name: 'connect'})

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -220,7 +220,7 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 		await expect(fdsSamplePage.sidePanel).toHaveClass(/is-hidden/);
 	});
 
-	await test.step('Sample view action opens an alert message and it receives the list of items', async () => {
+	await test.step('Sample view action opens an alert message', async () => {
 		let dialogMessage = '';
 
 		page.on('dialog', async (dialog) => {
@@ -228,14 +228,27 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 			await dialog.accept();
 		});
 
-		await fdsSamplePage.clickItemAction(sampleView);
-		await expect(dialogMessage).toContain('Hello Sample1!');
-		await expect(dialogMessage).toContain('element #1');
+		for (const visualizationMode of Object.values(EFDSVisualizationMode)) {
+			await test.step(`Sample view action receives the list of items, ${visualizationMode}`, async () => {
+				await fdsSamplePage.changeVisualizationMode({
+					page,
+					visualizationMode,
+				});
 
-		await fdsSamplePage.clickItemAction(sampleView, 19);
-		await expect(dialogMessage).toContain('Hello Sample32!');
-		await expect(dialogMessage).toContain('element #20');
+				await fdsSamplePage.clickItemAction(sampleView);
+				expect(dialogMessage).toContain('Hello Sample1!');
+				expect(dialogMessage).toContain('element #1');
 
+				await fdsSamplePage.clickItemAction(sampleView, 19);
+				expect(dialogMessage).toContain('Hello Sample32!');
+				expect(dialogMessage).toContain('element #20');
+			});
+		}
+
+		await fdsSamplePage.changeVisualizationMode({
+			page,
+			visualizationMode: EFDSVisualizationMode.TABLE,
+		});
 	});
 
 	await test.step('Async connection refused action opens an unexpected error alert toast', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -224,7 +224,7 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 		await fdsSamplePage.clickItemAction(sampleView);
 
 		page.on('dialog', async (dialog) => {
-			await expect(dialog.message).toBe('Hello Sample1!');
+			await expect(dialog.message).toContain('Hello Sample1!');
 		});
 	});
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -220,12 +220,22 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 		await expect(fdsSamplePage.sidePanel).toHaveClass(/is-hidden/);
 	});
 
-	await test.step('Sample view action opens an alert message', async () => {
+	await test.step('Sample view action opens an alert message and it receives the list of items', async () => {
+		let dialogMessage = '';
+
 		page.on('dialog', async (dialog) => {
-			await expect(dialog.message).toContain('Hello Sample1!');
+			dialogMessage = dialog.message();
+			await dialog.accept();
 		});
 
 		await fdsSamplePage.clickItemAction(sampleView);
+		await expect(dialogMessage).toContain('Hello Sample1!');
+		await expect(dialogMessage).toContain('element #1');
+
+		await fdsSamplePage.clickItemAction(sampleView, 19);
+		await expect(dialogMessage).toContain('Hello Sample32!');
+		await expect(dialogMessage).toContain('element #20');
+
 	});
 
 	await test.step('Async connection refused action opens an unexpected error alert toast', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/actions.spec.ts
@@ -221,11 +221,11 @@ test('Behavior of item actions', async ({fdsSamplePage, page}) => {
 	});
 
 	await test.step('Sample view action opens an alert message', async () => {
-		await fdsSamplePage.clickItemAction(sampleView);
-
 		page.on('dialog', async (dialog) => {
 			await expect(dialog.message).toContain('Hello Sample1!');
 		});
+
+		await fdsSamplePage.clickItemAction(sampleView);
 	});
 
 	await test.step('Async connection refused action opens an unexpected error alert toast', async () => {


### PR DESCRIPTION
### References

- Task ticket: https://liferay.atlassian.net/browse/LPD-62886
- Spike: https://liferay.atlassian.net/browse/LPD-59271

### Context

In the series of small improvements in FDS to accommodate CMS requiements, here we have an API contract enhancement in otder to provide the current list of `items` fetched by FDS to the provided _item action click event handler_. 

This way such handler can implement further navigations beyond the item where action was triggered from. Before this PR, such handler had no access to that data.

### What was done

Ensure `items` prop is passed through each ootb view implementation to the `handleActionClick` utility function, either via the `<Actions>` react component or by direct invocation (view implementation varies)

To complement and illustrate the proposal for developers, behavior was sample in one of the advanced sample item actions, which now renders an alert which lists the item ids as given by the new API. Note that this list is already **filtered** and **ordered** as per user / admin choices. Action click handler must not mutate items, just read them, in other words, there is no accces to the `setItems()` internal FDS function.

Finally, PW tests were improved to assert item list is passed and rendered in all views.

