### PR TITLE
LPD-78935 - Validate expiration date filter

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/DateRangeFilter.tsx
@@ -126,6 +126,9 @@ const DateRangeFilter = ({
 		selectedData?.to && formatDateObject(selectedData.to)
 	);
 
+	const [fromDateValid, setFromDateValid] = useState(true);
+	const [toDateValid, setToDateValid] = useState(true);
+
 	let actionType = 'edit';
 
 	if (selectedData && !fromValue && !toValue) {
@@ -136,9 +139,7 @@ const DateRangeFilter = ({
 		actionType = 'add';
 	}
 
-	let submitDisabled = true;
-
-	if (
+	const isChanged =
 		actionType === 'delete' ||
 		((!selectedData || !selectedData.from) && fromValue) ||
 		((!selectedData || !selectedData.to) && toValue) ||
@@ -147,28 +148,34 @@ const DateRangeFilter = ({
 			fromValue !== formatDateObject(selectedData.from)) ||
 		(selectedData &&
 			selectedData.to &&
-			toValue !== formatDateObject(selectedData.to))
-	) {
-		submitDisabled = false;
-	}
+			toValue !== formatDateObject(selectedData.to));
+
+	const submitDisabled = !isChanged || !fromDateValid || !toDateValid;
 
 	return (
 		<>
 			<ClayDropDown.Caption>
-				<div className="form-group">
+				<div className="fds-date-range form-group">
 					<ClayForm.Group className="form-group-sm">
 						<label htmlFor={`from-${id}`}>
 							{Liferay.Language.get('from')}
 						</label>
 
 						<input
-							className="form-control"
+							className="fds-from-date form-control"
 							id={`from-${id}`}
 							max={toValue || (max && formatDateObject(max))}
 							min={min && formatDateObject(min)}
-							onChange={(event) =>
-								setFromValue(event.target.value)
-							}
+							onBlur={(event) => {
+								event.target.reportValidity();
+
+								setFromDateValid(event.target.checkValidity());
+							}}
+							onChange={(event) => {
+								setFromValue(event.target.value);
+
+								setFromDateValid(event.target.checkValidity());
+							}}
 							pattern="\d{4}-\d{2}-\d{2}"
 							placeholder={placeholder || 'yyyy-mm-dd'}
 							type="date"
@@ -182,11 +189,20 @@ const DateRangeFilter = ({
 						</label>
 
 						<input
-							className="form-control"
+							className="fds-to-date form-control"
 							id={`to-${id}`}
 							max={max && formatDateObject(max)}
 							min={fromValue || (min && formatDateObject(min))}
-							onChange={(event) => setToValue(event.target.value)}
+							onBlur={(event) => {
+								event.target.reportValidity();
+
+								setToDateValid(event.target.checkValidity());
+							}}
+							onChange={(event) => {
+								setToValue(event.target.value);
+
+								setToDateValid(event.target.checkValidity());
+							}}
 							pattern="\d{4}-\d{2}-\d{2}"
 							placeholder={placeholder || 'yyyy-mm-dd'}
 							type="date"

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExpirationDateRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExpirationDateRangeFDSFilter.java
@@ -11,8 +11,6 @@ import com.liferay.frontend.data.set.filter.DateFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
-import java.util.Calendar;
-
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -56,11 +54,7 @@ public class ExpirationDateRangeFDSFilter extends BaseDateRangeFDSFilter {
 
 	@Override
 	public DateFDSFilterItem getMinDateFDSFilterItem() {
-		Calendar calendar = Calendar.getInstance();
-
-		return new DateFDSFilterItem(
-			calendar.get(Calendar.DAY_OF_MONTH),
-			calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.YEAR));
+		return new DateFDSFilterItem(0, 0, 0);
 	}
 
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExpirationDateRangeFDSFilter.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/frontend/data/set/filter/ExpirationDateRangeFDSFilter.java
@@ -11,6 +11,8 @@ import com.liferay.frontend.data.set.filter.DateFDSFilterItem;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.site.cms.site.initializer.internal.constants.CMSSiteInitializerFDSNames;
 
+import java.util.Calendar;
+
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -54,7 +56,11 @@ public class ExpirationDateRangeFDSFilter extends BaseDateRangeFDSFilter {
 
 	@Override
 	public DateFDSFilterItem getMinDateFDSFilterItem() {
-		return new DateFDSFilterItem(0, 0, 0);
+		Calendar calendar = Calendar.getInstance();
+
+		return new DateFDSFilterItem(
+			calendar.get(Calendar.DAY_OF_MONTH),
+			calendar.get(Calendar.MONTH) + 1, calendar.get(Calendar.YEAR));
 	}
 
 }

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1518,6 +1518,54 @@ test(
 );
 
 test(
+	'Expiration date filter does not allow "from" date to be before today',
+	{tag: '@LPD-78935'},
+	async ({assetsPage, page}) => {
+		const addFilterButton = page.getByRole('button', {name: 'Add Filter'});
+
+		await test.step('Go to All section', async () => {
+			await assetsPage.gotoAll();
+		});
+
+		await test.step('Choose to filter by Expiration Date', async () => {
+			await page.getByRole('button', {name: 'Filter'}).click();
+
+			await page.getByRole('menuitem', {name: 'Expiration Date'}).click();
+		});
+
+		const fromDateInput = page.getByLabel('From');
+		const toDateInput = page.getByLabel('To', {exact: true});
+
+		const fromDate = new Date();
+		const toDate = new Date();
+
+		await test.step('Check that the "Add filter" button is disabled if "from" date is before today', async () => {
+			fromDate.setDate(fromDate.getDate() - 1);
+			await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
+			await expect(addFilterButton).toBeDisabled();
+		});
+
+		await test.step('Check that the "Add filter" button is enabled if "from" date is today or after', async () => {
+			fromDate.setDate(fromDate.getDate() + 2);
+			await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
+			await expect(addFilterButton).toBeEnabled();
+		});
+
+		await test.step('Check that the "Add filter" button is disabled if "to" date is before "from date"', async () => {
+			toDate.setDate(toDate.getDate());
+			await toDateInput.fill(toDate.toISOString().split('T')[0]);
+			await expect(addFilterButton).toBeDisabled();
+		});
+
+		await test.step('Check that the "Add filter" button is enabled if "to" date is after "from date"', async () => {
+			toDate.setDate(toDate.getDate() + 5);
+			await toDateInput.fill(toDate.toISOString().split('T')[0]);
+			await expect(addFilterButton).toBeEnabled();
+		});
+	}
+);
+
+test(
 	'FDS Table content disappears after clicking "Show Details" and then "Expire"',
 	{tag: '@LPD-69267'},
 	async ({apiHelpers, assetsPage, page}) => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/all.spec.ts
@@ -1518,7 +1518,7 @@ test(
 );
 
 test(
-	'Expiration date filter does not allow "from" date to be before today',
+	'Expiration date filter does not allow "to" date to be before "from" date',
 	{tag: '@LPD-78935'},
 	async ({assetsPage, page}) => {
 		const addFilterButton = page.getByRole('button', {name: 'Add Filter'});
@@ -1539,7 +1539,7 @@ test(
 		const fromDate = new Date();
 		const toDate = new Date();
 
-		await test.step('Check that the "Add filter" button is disabled if "from" date is before today', async () => {
+		await test.step('Check that the "Add filter" button is disabled if "from" date is a past date', async () => {
 			fromDate.setDate(fromDate.getDate() - 1);
 			await fromDateInput.fill(fromDate.toISOString().split('T')[0]);
 			await expect(addFilterButton).toBeDisabled();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-78935

## Issue
_Expiration Date_ filter needs the following requirements (updated on 04/09/2026 after this [ticket comment](https://liferay.atlassian.net/browse/LPD-78935?focusedCommentId=5014348)):

To >= From
~~From >= today’s date~~
From >= should not have any restriction


~~To achieve this, we need to define a `minDate` in the filter ([ExpirationDateRangeFDSFilter.java](https://github.com/liferay-frontend/liferay-portal/pull/5408/changes#diff-2aabf0a5dd246cab3386fc09c9855a04b93bcee6aa262238042c1d80c0a89750R61)). This change will prevent users from selecting a date before today when using the datepicker.~~

However, users can still type the date directly in the `input[type=date]`, leading to invalid dates or combination of dates. To prevent this use case we leverage the native [Constraint_validation](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Constraint_validation) that will display a message to let the user know what is the expected date.

| Firefox  | Chrome |
| ------------- | ------------- |
| <img width="434" height="389" alt="image" src="https://github.com/user-attachments/assets/edf75cd2-d7ff-4eb4-919b-87b785211474" /> | <img width="434" height="389" alt="image" src="https://github.com/user-attachments/assets/2e79790e-9a8d-4841-8e56-88f5b2380355" /> |

Also, the filter button becomes disabled when the dates do not match the requirements.