### PR TITLE
LPD-87381 Update selector because new Application Menu is adding an extra search box to the page

### DIFF
--- a/modules/test/playwright/tests/client-extension-web/main/pages/ClientExtensionsPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/main/pages/ClientExtensionsPage.ts
@@ -93,7 +93,10 @@ export class ClientExtensionsPage extends POM {
 	}
 
 	async search(query: string) {
-		await this.page.getByPlaceholder('Search').fill(query);
+		await this.page
+			.getByTestId('managementToolbar')
+			.getByRole('searchbox', {name: 'Search'})
+			.fill(query);
 		await this.page.getByRole('button', {name: 'Search'}).click();
 	}
 


### PR DESCRIPTION
New Applications Menu is adding an extra search box to the page, so we need to update that locator to be sure we are selecting the one we want

<img width="1896" height="445" alt="image" src="https://github.com/user-attachments/assets/f6b46ee5-b017-4256-8365-6a6638d2d0c6" />
