### PR TITLE
LPD-60868 Hide visualization mode info alert when fields are assigned

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Cards.tsx
@@ -245,15 +245,17 @@ export default function Cards(props: IDataSetSectionProps) {
 
 	return (
 		<ClayLayout.ContentCol className="c-gap-4 cards-visualization-mode">
-			<ClayAlert
-				displayType="info"
-				title={`${Liferay.Language.get('info')}:`}
-				variant="stripe"
-			>
-				{Liferay.Language.get(
-					'this-visualization-mode-will-not-be-shown-until-you-assign-at-least-one-field-to-a-card-element'
-				)}
-			</ClayAlert>
+			{cardsSections.every((cardsSection) => !cardsSection.field) && (
+				<ClayAlert
+					displayType="info"
+					title={`${Liferay.Language.get('info')}:`}
+					variant="stripe"
+				>
+					{Liferay.Language.get(
+						'this-visualization-mode-will-not-be-shown-until-you-assign-at-least-one-field-to-a-card-element'
+					)}
+				</ClayAlert>
+			)}
 
 			<ClayTable className="mb-0">
 				<ClayTable.Head>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Cards.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Cards.tsx
@@ -245,7 +245,7 @@ export default function Cards(props: IDataSetSectionProps) {
 
 	return (
 		<ClayLayout.ContentCol className="c-gap-4 cards-visualization-mode">
-			{cardsSections.every((cardsSection) => !cardsSection.field) && (
+			{!cardsSections.some((cardsSection) => cardsSection.field) && (
 				<ClayAlert
 					displayType="info"
 					title={`${Liferay.Language.get('info')}:`}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/List.tsx
@@ -246,15 +246,17 @@ export default function List(props: IDataSetSectionProps) {
 
 	return (
 		<ClayLayout.ContentCol className="c-gap-4 list-visualization-mode">
-			<ClayAlert
-				displayType="info"
-				title={`${Liferay.Language.get('info')}:`}
-				variant="stripe"
-			>
-				{Liferay.Language.get(
-					'this-visualization-mode-will-not-be-shown-until-you-assign-at-least-one-field-to-a-list-element'
-				)}
-			</ClayAlert>
+			{listSections.every((listSection) => !listSection.field) && (
+				<ClayAlert
+					displayType="info"
+					title={`${Liferay.Language.get('info')}:`}
+					variant="stripe"
+				>
+					{Liferay.Language.get(
+						'this-visualization-mode-will-not-be-shown-until-you-assign-at-least-one-field-to-a-list-element'
+					)}
+				</ClayAlert>
+			)}
 
 			<ClayTable className="mb-0">
 				<ClayTable.Head>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/List.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/List.tsx
@@ -246,7 +246,7 @@ export default function List(props: IDataSetSectionProps) {
 
 	return (
 		<ClayLayout.ContentCol className="c-gap-4 list-visualization-mode">
-			{listSections.every((listSection) => !listSection.field) && (
+			{!listSections.some((listSection) => listSection.field) && (
 				<ClayAlert
 					displayType="info"
 					title={`${Liferay.Language.get('info')}:`}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
@@ -672,7 +672,7 @@ function Table(props: IDataSetSectionProps & {title?: string}) {
 
 	return tableSections ? (
 		<ClayLayout.ContentCol className="c-gap-4 table-visualization-mode">
-			{tableSections.length === 0 && (
+			{!tableSections.length && (
 				<ClayAlert
 					displayType="info"
 					title={`${Liferay.Language.get('info')}:`}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/visualization_modes/modes/Table.tsx
@@ -672,15 +672,17 @@ function Table(props: IDataSetSectionProps & {title?: string}) {
 
 	return tableSections ? (
 		<ClayLayout.ContentCol className="c-gap-4 table-visualization-mode">
-			<ClayAlert
-				displayType="info"
-				title={`${Liferay.Language.get('info')}:`}
-				variant="stripe"
-			>
-				{Liferay.Language.get(
-					'this-visualization-mode-will-not-be-shown-until-you-assign-at-least-one-field'
-				)}
-			</ClayAlert>
+			{tableSections.length === 0 && (
+				<ClayAlert
+					displayType="info"
+					title={`${Liferay.Language.get('info')}:`}
+					variant="stripe"
+				>
+					{Liferay.Language.get(
+						'this-visualization-mode-will-not-be-shown-until-you-assign-at-least-one-field'
+					)}
+				</ClayAlert>
+			)}
 
 			<OrderableTable
 				actions={[

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/data_set/tabs/VisualizationModesPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/data_set/tabs/VisualizationModesPage.ts
@@ -15,6 +15,7 @@ export class VisualizationModesPage {
 	private readonly container: Locator;
 	readonly dataSetPage: DataSetPage;
 	readonly fieldSelectModalPage: FieldSelectModalPage;
+	readonly infoAlert: Locator;
 	readonly listVisualizationModeContainer: Locator;
 	readonly page: Page;
 	readonly tableVisualizationModeContainer: Locator;
@@ -35,6 +36,9 @@ export class VisualizationModesPage {
 		this.container = page.locator('.visualization-modes');
 		this.dataSetPage = new DataSetPage(page);
 		this.fieldSelectModalPage = new FieldSelectModalPage(page);
+		this.infoAlert = page
+			.getByRole('alert')
+			.getByText('Info:This visualization mode will not be shown');
 		this.listVisualizationModeContainer = page.locator(
 			'.list-visualization-mode'
 		);

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
@@ -84,11 +84,7 @@ test('Configure cards visualization mode @LPD-10735', async ({
 	});
 
 	await test.step('Check info alert is visible when no fields are assigned', async () => {
-		await expect(
-			visualizationModesPage.cardsVisualizationModeContainer.locator(
-				'.alert'
-			)
-		).toBeVisible();
+		await expect(visualizationModesPage.infoAlert).toBeVisible();
 	});
 
 	await test.step('Assign a field to title section', async () => {
@@ -119,11 +115,7 @@ test('Configure cards visualization mode @LPD-10735', async ({
 	});
 
 	await test.step('Check info alert is hidden after a field is assigned', async () => {
-		await expect(
-			visualizationModesPage.cardsVisualizationModeContainer.locator(
-				'.alert'
-			)
-		).toBeHidden();
+		await expect(visualizationModesPage.infoAlert).toBeHidden();
 	});
 
 	await test.step('Edit field to title section', async () => {
@@ -275,11 +267,7 @@ test('Configure list visualization mode @LPD-10735', async ({
 	});
 
 	await test.step('Check info alert is visible when no fields are assigned', async () => {
-		await expect(
-			visualizationModesPage.listVisualizationModeContainer.locator(
-				'.alert'
-			)
-		).toBeVisible();
+		await expect(visualizationModesPage.infoAlert).toBeVisible();
 	});
 
 	await test.step('Assign a field to title section', async () => {
@@ -309,11 +297,7 @@ test('Configure list visualization mode @LPD-10735', async ({
 	});
 
 	await test.step('Check info alert is hidden after a field is assigned', async () => {
-		await expect(
-			visualizationModesPage.listVisualizationModeContainer.locator(
-				'.alert'
-			)
-		).toBeHidden();
+		await expect(visualizationModesPage.infoAlert).toBeHidden();
 	});
 
 	await test.step('Edit field to title section', async () => {
@@ -453,11 +437,7 @@ test('Configure table visualization mode @LPD-11049', async ({
 	});
 
 	await test.step('Check info alert is visible when no fields are added', async () => {
-		await expect(
-			visualizationModesPage.tableVisualizationModeContainer.locator(
-				'.alert'
-			)
-		).toBeVisible();
+		await expect(visualizationModesPage.infoAlert).toBeVisible();
 	});
 
 	await test.step('Add fields from field selection tree', async () => {
@@ -483,11 +463,7 @@ test('Configure table visualization mode @LPD-11049', async ({
 	});
 
 	await test.step('Check info alert is hidden after fields are added', async () => {
-		await expect(
-			visualizationModesPage.tableVisualizationModeContainer.locator(
-				'.alert'
-			)
-		).toBeHidden();
+		await expect(visualizationModesPage.infoAlert).toBeHidden();
 	});
 
 	await test.step('Add fields from text input', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/visualizationModes.spec.ts
@@ -83,6 +83,14 @@ test('Configure cards visualization mode @LPD-10735', async ({
 		]);
 	});
 
+	await test.step('Check info alert is visible when no fields are assigned', async () => {
+		await expect(
+			visualizationModesPage.cardsVisualizationModeContainer.locator(
+				'.alert'
+			)
+		).toBeVisible();
+	});
+
 	await test.step('Assign a field to title section', async () => {
 		const fieldName = 'fieldName';
 		const sectionLabel = 'Title';
@@ -108,6 +116,14 @@ test('Configure cards visualization mode @LPD-10735', async ({
 			});
 
 		await expect(assignedFieldLocator).toHaveText(fieldName);
+	});
+
+	await test.step('Check info alert is hidden after a field is assigned', async () => {
+		await expect(
+			visualizationModesPage.cardsVisualizationModeContainer.locator(
+				'.alert'
+			)
+		).toBeHidden();
 	});
 
 	await test.step('Edit field to title section', async () => {
@@ -258,6 +274,14 @@ test('Configure list visualization mode @LPD-10735', async ({
 		]);
 	});
 
+	await test.step('Check info alert is visible when no fields are assigned', async () => {
+		await expect(
+			visualizationModesPage.listVisualizationModeContainer.locator(
+				'.alert'
+			)
+		).toBeVisible();
+	});
+
 	await test.step('Assign a field to title section', async () => {
 		const fieldName = 'fieldName';
 		const sectionLabel = 'Title';
@@ -282,6 +306,14 @@ test('Configure list visualization mode @LPD-10735', async ({
 			});
 
 		await expect(assignedFieldLocator).toHaveText(fieldName);
+	});
+
+	await test.step('Check info alert is hidden after a field is assigned', async () => {
+		await expect(
+			visualizationModesPage.listVisualizationModeContainer.locator(
+				'.alert'
+			)
+		).toBeHidden();
 	});
 
 	await test.step('Edit field to title section', async () => {
@@ -420,6 +452,14 @@ test('Configure table visualization mode @LPD-11049', async ({
 		).toBeVisible();
 	});
 
+	await test.step('Check info alert is visible when no fields are added', async () => {
+		await expect(
+			visualizationModesPage.tableVisualizationModeContainer.locator(
+				'.alert'
+			)
+		).toBeVisible();
+	});
+
 	await test.step('Add fields from field selection tree', async () => {
 		await visualizationModesPage.openAddDataSourceFieldsModal();
 
@@ -440,6 +480,14 @@ test('Configure table visualization mode @LPD-11049', async ({
 		await saveFromModal({
 			page,
 		});
+	});
+
+	await test.step('Check info alert is hidden after fields are added', async () => {
+		await expect(
+			visualizationModesPage.tableVisualizationModeContainer.locator(
+				'.alert'
+			)
+		).toBeHidden();
 	});
 
 	await test.step('Add fields from text input', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-60868

**What is being fixed:** The Data Set Administration visualization modes (Table, List, Cards) always displayed the info alert "This visualization mode will not be shown until you assign at least one field." even after the user had assigned one or more fields. Leaving the message on screen once fields were assigned was confusing y suggested the user might still be missing a required step.

**How it is being fixed:** The alert is now rendered conditionally so it only appears while no fields are assigned. In the Table mode this is driven by `tableSections.length === 0`, since that state already holds the list of assigned fields. In the List and Cards modes the sections array always contains the four placeholders (title, description, image, symbol), so the check verifies that every section lacks a populated `field`. Once any field is assigned the alert disappears and users are no longer shown the informational message.