### PR TITLE
LPD-86272 Show 'Data Set' as the first column in the User Views table

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/ManageUserViews.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/ManageUserViews.tsx
@@ -47,15 +47,15 @@ const views = {
 	name: 'table',
 	schema: {
 		fields: [
-			{fieldName: 'label', label: Liferay.Language.get('user-view-name')},
-			{
-				fieldName: 'creator.name',
-				label: Liferay.Language.get('created-by'),
-			},
 			{
 				contentRenderer: 'dataSetNameRenderer',
 				fieldName: 'dataSetName',
 				label: Liferay.Language.get('data-set'),
+			},
+			{fieldName: 'label', label: Liferay.Language.get('user-view-name')},
+			{
+				fieldName: 'creator.name',
+				label: Liferay.Language.get('created-by'),
 			},
 			{
 				contentRenderer: 'dateTime',

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/userViews.spec.ts
@@ -97,6 +97,21 @@ test(
 			await expect(row.first()).toContainText(snapshotName);
 		});
 
+		await test.step('Check column order: Data Set → User View Name → Created By → Modified Date', async () => {
+			const allHeaders = await userViewsPage.table.headRow
+				.locator('th')
+				.allInnerTexts();
+
+			const dataSetIndex = allHeaders.indexOf('Data Set');
+			const userViewNameIndex = allHeaders.indexOf('User View Name');
+			const createdByIndex = allHeaders.indexOf('Created By');
+			const modifiedDateIndex = allHeaders.indexOf('Modified Date');
+
+			expect(dataSetIndex).toBeLessThan(userViewNameIndex);
+			expect(userViewNameIndex).toBeLessThan(createdByIndex);
+			expect(createdByIndex).toBeLessThan(modifiedDateIndex);
+		});
+
 		await test.step('Use delete action button to delete the User view', async () => {
 			page.once('dialog', async (dialog) => {
 				await dialog.accept();


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-86272

<h1>Show 'Data Set' as the first column in the User Views table</h1>

The goal of this PR is to reorder User Views table collumns to Data Set → User View name → Created By → Modified date

<img width="1078" height="137" alt="image" src="https://github.com/user-attachments/assets/acd6d5de-c0ce-41a0-9ec8-c7bc7316dff0" />
