### PR TITLE
LPD-83084 CMS Spaces Overview page does not load properly in Safari

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resources.jsp
@@ -24,11 +24,7 @@ String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute(CKE
 	</aui:style>
 
 	<aui:script type="module">
-		await import(
-			'@liferay/language/' +
-				Liferay.ThemeDisplay.getLanguageId() +
-				'/frontend-editor-ckeditor-web/all.js'
-		);
+		import '@liferay/language/frontend-editor-ckeditor-web/all.js';
 	</aui:script>
 
 	<aui:script hashedFile="<%= true %>" senna="temporary" src='<%= ckEditorServletContextName + "/ckeditor/ckeditor.js" %>' type="text/javascript"></aui:script>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/js/importmaps/extender/FrontendJSWebDynamicJSImportMapsContributor.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/js/importmaps/extender/FrontendJSWebDynamicJSImportMapsContributor.java
@@ -12,6 +12,7 @@ import com.liferay.frontend.js.web.internal.util.FrontendJSWebUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.frontend.hashed.files.CachingStrategy;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesRegistry;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.util.Portal;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -47,6 +48,8 @@ public class FrontendJSWebDynamicJSImportMapsContributor
 		writer.write(FrontendJSWebUtil.getPortalContextPath(_portal));
 		writer.write(
 			LanguageFrontendResourceRequestHandler.LANGUAGE_URI_PREFIX);
+		writer.write(_language.getLanguageId(httpServletRequest));
+		writer.write(StringPool.SLASH);
 		writer.write(StringPool.QUOTE);
 
 		CachingStrategy cachingStrategy =
@@ -112,6 +115,9 @@ public class FrontendJSWebDynamicJSImportMapsContributor
 
 	@Reference
 	private HashedFilesRegistry _hashedFilesRegistry;
+
+	@Reference
+	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/resource/handler/LanguageFrontendResourceRequestHandler.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/resource/handler/LanguageFrontendResourceRequestHandler.java
@@ -79,9 +79,37 @@ public class LanguageFrontendResourceRequestHandler
 
 		String[] requestURIParts = requestURI.split(StringPool.SLASH);
 
-		if ((requestURIParts.length != 3) ||
-			!Objects.equals(requestURIParts[2], "all.js")) {
+		if ((requestURIParts.length != 3) && (requestURIParts.length != 4)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Invalid request " + httpServletRequest.getRequestURI());
+			}
 
+			return null;
+		}
+
+		String servletContextPath = requestURIParts[1];
+
+		String allJS = requestURIParts[2];
+
+		// LPD-83084
+
+		if (requestURIParts.length == 4) {
+			servletContextPath = requestURIParts[2];
+			allJS = requestURIParts[3];
+
+			if (!Objects.equals(requestURIParts[0], requestURIParts[1])) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Invalid request " +
+							httpServletRequest.getRequestURI());
+				}
+
+				return null;
+			}
+		}
+
+		if (!Objects.equals(allJS, "all.js")) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Invalid request " + httpServletRequest.getRequestURI());
@@ -93,7 +121,7 @@ public class LanguageFrontendResourceRequestHandler
 		URL url = _hashedFilesRegistry.getResource(
 			StringBundler.concat(
 				portalContextPath, Portal.PATH_MODULE, StringPool.SLASH,
-				requestURIParts[1], "/language.json"));
+				servletContextPath, "/language.json"));
 
 		if (url == null) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/servlet/taglib/LiferayGlobalObjectPostAUIDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/servlet/taglib/LiferayGlobalObjectPostAUIDynamicInclude.java
@@ -69,9 +69,7 @@ public class LiferayGlobalObjectPostAUIDynamicInclude
 				"text/javascript");
 
 			_renderScript(
-				"await import(`@liferay/language" +
-					"/${Liferay.ThemeDisplay.getLanguageId()}/frontend-js-web" +
-						"/all.js`);",
+				"import '@liferay/language/frontend-js-web/all.js';",
 				httpServletRequest, httpServletResponse.getWriter(), null,
 				"module");
 		}

--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -24,6 +24,7 @@
 		"@types/jest": "26.0.14",
 		"@types/react-dom": "17.0.3",
 		"@types/vfile-message": "2.0.0",
+		"@typescript-eslint/parser": "^7.8.0",
 		"acorn": "^8.14.0",
 		"acorn-typescript": "^1.4.13",
 		"babel-eslint": "^10.1.0",
@@ -55,6 +56,7 @@
 		"sonda": "^0.7.1",
 		"stylelint": "13.2.0",
 		"tar": "^7.2.0",
+		"typescript": "4.4.2",
 		"unzipper": "^0.11.6"
 	},
 	"exports": {
@@ -63,8 +65,8 @@
 	},
 	"name": "@liferay/node-scripts",
 	"scripts": {
-		"checkFormat": "node-scripts format --check",
-		"format": "node-scripts format",
+		"checkFormat": "node-scripts format:self --check",
+		"format": "node-scripts format:self",
 		"install": "node-scripts setup"
 	},
 	"version": "1.0.0"

--- a/modules/frontend-sdk/node-scripts/package.json
+++ b/modules/frontend-sdk/node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "75829604b097e1be22723953f01cf1615d00beb90090cfe18546d7bea68d3af9"
+		"sha256": "12c714801a84bfc5af6a38279950ff592a16fbd07c9b7f5bc345a42cdf642697"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",
@@ -65,8 +65,8 @@
 	},
 	"name": "@liferay/node-scripts",
 	"scripts": {
-		"checkFormat": "node-scripts format:self --check",
-		"format": "node-scripts format:self",
+		"checkFormat": "node-scripts format --check",
+		"format": "node-scripts format",
 		"install": "node-scripts setup"
 	},
 	"version": "1.0.0"

