### PR TITLE
LPD-88400 Make legacy Poshi tests use CKEditor 4

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16884,6 +16884,50 @@ jdbc.default.password=${database.mysql.password}</echo>
 		<antcall target="clean-up-selenium-driver" />
 	</target>
 
+	<!--
+	LPD-88400 Make legacy Poshi tests use CKEditor 4 (enable LPD-11235 (CKEditor 4) per company)
+	-->
+
+	<target name="force-feature-flag-LPD-11235">
+		<exec executable="curl" failonerror="false" outputproperty="force.ff.company.json">
+			<arg value="-s" />
+			<arg value="-u" />
+			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
+		</exec>
+
+		<beanshell>
+			<![CDATA[
+				String json = project.getProperty("force.ff.company.json");
+
+				if (json != null) {
+					java.util.regex.Matcher matcher =
+						java.util.regex.Pattern.compile("\"id\"\\s*:\\s*\"?(\\d+)").matcher(json);
+
+					if (matcher.find()) {
+						project.setProperty("force.ff.companyId", matcher.group(1));
+					}
+				}
+			]]>
+		</beanshell>
+
+		<if>
+			<isset property="force.ff.companyId" />
+			<then>
+				<exec executable="curl" failonerror="false">
+					<arg value="-s" />
+					<arg value="-X" />
+					<arg value="POST" />
+					<arg value="-u" />
+					<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+					<arg value="-d" />
+					<arg value="companyId=${force.ff.companyId}&amp;key=LPD-11235&amp;enabled=true" />
+					<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
+				</exec>
+			</then>
+		</if>
+	</target>
+
 	<target name="run-simple-server">
 		<if>
 			<not>
@@ -17657,6 +17701,8 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 				</echo>
 			</then>
 		</if>
+
+		<antcall target="force-feature-flag-LPD-11235" />
 
 		<get-testcase-property property.name="skip.run.selenium.test" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -16793,7 +16793,7 @@ if (ppstate.equals("normal")) {
 		<poshi-execute failonerror="true" task="validatePoshi" />
 	</target>
 
-	<target depends="prepare-selenium" name="run-selenium-test">
+	<target depends="prepare-selenium,force-feature-flag-LPD-11235" name="run-selenium-test">
 		<if>
 			<and>
 				<equals arg1="${test.class}" arg2="PortalWebTestSuite" />
@@ -17701,8 +17701,6 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 				</echo>
 			</then>
 		</if>
-
-		<antcall target="force-feature-flag-LPD-11235" />
 
 		<get-testcase-property property.name="skip.run.selenium.test" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -16889,43 +16889,47 @@ jdbc.default.password=${database.mysql.password}</echo>
 	-->
 
 	<target name="force-feature-flag-LPD-11235">
-		<exec executable="curl" failonerror="false" outputproperty="force.ff.company.json">
+		<local name="json" />
+		<local name="companyId" />
+
+		<exec executable="curl" failonerror="true" outputproperty="json">
+			<arg value="-f" />
 			<arg value="-s" />
 			<arg value="-u" />
 			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
 			<arg value="${default.portal.url}/o/headless-portal-instances/v1.0/portal-instances" />
 		</exec>
 
+		<echo>JSON: ${json}</echo>
+
 		<beanshell>
 			<![CDATA[
-				String json = project.getProperty("force.ff.company.json");
+				String json = project.getProperty("json");
 
 				if (json != null) {
 					java.util.regex.Matcher matcher =
-						java.util.regex.Pattern.compile("\"id\"\\s*:\\s*\"?(\\d+)").matcher(json);
+						java.util.regex.Pattern.compile("\"companyId\"\\s*:\\s*\"?(\\d+)").matcher(json);
 
 					if (matcher.find()) {
-						project.setProperty("force.ff.companyId", matcher.group(1));
+						project.setProperty("companyId", matcher.group(1));
 					}
 				}
 			]]>
 		</beanshell>
 
-		<if>
-			<isset property="force.ff.companyId" />
-			<then>
-				<exec executable="curl" failonerror="false">
-					<arg value="-s" />
-					<arg value="-X" />
-					<arg value="POST" />
-					<arg value="-u" />
-					<arg value="test@liferay.com:${test.portal.default.admin.password}" />
-					<arg value="-d" />
-					<arg value="companyId=${force.ff.companyId}&amp;key=LPD-11235&amp;enabled=true" />
-					<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
-				</exec>
-			</then>
-		</if>
+		<echo>Company Id: ${companyId}</echo>
+
+		<exec executable="curl" failonerror="true">
+			<arg value="-f" />
+			<arg value="-s" />
+			<arg value="-X" />
+			<arg value="POST" />
+			<arg value="-u" />
+			<arg value="test@liferay.com:${test.portal.default.admin.password}" />
+			<arg value="-d" />
+			<arg value="companyId=${companyId}&amp;key=LPD-11235&amp;enabled=true" />
+			<arg value="${default.portal.url}/o/com-liferay-feature-flag-web/set-enabled" />
+		</exec>
 	</target>
 
 	<target name="run-simple-server">


### PR DESCRIPTION
This has been tested and compared to a baseline build here -> https://testray.liferay.com/#/project/473116959/routines/473359709/build/475529192 (kudos to @nikki-pru for helping with this :heart: ) 

Since most of the poshi tests that use CKEditor are fixed by switching to CKEditor 4 this should help with testing stability.

It is still possible that a small number of other tests break due to this switch, but the most affected teams (BPM and Content Management) agreed on fixing them later.