### PR TITLE
LPD-66608 accessibility issues in New Space pages (CMS)

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/learn_message/LearnMessage.tsx
@@ -3,8 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import getCN from 'classnames';
+import {sub} from 'frontend-js-web';
 import React, {useContext} from 'react';
 
 export const LearnResourcesContext = React.createContext<
@@ -117,6 +119,10 @@ export default function LearnMessage({
 	if (learnMessageObject.url) {
 		return (
 			<ClayLink
+				aria-label={sub(
+					Liferay.Language.get('x-opens-new-window'),
+					learnMessageObject.message
+				)}
 				className={getCN('learn-message', className)}
 				href={learnMessageObject.url}
 				rel="noopener noreferrer"
@@ -124,6 +130,8 @@ export default function LearnMessage({
 				{...otherProps}
 			>
 				{learnMessageObject.message}
+
+				<ClayIcon className="ml-1" fontSize={14} symbol="shortcut" />
 			</ClayLink>
 		);
 	}

--- a/modules/apps/frontend-js/frontend-js-components-web/test/learn_message/LearnMessage.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/learn_message/LearnMessage.js
@@ -49,6 +49,25 @@ describe('LearnMessage', () => {
 		expect(element.href).toEqual(URL);
 	});
 
+	it('displays aria label and shortcut icon', () => {
+		const {getByLabelText} = render(
+			<LearnMessageWithContext
+				resource="portal-search-web"
+				resourceKey="search-bar-suggestions"
+			/>
+		);
+
+		const element = getByLabelText('x-opens-new-window');
+
+		expect(element).not.toBeNull();
+
+		expect(
+			element
+				.querySelector('svg')
+				.classList.contains('lexicon-icon-shortcut')
+		).toBe(true);
+	});
+
 	it('displays nothing if LearnResourcesContext is missing', () => {
 		const {container} = render(
 			<LearnMessage

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/NewSpaceFormSection.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/NewSpaceFormSection.test.tsx
@@ -47,7 +47,7 @@ describe('NewSpaceFormSection', () => {
 			screen.getByText(props.children!.toString())
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole('link', {name: /Test Message/})
+			screen.getByRole('link', {name: 'x-opens-new-window'})
 		).toHaveAttribute('href', 'https://learn.liferay.com/test-url');
 	});
 


### PR DESCRIPTION
Link to issue: https://liferay.atlassian.net/browse/LPD-66608

### What is expected

> Update both links to include accessible hidden text and the Clay shortcut icon. Example below:

```
<a href="…" target="_blank" rel="noopener" aria-label="Learn more about spaces (opens in a new tab)">
   Learn more about spaces
   <span class="sr-only">(opens in a new tab)</span>
   <svg class="lexicon-icon lexicon-icon-shortcut"></svg>
</a>
```

### How did I solve it 
As we are using `LearnMessage` component, I added there the aria label and the shortcut icon. I have checked that there is a `sr-only` span (which I don't know where it comes from), the result now is 

```
<a class="learn-message font-weight-semi-bold text-decoration-underline" rel="noopener noreferrer" target="_blank" aria-label="Learn more about space memberships. (Opens New Window)" href="https://learn.liferay.com/w/dxp/content-management-system/liferay-cms/spaces/space-memberships">
    Learn more about space memberships.
    <button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary btn-xs" type="button">
        <svg class="lexicon-icon lexicon-icon-shortcut" role="presentation">
            <use href="http://localhost:8080/o/cms-theme/images/clay/icons.svg#shortcut"></use>
        </svg>
    </button>
    <span class="sr-only">(Opens a new window)</span>
</a>
```

### How to test it
You can check it directly in the CMS pages, when creating a new space. Also, I have added some tests: 

```
yarn test LearnMessage
yarn run v1.22.22
warning package.json: No license field
$ node-scripts test LearnMessage
 PASS  test/learn_message/LearnMessage.js

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        2.491s
✨  Done in 4.36s.
```

<img width="892" height="1034" alt="Screenshot 2025-10-07 at 11 59 10" src="https://github.com/user-attachments/assets/21bbe0d0-74e4-4b9b-b92f-a56ca9e43fc3" />

