### PR TITLE
LPD-63092 After double search the search hint changes to undesired state

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/ActiveFiltersBar.js
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/ActiveFiltersBar.js
@@ -14,7 +14,7 @@ import {VIEWS_ACTION_TYPES} from '../../../views/viewsReducer';
 import FilterResume from './FilterResume';
 import SearchResume from './SearchResume';
 
-function ActiveFiltersBar({disabled, total}) {
+function ActiveFiltersBar({dataLoading, disabled, total}) {
 	const {onSearch, searchParam, searching, setSearching} = useContext(
 		FrontendDataSetContext
 	);
@@ -54,7 +54,7 @@ function ActiveFiltersBar({disabled, total}) {
 						<li className="p-0 tbar-item tbar-item-expand">
 							<div className="tbar-section">
 								{Liferay.FeatureFlags['LPD-52212'] &&
-									(searching ? (
+									(dataLoading && searching ? (
 										<span>
 											{Liferay.Language.get(
 												'requesting-results-for-colon'
@@ -112,6 +112,7 @@ function ActiveFiltersBar({disabled, total}) {
 }
 
 ActiveFiltersBar.propTypes = {
+	dataLoading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	total: PropTypes.number,
 };

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -40,6 +40,7 @@ export class FDSSamplePage {
 	};
 	readonly managementToolbar: {
 		container: Locator;
+		searchButton: Locator;
 		searchInput: Locator;
 	};
 	readonly page: Page;
@@ -117,11 +118,17 @@ export class FDSSamplePage {
 			items: listItems,
 		};
 
+		const managementToolbarContainer =
+			page.getByTestId('managementToolbar');
+
 		this.managementToolbar = {
-			container: page.getByTestId('managementToolbar'),
-			searchInput: page
-				.getByTestId('managementToolbar')
-				.locator('input[type="search"]'),
+			container: managementToolbarContainer,
+			searchButton: managementToolbarContainer.getByRole('button', {
+				name: 'Search',
+			}),
+			searchInput: managementToolbarContainer.locator(
+				'input[type="search"]'
+			),
 		};
 
 		this.page = page;

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
@@ -70,9 +70,7 @@ test(
 					'Sample55'
 				);
 
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Search'})
-					.click();
+				await fdsSamplePage.managementToolbar.searchButton.click();
 			});
 
 			await test.step('Check that "1 Result Found for:" is displayed', async () => {
@@ -143,9 +141,7 @@ test(
 					'Sample'
 				);
 
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Search'})
-					.click();
+				await fdsSamplePage.managementToolbar.searchButton.click();
 
 				await expect(
 					page.getByText('75 Results Found for:')
@@ -153,9 +149,7 @@ test(
 			});
 
 			await test.step('Click search again', async () => {
-				await fdsSamplePage.managementToolbar.container
-					.getByRole('button', {name: 'Search'})
-					.click();
+				await fdsSamplePage.managementToolbar.searchButton.click();
 			});
 
 			await test.step('Check that "Requesting Results for:" is not displayed', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
@@ -10,6 +10,7 @@ import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
 import getRandomString from '../../../../../utils/getRandomString';
+import {EFDSVisualizationMode, waitForFDS} from '../../../../../utils/waitFor';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
 
 const test = mergeTests(
@@ -28,9 +29,7 @@ test.beforeEach(async ({fdsSamplePage, page, site}) => {
 
 	await fdsSamplePage.selectTab('Advanced');
 
-	await expect(
-		page.getByText('This is a description for sample 1.')
-	).toBeVisible();
+	await waitForFDS({page, visualizationMode: EFDSVisualizationMode.TABLE});
 });
 
 test('Check Search clear button', async ({fdsSamplePage}) => {
@@ -62,7 +61,7 @@ test('Check Search clear button', async ({fdsSamplePage}) => {
 test(
 	'Check behavior of search',
 	{
-		tag: ['@LPD-56876'],
+		tag: ['@LPD-56876', '@LPD-63092'],
 	},
 	async ({fdsSamplePage, page}) => {
 		await test.step('The total results label and search resume are displayed when a search is made', async () => {
@@ -126,6 +125,47 @@ test(
 				await expect(
 					fdsSamplePage.activeFiltersToolbar.locator('.search-resume')
 				).not.toBeVisible();
+			});
+		});
+
+		await test.step('Applying the same search twice does not show "Requesting Results for:" indefinitely', async () => {
+			await test.step('Reset the tab', async () => {
+				await fdsSamplePage.selectTab('Advanced');
+
+				await waitForFDS({
+					page,
+					visualizationMode: EFDSVisualizationMode.TABLE,
+				});
+			});
+
+			await test.step('Search for "Sample" and wait for the search to finish', async () => {
+				await fdsSamplePage.managementToolbar.searchInput.fill(
+					'Sample'
+				);
+
+				await fdsSamplePage.managementToolbar.container
+					.getByRole('button', {name: 'Search'})
+					.click();
+
+				await expect(
+					page.getByText('75 Results Found for:')
+				).toBeVisible();
+			});
+
+			await test.step('Click search again', async () => {
+				await fdsSamplePage.managementToolbar.container
+					.getByRole('button', {name: 'Search'})
+					.click();
+			});
+
+			await test.step('Check that "Requesting Results for:" is not displayed', async () => {
+				await expect(
+					page.getByText('Requesting Results for:')
+				).not.toBeVisible();
+
+				await expect(
+					page.getByText('75 Results Found for:')
+				).toBeVisible();
 			});
 		});
 	}


### PR DESCRIPTION
**Bug ticket:** https://liferay.atlassian.net/browse/LPD-63092

---

## **The Issue**

Searching state is set to true, but the data loading never happens so the searching state is never reset.

## **The Solution**

Check for both if the searching state is true AND data is loading to show the “requesting results for” so it checks when an actual request is being made, not just when a search is being attempted.

As a note: `dataLoading` was already passed into `ActiveFiltersBar`, so I only needed to add in the prop https://github.com/liferay/liferay-portal/blob/7165ca9285a44d2038e77a5cf869b429a726e9b3/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/ManagementBar.js#L81-L84