### PR TITLE
LPD-83803 Make ClayCardWithInfo img not draggable

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/src/CardWithInfo.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/src/CardWithInfo.tsx
@@ -192,6 +192,7 @@ export function ClayCardWithInfo({
 							['aspect-ratio-item-vertical-flush']: flushVertical,
 						}
 					)}
+					draggable={false}
 					{...(typeof imgProps === 'string'
 						? {src: imgProps}
 						: imgProps)}

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/src/__tests__/__snapshots__/index.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-card/src/__tests__/__snapshots__/index.tsx.snap
@@ -1926,6 +1926,7 @@ exports[`ClayCardWithInfo renders as image card specifying imageProps and not th
           >
             <img
               class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
+              draggable="false"
               src="path/to/an/image"
             />
             <span
@@ -2004,6 +2005,7 @@ exports[`ClayCardWithInfo renders as image card specifying the displayType and i
           >
             <img
               class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-fluid"
+              draggable="false"
               src="path/to/an/image"
             />
             <span
@@ -2167,6 +2169,7 @@ exports[`ClayCardWithInfo renders as image card with flush horizontal 1`] = `
           >
             <img
               class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-flush"
+              draggable="false"
               src="path/to/an/image"
             />
             <span
@@ -2245,6 +2248,7 @@ exports[`ClayCardWithInfo renders as image card with flush vertical 1`] = `
           >
             <img
               class="aspect-ratio-item aspect-ratio-item-center-middle aspect-ratio-item-vertical-flush"
+              draggable="false"
               src="path/to/an/image"
             />
             <span


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-83803

<h1>Make ClayCardWithInfo img not draggable</h1>

The goal of this PR is to fix a weird behavior involving images inside ClayCardWithInfo.

Dragging an image into a card (which is quite easy) caused the image to be treated as a new file upload. To prevent this, this PR disables the `dragable` property of the `img` tag, which HTML5 treats as `draggable` by default.