### PR TITLE
LPD-63141 Enable onFileDrop callback on FDS to facilitate integration of an external file uploader

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/AdvancedPropsTransformer.ts
@@ -10,6 +10,7 @@ import {fetch} from 'frontend-js-web';
 
 import CustomAuthorTableCell from './CustomAuthorTableCell';
 import SampleInfoPanel from './SampleInfoPanel';
+import dummyUploader from './dummyUploader';
 
 import type {
 	ICardSchema,
@@ -32,6 +33,7 @@ export default function propsTransformer({
 	const fileDropSettings: IFileDropSettings = {
 		enabled: true,
 		isDropTarget: ({item}: {item: any}) => item.color !== 'Green',
+		onFileDrop: dummyUploader,
 	};
 
 	const views: Array<IView> = otherProps.views;

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/dummyUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/resources/META-INF/resources/js/dummyUploader.tsx
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FrontendDataSet, TOnFileDrop} from '@liferay/frontend-data-set-web';
+import {openModal} from 'frontend-js-components-web';
+import React from 'react';
+
+const dummyUploader: TOnFileDrop = (droppedFiles: File[], dropTarget: any) => {
+	const ModalBody = () => {
+		return (
+			<>
+				<FrontendDataSet
+					id=""
+					items={droppedFiles.map((file: File) => ({
+						name: file.name,
+						size: file.size,
+						type: file.type,
+					}))}
+					views={[
+						{
+							contentRenderer: 'table',
+							default: true,
+							label: 'Table',
+							name: 'table',
+							schema: {
+								fields: [
+									{
+										contentRendererClientExtension: false,
+										fieldName: 'name',
+										label: 'Name',
+									},
+									{
+										contentRendererClientExtension: false,
+										fieldName: 'size',
+										label: 'Size',
+									},
+									{
+										contentRendererClientExtension: false,
+										fieldName: 'type',
+										label: 'Type',
+									},
+								],
+							},
+							thumbnail: 'table',
+						},
+					]}
+				/>
+
+				<div>
+					{dropTarget ? (
+						<span>Dropped on item {dropTarget.id}</span>
+					) : (
+						<span>Dropped on the FDS, no specific drop target</span>
+					)}
+				</div>
+			</>
+		);
+	};
+
+	openModal({
+		bodyComponent: ModalBody,
+		size: 'lg',
+		title: 'Custom dummy file uploader',
+	});
+};
+
+export default dummyUploader;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DnDContext.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/DnDContext.tsx
@@ -7,11 +7,11 @@ import React from 'react';
 
 import {IFileDropSettings} from './utils/types';
 
-export type TOnFileDrop = (droppedItem: any, dropTarget?: any) => void;
+export type THandleFileDrop = (droppedItem: any, dropTarget?: any) => void;
 
 export interface IFrontendDataSetDropContext {
 	fileDropSettings: IFileDropSettings;
-	onFileDrop: TOnFileDrop;
+	handleFileDrop: THandleFileDrop;
 }
 
 const DnDContext = React.createContext({
@@ -19,7 +19,7 @@ const DnDContext = React.createContext({
 		enabled: false,
 		isDropTarget: () => true,
 	},
-	onFileDrop: () => {},
+	handleFileDrop: () => {},
 } as unknown as IFrontendDataSetDropContext);
 
 export default DnDContext;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -1345,7 +1345,7 @@ const FrontendDataSet = ({
 				isDropTarget: () => true,
 			};
 
-	const {onFileDrop} = useFileUploader({
+	const {handleFileDrop} = useFileUploader({
 		fileDropSettings,
 		selectedItemsKey,
 	});
@@ -1354,7 +1354,7 @@ const FrontendDataSet = ({
 		<DnDContext.Provider
 			value={{
 				fileDropSettings,
-				onFileDrop,
+				handleFileDrop,
 			}}
 		>
 			<FDSDndProvider>

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFDSDrop.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFDSDrop.ts
@@ -28,7 +28,7 @@ const useFDSDrop = ({
 	targetDropRef?: RefObject<HTMLElement>;
 	targetDropRefQuerySelector?: string;
 }) => {
-	const {fileDropSettings, onFileDrop} = useContext(DnDContext);
+	const {fileDropSettings, handleFileDrop} = useContext(DnDContext);
 
 	const targetDropElementRef: MutableRefObject<HTMLElement | null> =
 		useRef<HTMLElement>(null);
@@ -69,7 +69,7 @@ const useFDSDrop = ({
 					);
 				}
 
-				onFileDrop?.(fileItem, item);
+				handleFileDrop?.(fileItem, item);
 			}
 		},
 	});

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
@@ -9,7 +9,7 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {THandleFileDrop} from '../DnDContext';
 import getSelectedItemValue from '../utils/getSelectedItemValue';
 import isFileDropEnabled from '../utils/isFileDropEnabled';
-import {IFileDropSettings} from '../utils/types';
+import {IFileDropSettings, TOnFileDrop} from '../utils/types';
 
 /* This hook connects FDS with state about dropped files, allowing integration
 	with a file uploader component in the future. Current implementation
@@ -27,7 +27,7 @@ const useFileUploader = ({
 	const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
 	const [dropTarget, setDropTarget] = useState(null);
 
-	const dummyUploader = useCallback(
+	const dummyUploader: TOnFileDrop = useCallback(
 		(droppedFiles: File[], dropTarget: any) => {
 			const ModalBody = () => {
 				const label = (file: File) =>
@@ -82,8 +82,22 @@ const useFileUploader = ({
 			return;
 		}
 
-		dummyUploader(droppedFiles, dropTarget);
-	}, [droppedFiles, dropTarget, fileDropSettings, selectedItemsKey]);
+		if (
+			fileDropSettings.onFileDrop &&
+			typeof fileDropSettings.onFileDrop === 'function'
+		) {
+			fileDropSettings.onFileDrop(droppedFiles, dropTarget);
+		}
+		else {
+			dummyUploader(droppedFiles, dropTarget);
+		}
+	}, [
+		dummyUploader,
+		droppedFiles,
+		dropTarget,
+		fileDropSettings,
+		selectedItemsKey,
+	]);
 
 	return {handleFileDrop};
 };

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
@@ -4,7 +4,7 @@
  */
 
 import {openModal} from 'frontend-js-components-web';
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {TOnFileDrop} from '../DnDContext';
 import getSelectedItemValue from '../utils/getSelectedItemValue';
@@ -27,6 +27,45 @@ const useFileUploader = ({
 	const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
 	const [dropTarget, setDropTarget] = useState(null);
 
+	const dummyUploader = useCallback(
+		(droppedFiles: File[], dropTarget: any) => {
+			const ModalBody = () => {
+				const label = (file: File) =>
+					`'${file.name}' of size '${file.size}' and type '${file.type}'`;
+
+				return (
+					<div>
+						{droppedFiles.map((file: File) => (
+							<li key={file.name}>{label(file)}</li>
+						))}
+
+						{dropTarget ? (
+							<span>
+								Dropped on item{' '}
+
+								{getSelectedItemValue({
+									item: dropTarget,
+									path: selectedItemsKey,
+								})}
+							</span>
+						) : (
+							<span>
+								Dropped on the FDS, no specific drop target
+							</span>
+						)}
+					</div>
+				);
+			};
+
+			openModal({
+				bodyComponent: ModalBody,
+				size: 'lg',
+				title: Liferay.Language.get('files'),
+			});
+		},
+		[selectedItemsKey]
+	);
+
 	const onFileDrop: TOnFileDrop = (droppedItem: any, dropTarget?: any) => {
 		if (droppedItem) {
 			const files: File[] = droppedItem.files;
@@ -40,37 +79,7 @@ const useFileUploader = ({
 			return;
 		}
 
-		const ModalBody = () => {
-			const label = (file: File) =>
-				`'${file.name}' of size '${file.size}' and type '${file.type}'`;
-
-			return (
-				<div>
-					{droppedFiles.map((file: File) => (
-						<li key={file.name}>{label(file)}</li>
-					))}
-
-					{dropTarget ? (
-						<span>
-							Dropped on item{' '}
-
-							{getSelectedItemValue({
-								item: dropTarget,
-								path: selectedItemsKey,
-							})}
-						</span>
-					) : (
-						<span>Dropped on the FDS, no specific drop target</span>
-					)}
-				</div>
-			);
-		};
-
-		openModal({
-			bodyComponent: ModalBody,
-			size: 'lg',
-			title: Liferay.Language.get('files'),
-		});
+		dummyUploader(droppedFiles, dropTarget);
 	}, [droppedFiles, dropTarget, fileDropSettings, selectedItemsKey]);
 
 	return {onFileDrop};

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
@@ -12,8 +12,10 @@ import isFileDropEnabled from '../utils/isFileDropEnabled';
 import {IFileDropSettings, TOnFileDrop} from '../utils/types';
 
 /* This hook connects FDS with state about dropped files, allowing integration
-	with a file uploader component in the future. Current implementation
-	shows a modal with the dropped files.
+	with a file uploader component in the future. To implement an uploader,
+	please provide the the onFileDrop function via fileDropSettings.
+	Default implementation is used if none provided, showing a modal with the
+	list of dropped files.
  */
 const useFileUploader = ({
 	fileDropSettings,
@@ -27,7 +29,7 @@ const useFileUploader = ({
 	const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
 	const [dropTarget, setDropTarget] = useState(null);
 
-	const dummyUploader: TOnFileDrop = useCallback(
+	const defaultUploader: TOnFileDrop = useCallback(
 		(droppedFiles: File[], dropTarget: any) => {
 			const ModalBody = () => {
 				const label = (file: File) =>
@@ -89,10 +91,10 @@ const useFileUploader = ({
 			fileDropSettings.onFileDrop(droppedFiles, dropTarget);
 		}
 		else {
-			dummyUploader(droppedFiles, dropTarget);
+			defaultUploader(droppedFiles, dropTarget);
 		}
 	}, [
-		dummyUploader,
+		defaultUploader,
 		droppedFiles,
 		dropTarget,
 		fileDropSettings,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
@@ -6,7 +6,7 @@
 import {openModal} from 'frontend-js-components-web';
 import React, {useCallback, useEffect, useState} from 'react';
 
-import {TOnFileDrop} from '../DnDContext';
+import {THandleFileDrop} from '../DnDContext';
 import getSelectedItemValue from '../utils/getSelectedItemValue';
 import isFileDropEnabled from '../utils/isFileDropEnabled';
 import {IFileDropSettings} from '../utils/types';
@@ -22,7 +22,7 @@ const useFileUploader = ({
 	fileDropSettings: IFileDropSettings;
 	selectedItemsKey: string | undefined;
 }): {
-	onFileDrop: TOnFileDrop;
+	handleFileDrop: THandleFileDrop;
 } => {
 	const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
 	const [dropTarget, setDropTarget] = useState(null);
@@ -66,7 +66,10 @@ const useFileUploader = ({
 		[selectedItemsKey]
 	);
 
-	const onFileDrop: TOnFileDrop = (droppedItem: any, dropTarget?: any) => {
+	const handleFileDrop: THandleFileDrop = (
+		droppedItem: any,
+		dropTarget?: any
+	) => {
 		if (droppedItem) {
 			const files: File[] = droppedItem.files;
 			setDroppedFiles(files);
@@ -82,7 +85,7 @@ const useFileUploader = ({
 		dummyUploader(droppedFiles, dropTarget);
 	}, [droppedFiles, dropTarget, fileDropSettings, selectedItemsKey]);
 
-	return {onFileDrop};
+	return {handleFileDrop};
 };
 
 export default useFileUploader;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/dnd/useFileUploader.tsx
@@ -24,15 +24,12 @@ const useFileUploader = ({
 }): {
 	onFileDrop: TOnFileDrop;
 } => {
-	const [droppedFiles, setDroppedFiles] = useState([]);
+	const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
 	const [dropTarget, setDropTarget] = useState(null);
 
 	const onFileDrop: TOnFileDrop = (droppedItem: any, dropTarget?: any) => {
 		if (droppedItem) {
-
-			// @ts-ignore
-
-			const files = droppedItem.files;
+			const files: File[] = droppedItem.files;
 			setDroppedFiles(files);
 			setDropTarget(dropTarget ? dropTarget : null);
 		}
@@ -44,18 +41,12 @@ const useFileUploader = ({
 		}
 
 		const ModalBody = () => {
-
-			// @ts-ignore
-
-			const label = (file) =>
+			const label = (file: File) =>
 				`'${file.name}' of size '${file.size}' and type '${file.type}'`;
 
 			return (
 				<div>
-					{droppedFiles.map((file) => (
-
-						// @ts-ignore
-
+					{droppedFiles.map((file: File) => (
 						<li key={file.name}>{label(file)}</li>
 					))}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/index.ts
@@ -36,6 +36,7 @@ export {
 	IItemsActions,
 	IItemActionsData,
 	IView,
+	TOnFileDrop,
 } from './utils/types';
 
 export {Card} from './views/cards/Cards';

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -246,9 +246,12 @@ export interface IView {
 	views?: Array<any>;
 }
 
+export type TOnFileDrop = (droppedFiles: File[], dropTarget: any) => void;
+
 export interface IFileDropSettings {
 	enabled: boolean;
 	isDropTarget: ({item}: {item: any}) => boolean;
+	onFileDrop?: TOnFileDrop;
 }
 
 export interface IFrontendDataSetProps {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/pages/FDSSamplePage.ts
@@ -96,7 +96,7 @@ export class FDSSamplePage {
 		});
 		this.fdsWrapper = page.locator('div.data-set-wrapper').first();
 		this.fileDropModal = page.getByRole('dialog', {
-			name: 'Files',
+			name: 'Custom dummy file uploader',
 		});
 		this.infoPanel = page.locator('.fds-info-panel');
 


### PR DESCRIPTION
Reference: 

- https://liferay.atlassian.net/browse/LPD-63141 
- Folloup of https://github.com/liferay-frontend/liferay-portal/pull/5045

In this PR we are creating an explicit contract between the FDS and any external file uploader. Such contract is based on:

- A new, react-dnd agnostic type `TOnFileDrop` representing the function signature that connects a file drop event originated in the FDS with the externally provided handler that will process the files
- An opt-in mechanism to provide such function to the FDS via `fileDropSetting` configurations

In addition, this PR samples the mechanism in the `Advanced` FDS sample, so that it provides a custom implementation for such function. I've made it similar enough to keep tests passing, but somehow different to ensure contract is working in tests.

Other notes:

- Contract is based on a function, not on a react component, because file handling UI is likely separated from the FDS react hierarchy. Common scenario is to mediate this separation via `openModal()` function
- Provided types are based on common browser API (`File`)  instead of react-dnd abstraction (`droppedItem`) which remains internal to the FDS file drop implementation. This makes external API agnostic and makes us able to change internals without breaking the contract

cc @thektan @oliv-yu