### PR TITLE
LPD-64708 - Stop loading external resources

### DIFF
--- a/modules/apps/map/map-openstreetmap/package.json
+++ b/modules/apps/map/map-openstreetmap/package.json
@@ -1,7 +1,8 @@
 {
 	"dependencies": {
 		"@liferay/map-common": "*",
-		"frontend-js-web": "*"
+		"frontend-js-web": "*",
+		"leaflet": "1.7.1"
 	},
 	"main": "js/index.js",
 	"name": "@liferay/map-openstreetmap",

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/init.jsp
@@ -7,10 +7,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
-taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
+<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/MapOpenStreetMap.js
@@ -4,6 +4,9 @@
  */
 
 import {MapBase} from '@liferay/map-common';
+import L from 'leaflet';
+
+import 'leaflet/dist/leaflet.css';
 
 import OpenStreetMapDialog from './OpenStreetMapDialog';
 import OpenStreetMapGeoJSON from './OpenStreetMapGeoJSON';

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapDialog.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapDialog.js
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import L from 'leaflet';
+
+import 'leaflet/dist/leaflet.css';
+
 /**
  * OpenStreetMapDialog
  * @review

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeoJSON.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeoJSON.js
@@ -4,6 +4,9 @@
  */
 
 import {GeoJSONBase} from '@liferay/map-common';
+import L from 'leaflet';
+
+import 'leaflet/dist/leaflet.css';
 
 /**
  * OpenStreetMapGeoJSONBase

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeocoder.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeocoder.js
@@ -84,6 +84,7 @@ export default class OpenStreetMapGeocoder {
 
 		fetch(reverseURL)
 			.then((response) => response.json())
+			.catch(() => ({error: true}))
 			.then((response) =>
 				this._handleReverse(
 					response.error ? location : response,

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeocoder.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapGeocoder.js
@@ -84,7 +84,12 @@ export default class OpenStreetMapGeocoder {
 
 		fetch(reverseURL)
 			.then((response) => response.json())
-			.then((response) => this._handleReverse(response, callback));
+			.then((response) =>
+				this._handleReverse(
+					response.error ? location : response,
+					callback
+				)
+			);
 	}
 }
 

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapMarker.js
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/js/OpenStreetMapMarker.js
@@ -4,6 +4,9 @@
  */
 
 import {MarkerBase} from '@liferay/map-common';
+import L from 'leaflet';
+
+import 'leaflet/dist/leaflet.css';
 
 /**
  * OpenStreetMapMarker

--- a/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-openstreetmap/src/main/resources/META-INF/resources/view.jsp
@@ -17,14 +17,6 @@ String points = (String)request.getAttribute("liferay-map:map:points");
 name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + name;
 %>
 
-<liferay-util:html-top
-	outputKey="com.liferay.map.openstreetmap#/view.jsp"
->
-	<aui:link crossOrigin="anonymous" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" integrity="sha384-VzLXTJGPSyTLX6d96AxgkKvE/LRb7ECGyTxuwtpjHnVWVZs2gp5RDjeM/tgBnVdM" rel="stylesheet" />
-
-	<aui:script crossOrigin="anonymous" integrity="sha384-RFZC58YeKApoNsIbBxf4z6JJXmh+geBSgkCQXFyh+4tiFSJmJBt+2FbjxW7Ar16M" src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js" type="text/javascript"></aui:script>
-</liferay-util:html-top>
-
 <liferay-frontend:component
 	context='<%=
 		HashMapBuilder.<String, Object>put(


### PR DESCRIPTION
Continuation of https://github.com/liferay-frontend/liferay-portal/pull/5068 where, in addition to rebase Bryce's commit, I'm adding a better error management for the openstreetmap reverse geocoder, which was making map not to display