--- a/modules/frontend-sdk/node-scripts/util/esbuild/plugins/getLiferayLanguageGetPlugin.mjs
+++ b/modules/frontend-sdk/node-scripts/util/esbuild/plugins/getLiferayLanguageGetPlugin.mjs
@@ -11,7 +11,7 @@ import {SRC_PATH} from '../../locations.mjs';
 const REGEXP = /Liferay\.Language\.get\(([^)]+)\)/g;
 
 /**
- * This plugin detects usages of `Liferay.Language.get` and injects a dynamic import for
+ * This plugin detects usages of `Liferay.Language.get` and injects a static import for
  * `@liferay/language/...` when necessary.
  *
  * This technique is only used for liferay-portal internal code (ie: it is not applied to external
@@ -74,10 +74,9 @@ export default function getLiferayLanguageGetPlugin(
 
 					if (keys.length) {
 						contents =
-							'await import(`@liferay/language/' +
-							'${Liferay.ThemeDisplay.getLanguageId()}' +
+							"import '@liferay/language" +
 							projectWebContextPath +
-							'/all.js`);\n' +
+							"/all.js';\n" +
 							contents;
 
 						languageJSON.keys.push(...keys);

--- a/modules/frontend-sdk/node-scripts/util/esbuild/plugins/getLinkerPlugin.mjs
+++ b/modules/frontend-sdk/node-scripts/util/esbuild/plugins/getLinkerPlugin.mjs
@@ -74,7 +74,7 @@ export default function getLinkerPlugin(
 				async (info) => {
 					const {importer, kind, path} = info;
 
-					// Resolve exported module locally inside export briges so
+					// Resolve exported module locally inside export bridges so
 					// that it is bundled instead of linked.
 
 					if (moduleName !== 'main' && path === moduleName) {
@@ -84,7 +84,10 @@ export default function getLinkerPlugin(
 					// Leave DXP runtime URLs untouched as they are trusted to
 					// be already correct.
 
-					if (path.includes('/__liferay__/')) {
+					if (
+						path.includes('/__liferay__/') ||
+						path.startsWith('@liferay/language')
+					) {
 						return {
 							external: true,
 							path,

--- a/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
+++ b/portal-impl/src/com/liferay/portal/language/LanguageImpl.java
@@ -1656,7 +1656,7 @@ public class LanguageImpl implements Language, Serializable {
 		else {
 			content = content.replaceAll(
 				_LIFERAY_LANGUAGE_IMPORT_REGEXP,
-				"{/*removed: await import('@liferay/language...')*/}");
+				"{/*removed: import '@liferay/language...'*/}");
 		}
 
 		StringBundler sb = null;
@@ -2030,7 +2030,7 @@ public class LanguageImpl implements Language, Serializable {
 		LanguageImpl.class.getName() + "._groupLocalesPortalCache";
 
 	private static final String _LIFERAY_LANGUAGE_IMPORT_REGEXP =
-		"await import\\(.@liferay/language/.+?/all\\.js.\\)";
+		"import\\s+'@liferay/language/.+?/all\\.js'";
 
 	private static final double _STORAGE_SIZE_DENOMINATOR = 1024.0;
 

--- a/portal-impl/test/unit/com/liferay/portal/language/LanguageImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/language/LanguageImplTest.java
@@ -28,18 +28,17 @@ public class LanguageImplTest {
 		LanguageImpl languageImpl = new LanguageImpl();
 
 		Assert.assertEquals(
-			"foo;bar;{/*removed: await import('@liferay/language...')*/};baz;",
+			"foo;bar;{/*removed: import '@liferay/language...'*/};baz;",
 			languageImpl.process(
-				null, null,
-				"foo;bar;await import('@liferay/language/foo/all.js');baz;"
+				null, null, "foo;bar;import '@liferay/language/foo/all.js';baz;"
 			).toString());
 		Assert.assertEquals(
-			"foo;{/*removed: await import('@liferay/language...')*/};bar;" +
-				"{/*removed: await import('@liferay/language...')*/};baz;",
+			"foo;{/*removed: import '@liferay/language...'*/};bar;" +
+				"{/*removed: import '@liferay/language...'*/};baz;",
 			languageImpl.process(
 				null, null,
-				"foo;await import('@liferay/language/foo/all.js');bar;" +
-					"await import('@liferay/language/foo/all.js');baz;"
+				"foo;import   '@liferay/language/foo/all.js';bar;" +
+					"import '@liferay/language/foo/all.js';baz;"
 			).toString());
 	}
 


### PR DESCRIPTION
References:
 - https://liferay.atlassian.net/browse/LPD-83084
 - https://liferay.atlassian.net/browse/LPD-84986
 - https://liferay.atlassian.net/browse/LPP-63566

In this PR we are transferring the calculation of the `all.js` label resources to the import map. Before this change, `node-scripts` was in charge of adding bits to dynamically importing them. `await import()` was needed because path calculation was made in the browser.

This PR moves that logic to the import map. Technique is basically to leverage **only one already existing import map entry**, so that all dynamic imports node-scripts generate can now be turned into static ones. This has deep implications in the way the translations are linked and resolved by the browser.

In addition, removing top-level await clauses makes Safari behave like a normal browser, circumventing a [long-standing issue ](https://bugs.webkit.org/show_bug.cgi?id=242740)