### PR TITLE
LPD-64999 Show DatePicker component in Basque

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-aui-web/build.gradle
@@ -7,7 +7,7 @@ configurations {
 
 task buildAlloyUI(type: Copy)
 
-String alloyUIVersion = "3.1.0-deprecated.128"
+String alloyUIVersion = "3.1.0-deprecated.129"
 
 File jsDestinationDir = file("tmp/META-INF/resources")
 

--- a/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
@@ -1,7 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/alert": "3.144.1",
-		"@clayui/date-picker": "3.145.0",
+		"@clayui/date-picker": "3.146.0",
 		"@clayui/tabs": "3.145.0",
 		"react": "18.2.0"
 	},

--- a/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-clay-sample-web/package.json
@@ -1,6 +1,8 @@
 {
 	"dependencies": {
 		"@clayui/alert": "3.144.1",
+		"@clayui/date-picker": "3.145.0",
+		"@clayui/tabs": "3.145.0",
 		"react": "18.2.0"
 	},
 	"main": "js/App.js",

--- a/modules/apps/frontend-js/frontend-js-clay-sample-web/src/main/resources/META-INF/resources/js/App.js
+++ b/modules/apps/frontend-js/frontend-js-clay-sample-web/src/main/resources/META-INF/resources/js/App.js
@@ -4,17 +4,96 @@
  */
 
 import ClayAlert from '@clayui/alert';
-import React from 'react';
+import ClayDatePicker from '@clayui/date-picker';
+import ClayTabs from '@clayui/tabs';
+import {dateUtils} from 'frontend-js-web';
+import React, {useState} from 'react';
 
 export function App() {
+	const [active, setActive] = useState(0);
+
 	return (
 		<div>
-			<ClayAlert title="Info">
-				This widget is used to test out Clay components. Simply add
-				whatever JS you want to App.js and redeploy.
-			</ClayAlert>
+			<ClayTabs
+				activation="manual"
+				active={active}
+				justified={false}
+				onActiveChange={setActive}
+			>
+				<ClayTabs.Item
+					innerProps={{
+						'aria-controls': 'tabpanel1',
+					}}
+				>
+					Clay Alert
+				</ClayTabs.Item>
 
-			<div className="clay-test-class">This is where your code goes.</div>
+				<ClayTabs.Item
+					innerProps={{
+						'aria-controls': 'tabpanel2',
+					}}
+				>
+					Clay Date Picker
+				</ClayTabs.Item>
+			</ClayTabs>
+
+			<ClayTabs.Content activeIndex={active} fade>
+				<ClayTabs.TabPane id="tabpanel1">
+					<ClayAlert title="Info">
+						This widget is used to test out Clay components. Simply
+						add whatever JS you want to App.js and redeploy.
+					</ClayAlert>
+
+					<div className="clay-test-class">
+						This is where your code goes.
+					</div>
+				</ClayTabs.TabPane>
+
+				<ClayTabs.TabPane id="tabpanel2">
+					<ClayDatePicker
+						ariaLabels={{
+							buttonChooseDate: `${Liferay.Language.get(
+								'select-date'
+							)}`,
+							buttonDot: `${Liferay.Language.get(
+								'select-current-date'
+							)}`,
+							buttonNextMonth: `${Liferay.Language.get(
+								'select-next-month'
+							)}`,
+							buttonPreviousMonth: `${Liferay.Language.get(
+								'select-previous-month'
+							)}`,
+							dialog: `${Liferay.Language.get('select-date')}`,
+							selectMonth: `${Liferay.Language.get('select-a-month')}`,
+							selectYear: `${Liferay.Language.get('select-a-year')}`,
+						}}
+						firstDayOfWeek={dateUtils.getFirstDayOfWeek()}
+						months={[
+							`${Liferay.Language.get('january')}`,
+							`${Liferay.Language.get('february')}`,
+							`${Liferay.Language.get('march')}`,
+							`${Liferay.Language.get('april')}`,
+							`${Liferay.Language.get('may')}`,
+							`${Liferay.Language.get('june')}`,
+							`${Liferay.Language.get('july')}`,
+							`${Liferay.Language.get('august')}`,
+							`${Liferay.Language.get('september')}`,
+							`${Liferay.Language.get('october')}`,
+							`${Liferay.Language.get('november')}`,
+							`${Liferay.Language.get('december')}`,
+						]}
+						placeholder="YYYY-MM-DD HH:mm"
+						required
+						time
+						weekdaysShort={dateUtils.getWeekdaysShort()}
+						years={{
+							end: 9999,
+							start: new Date().getFullYear(),
+						}}
+					/>
+				</ClayTabs.TabPane>
+			</ClayTabs.Content>
 		</div>
 	);
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/utils/date_time/constants.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/utils/date_time/constants.ts
@@ -64,10 +64,10 @@ export const FIRST_DAY_OF_WEEK_MAP = {
 	'zh-CN': 1,
 } as const;
 
-export const WEEKDAYS_SHORT_MAP = {
-	'eu-ES': ["ig","al","ar","az","og","or","lr"],
-} as const;
-
 export const MONTHS_LONG_MAP = {
 	'eu-ES': ["urtarrila","otsaila","martxoa","apirila","maiatza","ekaina","uztaila","abuztua","iraila","urria","azaroa","abendua"],
+} as const;
+
+export const WEEKDAYS_SHORT_MAP = {
+	'eu-ES': ["ig","al","ar","az","og","or","lr"],
 } as const;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/utils/date_time/constants.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/utils/date_time/constants.ts
@@ -34,6 +34,7 @@ export const FIRST_DAY_OF_WEEK_MAP = {
 	'en-US': 0,
 	'es-ES': 1,
 	'et-EE': 1,
+	'eu-ES': 1,
 	'fi-FI': 1,
 	'fr-FR': 1,
 	'hu-HU': 1,
@@ -61,4 +62,12 @@ export const FIRST_DAY_OF_WEEK_MAP = {
 	'tw-TW': 0,
 	'vi-VN': 1,
 	'zh-CN': 1,
+} as const;
+
+export const WEEKDAYS_SHORT_MAP = {
+	'eu-ES': ["ig","al","ar","az","og","or","lr"],
+} as const;
+
+export const MONTHS_LONG_MAP = {
+	'eu-ES': ["urtarrila","otsaila","martxoa","apirila","maiatza","ekaina","uztaila","abuztua","iraila","urria","azaroa","abendua"],
 } as const;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/utils/date_time/index.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/utils/date_time/index.ts
@@ -5,12 +5,14 @@
 
 import {
 	FIRST_DAY_OF_WEEK_MAP,
+	MONTHS_LONG_MAP,
 	SECONDS_IN_DAY,
 	SECONDS_IN_HOUR,
 	SECONDS_IN_MINUTE,
 	SECONDS_IN_MONTH,
 	SECONDS_IN_WEEK,
 	SECONDS_IN_YEAR,
+	WEEKDAYS_SHORT_MAP,
 } from './constants';
 import {format} from './format';
 import {parse} from './parse';
@@ -28,6 +30,10 @@ function getFirstDayOfWeek(
 }
 
 function getWeekdaysShort(locale = Liferay.ThemeDisplay.getBCP47LanguageId()) {
+	if (locale in WEEKDAYS_SHORT_MAP) {
+		return WEEKDAYS_SHORT_MAP[locale as keyof typeof WEEKDAYS_SHORT_MAP];
+	}
+
 	const weekdaysShort = Array.from({length: 7}, (_, i) => {
 		const date = new Date(2025, 0, i + 5); // 2025-01-05 is a Sunday
 
@@ -38,6 +44,10 @@ function getWeekdaysShort(locale = Liferay.ThemeDisplay.getBCP47LanguageId()) {
 }
 
 function getMonthsLong(locale = Liferay.ThemeDisplay.getBCP47LanguageId()) {
+	if (locale in MONTHS_LONG_MAP) {
+		return MONTHS_LONG_MAP[locale as keyof typeof MONTHS_LONG_MAP];
+	}
+
 	const weekdaysShort = Array.from({length: 12}, (_, i) => {
 		const date = new Date(2025, i);
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/build.gradle
@@ -15,7 +15,7 @@ task buildLexiconIcons(type: Copy)
 task buildTheme
 task publishNodeModule(type: PublishNodeModuleTask)
 
-String alloyUIVersion = "3.1.0-deprecated.128"
+String alloyUIVersion = "3.1.0-deprecated.129"
 
 String fontAwesomeVersion = "3.2.1"
 

--- a/modules/test/playwright/tests/frontend-js-web/main/dateTimeUtils.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-web/main/dateTimeUtils.spec.ts
@@ -45,13 +45,13 @@ test(
             const datePickerDialog = page.getByRole('dialog', {name: 'Aukeratu data'});
             await expect(datePickerDialog).toBeVisible();
 
-            await expect(datePickerDialog.getByText('al')).toBeVisible();
-            await expect(datePickerDialog.getByText('ar')).toBeVisible();
-            await expect(datePickerDialog.getByText('az')).toBeVisible();
-            await expect(datePickerDialog.getByText('og')).toBeVisible();
-            await expect(datePickerDialog.getByText('ol')).toBeVisible();
-            await expect(datePickerDialog.getByText('lr')).toBeVisible();
-            await expect(datePickerDialog.getByText('ig')).toBeVisible();
+            await expect(datePickerDialog.getByText('al', {exact: true})).toBeVisible();
+            await expect(datePickerDialog.getByText('ar', {exact: true})).toBeVisible();
+            await expect(datePickerDialog.getByText('az', {exact: true})).toBeVisible();
+            await expect(datePickerDialog.getByText('og', {exact: true})).toBeVisible();
+            await expect(datePickerDialog.getByText('or', {exact: true})).toBeVisible();
+            await expect(datePickerDialog.getByText('lr', {exact: true})).toBeVisible();
+            await expect(datePickerDialog.getByText('ig', {exact: true})).toBeVisible();
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-js-web/main/dateTimeUtils.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-web/main/dateTimeUtils.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {samplePageTest} from './fixtures/samplePageTest';
+
+export const test = mergeTests(
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+    samplePageTest,
+);
+
+const linkName = 'Clay Date Picker';
+
+test(
+	'Date Picker is using right translations in Basque locale',
+	{tag: '@LPD-64999'},
+	async ({page, site, samplePage}) => {
+		await test.step('Create a content site showing it in Basque and add the taglib sample widget', async () => {
+            const locale = 'eu-ES';
+			await samplePage.setupSampleWidget({
+				site,
+                locale
+			});
+		});
+
+		await test.step('Select Panel link', async () => {
+			await samplePage.selectLink(linkName);
+
+            await expect(samplePage.page.getByPlaceholder('YYYY-MM-DD HH:mm')).toBeVisible();
+		});
+
+        await test.step('Open Date Picker and assert weekdays are shown in Basque', async () => {
+			await page.getByRole('button', {name: 'Aukeratu data'}).click();
+
+            const datePickerDialog = page.getByRole('dialog', {name: 'Aukeratu data'});
+            await expect(datePickerDialog).toBeVisible();
+
+            await expect(datePickerDialog.getByText('al')).toBeVisible();
+            await expect(datePickerDialog.getByText('ar')).toBeVisible();
+            await expect(datePickerDialog.getByText('az')).toBeVisible();
+            await expect(datePickerDialog.getByText('og')).toBeVisible();
+            await expect(datePickerDialog.getByText('ol')).toBeVisible();
+            await expect(datePickerDialog.getByText('lr')).toBeVisible();
+            await expect(datePickerDialog.getByText('ig')).toBeVisible();
+		});
+	}
+);

--- a/modules/test/playwright/tests/frontend-js-web/main/env/osgi-modules.list
+++ b/modules/test/playwright/tests/frontend-js-web/main/env/osgi-modules.list
@@ -1,0 +1,1 @@
+frontend-js-clay-sample-web

--- a/modules/test/playwright/tests/frontend-js-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/frontend-js-web/main/env/portal-ext.properties
@@ -14,4 +14,4 @@ locales.enabled=\
     pt_BR,\
     es_ES,\
     sv_SE,\
-    eu_ES,
+    eu_ES

--- a/modules/test/playwright/tests/frontend-js-web/main/env/portal-ext.properties
+++ b/modules/test/playwright/tests/frontend-js-web/main/env/portal-ext.properties
@@ -1,1 +1,17 @@
 search.container.page.delta.values=1,4,6,8
+
+locales.enabled=\
+    ar_SA,\
+    ca_ES,\
+    zh_CN,\
+    nl_NL,\
+    en_US,\
+    fi_FI,\
+    fr_FR,\
+    de_DE,\
+    hu_HU,\
+    ja_JP,\
+    pt_BR,\
+    es_ES,\
+    sv_SE,\
+    eu_ES,

--- a/modules/test/playwright/tests/frontend-js-web/main/fixtures/samplePageTest.ts
+++ b/modules/test/playwright/tests/frontend-js-web/main/fixtures/samplePageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {SamplePage} from '../pages/SamplePage';
+
+const samplePageTest = test.extend<{
+	samplePage: SamplePage;
+}>({
+	samplePage: async ({page}, use) => {
+		await use(new SamplePage(page));
+	},
+});
+
+export {samplePageTest};

--- a/modules/test/playwright/tests/frontend-js-web/main/pages/SamplePage.ts
+++ b/modules/test/playwright/tests/frontend-js-web/main/pages/SamplePage.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+import {ApiHelpers} from '../../../../helpers/ApiHelpers';
+import {liferayConfig} from '../../../../liferay.config';
+import getRandomString from '../../../../utils/getRandomString';
+import getPageDefinition from '../../../layout-content-page-editor-web/main/utils/getPageDefinition';
+import getWidgetDefinition from '../../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
+
+export class SamplePage {
+	readonly apiHelpers: ApiHelpers;
+	readonly page: Page;
+	readonly tabList: Locator;
+
+	constructor(page: Page) {
+		this.apiHelpers = new ApiHelpers(page);
+		this.page = page;
+		this.tabList = page.getByRole('tab');
+	}
+
+	async selectLink(tabName: string) {
+		const tabHeading = this.tabList.getByText(tabName);
+
+		await expect(tabHeading).toBeInViewport();
+
+		await tabHeading.click();
+	}
+
+	async setupSampleWidget({site, locale = 'en-US'}: {site: Site; locale?: string}) {
+		const widgetDefinition = getWidgetDefinition({
+			id: getRandomString(),
+			widgetName:
+				'com_liferay_frontend_js_clay_sample_web_internal_portlet_FrontendJSClaySampleWebPortlet',
+		});
+
+		const layout = await this.apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await this.page.goto(
+			`${liferayConfig.environment.baseUrl}/${locale}/web${site.friendlyUrlPath}${layout.friendlyUrlPath}`
+		);
+	}
+}


### PR DESCRIPTION
Hi,

Both of our DatePickers (Clay and AlloyUI) are showing mixing translations when using Basque language.
 * In order to fix AlloyUI one, we just need to update to the latest version
 * In order to fix Clay one, I'm adding some exceptions so we don't need to use `toLocaleDateString` which relies on browser implementation and not all of them support Basque language.

In order to test it, I add a Clay Picker within our frontend-js-clay-sample-web and made that module a bit easier to extend in the future with other Clay components which can't be tested through a taglib. 

Thanks.

Regards.