### PR TITLE
LPD-87221 Fix saved filters not appearing in object entries Filter dropdown

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.tsx
@@ -59,7 +59,7 @@ const FiltersDropdown = () => {
 			.filter(Boolean);
 	}, [groupedFilters, validFilters]);
 
-	const filtersList = groupedFilters
+	const filtersList = groupedFilters?.length
 		? renderableGroupedFilters
 		: validFilters;
 
@@ -123,7 +123,7 @@ const FiltersDropdown = () => {
 
 					{filtersList?.length ? (
 						<ClayDropDown.ItemList items={filtersList}>
-							{groupedFilters
+							{groupedFilters?.length
 								? (group: any) => (
 										<ClayDropDown.Group
 											header={group.label}

--- a/modules/test/playwright/tests/object-web/view/objectView.spec.ts
+++ b/modules/test/playwright/tests/object-web/view/objectView.spec.ts
@@ -1835,17 +1835,11 @@ test(
 
 		yesterday.setDate(yesterday.getDate() - 1);
 
-		const tomorrow = new Date(today);
-
-		tomorrow.setDate(tomorrow.getDate() + 1);
-
 		const formatDate = (d: Date) =>
 			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
 		await page.getByLabel('From').fill(formatDate(yesterday));
-		await page
-			.getByRole('textbox', {name: 'To'})
-			.fill(formatDate(tomorrow));
+		await page.getByRole('textbox', {name: 'To'}).fill(formatDate(today));
 
 		await page.getByRole('button', {name: 'Add Filter'}).click();
 
@@ -1935,17 +1929,11 @@ test(
 
 		yesterday.setDate(yesterday.getDate() - 1);
 
-		const tomorrow = new Date(today);
-
-		tomorrow.setDate(tomorrow.getDate() + 1);
-
 		const formatDate = (d: Date) =>
 			`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 
 		await page.getByLabel('From').fill(formatDate(yesterday));
-		await page
-			.getByRole('textbox', {name: 'To'})
-			.fill(formatDate(tomorrow));
+		await page.getByRole('textbox', {name: 'To'}).fill(formatDate(today));
 
 		await page.getByRole('button', {name: 'Add Filter'}).click();
 


### PR DESCRIPTION
Issue [LPD-87221](https://liferay.atlassian.net/browse/LPD-87221)
Cause by [LPD-78377](https://liferay.atlassian.net/browse/LPD-78377)


**What is being fixed:** Filters configured on a custom view's Filters tab were not displayed in the Filter dropdown on the object entries page. Instead, the dropdown rendered an empty state ("No filters were found.") even after the view had been saved with filters. Three Playwright tests tracked under LPD-87191 fail against this regression.

**How it is being fixed:** `FiltersDropdown` decided which list to render based on a truthy check of `groupedFilters`, but that value was an empty object/array rather than `null`/`undefined` when no grouped filters existed, causing the component to render an empty grouped list instead of falling back to the flat `validFilters`. The check is now `groupedFilters?.length`, which correctly falls back to the flat list whenever no groups exist.