### PR TITLE
LPD-88583 Fix flaky test

### DIFF
--- a/modules/test/playwright/tests/frontend-js-spa-web/main/settings.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/main/settings.spec.ts
@@ -103,21 +103,13 @@ test(
 
 			await userNotificationTimeoutInput.waitFor({state: 'visible'});
 
-			let warningWasDisplayed = false;
-
-			page.on('request', () => {
-				if (
-					page.getByText(
-						'It looks like this is taking longer than expected.'
-					)
-				) {
-					warningWasDisplayed = true;
-				}
-			});
-
 			await saveButton.click();
 
-			expect(warningWasDisplayed).toBe(true);
+			await expect(
+				page.getByText(
+					'It looks like this is taking longer than expected.'
+				)
+			).toBeVisible();
 		});
 
 		await test.step('Change the timeout back to 30000ms', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88583
https://liferay.atlassian.net/browse/LPD-82112

The test is flaky since the request wont always pick up the text before we check for it. 
Remove the request and wait for playwright to pick up the text instead.

Let me know if there are any questions or comments about this.
Thank you!