### PR TITLE
LPD-67029 Make IItemsActions `type` type less strict

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/types.ts
@@ -125,6 +125,11 @@ export interface ICreationActionItem {
 		| string;
 }
 
+export enum EItemActionsType {
+	GROUP = 'group',
+	ITEM = 'item',
+}
+
 export interface IItemsActions {
 	className?: string;
 	data?: IItemActionsData;
@@ -150,12 +155,7 @@ export interface IItemsActions {
 		| 'modal-permissions'
 		| 'sidePanel'
 		| 'event';
-	type?: EItemActionsType;
-}
-
-export enum EItemActionsType {
-	GROUP = 'group',
-	ITEM = 'item',
+	type?: EItemActionsType | `${EItemActionsType}`;
 }
 
 export interface IItemActionsData {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-67029

This fixes `ci:test:sf` errors in other modules like https://github.com/liferay-bpm/liferay-portal/pull/5192#issuecomment-3353786097.

This makes the type-checking less strict to allow strings "item" or "group" instead of needing to use the `EItemActionsType` enum.

I tested this fix here https://github.com/thektan/liferay-portal/pull/268 where I:
- Made a change to the the objects-web module
- Checked that SF failed
- Applied this fix
- Checked that SF passed

## Dev Notes
Given:
```
export enum EItemActionsType {
	GROUP = 'group',
	ITEM = 'item',
}
```

``${EItemActionsType}`` is a shorthand way of returning `'group' | 'item'`

So the new full type is:

```
type?: EItemActionsType | `${EItemActionsType}`;
```