### PR TITLE
LPD-86116: Make style book entries transport modification date in export-import

### DIFF
--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -434,6 +434,17 @@ public interface StyleBookEntryLocalService
 			long styleBookEntryId, long previewFileEntryId)
 		throws PortalException;
 
+	public StyleBookEntry updatePreviewFileEntryId(
+			long previewFileEntryId, ServiceContext serviceContext,
+			long styleBookEntryId)
+		throws PortalException;
+
+	public StyleBookEntry updateStyleBookEntry(
+			boolean defaultStylebookEntry, String frontendTokensValues,
+			String name, long previewFileEntryId, ServiceContext serviceContext,
+			long styleBookEntryId, String styleBookEntryKey, long userId)
+		throws PortalException;
+
 	public StyleBookEntry updateStyleBookEntry(
 			long userId, long styleBookEntryId, boolean defaultStylebookEntry,
 			String frontendTokensValues, String name, String styleBookEntryKey,
@@ -442,6 +453,11 @@ public interface StyleBookEntryLocalService
 
 	public StyleBookEntry updateStyleBookEntry(
 			long styleBookEntryId, String frontendTokensValues, String name)
+		throws PortalException;
+
+	public StyleBookEntry updateStyleBookEntry(
+			String frontendTokensValues, String name,
+			ServiceContext serviceContext, long styleBookEntryId)
 		throws PortalException;
 
 	/**
@@ -475,4 +491,4 @@ public interface StyleBookEntryLocalService
 		throws E;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1575871872
+// LIFERAY-SERVICE-BUILDER-HASH:1913896399

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -540,6 +540,29 @@ public class StyleBookEntryLocalServiceUtil {
 			styleBookEntryId, previewFileEntryId);
 	}
 
+	public static StyleBookEntry updatePreviewFileEntryId(
+			long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			long styleBookEntryId)
+		throws PortalException {
+
+		return getService().updatePreviewFileEntryId(
+			previewFileEntryId, serviceContext, styleBookEntryId);
+	}
+
+	public static StyleBookEntry updateStyleBookEntry(
+			boolean defaultStylebookEntry, String frontendTokensValues,
+			String name, long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			long styleBookEntryId, String styleBookEntryKey, long userId)
+		throws PortalException {
+
+		return getService().updateStyleBookEntry(
+			defaultStylebookEntry, frontendTokensValues, name,
+			previewFileEntryId, serviceContext, styleBookEntryId,
+			styleBookEntryKey, userId);
+	}
+
 	public static StyleBookEntry updateStyleBookEntry(
 			long userId, long styleBookEntryId, boolean defaultStylebookEntry,
 			String frontendTokensValues, String name, String styleBookEntryKey,
@@ -557,6 +580,16 @@ public class StyleBookEntryLocalServiceUtil {
 
 		return getService().updateStyleBookEntry(
 			styleBookEntryId, frontendTokensValues, name);
+	}
+
+	public static StyleBookEntry updateStyleBookEntry(
+			String frontendTokensValues, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			long styleBookEntryId)
+		throws PortalException {
+
+		return getService().updateStyleBookEntry(
+			frontendTokensValues, name, serviceContext, styleBookEntryId);
 	}
 
 	/**
@@ -586,4 +619,4 @@ public class StyleBookEntryLocalServiceUtil {
 			StyleBookEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1778702003
+// LIFERAY-SERVICE-BUILDER-HASH:1398155145

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -622,6 +622,31 @@ public class StyleBookEntryLocalServiceWrapper
 	}
 
 	@Override
+	public StyleBookEntry updatePreviewFileEntryId(
+			long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			long styleBookEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _styleBookEntryLocalService.updatePreviewFileEntryId(
+			previewFileEntryId, serviceContext, styleBookEntryId);
+	}
+
+	@Override
+	public StyleBookEntry updateStyleBookEntry(
+			boolean defaultStylebookEntry, String frontendTokensValues,
+			String name, long previewFileEntryId,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			long styleBookEntryId, String styleBookEntryKey, long userId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _styleBookEntryLocalService.updateStyleBookEntry(
+			defaultStylebookEntry, frontendTokensValues, name,
+			previewFileEntryId, serviceContext, styleBookEntryId,
+			styleBookEntryKey, userId);
+	}
+
+	@Override
 	public StyleBookEntry updateStyleBookEntry(
 			long userId, long styleBookEntryId, boolean defaultStylebookEntry,
 			String frontendTokensValues, String name, String styleBookEntryKey,
@@ -640,6 +665,17 @@ public class StyleBookEntryLocalServiceWrapper
 
 		return _styleBookEntryLocalService.updateStyleBookEntry(
 			styleBookEntryId, frontendTokensValues, name);
+	}
+
+	@Override
+	public StyleBookEntry updateStyleBookEntry(
+			String frontendTokensValues, String name,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext,
+			long styleBookEntryId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _styleBookEntryLocalService.updateStyleBookEntry(
+			frontendTokensValues, name, serviceContext, styleBookEntryId);
 	}
 
 	/**
@@ -701,4 +737,4 @@ public class StyleBookEntryLocalServiceWrapper
 	private StyleBookEntryLocalService _styleBookEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:436187170
+// LIFERAY-SERVICE-BUILDER-HASH:1160539274

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 6.3.0

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/data/handler/StylebookEntryStagedModelDataHandler.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/data/handler/StylebookEntryStagedModelDataHandler.java
@@ -150,8 +150,9 @@ public class StylebookEntryStagedModelDataHandler
 
 			importedStyleBookEntry =
 				_styleBookEntryLocalService.updatePreviewFileEntryId(
-					importedStyleBookEntry.getStyleBookEntryId(),
-					previewFileEntryId);
+					previewFileEntryId,
+					portletDataContext.createServiceContext(styleBookEntry),
+					importedStyleBookEntry.getStyleBookEntryId());
 		}
 
 		portletDataContext.importClassedModel(

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
@@ -129,12 +129,13 @@ public class StylebookEntryStagedModelRepository
 		throws PortalException {
 
 		return _styleBookEntryLocalService.updateStyleBookEntry(
-			portletDataContext.getUserId(styleBookEntry.getUserUuid()),
-			styleBookEntry.getStyleBookEntryId(),
 			styleBookEntry.isDefaultStyleBookEntry(),
 			styleBookEntry.getFrontendTokensValues(), styleBookEntry.getName(),
+			styleBookEntry.getPreviewFileEntryId(),
+			portletDataContext.createServiceContext(styleBookEntry),
+			styleBookEntry.getStyleBookEntryId(),
 			styleBookEntry.getStyleBookEntryKey(),
-			styleBookEntry.getPreviewFileEntryId());
+			portletDataContext.getUserId(styleBookEntry.getUserUuid()));
 	}
 
 	@Reference

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -423,10 +423,18 @@ public class StyleBookEntryLocalServiceImpl
 			long styleBookEntryId, long previewFileEntryId)
 		throws PortalException {
 
+		return updatePreviewFileEntryId(
+			previewFileEntryId, new ServiceContext(), styleBookEntryId);
+	}
+
+	@Override
+	public StyleBookEntry updatePreviewFileEntryId(
+			long previewFileEntryId, ServiceContext serviceContext,
+			long styleBookEntryId)
+		throws PortalException {
+
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
-
-		styleBookEntry.setModifiedDate(new Date());
 
 		long previousPreviewFileEntryId =
 			styleBookEntry.getPreviewFileEntryId();
@@ -442,7 +450,8 @@ public class StyleBookEntryLocalServiceImpl
 			updateDraft(draftStyleBookEntry);
 		}
 
-		styleBookEntry = styleBookEntryPersistence.update(styleBookEntry);
+		styleBookEntry = styleBookEntryPersistence.update(
+			styleBookEntry, serviceContext);
 
 		if ((previewFileEntryId == 0) && (previousPreviewFileEntryId > 0)) {
 			_portletFileRepository.deletePortletFileEntry(
@@ -454,9 +463,9 @@ public class StyleBookEntryLocalServiceImpl
 
 	@Override
 	public StyleBookEntry updateStyleBookEntry(
-			long userId, long styleBookEntryId, boolean defaultStylebookEntry,
-			String frontendTokensValues, String name, String styleBookEntryKey,
-			long previewFileEntryId)
+			boolean defaultStylebookEntry, String frontendTokensValues,
+			String name, long previewFileEntryId, ServiceContext serviceContext,
+			long styleBookEntryId, String styleBookEntryKey, long userId)
 		throws PortalException {
 
 		StyleBookEntry styleBookEntry =
@@ -481,7 +490,6 @@ public class StyleBookEntryLocalServiceImpl
 		}
 
 		styleBookEntry.setUserId(userId);
-		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 		styleBookEntry.setName(name);
 		styleBookEntry.setPreviewFileEntryId(previewFileEntryId);
@@ -500,7 +508,20 @@ public class StyleBookEntryLocalServiceImpl
 			styleBookEntry.setDefaultStyleBookEntry(true);
 		}
 
-		return styleBookEntryPersistence.update(styleBookEntry);
+		return styleBookEntryPersistence.update(styleBookEntry, serviceContext);
+	}
+
+	@Override
+	public StyleBookEntry updateStyleBookEntry(
+			long userId, long styleBookEntryId, boolean defaultStylebookEntry,
+			String frontendTokensValues, String name, String styleBookEntryKey,
+			long previewFileEntryId)
+		throws PortalException {
+
+		return updateStyleBookEntry(
+			defaultStylebookEntry, frontendTokensValues, name,
+			previewFileEntryId, new ServiceContext(), styleBookEntryId,
+			styleBookEntryKey, userId);
 	}
 
 	@Override
@@ -508,12 +529,21 @@ public class StyleBookEntryLocalServiceImpl
 			long styleBookEntryId, String frontendTokensValues, String name)
 		throws PortalException {
 
+		return updateStyleBookEntry(
+			frontendTokensValues, name, new ServiceContext(), styleBookEntryId);
+	}
+
+	@Override
+	public StyleBookEntry updateStyleBookEntry(
+			String frontendTokensValues, String name,
+			ServiceContext serviceContext, long styleBookEntryId)
+		throws PortalException {
+
 		StyleBookEntry styleBookEntry =
 			styleBookEntryPersistence.findByPrimaryKey(styleBookEntryId);
 
 		_validate(styleBookEntry.getGroupId(), name, styleBookEntryId);
 
-		styleBookEntry.setModifiedDate(new Date());
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 		styleBookEntry.setName(name);
 
@@ -527,7 +557,7 @@ public class StyleBookEntryLocalServiceImpl
 			updateDraft(draftStyleBookEntry);
 		}
 
-		return styleBookEntryPersistence.update(styleBookEntry);
+		return styleBookEntryPersistence.update(styleBookEntry, serviceContext);
 	}
 
 	private long _copyStyleBookEntryPreviewFileEntry(

--- a/modules/apps/style-book/style-book-test/build.gradle
+++ b/modules/apps/style-book/style-book-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:client-extension:client-extension-api")
+	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:frontend-token:frontend-token-definition-api")
 	testIntegrationImplementation project(":apps:layout:layout-page-template-api")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")

--- a/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/exportimport/data/handler/test/StyleBookEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/style-book/style-book-test/src/testIntegration/java/com/liferay/style/book/exportimport/data/handler/test/StyleBookEntryStagedModelDataHandlerTest.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.style.book.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.service.StyleBookEntryLocalService;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Petteri Karttunen
+ */
+@RunWith(Arquillian.class)
+public class StyleBookEntryStagedModelDataHandlerTest
+	extends BaseStagedModelDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Override
+	protected StagedModel addStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		return _styleBookEntryLocalService.addStyleBookEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(), false,
+			StringPool.BLANK, RandomTestUtil.randomString(), StringPool.BLANK,
+			RandomTestUtil.randomString(),
+			ServiceContextTestUtil.getServiceContext());
+	}
+
+	@Override
+	protected StagedModel getStagedModel(String uuid, Group group)
+		throws PortalException {
+
+		return _styleBookEntryLocalService.fetchStyleBookEntryByUuidAndGroupId(
+			uuid, group.getGroupId());
+	}
+
+	@Override
+	protected Class<? extends StagedModel> getStagedModelClass() {
+		return StyleBookEntry.class;
+	}
+
+	@Inject
+	private StyleBookEntryLocalService _styleBookEntryLocalService;
+
+}


### PR DESCRIPTION
# Tickets
- https://liferay.atlassian.net/browse/LPD-84210
  - https://liferay.atlassian.net/browse/LPD-86116

## Motivation
Fixes style book entry modification date not being transported in export-import in subsequent imports or when there was a preview image.

## Proposed Solution
Add service signatures being able to accept service context and dates within 


