### PR TITLE
LPD-65813 Use event.target instead

### DIFF
--- a/portal-web/docroot/html/taglib/ui/error/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/error/page.jsp
@@ -18,7 +18,7 @@ String alertTitle = (String)request.getAttribute("liferay-ui:error:alertTitle");
 	<c:when test='<%= GetterUtil.getBoolean((String)request.getAttribute("liferay-ui:error:embed")) %>'>
 		<div class="alert alert-dismissible alert-<%= alertStyle %>" role="alert">
 			<liferay-ui:csp>
-				<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" onclick="event.preventDefault();const container = event.delegateTarget.closest('.alert');if (container) {container.parentNode.removeChild(container);}" type="button">
+				<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" onclick="event.preventDefault();const container = event.target.closest('.alert');if (container) {container.parentNode.removeChild(container);}" type="button">
 					<aui:icon image="times" markupView="lexicon" />
 
 					<span class="sr-only"><liferay-ui:message key="close" /></span>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-65813
https://liferay.atlassian.net/browse/LPP-60733

`event.delegateTarget` is null and created an error when the close button is pressed for the error UI. I changed it to `event.target` to avoid this error and close the UI.
Please let me know if there are any questions or comments about this.

Thank you!