### PR TITLE
LPD-85420 Build complete nestedFields URLs for Data Set bindings

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializer.java
@@ -167,8 +167,9 @@ public class CustomFDSSerializer
 			tokenResolutionsJSONObject
 		);
 
-		List<ObjectEntry> objectEntries = getSortedRelatedObjectEntries(
-			fdsName, httpServletRequest, (Predicate)null, "tableSectionsOrder",
+		List<ObjectEntry> objectEntries = getRelatedObjectEntries(
+			fdsName, httpServletRequest, (Predicate)null,
+			"dataSetToDataSetCardsSections", "dataSetToDataSetListSections",
 			"dataSetToDataSetTableSections");
 
 		if (objectEntries == null) {

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/test/java/com/liferay/frontend/data/set/internal/serializer/CustomFDSSerializerTest.java
@@ -1369,8 +1369,9 @@ public class CustomFDSSerializerTest extends BaseFDSSerializerTestCase {
 			});
 
 		Mockito.when(
-			_customFDSSerializer.getSortedRelatedObjectEntries(
-				fdsName, httpServletRequest, null, "tableSectionsOrder",
+			_customFDSSerializer.getRelatedObjectEntries(
+				fdsName, httpServletRequest, null,
+				"dataSetToDataSetCardsSections", "dataSetToDataSetListSections",
 				"dataSetToDataSetTableSections")
 		).thenReturn(
 			objectEntries

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/visualizationModes.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/visualizationModes.spec.ts
@@ -264,3 +264,88 @@ test('Show mapped scalar array field in the fragment @LPD-11769', async ({
 		).toEqual(['one, two, three', '']);
 	});
 });
+
+test('Request URL includes nestedFields when a card-only binding is nested @LPD-85420', async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	page,
+}) => {
+	const NESTED_OBJECT_FIELD = 'dataSetToDataSetTableSections';
+	const NESTED_CHILD_FIELD = 'label';
+
+	await test.step('Create cards section field with nested binding', async () => {
+		await dataSetManagerApiHelpers.createDataSetCardsSection({
+			dataSetERC,
+			fieldName: `${NESTED_OBJECT_FIELD}.${NESTED_CHILD_FIELD}`,
+			name: 'title',
+		});
+	});
+
+	const datasetRequestPromise = page.waitForRequest((request) =>
+		request.url().includes(`nestedFields=${NESTED_OBJECT_FIELD}`)
+	);
+
+	await test.step('Configure Data Set in the page', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step('Data Set request URL contains nestedFields for cards binding', async () => {
+		const datasetRequest = await datasetRequestPromise;
+
+		const datasetRequestUrl = decodeURIComponent(datasetRequest.url());
+
+		expect(datasetRequestUrl).toContain(
+			`nestedFields=${NESTED_OBJECT_FIELD}`
+		);
+	});
+});
+
+test('Request URL includes nestedFields when a list-only binding is nested @LPD-85420', async ({
+	dataSetFragmentPage,
+	dataSetManagerApiHelpers,
+	layout,
+	page,
+}) => {
+	const NESTED_OBJECT_FIELD = 'dataSetToDataSetTableSections';
+	const NESTED_CHILD_FIELD = 'label';
+
+	await test.step('Update Data Set defaultVisualizationMode to list', async () => {
+		await dataSetManagerApiHelpers.updateDataSet({
+			defaultVisualizationMode: 'list',
+			erc: dataSetERC,
+		});
+	});
+
+	await test.step('Create list section field with nested binding', async () => {
+		await dataSetManagerApiHelpers.createDataSetListSection({
+			dataSetERC,
+			fieldName: `${NESTED_OBJECT_FIELD}.${NESTED_CHILD_FIELD}`,
+			name: 'title',
+		});
+	});
+
+	const datasetRequestPromise = page.waitForRequest((request) =>
+		request.url().includes(`nestedFields=${NESTED_OBJECT_FIELD}`)
+	);
+
+	await test.step('Configure Data Set in the page', async () => {
+		await dataSetFragmentPage.configureDataSetFragment({
+			dataSetLabel,
+			layout,
+		});
+	});
+
+	await test.step('Data Set request URL contains nestedFields for list binding', async () => {
+		const datasetRequest = await datasetRequestPromise;
+
+		const datasetRequestUrl = decodeURIComponent(datasetRequest.url());
+
+		expect(datasetRequestUrl).toContain(
+			`nestedFields=${NESTED_OBJECT_FIELD}`
+		);
+	});
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85420

## What is being fixed

When a CMS Document Data Set was bound in a card or list view to a nested field — for example, `file.thumbnailURL` for a thumbnail or `creator.name` for an author — the value came back null and the fragment rendered an empty image or blank value. The serializer that builds the Data Set's API URL only scanned table-section bindings, missed card and list bindings entirely, stripped the leaf segment from any binding it did scan, and passed literal `*` wildcards through to the URL.

## How it is being fixed

`CustomFDSSerializer.serializeAPIURL` now collects bindings from `dataSetToDataSetCardsSections`, `dataSetToDataSetListSections`, and `dataSetToDataSetTableSections`, so a binding declared in any visualization mode contributes to `nestedFields`.
Existing unit tests in `CustomFDSSerializerTest` were updated for the new emission shape, and two `@LPD-85420` Playwright tests were added that bind a nested field only in a card section and only in a list section to lock down the regression.