### PR TITLE
LPD-56706 Allow Admin Users to only select filterable fields to create a DSM filter

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/DataSet.tsx
@@ -16,7 +16,8 @@ import React, {useEffect, useState} from 'react';
 
 import {DEFAULT_FETCH_HEADERS} from '../utils/constants';
 import getDataSetResourceURL from '../utils/getDataSetResourceURL';
-import getFields from '../utils/getFields';
+import getFields, {getFilterableFields} from '../utils/getFields';
+import getOpenApiData from '../utils/getOpenApiData';
 import openDefaultFailureToast from '../utils/openDefaultFailureToast';
 import {IDataSet, IFieldTreeItem} from '../utils/types';
 import Actions from './actions/Actions';
@@ -64,6 +65,7 @@ export interface IDataSetSectionProps {
 	dataSet: IDataSet;
 	fieldTreeItems: Array<IFieldTreeItem>;
 	filterClientExtensionRenderers: IClientExtensionRenderer[];
+	filterableFieldTreeItems: Array<IFieldTreeItem>;
 	manageUserViewsURL: string;
 	namespace: string;
 	onActiveSectionChange: (section: number) => void;
@@ -109,6 +111,9 @@ const DataSet = ({
 	const [fieldTreeItems, setFieldTreeItems] = useState<Array<IFieldTreeItem>>(
 		[]
 	);
+	const [filterableFieldTreeItems, setFilterableFieldTreeItems] = useState<
+		Array<IFieldTreeItem>
+	>([]);
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
@@ -128,11 +133,26 @@ const DataSet = ({
 
 				const {restApplication, restSchema} = responseJSON;
 
-				getFields({restApplication, restSchema}).then((fields) => {
-					setFieldTreeItems(fields);
+				getOpenApiData({restApplication, restSchema}).then(
+					(oApiData) => {
+						if (!oApiData) {
+							return;
+						}
 
-					setLoading(false);
-				});
+						const {restSchema, schemas} = oApiData;
+
+						getFields({restSchema, schemas}).then((fields) => {
+							setFieldTreeItems(fields);
+							setLoading(false);
+						});
+
+						getFilterableFields({restSchema, schemas}).then(
+							(filterableFields) => {
+								setFilterableFieldTreeItems(filterableFields);
+							}
+						);
+					}
+				);
 			}
 			else {
 				openDefaultFailureToast();
@@ -176,6 +196,7 @@ const DataSet = ({
 							filterClientExtensionRenderers={
 								filterClientExtensionRenderers
 							}
+							filterableFieldTreeItems={filterableFieldTreeItems}
 							manageUserViewsURL={manageUserViewsURL}
 							namespace={namespace}
 							onActiveSectionChange={(tab) => setActiveIndex(tab)}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -563,7 +563,7 @@ function Filters({
 						<FilterFormComponent
 							dataSet={dataSet}
 							fieldNames={fieldNames}
-							fields={fields}
+							fields={availableFields}
 							filter={activeFilter}
 							filterClientExtensionRenderers={
 								filterClientExtensionRenderers

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -10,7 +10,6 @@ import {openModal} from 'frontend-js-components-web';
 import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-import {visit} from '../../components/AddDataSourceFieldsModalContent';
 import {
 	DEFAULT_FETCH_HEADERS,
 	OBJECT_RELATIONSHIP,
@@ -59,7 +58,8 @@ const FILTER_TYPES: Record<EFilterType, IFilterTypeProps> = {
 		Component: DateRangeFilterFormContent,
 		availableFieldsFilter: (item: IField) =>
 			item.format === EFieldFormat.DATE ||
-			item.format === EFieldFormat.DATE_TIME,
+			item.format === EFieldFormat.DATE_TIME ||
+			item.format === EFieldFormat.F_DATE_TIME,
 		displayType: () => Liferay.Language.get('date-filter'),
 		fdsViewRelationship: OBJECT_RELATIONSHIP.DATA_SET_DATE_FILTERS,
 		label: Liferay.Language.get('date-range'),
@@ -67,8 +67,10 @@ const FILTER_TYPES: Record<EFilterType, IFilterTypeProps> = {
 	[EFilterType.SELECTION]: {
 		Component: SelectionFilterFormContent,
 		availableFieldsFilter: (item: IField) =>
-			(item.type === EFieldType.STRING && !item.format) ||
-			item.type === EFieldType.INTEGER,
+			item.type === EFieldType.STRING ||
+			item.type === EFieldType.INTEGER ||
+			item.type === EFieldType.ARRAY ||
+			item.type === EFieldType.BOOLEAN,
 		displayType: (filter: IFilter | undefined) => {
 			if (filter?.sourceType === ESelectionFilterSourceType.ITEM_PROXY) {
 				return Liferay.Language.get('system-filter');
@@ -187,8 +189,8 @@ function FilterFormComponent({
 
 function Filters({
 	dataSet,
-	fieldTreeItems: fields,
 	filterClientExtensionRenderers,
+	filterableFieldTreeItems: filterableFields,
 	namespace,
 	resolvedRESTSchemas,
 	restApplications,
@@ -197,7 +199,7 @@ function Filters({
 	const [activeFilterType, setActiveFilterType] =
 		useState<EFilterType | null>(null);
 	const [activeMode, setActiveMode] = useState(FILTER_MODE.LIST);
-	const [availableFields, setAvailableFields] = useState(fields);
+	const [availableFields, setAvailableFields] = useState(filterableFields);
 	const [fieldNames, setFieldNames] = useState<string[]>([]);
 	const [filters, setFilters] = useState<IFilter[]>([]);
 	const [toggleActiveDisabled, setToogleActiveDisabled] =
@@ -325,28 +327,20 @@ function Filters({
 	};
 
 	const onCreationButtonClick = (filterType: EFilterType) => {
-		let availableFieldsListLength = 0;
+		const currentFilterTypeFields: IFieldTreeItem[] = JSON.parse(
+			JSON.stringify(filterableFields)
+		);
 
-		const availableFilterTypeFields = JSON.parse(JSON.stringify(fields));
-
-		visit(availableFilterTypeFields, (field: IFieldTreeItem) => {
-			if (
-				!FILTER_TYPES[filterType as EFilterType].availableFieldsFilter(
+		const availableFilterTypeFields = currentFilterTypeFields.filter(
+			(field) =>
+				FILTER_TYPES[filterType as EFilterType].availableFieldsFilter(
 					field
 				)
-			) {
-				field.disabled = true;
-			}
-			else {
-				availableFieldsListLength++;
-
-				field.disabled = false;
-			}
-		});
+		);
 
 		setAvailableFields(availableFilterTypeFields);
 
-		if (!availableFieldsListLength) {
+		if (!availableFilterTypeFields.length) {
 			openModal({
 				bodyHTML: Liferay.Language.get(
 					'there-are-no-fields-compatible-with-this-type-of-filter'

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
@@ -67,7 +67,14 @@ function Body({
 		filter?.label_i18n ?? {}
 	);
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
-		filter ? {label: filter.fieldName, name: filter.fieldName} : undefined
+		filter
+			? {
+					entityFieldType: filter.entityFieldType,
+					entityFieldTypeCollection: filter.entityFieldTypeCollection,
+					label: filter.fieldName,
+					name: filter.fieldName,
+				}
+			: undefined
 	);
 	const filterClientExtensionFormElementId = `${namespace}clientExtensionEntryERC`;
 
@@ -129,8 +136,12 @@ function Body({
 			const formData = {
 				clientExtensionEntryERC:
 					selectedClientExtension?.externalReferenceCode,
+				entityFieldType: selectedField?.entityFieldType,
+				entityFieldTypeCollection:
+					selectedField?.entityFieldTypeCollection,
 				fieldName: selectedField?.name,
 				label_i18n: i18nFilterLabels,
+				type: selectedField?.type,
 			};
 
 			onSave(formData);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
@@ -70,7 +70,6 @@ function Body({
 		filter
 			? {
 					entityFieldType: filter.entityFieldType,
-					entityFieldTypeCollection: filter.entityFieldTypeCollection,
 					label: filter.fieldName,
 					name: filter.fieldName,
 				}
@@ -137,8 +136,6 @@ function Body({
 				clientExtensionEntryERC:
 					selectedClientExtension?.externalReferenceCode,
 				entityFieldType: selectedField?.entityFieldType,
-				entityFieldTypeCollection:
-					selectedField?.entityFieldTypeCollection,
 				fieldName: selectedField?.name,
 				label_i18n: i18nFilterLabels,
 				type: selectedField?.type,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
@@ -87,7 +87,14 @@ function Body({
 		JSON.parse(filter?.preselectedValues || '[]')
 	);
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
-		filter ? {label: filter.fieldName, name: filter.fieldName} : undefined
+		filter
+			? {
+					entityFieldType: filter.entityFieldType,
+					entityFieldTypeCollection: filter.entityFieldTypeCollection,
+					label: filter.fieldName,
+					name: filter.fieldName,
+				}
+			: undefined
 	);
 	const [source, setSource] = useState<string | undefined>(filter?.source);
 	const [sourceType, setSourceType] = useState(filter?.sourceType);
@@ -215,6 +222,9 @@ function Body({
 
 		if (success) {
 			let formData: any = {
+				entityFieldType: selectedField?.entityFieldType,
+				entityFieldTypeCollection:
+					selectedField?.entityFieldTypeCollection,
 				fieldName: selectedField?.name,
 				include: includeMode === 'include',
 				label_i18n: i18nFilterLabels,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
@@ -90,7 +90,6 @@ function Body({
 		filter
 			? {
 					entityFieldType: filter.entityFieldType,
-					entityFieldTypeCollection: filter.entityFieldTypeCollection,
 					label: filter.fieldName,
 					name: filter.fieldName,
 				}
@@ -223,8 +222,6 @@ function Body({
 		if (success) {
 			let formData: any = {
 				entityFieldType: selectedField?.entityFieldType,
-				entityFieldTypeCollection:
-					selectedField?.entityFieldTypeCollection,
 				fieldName: selectedField?.name,
 				include: includeMode === 'include',
 				label_i18n: i18nFilterLabels,

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/source_type/ApiRestApplication.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/source_type/ApiRestApplication.tsx
@@ -22,12 +22,10 @@ import {
 	ALLOWED_ENDPOINTS_PARAMETERS,
 	FUZZY_OPTIONS,
 } from '../../../../../utils/constants';
-import getFields, {
-	ISchemas,
-	getValidFields,
-} from '../../../../../utils/getFields';
+import getFields, {getValidFields} from '../../../../../utils/getFields';
+import getOpenApiData from '../../../../../utils/getOpenApiData';
 import openDefaultFailureToast from '../../../../../utils/openDefaultFailureToast';
-import {IField, ISelectionFilter} from '../../../../../utils/types';
+import {IField, ISchemas, ISelectionFilter} from '../../../../../utils/types';
 
 import type {TItem} from '@clayui/form/src/SelectBox';
 
@@ -368,19 +366,30 @@ function ApiRestApplication({
 					});
 
 					if (selectedRESTApplication && item) {
-						getFields({
+						getOpenApiData({
 							restApplication: selectedRESTApplication,
 							restSchema: item,
-						}).then((fields: IField[]) => {
-							if (fields) {
-								setFields(
-									fields.filter(
-										(field) =>
-											field.type !== 'array' &&
-											field.type !== 'object'
-									)
-								);
+						}).then((oApiData) => {
+							if (!oApiData) {
+								return;
 							}
+
+							const {restSchema, schemas} = oApiData;
+
+							getFields({
+								restSchema,
+								schemas,
+							}).then((fields: IField[]) => {
+								if (fields) {
+									setFields(
+										fields.filter(
+											(field) =>
+												field.type !== 'array' &&
+												field.type !== 'object'
+										)
+									);
+								}
+							});
 						});
 					}
 				}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -9,10 +9,16 @@ import {
 	FDS_NESTED_FIELD_NAME_DELIMITER,
 	FDS_NESTED_FIELD_NAME_PARENT_SUFFIX,
 } from '@liferay/frontend-data-set-web';
-import {fetch} from 'frontend-js-web';
 
 import openDefaultFailureToast from './openDefaultFailureToast';
-import {EFieldFormat, EFieldType, IField} from './types';
+import {
+	EFieldFormat,
+	EFieldType,
+	IField,
+	IFilterable,
+	IProperties,
+	ISchemas,
+} from './types';
 
 export const BLACKLISTED_FIELDS = [
 	'actions',
@@ -22,25 +28,6 @@ export const BLACKLISTED_FIELDS = [
 ];
 
 const LOCALIZABLE_PROPERTY_SUFFIX = '_i18n';
-
-interface IProperty {
-	$ref?: string;
-	format?: EFieldFormat;
-	items?: any;
-	type?: EFieldType;
-	['x-parent-map']?: string;
-}
-
-interface IProperties {
-	[key: string]: IProperty;
-}
-
-interface ISchemas {
-	[key: string]: {
-		properties: IProperties;
-		type: string;
-	};
-}
 
 const validSchemaPropertyFilter = (propertyKey: string) => {
 	return (
@@ -135,30 +122,12 @@ function getValidFields({
 }
 
 export default async function getFields({
-	restApplication,
 	restSchema,
+	schemas,
 }: {
-	restApplication: string;
 	restSchema: string;
+	schemas: ISchemas;
 }) {
-	const response = await fetch(`/o${restApplication}/openapi.json`);
-
-	if (!response.ok) {
-		openDefaultFailureToast();
-
-		return [];
-	}
-
-	const responseJSON = await response.json();
-
-	const schemas = responseJSON?.components?.schemas;
-
-	if (!schemas?.[restSchema]?.properties) {
-		openDefaultFailureToast();
-
-		return [];
-	}
-
 	return getValidFields({
 		contextPath: '',
 		schemaName: restSchema,
@@ -167,4 +136,54 @@ export default async function getFields({
 	});
 }
 
-export {getValidFields, ISchemas};
+async function getFilterableFields({
+	restSchema,
+	schemas,
+}: {
+	restSchema: string;
+	schemas: ISchemas;
+}): Promise<IField[]> {
+	if (!schemas[restSchema]['x-filterable']) {
+		openDefaultFailureToast();
+
+		return [];
+	}
+
+	const filterablePaths: IFilterable = schemas[restSchema]['x-filterable'];
+	const filterableItemList = Object.keys(filterablePaths);
+
+	if (!filterableItemList) {
+		return [];
+	}
+
+	const filterableFields: Array<IField> = [];
+
+	filterableItemList.forEach((item) => {
+		const type = filterablePaths[item].type;
+		const entityFieldType =
+			type === EFieldType.ARRAY ? filterablePaths[item].items : type;
+
+		const field: IField = {
+			entityFieldType,
+			entityFieldTypeCollection: false,
+			format: type,
+			label: item,
+			name: item,
+			type,
+		};
+
+		if (type === EFieldType.ARRAY) {
+			field.entityFieldTypeCollection = true;
+		}
+
+		if (field.type === EFieldFormat.F_DATE_TIME) {
+			field.entityFieldType = EFieldType.STRING;
+		}
+
+		filterableFields.push(field);
+	});
+
+	return filterableFields;
+}
+
+export {getValidFields, getFilterableFields};

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -11,14 +11,7 @@ import {
 } from '@liferay/frontend-data-set-web';
 
 import openDefaultFailureToast from './openDefaultFailureToast';
-import {
-	EFieldFormat,
-	EFieldType,
-	IField,
-	IFilterable,
-	IProperties,
-	ISchemas,
-} from './types';
+import {EFieldFormat, EFieldType, IField, IProperties, ISchemas} from './types';
 
 export const BLACKLISTED_FIELDS = [
 	'actions',
@@ -149,7 +142,12 @@ async function getFilterableFields({
 		return [];
 	}
 
-	const filterablePaths: IFilterable = schemas[restSchema]['x-filterable'];
+	const filterablePaths = schemas[restSchema]['x-filterable'];
+
+	if (!filterablePaths) {
+		return [];
+	}
+
 	const filterableItemList = Object.keys(filterablePaths);
 
 	if (!filterableItemList) {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getFields.ts
@@ -165,7 +165,6 @@ async function getFilterableFields({
 
 		const field: IField = {
 			entityFieldType,
-			entityFieldTypeCollection: false,
 			format: type,
 			label: item,
 			name: item,
@@ -173,7 +172,7 @@ async function getFilterableFields({
 		};
 
 		if (type === EFieldType.ARRAY) {
-			field.entityFieldTypeCollection = true;
+			field.entityFieldType = `collection-${field.entityFieldType}`;
 		}
 
 		if (field.type === EFieldFormat.F_DATE_TIME) {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getOpenApiData.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/getOpenApiData.ts
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {fetch} from 'frontend-js-web';
+
+import openDefaultFailureToast from './openDefaultFailureToast';
+import {ISchemas} from './types';
+
+export default async function getOpenApiData({
+	restApplication,
+	restSchema,
+}: {
+	restApplication: string;
+	restSchema: string;
+}) {
+	const response = await fetch(`/o${restApplication}/openapi.json`);
+
+	if (!response.ok) {
+		openDefaultFailureToast();
+
+		return null;
+	}
+
+	const responseJSON = await response.json();
+	const schemas: ISchemas = responseJSON?.components?.schemas;
+
+	if (!schemas?.[restSchema]?.properties) {
+		openDefaultFailureToast();
+
+		return null;
+	}
+
+	return {restSchema, schemas};
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -19,6 +19,8 @@ export enum EFieldType {
 	OBJECT = 'object',
 	STRING = 'string',
 	BOOLEAN = 'boolean',
+	COLLECTION_STRING = 'collection-string',
+	COLLECTION_INTEGER = 'collection-integer',
 }
 
 export enum EFilterType {
@@ -121,8 +123,7 @@ export interface IDateFilter extends IFilter {
 
 export interface IField {
 	children?: Array<IField>;
-	entityFieldType?: EFieldType;
-	entityFieldTypeCollection?: boolean;
+	entityFieldType?: EFieldType | `collection-${string}`;
 	format?: EFieldFormat | EFieldType;
 	id?: string;
 	label?: string;
@@ -144,7 +145,6 @@ export interface IFieldTreeItem extends IField {
 
 export interface IFilter extends IOrderable {
 	entityFieldType: EFieldType;
-	entityFieldTypeCollection: boolean;
 	fieldName: string;
 	filterType?: EFilterType;
 	include?: boolean;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/utils/types.ts
@@ -8,6 +8,7 @@ import {JSXElementConstructor} from 'react';
 export enum EFieldFormat {
 	DATE = 'date',
 	DATE_TIME = 'date-time',
+	F_DATE_TIME = 'date_time',
 	INT32 = 'int32',
 	INT64 = 'int64',
 }
@@ -17,6 +18,7 @@ export enum EFieldType {
 	INTEGER = 'integer',
 	OBJECT = 'object',
 	STRING = 'string',
+	BOOLEAN = 'boolean',
 }
 
 export enum EFilterType {
@@ -31,6 +33,29 @@ export enum ESelectionFilterSourceType {
 	API_REST_APPLICATION = 'API_REST_APPLICATION',
 }
 
+export interface IProperty {
+	$ref?: string;
+	format?: EFieldFormat;
+	items?: any;
+	type?: EFieldType;
+	['x-parent-map']?: string;
+}
+
+export interface IProperties {
+	[key: string]: IProperty;
+}
+
+export interface IFilterable {
+	[key: string]: IProperty;
+}
+
+export interface ISchemas {
+	[key: string]: {
+		'properties': IProperties;
+		'type': string;
+		'x-filterable'?: IFilterable;
+	};
+}
 export interface IBaseVisualizationMode<Mode extends string> {
 	label: string;
 	mode: Mode;
@@ -96,7 +121,9 @@ export interface IDateFilter extends IFilter {
 
 export interface IField {
 	children?: Array<IField>;
-	format?: EFieldFormat;
+	entityFieldType?: EFieldType;
+	entityFieldTypeCollection?: boolean;
+	format?: EFieldFormat | EFieldType;
 	id?: string;
 	label?: string;
 	name: string;
@@ -116,6 +143,8 @@ export interface IFieldTreeItem extends IField {
 }
 
 export interface IFilter extends IOrderable {
+	entityFieldType: EFieldType;
+	entityFieldTypeCollection: boolean;
 	fieldName: string;
 	filterType?: EFilterType;
 	include?: boolean;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/test/utils/getFields.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/test/utils/getFields.ts
@@ -5,10 +5,9 @@
 
 import {
 	BLACKLISTED_FIELDS,
-	ISchemas,
 	getValidFields,
 } from '../../src/main/resources/META-INF/resources/js/utils/getFields';
-import {IField} from '../../src/main/resources/META-INF/resources/js/utils/types';
+import {IField, ISchemas} from '../../src/main/resources/META-INF/resources/js/utils/types';
 
 /*
  * A points to B using scalar field via $ref

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
@@ -12,6 +12,10 @@ public class FDSEntityFieldTypes {
 
 	public static final String COLLECTION = "collection";
 
+	public static final String COLLECTION_INTEGER = "collection-integer";
+
+	public static final String COLLECTION_STRING = "collection-string";
+
 	public static final String DATE = "date";
 
 	public static final String DATE_TIME = "date-time";

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
@@ -10,6 +10,8 @@ package com.liferay.frontend.data.set.constants;
  */
 public class FDSEntityFieldTypes {
 
+	public static final Object BOOLEAN = "boolean";
+
 	public static final String COLLECTION = "collection";
 
 	public static final String COLLECTION_INTEGER = "collection-integer";
@@ -24,5 +26,4 @@ public class FDSEntityFieldTypes {
 
 	public static final String STRING = "string";
 
-	public static final Object BOOLEAN = "boolean";
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/constants/FDSEntityFieldTypes.java
@@ -20,4 +20,5 @@ public class FDSEntityFieldTypes {
 
 	public static final String STRING = "string";
 
+	public static final Object BOOLEAN = "boolean";
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -1033,7 +1033,9 @@ public class CustomFDSSerializer
 
 		String type = MapUtil.getString(properties, "type");
 
-		if (Objects.equals(type, "date") || Objects.equals(type, "date-time")) {
+		if (Objects.equals(type, "date") || Objects.equals(type, "date-time") ||
+			Objects.equals(type, "date_time")) {
+
 			return _serializeFilterDateOrDateTime(fieldName, properties, type);
 		}
 
@@ -1079,7 +1081,7 @@ public class CustomFDSSerializer
 			}
 		).put(
 			"entityFieldTypeCollection",
-			(boolean)properties.get("entityFieldTypeCollection")
+			GetterUtil.getBoolean(properties.get("entityFieldTypeCollection"))
 		).put(
 			"id", fieldName
 		).put(
@@ -1186,7 +1188,10 @@ public class CustomFDSSerializer
 				if(_isCollection(
 						String.valueOf(properties.get("fieldName")),
 						sourceType) ||
-					!(boolean)properties.get("entityFieldTypeCollection")) {
+					(!(boolean)properties.get("entityFieldTypeCollection") &&
+					 !Objects.equals(
+						 properties.get("entityFieldType"),
+						 FDSEntityFieldTypes.BOOLEAN))) {
 
 					return FDSEntityFieldTypes.COLLECTION;
 				}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -1069,7 +1069,17 @@ public class CustomFDSSerializer
 		return JSONUtil.put(
 			"clientExtensionFilterURL", fdsFilterCET.getURL()
 		).put(
-			"entityFieldType", FDSEntityFieldTypes.STRING
+			"entityFieldType",
+			() -> {
+				if (Validator.isNotNull(properties.get("entityFieldType"))) {
+					return String.valueOf(properties.get("entityFieldType"));
+				}
+
+				return FDSEntityFieldTypes.STRING;
+			}
+		).put(
+			"entityFieldTypeCollection",
+			(boolean)properties.get("entityFieldTypeCollection")
 		).put(
 			"id", fieldName
 		).put(
@@ -1138,6 +1148,9 @@ public class CustomFDSSerializer
 			Map<String, Object> properties, String sourceType)
 		throws Exception {
 
+		String entityFieldType = String.valueOf(
+			properties.get("entityFieldType"));
+
 		if (Objects.equals(
 				sourceType, FDSEntryItemImportPolicy.ITEM_PROXY.toString())) {
 
@@ -1161,19 +1174,28 @@ public class CustomFDSSerializer
 		).put(
 			"entityFieldType",
 			() -> {
-				if (_isCollection(
-						String.valueOf(properties.get("fieldName")),
-						sourceType)) {
-
-					return FDSEntityFieldTypes.COLLECTION;
+				if (Validator.isNotNull(entityFieldType)) {
+					return entityFieldType;
 				}
 
 				return FDSEntityFieldTypes.STRING;
 			}
 		).put(
+			"entityFieldTypeCollection",
+			() -> {
+				if(_isCollection(
+						String.valueOf(properties.get("fieldName")),
+						sourceType) ||
+					!(boolean)properties.get("entityFieldTypeCollection")) {
+
+					return FDSEntityFieldTypes.COLLECTION;
+				}
+				return (boolean)properties.get("entityFieldTypeCollection");
+			}
+		).put(
 			"id",
 			() -> {
-				if (!Objects.equals(sourceType, "OBJECT_PICKLIST")) {
+				if (!Objects.equals(sourceType, "OBJECT_PICKLIST") || Validator.isNotNull(entityFieldType)) {
 					return fieldName;
 				}
 
@@ -1249,7 +1271,17 @@ public class CustomFDSSerializer
 					listTypeEntry.getName(
 						PortalUtil.getLocale(httpServletRequest))
 				).put(
-					"value", listTypeEntry.getKey()
+					"value",
+					() -> {
+						if (Validator.isNotNull(entityFieldType) &&
+							StringUtil.equalsIgnoreCase(
+								entityFieldType, FDSEntityFieldTypes.INTEGER)) {
+
+							return Integer.valueOf(listTypeEntry.getKey());
+						}
+
+						return listTypeEntry.getKey();
+					}
 				))
 		).put(
 			"preloadedData",
@@ -1280,7 +1312,19 @@ public class CustomFDSSerializer
 								listTypeEntry.getName(
 									PortalUtil.getLocale(httpServletRequest))
 							).put(
-								"value", listTypeEntry.getKey()
+								"value",
+								() -> {
+									if (Validator.isNotNull(entityFieldType) &&
+										StringUtil.equalsIgnoreCase(
+											entityFieldType,
+											FDSEntityFieldTypes.INTEGER)) {
+
+										return Integer.valueOf(
+											listTypeEntry.getKey());
+									}
+
+									return listTypeEntry.getKey();
+								}
 							));
 					}
 				}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -895,6 +895,23 @@ public class CustomFDSSerializer
 		);
 	}
 
+	private Object _getIntegerKey(
+		String entityFieldType, ListTypeEntry listTypeEntry) {
+
+		if (Objects.equals(entityFieldType, FDSEntityFieldTypes.INTEGER)) {
+			try {
+				return Integer.valueOf(listTypeEntry.getKey());
+			}
+			catch (NumberFormatException numberFormatException) {
+				throw new IllegalArgumentException(
+					"Invalid integer key: " + listTypeEntry.getKey(),
+					numberFormatException);
+			}
+		}
+
+		return listTypeEntry.getKey();
+	}
+
 	private ObjectDefinition _getObjectDefinition(
 		HttpServletRequest httpServletRequest) {
 
@@ -1150,9 +1167,6 @@ public class CustomFDSSerializer
 			Map<String, Object> properties, String sourceType)
 		throws Exception {
 
-		String entityFieldType = String.valueOf(
-			properties.get("entityFieldType"));
-
 		if (Objects.equals(
 				sourceType, FDSEntryItemImportPolicy.ITEM_PROXY.toString())) {
 
@@ -1171,6 +1185,9 @@ public class CustomFDSSerializer
 			}
 		}
 
+		String entityFieldType = String.valueOf(
+			properties.get("entityFieldType"));
+
 		JSONObject jsonObject = JSONUtil.put(
 			"autocompleteEnabled", true
 		).put(
@@ -1185,22 +1202,24 @@ public class CustomFDSSerializer
 		).put(
 			"entityFieldTypeCollection",
 			() -> {
-				if(_isCollection(
+				if (_isCollection(
 						String.valueOf(properties.get("fieldName")),
 						sourceType) ||
 					(!(boolean)properties.get("entityFieldTypeCollection") &&
 					 !Objects.equals(
-						 properties.get("entityFieldType"),
-						 FDSEntityFieldTypes.BOOLEAN))) {
+						 entityFieldType, FDSEntityFieldTypes.BOOLEAN))) {
 
 					return FDSEntityFieldTypes.COLLECTION;
 				}
+
 				return (boolean)properties.get("entityFieldTypeCollection");
 			}
 		).put(
 			"id",
 			() -> {
-				if (!Objects.equals(sourceType, "OBJECT_PICKLIST") || Validator.isNotNull(entityFieldType)) {
+				if (!Objects.equals(sourceType, "OBJECT_PICKLIST") ||
+					Validator.isNotNull(entityFieldType)) {
+
 					return fieldName;
 				}
 
@@ -1277,16 +1296,7 @@ public class CustomFDSSerializer
 						PortalUtil.getLocale(httpServletRequest))
 				).put(
 					"value",
-					() -> {
-						if (Validator.isNotNull(entityFieldType) &&
-							StringUtil.equalsIgnoreCase(
-								entityFieldType, FDSEntityFieldTypes.INTEGER)) {
-
-							return Integer.valueOf(listTypeEntry.getKey());
-						}
-
-						return listTypeEntry.getKey();
-					}
+					() -> _getIntegerKey(entityFieldType, listTypeEntry)
 				))
 		).put(
 			"preloadedData",
@@ -1318,18 +1328,8 @@ public class CustomFDSSerializer
 									PortalUtil.getLocale(httpServletRequest))
 							).put(
 								"value",
-								() -> {
-									if (Validator.isNotNull(entityFieldType) &&
-										StringUtil.equalsIgnoreCase(
-											entityFieldType,
-											FDSEntityFieldTypes.INTEGER)) {
-
-										return Integer.valueOf(
-											listTypeEntry.getKey());
-									}
-
-									return listTypeEntry.getKey();
-								}
+								() -> _getIntegerKey(
+									entityFieldType, listTypeEntry)
 							));
 					}
 				}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -895,23 +895,6 @@ public class CustomFDSSerializer
 		);
 	}
 
-	private Object _getIntegerKey(
-		String entityFieldType, ListTypeEntry listTypeEntry) {
-
-		if (Objects.equals(entityFieldType, FDSEntityFieldTypes.INTEGER)) {
-			try {
-				return Integer.valueOf(listTypeEntry.getKey());
-			}
-			catch (NumberFormatException numberFormatException) {
-				throw new IllegalArgumentException(
-					"Invalid integer key: " + listTypeEntry.getKey(),
-					numberFormatException);
-			}
-		}
-
-		return listTypeEntry.getKey();
-	}
-
 	private ObjectDefinition _getObjectDefinition(
 		HttpServletRequest httpServletRequest) {
 
@@ -1012,7 +995,24 @@ public class CustomFDSSerializer
 		return GetterUtil.getString(properties.get("type"));
 	}
 
-	private boolean _isActive(ObjectEntry objectEntry) {
+	private Object _getTypedKey(
+		String entityFieldType, ListTypeEntry listTypeEntry) {
+
+		if (Objects.equals(entityFieldType, FDSEntityFieldTypes.INTEGER)) {
+			try {
+				return Integer.valueOf(listTypeEntry.getKey());
+			}
+			catch (NumberFormatException numberFormatException) {
+				throw new IllegalArgumentException(
+					"Invalid integer key: " + listTypeEntry.getKey(),
+					numberFormatException);
+			}
+		}
+
+		return listTypeEntry.getKey();
+	}
+
+	private Boolean _isActive(ObjectEntry objectEntry) {
 		Map<String, Object> properties = objectEntry.getProperties();
 
 		return (boolean)properties.get("active");
@@ -1096,9 +1096,6 @@ public class CustomFDSSerializer
 
 				return FDSEntityFieldTypes.STRING;
 			}
-		).put(
-			"entityFieldTypeCollection",
-			GetterUtil.getBoolean(properties.get("entityFieldTypeCollection"))
 		).put(
 			"id", fieldName
 		).put(
@@ -1193,26 +1190,29 @@ public class CustomFDSSerializer
 		).put(
 			"entityFieldType",
 			() -> {
+				boolean collection =
+					_isCollection(
+						String.valueOf(properties.get("fieldName")),
+						sourceType) ||
+					Objects.equals(
+						entityFieldType,
+						FDSEntityFieldTypes.COLLECTION_INTEGER) ||
+					Objects.equals(
+						entityFieldType, FDSEntityFieldTypes.COLLECTION_STRING);
+
+				if (collection) {
+					if (Validator.isNotNull(entityFieldType)) {
+						return entityFieldType;
+					}
+
+					return FDSEntityFieldTypes.COLLECTION;
+				}
+
 				if (Validator.isNotNull(entityFieldType)) {
 					return entityFieldType;
 				}
 
 				return FDSEntityFieldTypes.STRING;
-			}
-		).put(
-			"entityFieldTypeCollection",
-			() -> {
-				if (_isCollection(
-						String.valueOf(properties.get("fieldName")),
-						sourceType) ||
-					(!(boolean)properties.get("entityFieldTypeCollection") &&
-					 !Objects.equals(
-						 entityFieldType, FDSEntityFieldTypes.BOOLEAN))) {
-
-					return FDSEntityFieldTypes.COLLECTION;
-				}
-
-				return (boolean)properties.get("entityFieldTypeCollection");
 			}
 		).put(
 			"id",
@@ -1295,8 +1295,7 @@ public class CustomFDSSerializer
 					listTypeEntry.getName(
 						PortalUtil.getLocale(httpServletRequest))
 				).put(
-					"value",
-					() -> _getIntegerKey(entityFieldType, listTypeEntry)
+					"value", () -> _getTypedKey(entityFieldType, listTypeEntry)
 				))
 		).put(
 			"preloadedData",
@@ -1328,7 +1327,7 @@ public class CustomFDSSerializer
 									PortalUtil.getLocale(httpServletRequest))
 							).put(
 								"value",
-								() -> _getIntegerKey(
+								() -> _getTypedKey(
 									entityFieldType, listTypeEntry)
 							));
 					}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
@@ -1163,22 +1163,6 @@
 					"type": "String"
 				},
 				{
-					"DBType": "Boolean",
-					"businessType": "Boolean",
-					"externalReferenceCode": "ENTITY_FIELD_TYPE_COLLECTION",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"label": {
-						"en_US": "Entity Field Type Collection"
-					},
-					"localized": false,
-					"name": "entityFieldTypeCollection",
-					"required": false,
-					"state": false,
-					"system": true,
-					"type": "Boolean"
-				},
-				{
 					"DBType": "String",
 					"businessType": "Text",
 					"externalReferenceCode": "FIELD_NAME",

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/resources/com/liferay/frontend/data/set/internal/batch/01-object-definition.batch-engine-data.json
@@ -1149,6 +1149,38 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
+					"externalReferenceCode": "ENTITY_FIELD_TYPE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Entity Field Type"
+					},
+					"localized": false,
+					"name": "entityFieldType",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "String"
+				},
+				{
+					"DBType": "Boolean",
+					"businessType": "Boolean",
+					"externalReferenceCode": "ENTITY_FIELD_TYPE_COLLECTION",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"label": {
+						"en_US": "Entity Field Type Collection"
+					},
+					"localized": false,
+					"name": "entityFieldTypeCollection",
+					"required": false,
+					"state": false,
+					"system": true,
+					"type": "Boolean"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
 					"externalReferenceCode": "FIELD_NAME",
 					"indexed": true,
 					"indexedAsKeyword": false,

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -415,8 +415,6 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				).put(
 					"entityFieldType", FDSEntityFieldTypes.STRING
 				).put(
-					"entityFieldTypeCollection", false
-				).put(
 					"id", FIELD_NAMES[0]
 				).put(
 					"label", LABELS[0]
@@ -576,8 +574,6 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 			).put(
 				"entityFieldType", FDSEntityFieldTypes.STRING
 			).put(
-				"entityFieldTypeCollection", false
-			).put(
 				"fieldName", FIELD_NAMES[0]
 			).put(
 				"include", true
@@ -618,8 +614,6 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 					"autocompleteEnabled", true
 				).put(
 					"entityFieldType", FDSEntityFieldTypes.STRING
-				).put(
-					"entityFieldTypeCollection", FDSEntityFieldTypes.COLLECTION
 				).put(
 					"id", FIELD_NAMES[0]
 				).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -413,7 +413,9 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 					"clientExtensionFilterURL",
 					"/o/" + cetExternalReferenceCode + "/index.js"
 				).put(
-					"entityFieldType", "string"
+					"entityFieldType", FDSEntityFieldTypes.STRING
+				).put(
+					"entityFieldTypeCollection", false
 				).put(
 					"id", FIELD_NAMES[0]
 				).put(
@@ -570,6 +572,12 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 		_mockSerializeFilters(
 			FDS_NAMES[0],
 			HashMapBuilder.<String, Object>put(
+				"autocompleteEnabled", true
+			).put(
+				"entityFieldType", FDSEntityFieldTypes.STRING
+			).put(
+				"entityFieldTypeCollection", false
+			).put(
 				"fieldName", FIELD_NAMES[0]
 			).put(
 				"include", true
@@ -609,7 +617,9 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 				).put(
 					"autocompleteEnabled", true
 				).put(
-					"entityFieldType", "string"
+					"entityFieldType", FDSEntityFieldTypes.STRING
+				).put(
+					"entityFieldTypeCollection", FDSEntityFieldTypes.COLLECTION
 				).put(
 					"id", FIELD_NAMES[0]
 				).put(

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -37,7 +37,6 @@ export interface SelectionFilterImplementationArgs
 	apiURL: string;
 	autocompleteEnabled: boolean;
 	entityFieldType: EEntityFieldType;
-	entityFieldTypeCollection: boolean;
 	inputPlaceholder: string;
 	itemKey: string;
 	itemLabel: string;
@@ -109,7 +108,6 @@ function getSelectedItemsLabel({
 
 function getOdataString({
 	entityFieldType,
-	entityFieldTypeCollection,
 	id,
 	multiple,
 	selectedData,
@@ -121,21 +119,36 @@ function getOdataString({
 	}
 
 	const quotedSelectedItems = selectedItems.map((item) => {
-		if(entityFieldType === EEntityFieldType.INTEGER) {
+		if (
+			entityFieldType === EEntityFieldType.INTEGER ||
+			entityFieldType === EEntityFieldType.COLLECTION_INTEGER
+		) {
 			return item.value;
 		}
 
-		if(entityFieldType === EEntityFieldType.BOOLEAN) {
+		if (
+			entityFieldType === EEntityFieldType.STRING ||
+			entityFieldType === EEntityFieldType.COLLECTION_STRING
+		) {
+			return `'${item.value}'`;
+		}
+
+		if (entityFieldType === EEntityFieldType.BOOLEAN) {
 			let parsedValue = item.value;
 			item.value === '0' && (parsedValue = `false`);
 			item.value === '1' && (parsedValue = `true`);
+
 			return parsedValue.toLocaleLowerCase();
 		}
 
-		return `'${item.value}'`;
+		return item.value;
 	});
 
-	if (entityFieldTypeCollection) {
+	if (
+		entityFieldType === EEntityFieldType.COLLECTION_STRING ||
+		entityFieldType === EEntityFieldType.COLLECTION_INTEGER ||
+		entityFieldType === EEntityFieldType.COLLECTION
+	) {
 		return `${id}/any(x:${quotedSelectedItems
 			.map((value) => `(x ${exclude ? 'ne' : 'eq'} ${value})`)
 			.join(exclude ? ' and ' : ' or ')})`;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -37,6 +37,7 @@ export interface SelectionFilterImplementationArgs
 	apiURL: string;
 	autocompleteEnabled: boolean;
 	entityFieldType: EEntityFieldType;
+	entityFieldTypeCollection: boolean;
 	inputPlaceholder: string;
 	itemKey: string;
 	itemLabel: string;
@@ -108,6 +109,7 @@ function getSelectedItemsLabel({
 
 function getOdataString({
 	entityFieldType,
+	entityFieldTypeCollection,
 	id,
 	multiple,
 	selectedData,
@@ -118,15 +120,22 @@ function getOdataString({
 		return '';
 	}
 
-	const quotedSelectedItems = selectedItems.map((item) =>
-		entityFieldType === EEntityFieldType.STRING ||
-		(typeof item.value === 'string' &&
-			entityFieldType !== EEntityFieldType.INTEGER)
-			? `'${item.value}'`
-			: item.value
-	);
+	const quotedSelectedItems = selectedItems.map((item) => {
+		if(entityFieldType === EEntityFieldType.INTEGER) {
+			return item.value;
+		}
 
-	if (entityFieldType === EEntityFieldType.COLLECTION) {
+		if(entityFieldType === EEntityFieldType.BOOLEAN) {
+			let parsedValue = item.value;
+			item.value === '0' && (parsedValue = `false`);
+			item.value === '1' && (parsedValue = `true`);
+			return parsedValue.toLocaleLowerCase();
+		}
+
+		return `'${item.value}'`;
+	});
+
+	if (entityFieldTypeCollection) {
 		return `${id}/any(x:${quotedSelectedItems
 			.map((value) => `(x ${exclude ? 'ne' : 'eq'} ${value})`)
 			.join(exclude ? ' and ' : ' or ')})`;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/utils/types.ts
@@ -9,4 +9,5 @@ export enum EEntityFieldType {
 	DATE_TIME = 'date-time',
 	INTEGER = 'integer',
 	STRING = 'string',
+	BOOLEAN  = 'boolean',
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/utils/types.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/utils/types.ts
@@ -9,5 +9,7 @@ export enum EEntityFieldType {
 	DATE_TIME = 'date-time',
 	INTEGER = 'integer',
 	STRING = 'string',
-	BOOLEAN  = 'boolean',
+	BOOLEAN = 'boolean',
+	COLLECTION_STRING = 'collection-string',
+	COLLECTION_INTEGER = 'collection-integer',
 }

--- a/modules/test/playwright/helpers/DataSetManagerApiHelpers.ts
+++ b/modules/test/playwright/helpers/DataSetManagerApiHelpers.ts
@@ -27,6 +27,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 		defaultVisualizationMode,
 		description = 'Sample description',
 		erc = 'sampleDataSetERC',
+		keywords,
 		label = DEFAULT_LABEL.DATA_SET,
 		listOfItemsPerPage = '4, 8, 20, 40, 60',
 		restApplication = API_ENDPOINT_PATH,
@@ -40,6 +41,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 		defaultVisualizationMode?: string;
 		description?: string;
 		erc?: string;
+		keywords?: Array<string>;
 		label?: string;
 		listOfItemsPerPage?: string;
 		restApplication?: string;
@@ -56,6 +58,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 			defaultVisualizationMode,
 			description,
 			externalReferenceCode: erc,
+			keywords,
 			label,
 			listOfItemsPerPage,
 			restApplication,
@@ -233,6 +236,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 	async createDataSetSelectionFilter({
 		active,
 		dataSetERC = DEFAULT_DATA_SET_ERC,
+		entityFieldType,
 		fieldName,
 		include = true,
 		itemKey,
@@ -245,6 +249,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 	}: {
 		active?: boolean;
 		dataSetERC?: string;
+		entityFieldType?: string;
 		fieldName: string;
 		include?: boolean;
 		itemKey?: string;
@@ -262,6 +267,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 
 		const data = {
 			active,
+			entityFieldType,
 			fieldName,
 			include,
 			itemKey,
@@ -431,6 +437,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 		defaultVisualizationMode,
 		erc = DEFAULT_DATA_SET_ERC,
 		filtersOrder,
+		keywords,
 		label,
 		listOfItemsPerPage,
 		showSearch,
@@ -441,6 +448,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 		defaultVisualizationMode?: string;
 		erc?: string;
 		filtersOrder?: string;
+		keywords?: Array<string>;
 		label?: string;
 		listOfItemsPerPage?: string;
 		showSearch?: boolean;
@@ -455,6 +463,7 @@ export class DataSetManagerApiHelpers extends ApiHelpers {
 			defaultItemsPerPage,
 			defaultVisualizationMode,
 			filtersOrder,
+			keywords,
 			label,
 			listOfItemsPerPage,
 			showSearch,

--- a/modules/test/playwright/helpers/PicklistApiHelpers.ts
+++ b/modules/test/playwright/helpers/PicklistApiHelpers.ts
@@ -26,6 +26,16 @@ export class PicklistApiHelpers extends ApiHelpers {
 		return this.delete(url);
 	}
 
+	async deleteBatchPicklist(names: Array<string>, picklistItems: Array<any>) {
+		const url = `${this.baseUrl}headless-admin-list-type/v1.0/list-type-definitions/batch`;
+		
+		const items = picklistItems
+		.filter(item => names.includes(item.name))
+		.map(item => ({ id: item.id }));
+
+		return this.delete(url, {data: items});
+	}
+
 	async editPicklist({
 		externalReferenceCode,
 		key,
@@ -54,4 +64,13 @@ export class PicklistApiHelpers extends ApiHelpers {
 
 		return this.get(url);
 	}
+
+	async getPicklists() {
+		const url = `${this.baseUrl}headless-admin-list-type/v1.0/list-type-definitions`;
+
+		const picklists = await this.get(url);
+
+		return picklists.items;
+	}	
+
 }

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/components/FieldSelectModalPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/components/FieldSelectModalPage.ts
@@ -44,13 +44,18 @@ export class FieldSelectModalPage {
 		expected: boolean;
 		fieldName: string;
 	}) {
-		const treeItem = this.fieldSelectModalContainer.locator(
-			`.treeview-link[data-id$="${dataId ?? fieldName}"]`
-		);
+  const treeItem = dataId
+    ? this.fieldSelectModalContainer.locator(
+        `.treeview-link[data-id="${dataId}"]`
+      )
+    : this.fieldSelectModalContainer.getByRole('treeitem', {
+        name: fieldName,
+        exact: true,
+      });
 
-		await treeItem.filter({hasText: fieldName}).click();
+  await treeItem.click();
 
-		const checkbox = treeItem.locator('input[type="checkbox"]');
+		const checkbox = treeItem.getByRole('checkbox');
 
 		if (expected) {
 			await checkbox.check();

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/data_set/tabs/FiltersPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/data_set/tabs/FiltersPage.ts
@@ -272,10 +272,6 @@ export class FiltersPage {
 
 		await this.newDateRangeFilterForm.filterBySelectButton.click();
 
-		const notDateField = 'label';
-		await expect(
-			this.fieldSelectModalPage.getFieldCheckboxByLabel(notDateField)
-		).toBeDisabled();
 		await expect(
 			this.fieldSelectModalPage.getFieldCheckboxByLabel(filterBy)
 		).toBeEnabled();
@@ -317,12 +313,6 @@ export class FiltersPage {
 
 		await this.newSelectionFilterForm.filterBySelectButton.click();
 
-		const notSelectionFilterField = 'keywords';
-		await expect(
-			this.fieldSelectModalPage.getFieldCheckboxByLabel(
-				notSelectionFilterField
-			)
-		).toBeDisabled();
 		await expect(
 			this.fieldSelectModalPage.getFieldCheckboxByLabel(filterBy)
 		).toBeEnabled();

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/selectionFilters.spec.ts
@@ -333,7 +333,7 @@ test(
 	'Can create and edit a selection filter with API Headless source using composed/complex fields',
 	{tag: '@LPD-25905'},
 	async ({filtersPage, page}) => {
-		const composedFieldName = 'removedBy.name';
+		const composedFieldName = 'dataSetToDataSetTableSections/keywords';
 
 		await test.step('Create a selection filter from API Headless source', async () => {
 			await filtersPage.createSelectionFilterApiHeadless({
@@ -480,6 +480,114 @@ test(
 			await waitForAlert(page);
 
 			await expect(filtersPage.activeToggle.first()).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Can create a filter for a boolean field',
+	{tag: '@LPD-56706'},
+	async ({ filtersPage, page, picklistApiHelpers }) => {
+		const fieldName = 'active';
+		const picklistEntryKey = '0';
+
+		await picklistApiHelpers.editPicklist({
+			key: picklistEntryKey,
+			name: picklistName,
+			value: fieldName,
+		});
+
+
+		await test.step('Create a selection filter from API Headless source', async () => {
+
+			await filtersPage.createSelectionFilterPicklist({
+				filterBy: 'externalReferenceCode',
+				filterMode: 'Include',
+				name: SELECTION_PICKLIST_FILTER_NAME,
+				preselectedValues: [fieldName],
+				selectionType: 'Single',
+				source: picklistName,
+				sourceType: 'Object Picklist',
+
+			})
+
+			await filtersPage.newSelectionFilterForm.filterBySelectButton.click();
+			await filtersPage.fieldSelectModalPage.searchAndSelectField(
+				fieldName
+			);
+			await filtersPage.fieldSelectModalPage.saveAddFieldsModal();
+			await filtersPage.saveAddFilterForm();
+		});
+
+		await test.step('Check that the selection filter is in the list', async () => {
+			await expect(
+				page.getByRole('cell', {
+					exact: true,
+					name: SELECTION_PICKLIST_FILTER_NAME,
+				})
+			).toBeVisible();
+		});
+
+		await test.step('Open the edit filter form', async () => {
+			const filterActionsButton = page
+				.getByRole('cell', { name: 'Actions' })
+				.getByRole('button');
+
+			await expect(filterActionsButton).toBeVisible();
+
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', { name: 'Edit' }),
+				trigger: filterActionsButton,
+			});
+
+			const dialogFilterSourceSubtitle = page.getByRole('heading', {
+				name: 'Filter Source',
+			});
+
+			await expect(dialogFilterSourceSubtitle).toBeVisible();
+
+			const dialogFilterOptionsSubtitle = page.getByRole('heading', {
+				name: 'Filter Options',
+			});
+
+			await expect(dialogFilterOptionsSubtitle).toBeVisible();
+		});
+
+		await test.step('Change the filter name', async () => {
+			await filtersPage.newSelectionFilterForm.nameInput.clear();
+
+			await filtersPage.saveAddFilterForm();
+		});
+
+		await test.step('Confirm that a "This field is required." message appears in the form', async () => {
+			await filtersPage.page
+				.getByText('This field is required.')
+				.isVisible();
+		});
+
+		await test.step('Save filter form without errors', async () => {
+			await filtersPage.newSelectionFilterForm.nameInput.fill(
+				SELECTION_PICKLIST_FILTER_NAME
+			);
+
+			await filtersPage.saveAddFilterForm();
+		});
+
+		await test.step('Check that the selection filter is in the list', async () => {
+			await expect(
+				page.getByRole('cell', {
+					exact: true,
+					name: SELECTION_PICKLIST_FILTER_NAME,
+				})
+			).toBeVisible();
+
+			await expect(
+				page.getByRole('cell', {
+					exact: true,
+					name: SELECTION_DISPLAY_TYPE,
+				})
+			).toBeVisible();
 		});
 	}
 );

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/selectionFilters.spec.ts
@@ -492,8 +492,8 @@ test(
 		const picklistEntryKey = '0';
 
 		await picklistApiHelpers.editPicklist({
+			externalReferenceCode: picklistERC,
 			key: picklistEntryKey,
-			name: picklistName,
 			value: fieldName,
 		});
 

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/selectionFilters.spec.ts
@@ -127,14 +127,14 @@ test.beforeEach(
 			integerPicklistERC = integerPicklist.externalReferenceCode;
 
 			picklistIntegerOptionInactive = await picklistApiHelpers.editPicklist({
+				externalReferenceCode: integerPicklistERC,
 				key: picklistIntegerOptionKeyInactive,
-				name: integerPicklistName,
 				value: picklistIntegerOptionLabelInactive,
 			});
 
 			picklistIntegerOptionActive = await picklistApiHelpers.editPicklist({
+				externalReferenceCode: integerPicklistERC,
 				key: picklistIntegerOptionKeyActive,
-				name: integerPicklistName,
 				value: picklistIntegerOptionLabelActive,
 			});
 
@@ -148,14 +148,14 @@ test.beforeEach(
 			booleanPicklistERC = booleanPicklist.externalReferenceCode;
 
 			picklistBooleanOptionTrue = await picklistApiHelpers.editPicklist({
+				externalReferenceCode: booleanPicklistERC,
 				key: picklistBooleanOptionKeyTrue,
-				name: booleanPicklistName,
 				value: picklistBooleanOptionLabelTrue,
 			});
 
 			picklistBooleanOptionFalse = await picklistApiHelpers.editPicklist({
+				externalReferenceCode: booleanPicklistERC,
 				key: picklistBooleanOptionKeyFalse,
-				name: booleanPicklistName,
 				value: picklistBooleanOptionLabelFalse,
 			});
 
@@ -169,14 +169,14 @@ test.beforeEach(
 			collectionPicklistERC = collectionPicklist.externalReferenceCode;
 
 			picklistCollectionOptionAnyKey = await picklistApiHelpers.editPicklist({
+				externalReferenceCode: collectionPicklistERC,
 				key: picklistCollectionOptionKeyAnyKey,
-				name: collectionPicklistName,
 				value: picklistCollectionOptionLabelAnyKey,
 			});
 
 			picklistCollectionOptionEggs = await picklistApiHelpers.editPicklist({
+				externalReferenceCode: collectionPicklistERC,
 				key: picklistCollectionOptioKeyEggs,
-				name: collectionPicklistName,
 				value: picklistCollectionOptionLabelEggs,
 			});
 
@@ -1024,7 +1024,7 @@ test('x-filterable: Selection filter of type "Object Picklist" can filter intege
 	});
 
 	await test.step('Create a new selection filter with preselected values and include mode', async () => {
-		const picklist = await picklistApiHelpers.getPicklist(integerPicklistName);
+		const picklist = await picklistApiHelpers.getPicklist(integerPicklistERC);
 
 		selectionFilter =
 			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
@@ -1134,7 +1134,7 @@ test('x-filterable: Selection filter of type "Object Picklist" can filter boolea
 	});
 
 	await test.step('Create a new selection filter with preselected values and include mode', async () => {
-		const picklist = await picklistApiHelpers.getPicklist(booleanPicklistName);
+		const picklist = await picklistApiHelpers.getPicklist(booleanPicklistERC);
 
 		selectionFilter =
 			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
@@ -1253,7 +1253,7 @@ test('x-filterable: Selection filter of type "Object Picklist" can filter a coll
 	});
 
 	await test.step('Create a new selection filter with preselected values and include mode', async () => {
-		const picklist = await picklistApiHelpers.getPicklist(collectionPicklistName);
+		const picklist = await picklistApiHelpers.getPicklist(collectionPicklistERC);
 
 		selectionFilter =
 			await dataSetManagerApiHelpers.createDataSetSelectionFilter({

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/selectionFilters.spec.ts
@@ -22,6 +22,21 @@ const picklistDefaultOptionLabel = 'Default';
 const picklistBooleanOptionKey = picklistBooleanOptionLabel.toLocaleLowerCase();
 const picklistDefaultOptionKey = picklistDefaultOptionLabel.toLocaleLowerCase();
 
+const picklistIntegerOptionLabelActive = 'Active';
+const picklistIntegerOptionLabelInactive = 'Inactive';
+const picklistIntegerOptionKeyActive = '1';
+const picklistIntegerOptionKeyInactive = '0';
+
+const picklistBooleanOptionLabelTrue = 'True';
+const picklistBooleanOptionLabelFalse = 'False';
+const picklistBooleanOptionKeyTrue = picklistBooleanOptionLabelTrue.toLocaleLowerCase();
+const picklistBooleanOptionKeyFalse = picklistBooleanOptionLabelFalse.toLocaleLowerCase();
+
+const picklistCollectionOptionLabelAnyKey = "AnyKey";
+const picklistCollectionOptionLabelEggs = "Eggs";
+const picklistCollectionOptionKeyAnyKey = picklistCollectionOptionLabelAnyKey.toLocaleLowerCase();
+const picklistCollectionOptioKeyEggs = picklistCollectionOptionLabelEggs.toLocaleLowerCase();
+
 const apiHeadlessName = 'FieldType';
 const apiHeadlessURL = `c/${apiHeadlessName.toLocaleLowerCase()}s`;
 const dataSetERCs: string[] = [];
@@ -30,6 +45,28 @@ let dataSetLabel: string;
 let objectDefinition: any;
 let picklistBooleanOption: any;
 let picklistDefaultOption: any;
+
+let picklistIntegerOptionActive: any;
+let picklistIntegerOptionInactive: any;
+
+let picklistBooleanOptionTrue: any;
+let picklistBooleanOptionFalse: any;
+
+let integerPicklist;
+let integerPicklistERC;
+let integerPicklistName: string;
+
+let booleanPicklist;
+let booleanPicklistERC;
+let booleanPicklistName: string;
+
+let collectionPicklist;
+let collectionPicklistERC;
+let collectionPicklistName: string;
+
+let picklistCollectionOptionAnyKey: any;
+let picklistCollectionOptionEggs: any;
+
 let picklistERC: any;
 let picklistName: string;
 
@@ -50,11 +87,15 @@ test.beforeEach(
 		dataSetERC = getRandomString();
 		dataSetLabel = getRandomString();
 		picklistName = getRandomString();
+		integerPicklistName = getRandomString();
+		booleanPicklistName = getRandomString();
+		collectionPicklistName = getRandomString();
 
 		dataSetERCs.push(dataSetERC);
 
 		await dataSetManagerApiHelpers.createDataSet({
 			erc: dataSetERC,
+			keywords: ["foo", "bar",],
 			label: dataSetLabel,
 		});
 
@@ -76,6 +117,69 @@ test.beforeEach(
 				key: picklistBooleanOptionKey,
 				value: picklistBooleanOptionLabel,
 			});
+		});
+
+		await test.step('Create and populate a picklist within integer options', async () => {
+			integerPicklist = await picklistApiHelpers.createPicklist({
+				name: integerPicklistName,
+			});
+
+			integerPicklistERC = integerPicklist.externalReferenceCode;
+
+			picklistIntegerOptionInactive = await picklistApiHelpers.editPicklist({
+				key: picklistIntegerOptionKeyInactive,
+				name: integerPicklistName,
+				value: picklistIntegerOptionLabelInactive,
+			});
+
+			picklistIntegerOptionActive = await picklistApiHelpers.editPicklist({
+				key: picklistIntegerOptionKeyActive,
+				name: integerPicklistName,
+				value: picklistIntegerOptionLabelActive,
+			});
+
+		});
+
+		await test.step('Create and populate a picklist within boolean options', async () => {
+			booleanPicklist = await picklistApiHelpers.createPicklist({
+				name: booleanPicklistName,
+			});
+
+			booleanPicklistERC = booleanPicklist.externalReferenceCode;
+
+			picklistBooleanOptionTrue = await picklistApiHelpers.editPicklist({
+				key: picklistBooleanOptionKeyTrue,
+				name: booleanPicklistName,
+				value: picklistBooleanOptionLabelTrue,
+			});
+
+			picklistBooleanOptionFalse = await picklistApiHelpers.editPicklist({
+				key: picklistBooleanOptionKeyFalse,
+				name: booleanPicklistName,
+				value: picklistBooleanOptionLabelFalse,
+			});
+
+		});
+	
+		await test.step('Create and populate a picklist with collection options', async () => {
+			collectionPicklist = await picklistApiHelpers.createPicklist({
+				name: collectionPicklistName,
+			});
+
+			collectionPicklistERC = collectionPicklist.externalReferenceCode;
+
+			picklistCollectionOptionAnyKey = await picklistApiHelpers.editPicklist({
+				key: picklistCollectionOptionKeyAnyKey,
+				name: collectionPicklistName,
+				value: picklistCollectionOptionLabelAnyKey,
+			});
+
+			picklistCollectionOptionEggs = await picklistApiHelpers.editPicklist({
+				key: picklistCollectionOptioKeyEggs,
+				name: collectionPicklistName,
+				value: picklistCollectionOptionLabelEggs,
+			});
+
 		});
 
 		const objectDefinitionAPIClient =
@@ -179,14 +283,18 @@ test.afterEach(
 
 		dataSetERCs.length = 0;
 
-		await picklistApiHelpers.deletePicklist(picklistERC);
-
 		const objectDefinitionAPIClient =
 			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
 
 		await objectDefinitionAPIClient.deleteObjectDefinition(
 			objectDefinition.id
 		);
+
+		const picklists = await picklistApiHelpers.getPicklists();
+		const picklistsNames = [picklistName, integerPicklistName, booleanPicklistName, collectionPicklistName];
+	
+		await picklistApiHelpers.deleteBatchPicklist(picklistsNames, picklists);
+
 	}
 );
 
@@ -498,6 +606,7 @@ test(
 
 			await dataSetManagerApiHelpers.createDataSet({
 				erc: picklistDataSetERC,
+				keywords: ["foo", "fred"],
 				label: picklistDataSetLabel,
 				restApplication: `/${apiHeadlessURL}`,
 				restSchema: apiHeadlessName,
@@ -783,6 +892,7 @@ test(
 		await test.step('Create custom data set of Data Sets', async () => {
 			await dataSetManagerApiHelpers.createDataSet({
 				erc: customDataSetERC,
+				keywords: ["bar", "eggs"],
 				label: customDataSetLabel,
 				restEndpoint: '/',
 				restSchema: 'DataSet',
@@ -879,3 +989,348 @@ test(
 		});
 	}
 );
+
+test('x-filterable: Selection filter of type "Object Picklist" can filter integer field type', {tag: '@LPD-56706'}, async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	page,
+	picklistApiHelpers,
+}) => {
+	const filterLabel = getRandomString();
+	let selectionFilter;
+
+	await test.step('Add fields, so FDS has something to show', async () => {
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC,
+			fieldName: 'renderer',
+			label_i18n: {en_US: 'Renderer'},
+		});
+
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC,
+			fieldName: 'sortable',
+			label_i18n: {en_US: 'Sortable'},
+			renderer: 'boolean',
+		});
+
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC,
+			fieldName: 'status.label',
+			label_i18n: {en_US: 'Status'},
+			renderer: 'integer',
+		});
+
+	});
+
+	await test.step('Create a new selection filter with preselected values and include mode', async () => {
+		const picklist = await picklistApiHelpers.getPicklist(integerPicklistName);
+
+		selectionFilter =
+			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+				dataSetERC,
+				entityFieldType: "integer",
+				fieldName: 'dataSetToDataSetTableSections/status',
+				include: true,
+				label_i18n: {en_US: filterLabel},
+				multiple: false,
+				preselectedValues: JSON.stringify([
+					{
+						label: getRandomString(),
+						value: picklistIntegerOptionActive.externalReferenceCode,
+					},
+				]),
+				source: picklist.externalReferenceCode,
+				sourceType: 'OBJECT_PICKLIST',
+			});
+		
+	});
+
+	await test.step('Configure Data Set fragment', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step('Check current filter is applied in the Frontend Data Set and return no results', async () => {
+		await expect(dataSetFragmentPage.filterResumeButton).toBeVisible();
+		await expect(dataSetFragmentPage.filterResumeButton).toContainText(
+			`${filterLabel}: ${picklistIntegerOptionLabelActive}`
+		);
+		await expect(dataSetFragmentPage.emptyStateTitle).toBeVisible();
+	});
+
+	await test.step('Update filter to apply Inactive key', async () => {
+		await dataSetManagerApiHelpers.updateDataSetSelectionFilter({
+			dataSetERC,
+			preselectedValues: JSON.stringify([
+				{
+					label: getRandomString(),
+					value: picklistIntegerOptionInactive.externalReferenceCode,
+				},
+			]),
+			selectionFilterERC: selectionFilter.externalReferenceCode,
+		});
+	});
+
+	await test.step('Check current items in the Frontend Data Set', async () => {
+		await page.reload();
+		await expect(dataSetFragmentPage.filterResumeButton).toBeVisible();
+		await expect(dataSetFragmentPage.filterResumeButton).toContainText(
+			`${filterLabel}: ${picklistIntegerOptionLabelInactive}`
+		);
+		await dataSetFragmentPage.paginationResults.scrollIntoViewIfNeeded();
+
+		await expect(
+			dataSetFragmentPage.table.bodyRows.first().locator('td')
+		).toHaveText(['default', 'No', 'approved', '']);
+
+		await expect(
+			dataSetFragmentPage.paginationResults.getByText("Showing 1 to 3 of 3 entries.")
+		).toBeVisible();
+	});
+
+	await test.step('Can remove the current filter', async () => {
+		await dataSetFragmentPage.page
+			.getByRole('button', {exact: true, name: 'Remove Filter'})
+			.click();
+		await expect(dataSetFragmentPage.filterResumeButton).not.toBeVisible();
+
+		await dataSetFragmentPage.paginationResults.scrollIntoViewIfNeeded();
+
+		await expect(
+			dataSetFragmentPage.paginationResults.getByText(
+				'Showing 1 to 3 of 3 entries.'
+			)
+		).toBeVisible();
+	});
+});
+
+test('x-filterable: Selection filter of type "Object Picklist" can filter boolean field type', {tag: '@LPD-56706'}, async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	page,
+	picklistApiHelpers,
+}) => {
+	const filterLabel = getRandomString();
+	let selectionFilter;
+
+	await test.step('Add fields, so FDS has something to show', async () => {
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC,
+			fieldName: 'renderer',
+			label_i18n: {en_US: 'Renderer'},
+		});
+
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC,
+			fieldName: 'sortable',
+			label_i18n: {en_US: 'Sortable'},
+			renderer: 'boolean',
+		});
+
+	});
+
+	await test.step('Create a new selection filter with preselected values and include mode', async () => {
+		const picklist = await picklistApiHelpers.getPicklist(booleanPicklistName);
+
+		selectionFilter =
+			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+				dataSetERC,
+				entityFieldType: "boolean",
+				fieldName: 'sortable',
+				include: true,
+				label_i18n: {en_US: filterLabel},
+				multiple: false,
+				preselectedValues: JSON.stringify([
+					{
+						label: getRandomString(),
+						value: picklistBooleanOptionTrue.externalReferenceCode,
+					},
+				]),
+				source: picklist.externalReferenceCode,
+				sourceType: 'OBJECT_PICKLIST',
+			});
+		
+	});
+
+	await test.step('Configure Data Set fragment', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step('Check current filter is applied in the Frontend Data Set and return no results', async () => {
+		await expect(dataSetFragmentPage.filterResumeButton).toBeVisible();
+		await expect(dataSetFragmentPage.filterResumeButton).toContainText(
+			`${filterLabel}: ${picklistBooleanOptionLabelTrue}`
+		);
+	});
+
+	await test.step('Update filter to apply false key', async () => {
+		await dataSetManagerApiHelpers.updateDataSetSelectionFilter({
+			dataSetERC,
+			preselectedValues: JSON.stringify([
+				{
+					label: getRandomString(),
+					value: picklistBooleanOptionFalse.externalReferenceCode,
+				},
+			]),
+			selectionFilterERC: selectionFilter.externalReferenceCode,
+		});
+	});
+
+	await test.step('Check current items in the Frontend Data Set', async () => {
+		await page.reload();
+		await expect(dataSetFragmentPage.filterResumeButton).toBeVisible();
+		await expect(dataSetFragmentPage.filterResumeButton).toContainText(
+			`${filterLabel}: ${picklistBooleanOptionLabelFalse}`
+		);
+		await dataSetFragmentPage.paginationResults.scrollIntoViewIfNeeded();
+
+		await expect(
+			dataSetFragmentPage.table.bodyRows.first().locator('td')
+		).toHaveText(['default', 'No', '']);
+
+		await expect(
+			dataSetFragmentPage.paginationResults.getByText("Showing 1 to 2 of 2 entries.")
+		).toBeVisible();
+	});
+
+	await test.step('Can remove the current filter', async () => {
+		await dataSetFragmentPage.page
+			.getByRole('button', {exact: true, name: 'Remove Filter'})
+			.click();
+		await expect(dataSetFragmentPage.filterResumeButton).not.toBeVisible();
+
+		await dataSetFragmentPage.paginationResults.scrollIntoViewIfNeeded();
+
+		await expect(
+			dataSetFragmentPage.paginationResults.getByText(
+				'Showing 1 to 2 of 2 entries.'
+			)
+		).toBeVisible();
+	});
+});
+
+test('x-filterable: Selection filter of type "Object Picklist" can filter a collection type', {tag: '@LPD-56706'}, async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	page,
+	picklistApiHelpers,
+}) => {
+	const filterLabel = getRandomString();
+	let selectionFilter;
+
+	const customDataSetLabel = getRandomString();
+	const customDataSetERC = getRandomString();
+	dataSetERCs.push(customDataSetERC);
+
+	await test.step('Create custom data set of Data Sets', async () => {
+		await dataSetManagerApiHelpers.createDataSet({
+			erc: customDataSetERC,
+			keywords: ["bar", "eggs", "more eggs"],
+			label: customDataSetLabel,
+			restEndpoint: '/',
+			restSchema: 'DataSet',
+		});
+	});
+
+	await test.step('Add fields, so FDS has something to show', async () => {
+
+		await dataSetManagerApiHelpers.createDataSetTableSection({
+			dataSetERC: customDataSetERC,
+			fieldName: 'keywords',
+			label_i18n: {en_US: 'Keywords'},
+			type: "array",
+			renderer: 'default'
+		});
+
+	});
+
+	await test.step('Create a new selection filter with preselected values and include mode', async () => {
+		const picklist = await picklistApiHelpers.getPicklist(collectionPicklistName);
+
+		selectionFilter =
+			await dataSetManagerApiHelpers.createDataSetSelectionFilter({
+				dataSetERC: customDataSetERC,
+				entityFieldType: "collection-string",
+				fieldName: 'keywords',
+				include: true,
+				label_i18n: {en_US: filterLabel},
+				multiple: true,
+				preselectedValues: JSON.stringify([
+					{
+						label: getRandomString(),
+						value: picklistCollectionOptionAnyKey.externalReferenceCode,
+					},
+				]),
+				source: picklist.externalReferenceCode,
+				sourceType: 'OBJECT_PICKLIST',
+			});
+		
+	});
+
+	await test.step('Configure Data Set fragment', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel: customDataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step('Check current filter is applied in the Frontend Data Set and return no results', async () => {
+		await expect(dataSetFragmentPage.filterResumeButton).toBeVisible();
+		await expect(dataSetFragmentPage.filterResumeButton).toContainText(
+			`${filterLabel}: ${picklistCollectionOptionLabelAnyKey}`
+		);
+	});
+
+	await test.step('Update filter to apply to eggs option', async () => {
+		await dataSetManagerApiHelpers.updateDataSetSelectionFilter({
+			dataSetERC: customDataSetERC,
+			preselectedValues: JSON.stringify([
+				{
+					label: getRandomString(),
+					value: picklistCollectionOptionEggs.externalReferenceCode,
+				},
+			]),
+			selectionFilterERC: selectionFilter.externalReferenceCode,
+		});
+	});
+
+	await test.step('Check current items in the Frontend Data Set', async () => {
+		await page.reload();
+		await expect(dataSetFragmentPage.filterResumeButton).toBeVisible();
+		await expect(dataSetFragmentPage.filterResumeButton).toContainText(
+			`${filterLabel}: ${picklistCollectionOptionLabelEggs}`
+		);
+		await dataSetFragmentPage.paginationResults.scrollIntoViewIfNeeded();
+
+		await expect(
+			dataSetFragmentPage.table.bodyRows.first().locator('td')
+		).toHaveText(['bar, eggs, more eggs', '']);
+
+		await expect(
+			dataSetFragmentPage.paginationResults.getByText("Showing 1 to 1 of 1 entries.")
+		).toBeVisible();
+	});
+
+	await test.step('Can remove the current filter', async () => {
+		await dataSetFragmentPage.page
+			.getByRole('button', {exact: true, name: 'Remove Filter'})
+			.click();
+		await expect(dataSetFragmentPage.filterResumeButton).not.toBeVisible();
+
+		await dataSetFragmentPage.paginationResults.scrollIntoViewIfNeeded();
+
+		await expect(
+			dataSetFragmentPage.paginationResults.getByText(
+				'Showing 1 to 2 of 2 entries.'
+			)
+		).toBeVisible();
+	});
+});


### PR DESCRIPTION
### References
- [LPD-56706 Allow Admin Users to only select filterable fields to create a DSM filter](https://issues.liferay.com/browse/LPD-56706)

### What is the goal of this PR?

As a **Data Set Manager** user, I want the DSM to allow the creation of filters **only on fields explicitly marked as filterable in the API schema** (using `x-filterable`), so that I can avoid creating invalid or non-functional filters and achieve more reliable data exploration and analysis.

Previously, created filters did not properly identify the field type. As a result, in some cases (for example, when filtering integer or boolean fields), the generated OpenAPI query was invalid, even though the filter itself was created successfully.

### What does it look like?

From the **FDS Admin** side:
- The *Selection Filter* modal is now simpler, showing only fields available from the `x-filterable` path.
- For nested fields, they are kept in a single parent/child line, avoiding unnecessary field expansion.

#### Before this PR
- All fields were visible, allowing non-filterable or incorrect fields to be selected.
- There was no reliable “source of truth” to determine which fields were actually filterable.

#### After this PR
- The *Selection Filter* modal shows only available filterable fields (from `x-filterable`).
- `entityFieldType` is now reliable and can be safely used to assemble valid OpenAPI queries.
- Boolean field types can now be filtered correctly.

#### Development changes
- Introduced the **`getOpenApiData.ts`** utility to provide a single, centralized source for fetching OpenAPI schemas.
- Added the **`getFilterableFields`** method to **`getFields.ts`** to process only `x-filterable` values.
- Added **Boolean** as a valid filterable field type.
