### PR TITLE
LPD-83856 Track nonce

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/ContentSecurityPolicyNonceManager.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/ContentSecurityPolicyNonceManager.java
@@ -11,10 +11,13 @@ import com.liferay.portal.kernel.security.SecureRandom;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfigurationUtil;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
@@ -49,7 +52,10 @@ public class ContentSecurityPolicyNonceManager {
 		return GetterUtil.getString(httpServletRequest.getAttribute(_NONCE));
 	}
 
-	public String setNonce(HttpServletRequest httpServletRequest) {
+	public String setNonce(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
 		String nonce = null;
 
 		httpServletRequest = _portal.getOriginalServletRequest(
@@ -70,14 +76,40 @@ public class ContentSecurityPolicyNonceManager {
 			nonce = (String)httpSession.getAttribute(_NONCE);
 
 			if (nonce == null) {
-				synchronized (httpSession) {
-					nonce = (String)httpSession.getAttribute(_NONCE);
+				nonce = _getNonceFromCookie(httpServletRequest);
 
-					if (nonce == null) {
-						nonce = _generateNonce();
+				if (nonce != null) {
+					httpSession.setAttribute(_NONCE, nonce);
 
-						httpSession.setAttribute(_NONCE, nonce);
+					_removeNonceCookie(httpServletRequest, httpServletResponse);
+				}
+				else {
+					synchronized (httpSession) {
+						nonce = (String)httpSession.getAttribute(_NONCE);
+
+						if (nonce == null) {
+							nonce = _generateNonce();
+
+							httpSession.setAttribute(_NONCE, nonce);
+						}
 					}
+				}
+			}
+
+			if (nonce != null) {
+				String requestURI = httpServletRequest.getRequestURI();
+
+				if (Validator.isNotNull(requestURI) &&
+					(requestURI.contains("/sign-in") ||
+					 requestURI.contains("/logout"))) {
+
+					_addNonceCookie(
+						httpServletRequest, httpServletResponse, nonce);
+				}
+				else if ((httpSession.getAttribute(_NONCE) != null) &&
+						 (_getNonceFromCookie(httpServletRequest) != null)) {
+
+					_removeNonceCookie(httpServletRequest, httpServletResponse);
 				}
 			}
 		}
@@ -92,6 +124,24 @@ public class ContentSecurityPolicyNonceManager {
 		return nonce;
 	}
 
+	private void _addNonceCookie(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, String nonce) {
+
+		if (httpServletResponse == null) {
+			return;
+		}
+
+		Cookie cookie = new Cookie(_CSP_COOKIE, nonce);
+
+		cookie.setHttpOnly(true);
+		cookie.setPath(StringPool.SLASH);
+		cookie.setSecure(httpServletRequest.isSecure());
+		cookie.setMaxAge(-1);
+
+		httpServletResponse.addCookie(cookie);
+	}
+
 	private String _generateNonce() {
 		SecureRandom secureRandom = new SecureRandom();
 
@@ -101,6 +151,42 @@ public class ContentSecurityPolicyNonceManager {
 
 		return Base64.encode(bytes);
 	}
+
+	private String _getNonceFromCookie(HttpServletRequest httpServletRequest) {
+		Cookie[] cookies = httpServletRequest.getCookies();
+
+		if (cookies == null) {
+			return null;
+		}
+
+		for (Cookie cookie : cookies) {
+			if (_CSP_COOKIE.equals(cookie.getName())) {
+				return cookie.getValue();
+			}
+		}
+
+		return null;
+	}
+
+	private void _removeNonceCookie(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		if (httpServletResponse == null) {
+			return;
+		}
+
+		Cookie cookie = new Cookie(_CSP_COOKIE, StringPool.BLANK);
+
+		cookie.setHttpOnly(true);
+		cookie.setPath(StringPool.SLASH);
+		cookie.setSecure(httpServletRequest.isSecure());
+		cookie.setMaxAge(0);
+
+		httpServletResponse.addCookie(cookie);
+	}
+
+	private static final String _CSP_COOKIE = "LFR_CSP_NONCE";
 
 	private static final String _NONCE =
 		ContentSecurityPolicyNonceManager.class.getName() + "#NONCE";

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -84,7 +84,7 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		throws Exception {
 
 		String nonce = _contentSecurityPolicyNonceManager.setNonce(
-			httpServletRequest);
+			httpServletRequest, httpServletResponse);
 
 		try {
 			httpServletResponse.setContentType("text/html; charset=UTF-8");

--- a/modules/test/playwright/tests/portal-security-content-security-policy/main/contentSecurityPolicyNonceManager.spec.ts
+++ b/modules/test/playwright/tests/portal-security-content-security-policy/main/contentSecurityPolicyNonceManager.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {contentSecurityPolicyPagesTest} from '../../../fixtures/contentSecurityPolicyPagesTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {virtualInstancesPagesTest} from '../../../fixtures/virtualInstancesPagesTest';
+import performLogin, {performLogout} from '../../../utils/performLogin';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	contentSecurityPolicyPagesTest,
+	featureFlagsTest({
+		'LPD-36105': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	virtualInstancesPagesTest
+);
+
+test('No CSP nonce errors when logging in', async ({
+	contentSecurityPolicyPage,
+	page,
+}) => {
+	await contentSecurityPolicyPage.gotoAndConfigurePolicy(
+		`style-src '[$NONCE$]'; script-src '[$NONCE$]';`
+	);
+
+	const errors = [];
+
+	page.on('console', (msg) => {
+		if (
+			msg.type() === 'error' &&
+			msg
+				.text()
+				.includes('Content Security Policy directive: "script-src')
+		) {
+			errors.push({text: msg.text(), type: msg.type()});
+		}
+	});
+
+	await performLogout(page);
+
+	await performLogin(page, 'test');
+
+	expect(errors).toHaveLength(0);
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83856
https://liferay.atlassian.net/browse/LPP-63356

When using CSP during a login, a new session is created which results in the old and new nonce conflicting and causing errors.
To resolve this, I added a temporary cookie that will store the nonce and then remove it during login.

Let me know if there are any questions or comments about this.
Thank you!