### PR TITLE
LPD-86270 Enable sorting in the User Views management FDS

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/ManageUserViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/ManageUserViews.tsx
@@ -332,6 +332,23 @@ export default function ManageUserViews({
 					portletId={portletId}
 					selectedItemsKey="externalReferenceCode"
 					selectionType="multiple"
+					sorts={[
+						{
+							direction: 'asc',
+							key: 'fdsName',
+							label: Liferay.Language.get('data-set'),
+						},
+						{
+							direction: 'asc',
+							key: 'creator',
+							label: Liferay.Language.get('created-by'),
+						},
+						{
+							direction: 'asc',
+							key: 'dateModified',
+							label: Liferay.Language.get('modified-date'),
+						},
+					]}
 					style="fluid"
 					views={[views]}
 				/>

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/UserViewsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/UserViewsPage.ts
@@ -15,6 +15,7 @@ export class UserViewsPage {
 		container: Locator;
 		deleteButton: Locator;
 	};
+	readonly dropdownMenu: Locator;
 	readonly emptyStateTitle: Locator;
 	readonly filterActionButton: Locator;
 	readonly filterButton: Locator;
@@ -25,6 +26,7 @@ export class UserViewsPage {
 	readonly managementToolbar: {
 		container: Locator;
 	};
+	readonly orderButton: Locator;
 	readonly page: Page;
 	readonly pageContainer: Locator;
 	readonly table: {
@@ -37,6 +39,7 @@ export class UserViewsPage {
 		this.adminOptionsDropdown = page.locator(
 			'button[data-qa-id="fdsAdminOptionsMenu"]'
 		);
+		this.dropdownMenu = page.locator('.dropdown-menu.show');
 		this.emptyStateTitle = page
 			.getByTestId('visualization-mode-table')
 			.getByText('No Results Found');
@@ -56,6 +59,7 @@ export class UserViewsPage {
 		this.managementToolbar = {
 			container: managementToolbarContainer,
 		};
+		this.orderButton = page.getByRole('button', {name: 'Order'});
 		this.page = page;
 		this.pageContainer = page.locator('.data-sets.manage-user-views');
 		const bulkActionsContainer = page.locator('.bulk-actions');
@@ -75,6 +79,14 @@ export class UserViewsPage {
 			container: tableContainer,
 			headRow: tableContainer.locator('thead tr'),
 		};
+	}
+
+	async sortDropdownItemHasCheck(itemName: string): Promise<boolean> {
+		return this.dropdownMenu
+			.getByRole('menuitem', {exact: true, name: itemName})
+			.locator('svg use[*|href$="#check"]')
+			.count()
+			.then((count) => count > 0);
 	}
 
 	async goto() {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/userViews.spec.ts
@@ -8,6 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {dataSetManagerApiHelpersTest} from '../../../fixtures/dataSetManagerApiHelpersTest';
 import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {DataSetManagerApiHelpers} from '../../../helpers/DataSetManagerApiHelpers';
 import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {settingsPageTest} from './fixtures/settingsPageTest';
@@ -30,11 +31,12 @@ interface IDataSet {
 
 let dataSetERCs: string[] = [];
 
-const createDataSet = async ({dataSetManagerApiHelpers}): Promise<IDataSet> => {
-	const dataSet = {
-		erc: getRandomString(),
-		label: getRandomString(),
-	};
+const createDataSet = async ({
+	dataSetManagerApiHelpers,
+	erc = getRandomString(),
+	label = getRandomString(),
+}): Promise<IDataSet> => {
+	const dataSet = {erc, label};
 
 	await dataSetManagerApiHelpers.createDataSet({
 		erc: dataSet.erc,
@@ -47,29 +49,33 @@ const createDataSet = async ({dataSetManagerApiHelpers}): Promise<IDataSet> => {
 	return dataSet;
 };
 
-test.beforeEach(async ({dataSetManagerApiHelpers}) => {
-	dataSetERCs = [];
+const deleteAllSnapshots = async (
+	dataSetManagerApiHelpers: DataSetManagerApiHelpers
+) => {
+	const response = (await dataSetManagerApiHelpers.get(
+		'/o/data-set-admin/snapshots?page=1&pageSize=100'
+	)) as {items?: Array<{id?: number}>};
 
-	await test.step('Delete previous snapshots', async () => {
-		const response = (await dataSetManagerApiHelpers.get(
-			'/o/data-set-admin/snapshots?page=1&pageSize=100'
-		)) as {items?: Array<{id?: number}>};
-
-		const snapshots = response.items || [];
-
-		for (const snapshot of snapshots) {
-			if (!snapshot.id) {
-				continue;
-			}
-
+	for (const snapshot of response.items || []) {
+		if (snapshot.id) {
 			await dataSetManagerApiHelpers.delete(
 				`/o/data-set-admin/snapshots/${snapshot.id}`
 			);
 		}
+	}
+};
+
+test.beforeEach(async ({dataSetManagerApiHelpers}) => {
+	dataSetERCs = [];
+
+	await test.step('Delete leftover snapshots', async () => {
+		await deleteAllSnapshots(dataSetManagerApiHelpers);
 	});
 });
 
 test.afterEach(async ({dataSetManagerApiHelpers}) => {
+	await deleteAllSnapshots(dataSetManagerApiHelpers);
+
 	for (const dataSetERC of dataSetERCs) {
 		await dataSetManagerApiHelpers.deleteDataSet({erc: dataSetERC});
 	}
@@ -238,3 +244,92 @@ test('Delete User Views through bulk action', async ({
 		).toHaveCount(0);
 	});
 });
+
+test(
+	'Sort User Views by Data Set and Modified Date in ascending and descending order',
+	{tag: '@LPD-86270'},
+	async ({dataSetManagerApiHelpers, page, userViewsPage}) => {
+		const firstDataSet = await createDataSet({
+			dataSetManagerApiHelpers,
+			erc: `aaa-${getRandomString()}`,
+		});
+		const lastDataSet = await createDataSet({
+			dataSetManagerApiHelpers,
+			erc: `zzz-${getRandomString()}`,
+		});
+
+		const firstSnapshotName = getRandomString();
+		const lastSnapshotName = getRandomString();
+
+		await dataSetManagerApiHelpers.createDataSetSnapshot({
+			dataSetERC: firstDataSet.erc,
+			snapshotName: firstSnapshotName,
+		});
+
+		// Ensure distinct dateModified values (API timestamps have second precision).
+
+		await page.waitForTimeout(1100);
+
+		await dataSetManagerApiHelpers.createDataSetSnapshot({
+			dataSetERC: lastDataSet.erc,
+			snapshotName: lastSnapshotName,
+		});
+
+		await userViewsPage.goto();
+
+		await test.step('Sort by Data Set ascending places aaa-prefixed row first', async () => {
+			await userViewsPage.orderButton.click();
+			await userViewsPage.dropdownMenu
+				.getByRole('menuitem', {exact: true, name: 'Data Set'})
+				.click();
+
+			await expect(userViewsPage.table.bodyRows.first()).toContainText(
+				firstSnapshotName
+			);
+		});
+
+		await test.step('Switching to Descending reverses the order', async () => {
+			await userViewsPage.orderButton.click();
+			await userViewsPage.dropdownMenu
+				.getByRole('menuitem', {exact: true, name: 'Descending'})
+				.click();
+
+			await expect(userViewsPage.table.bodyRows.first()).toContainText(
+				lastSnapshotName
+			);
+		});
+
+		await test.step('Switching to Modified Date keeps the Descending direction and shows newest first', async () => {
+			await userViewsPage.orderButton.click();
+			await userViewsPage.dropdownMenu
+				.getByRole('menuitem', {exact: true, name: 'Modified Date'})
+				.click();
+
+			await expect(userViewsPage.table.bodyRows.first()).toContainText(
+				lastSnapshotName
+			);
+
+			await userViewsPage.orderButton.click();
+
+			expect(
+				await userViewsPage.sortDropdownItemHasCheck('Modified Date')
+			).toBe(true);
+			expect(
+				await userViewsPage.sortDropdownItemHasCheck('Descending')
+			).toBe(true);
+
+			await userViewsPage.orderButton.click();
+		});
+
+		await test.step('Switching to Ascending shows oldest first', async () => {
+			await userViewsPage.orderButton.click();
+			await userViewsPage.dropdownMenu
+				.getByRole('menuitem', {exact: true, name: 'Ascending'})
+				.click();
+
+			await expect(userViewsPage.table.bodyRows.first()).toContainText(
+				firstSnapshotName
+			);
+		});
+	}
+);


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-86270

<h1>Enable sorting in the User Views management FDS</h1>

The goal of this PR is to enable the sorting dropdown in Manage User Views page's management bar

The available sort fields are Data Set, Created by and Modified Date.

Each field supports ascending and descending order.

<img width="483" height="330" alt="image" src="https://github.com/user-attachments/assets/c5400dc8-7439-4529-b4bf-53dd7771fb1a" />
