### PR TITLE
LPD-24670 WIP.

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/item/selector/FDSAdminItemSelector.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/item/selector/FDSAdminItemSelector.tsx
@@ -28,6 +28,20 @@ const views = [
 			symbol: 'symbol',
 			title: 'label',
 		},
+		setItemComponentProps: ({item, props}: {item: any; props: any}) => {
+			if (
+				!item.dataSetToDataSetCardsSections.length &&
+				!item.dataSetToDataSetTableSections.length &&
+				!item.dataSetToDataSetListSections.length
+			) {
+
+				// we need to avoid item mutation
+
+				item.symbol = 'warning';
+			}
+
+			return props;
+		},
 	},
 ];
 
@@ -67,7 +81,12 @@ const FDSAdminItemSelector = ({
 			<ClayModal.Body>
 				<FrontendDataSet
 					{...FDS_DEFAULT_PROPS}
-					apiURL={getDataSetResourceURL({})}
+					apiURL={getDataSetResourceURL({
+						params: {
+							nestedFields:
+								'dataSetToDataSetCardsSections, dataSetToDataSetTableSections, dataSetToDataSetListSections',
+						},
+					})}
 					id={`${namespace}FDSAdminItemSelector`}
 					onSelectedItemsChange={(
 						selectedItems: Array<ISelectedItem>


### PR DESCRIPTION
 Check selected item has no visualization modes. In the case of list we need to mutate item as ClayList.Item does not take any prop we can remap.

Proposal to handle this case for list views, which we can use in all views: 

- Extend api to allow a `setItemProps` function that returns a modified item to be consumed by views.
- Use it from views as follows (example with `List`):
``` jsx
const ListItem = forwardRef<HTMLLIElement, any>(
	(
		{
			className,
			item: originalItem,
			...
		}: {
			...
		},
		ref
	) => {
...

		const item = {...originalItem, activeView.setItemProps?.({originalItem})}		

		// use item normally
		const itemId = getObjectValueFromPath({
			object: item,
			path: selectedItemsKey,
		});

...

		return (
			<ClayList.Item
				{...props}
				{...(activeView.setItemComponentProps?.({item, props}) ?? {})}
				ref={ref}
			>
```

cc @markocikos as you designed this solution, pls chime in