### PR TITLE
LPD-83856 Update session attributes with CSP

### DIFF
--- a/modules/test/playwright/tests/portal-security-content-security-policy/main/contentSecurityPolicyNonceManager.spec.ts
+++ b/modules/test/playwright/tests/portal-security-content-security-policy/main/contentSecurityPolicyNonceManager.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {contentSecurityPolicyPagesTest} from '../../../fixtures/contentSecurityPolicyPagesTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import {virtualInstancesPagesTest} from '../../../fixtures/virtualInstancesPagesTest';
+import performLogin, {performLogout} from '../../../utils/performLogin';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	contentSecurityPolicyPagesTest,
+	featureFlagsTest({
+		'LPD-36105': {enabled: true},
+		'LPS-178052': {enabled: true},
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest,
+	virtualInstancesPagesTest
+);
+
+test('No CSP nonce errors when logging in', async ({
+	contentSecurityPolicyPage,
+	page,
+}) => {
+	await contentSecurityPolicyPage.gotoAndConfigurePolicy(
+		`style-src '[$NONCE$]'; script-src '[$NONCE$]';`
+	);
+
+	const errors = [];
+
+	page.on('console', (msg) => {
+		if (
+			msg.type() === 'error' &&
+			msg
+				.text()
+				.includes('Content Security Policy directive: "script-src')
+		) {
+			errors.push({text: msg.text(), type: msg.type()});
+		}
+	});
+
+	await performLogout(page);
+
+	await performLogin(page, 'test');
+
+	expect(errors).toHaveLength(0);
+});

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3211,6 +3211,7 @@
     # Env: LIFERAY_SESSION_PERIOD_PHISHING_PERIOD_PROTECTED_PERIOD_ATTRIBUTES
     #
     session.phishing.protected.attributes=\
+        com.liferay.portal.security.content.security.policy.internal.ContentSecurityPolicyNonceManager#NONCE,\
         HTTPS_INITIAL,\
         LAST_PATH,\
         SAML_SP_SESSION_KEY,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83856
https://liferay.atlassian.net/browse/LPP-63356

When using CSP during a login, a new session is created which results in the old and new nonce conflicting and causing errors.
Adding `com.liferay.portal.security.content.security.policy.internal.ContentSecurityPolicyNonceManager#NONCE` to the portal property would add the CSP nonce to the new session.

Let me know if there are any questions or comments about this.
Thank you!