### PR TITLE
LPD-87898 Now we have two different dialog title for creating and renaming

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
@@ -51,6 +51,7 @@ export class DataSetFragmentPage {
 	readonly userViewsActionsButton: Locator;
 	readonly userViewsDeleteAlert: Locator;
 	readonly userViewsSelectorButton: Locator;
+	readonly userViewsRenameModal: Locator;
 	readonly userViewsSaveModal: Locator;
 
 	constructor(page: Page) {
@@ -138,6 +139,9 @@ export class DataSetFragmentPage {
 			name: 'Delete View',
 		});
 		this.userViewsSelectorButton = page.getByLabel('Views');
+		this.userViewsRenameModal = page.getByRole('dialog', {
+			name: 'Rename View',
+		});
 		this.userViewsSaveModal = page.getByRole('dialog', {
 			name: 'Save New View As',
 		});

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/pages/DataSetFragmentPage.ts
@@ -50,8 +50,8 @@ export class DataSetFragmentPage {
 	};
 	readonly userViewsActionsButton: Locator;
 	readonly userViewsDeleteAlert: Locator;
-	readonly userViewsSelectorButton: Locator;
 	readonly userViewsRenameModal: Locator;
+	readonly userViewsSelectorButton: Locator;
 	readonly userViewsSaveModal: Locator;
 
 	constructor(page: Page) {
@@ -138,10 +138,10 @@ export class DataSetFragmentPage {
 		this.userViewsDeleteAlert = page.getByRole('dialog', {
 			name: 'Delete View',
 		});
-		this.userViewsSelectorButton = page.getByLabel('Views');
 		this.userViewsRenameModal = page.getByRole('dialog', {
 			name: 'Rename View',
 		});
+		this.userViewsSelectorButton = page.getByLabel('Views');
 		this.userViewsSaveModal = page.getByRole('dialog', {
 			name: 'Save New View As',
 		});

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
@@ -400,14 +400,14 @@ test(
 			await menuItem.click();
 
 			await expect(
-				dataSetFragmentPage.userViewsSaveModal
+				dataSetFragmentPage.userViewsRenameModal
 			).toBeInViewport();
 
-			await dataSetFragmentPage.userViewsSaveModal
+			await dataSetFragmentPage.userViewsRenameModal
 				.getByLabel('NameRequired')
 				.fill(userView2Name);
 
-			await dataSetFragmentPage.userViewsSaveModal
+			await dataSetFragmentPage.userViewsRenameModal
 				.getByRole('button', {name: 'Save'})
 				.click();
 


### PR DESCRIPTION
This test got broken in [this commit](https://github.com/brianchandotcom/liferay-portal/pull/173348/changes/29126dd44f18c45e282d2f80be6391caf97ed050#diff-cccbbb93e54479046a0a5f193964ae1c6417aaaa57604eeace3739050cce3906R378) where dialog title was moved from "Save new view as" to "Rename View".