### PR TITLE
LPD-86445 Remove apiHelpers.headlessSite calls for Frontend Infrastructure

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/external/commerce.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/external/commerce.spec.ts
@@ -42,15 +42,10 @@ test(
 	},
 	async ({apiHelpers, globalMenuPage, page}) => {
 		await test.step('Create commerce site', async () => {
-			const site = await apiHelpers.headlessSite.createSite({
+			await apiHelpers.headlessAdminSite.postSite({
 				name: 'Minium',
 				templateKey: 'minium-initializer',
 				templateType: 'site-initializer',
-			});
-
-			apiHelpers.data.push({
-				id: site.externalReferenceCode,
-				type: 'site',
 			});
 
 			await globalMenuPage.goToSite('Minium');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86445

### Summary
Standardized Playwright tests by replacing legacy `apiHelpers.headlessSite` with `apiHelpers.headlessAdminSite`.

### Site Cleanup
- Automated: Manual `deleteSite` calls were removed when using `dataApiHelpersTest`, as cleanup is now handled automatically through `ApiHelpers.clearData`.
- Manual: Explicit deletion remains for tests using `apiHelpersTest` (which lacks the automatic registry) or where immediate cleanup is required for state validation.

If you encounter any failures or flakiness related to these changes, please let me know.