### PR TITLE
LPD-63521 Unable to update DSM fields, filters, sorting, and actions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/components/ActionForm.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/actions/components/ActionForm.tsx
@@ -258,7 +258,7 @@ const ActionForm = ({
 				relationship: OBJECT_RELATIONSHIP.DATA_SET_ACTIONS,
 			});
 
-			fetchMethod = 'PUT';
+			fetchMethod = 'PATCH';
 		}
 		else {
 			apiURL = getDataSetResourceURL({

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -120,7 +120,7 @@ function FilterFormComponent({
 		let url;
 
 		if (filter) {
-			method = 'PUT';
+			method = 'PATCH';
 
 			url = getDataSetResourceURL({
 				dataSetERC: dataSet.externalReferenceCode,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-63521

`PATCH` methods are now implemented by https://liferay.atlassian.net/browse/LPD-62771, but `PUT` doesn't accept a request body so those requests will fail. Only Filters and Actions uses `PUT` requests, so I'm switching them `PATCH`. 

cc @dsanz 