### PR TITLE
LPD-64002 Make JSPortletExtender manage fragment alias registration lifecycle, if applies

### DIFF
--- a/modules/apps/frontend-js/frontend-js-portlet-extender/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:configuration-admin:configuration-admin-web")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
+	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/JSPortletExtender.java
+++ b/modules/apps/frontend-js/frontend-js-portlet-extender/src/main/java/com/liferay/frontend/js/portlet/extender/internal/JSPortletExtender.java
@@ -8,6 +8,7 @@ package com.liferay.frontend.js.portlet.extender.internal;
 import com.liferay.dynamic.data.mapping.form.renderer.DDMFormRenderer;
 import com.liferay.dynamic.data.mapping.form.values.factory.DDMFormValuesFactory;
 import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.frontend.js.portlet.extender.internal.portlet.JSPortlet;
 import com.liferay.frontend.js.portlet.extender.internal.portlet.action.PortletExtenderConfigurationAction;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.URLUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -37,6 +39,7 @@ import java.util.Set;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
+import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.wiring.BundleCapability;
 import org.osgi.framework.wiring.BundleWire;
@@ -210,6 +213,14 @@ public class JSPortletExtender {
 
 		String packageVersion = packageJSONObject.getString("version");
 
+		String fragmentAlias = GetterUtil.getString(
+			properties.get(_FRAGMENT_ALIAS_PROPERTY_NAME));
+
+		if (Validator.isNotNull(fragmentAlias)) {
+			_portletRegistry.registerAlias(
+				fragmentAlias, _getPortletName(packageJSONObject));
+		}
+
 		return bundleContext.registerService(
 			new String[] {
 				ManagedService.class.getName(), Portlet.class.getName()
@@ -219,6 +230,9 @@ public class JSPortletExtender {
 				portletPreferencesFieldNames),
 			properties);
 	}
+
+	private static final String _FRAGMENT_ALIAS_PROPERTY_NAME =
+		"com.liferay.fragment.entry.processor.portlet.alias";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JSPortletExtender.class);
@@ -289,6 +303,17 @@ public class JSPortletExtender {
 					Bundle bundle, BundleEvent bundleEvent,
 					ServiceRegistration<?> serviceRegistration) {
 
+					ServiceReference<?> serviceReference =
+						serviceRegistration.getReference();
+
+					String fragmentAlias = GetterUtil.getString(
+						serviceReference.getProperty(
+							_FRAGMENT_ALIAS_PROPERTY_NAME));
+
+					if (Validator.isNotNull(fragmentAlias)) {
+						_portletRegistry.unregisterAlias(fragmentAlias);
+					}
+
 					serviceRegistration.unregister();
 				}
 
@@ -308,5 +333,8 @@ public class JSPortletExtender {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortletRegistry _portletRegistry;
 
 }


### PR DESCRIPTION
Reference: 

- https://liferay.atlassian.net/browse/LPD-64002

In this PR we are enhancing JSPortlet registration process to manage "fragment alias" registration lifcecycle, in cases where the corresponding property comes in the JS Portlet `package.json` file.

This worked well in the past, but the embedding mechanism [changed long ago,](https://learn.liferay.com/w/dxp/development/developing-page-fragments/reference/fragment-specific-tags-and-attributes-reference) and JSPortlet registration was not updated back then.

I don't believe this needs any tests as: (i) JSPortlet has no backend tests, (ii) whole feature is deprecated and (iii) logic is simple enough as it belongs to the extender, not to the JSPortlet