### PR TITLE
LPD-65003 [BUG-LPP] Folder select border still visible, after clicking `Clear` in Documents & Media

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/SelectionControls.js
@@ -272,6 +272,11 @@ const SelectionControls = ({
 									setCheckboxStatus('unchecked');
 
 									onClearButtonClick(event);
+
+									Liferay.fire(
+										EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+										{checked: false}
+									);
 								}}
 								symbol="times-circle"
 								title={Liferay.Language.get('clear')}
@@ -301,6 +306,11 @@ const SelectionControls = ({
 										setSelectedItems(itemsTotal);
 
 										onSelectAllButtonClick(event);
+
+										Liferay.fire(
+											EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS,
+											{checked: true}
+										);
 									}}
 								>
 									<span className="text-truncate-inline">


### PR DESCRIPTION
### LPD: https://liferay.atlassian.net/browse/LPD-65003  
### Related LPP: https://liferay.atlassian.net/browse/LPP-60564

# What is this solving?

[HorizontalCards](https://github.com/liferay/liferay-portal/blob/c9150aed3be5328d444c4f9c5b4f6a60a905f32f/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/HorizontalCard.js) are not completely deselected when clicking the management toolbar `Clear` button.

# How is it fixed?

Fires `EVENT_MANAGEMENT_TOOLBAR_TOGGLE_ALL_ITEMS` when clicking the `Clear` and `Select All` buttons.

> [!NOTE]
> I added this on the `Select All` click for consistency, even though it currently has no effect. 
> I can remove it if you think it's unnecessary.

# How to verify?

Follow the steps described in https://liferay.atlassian.net/browse/LPD-65003.

# Visual changes

## Before
https://github.com/user-attachments/assets/12d38c10-16e6-45a3-b9e1-7e3c5a09b01d

## After
https://github.com/user-attachments/assets/f969af43-48ad-4a7c-9956-c99a430e61e4


# Why no tests?
Minor UI adjustment.