### PR TITLE
LPD-87534 Fixed overlapping items on first open of virtualized clay dropdown tags

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/__tests__/VirtualizedRendering.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/__tests__/VirtualizedRendering.tsx
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import {useCollection} from '../useCollection';
+
+import '@testing-library/jest-dom';
+
+function TagList({virtualizer}: {virtualizer: any}) {
+	const {collection} = useCollection({
+		children: (tag: string) => <li key={tag}>{tag}</li>,
+		items: ['A', 'B', 'C', 'D'],
+		virtualizer,
+	});
+
+	return <ul>{collection}</ul>;
+}
+
+const transforms = (container: HTMLElement) =>
+	Array.from(container.querySelectorAll('li')).map(
+		(li) => li.style.transform
+	);
+
+const stub = (items: Array<{index: number; size: number; start: number}>) => ({
+	getTotalSize: () => 0,
+	getVirtualItems: () => items,
+	measureElement: () => {},
+});
+
+describe('useCollection virtualized rendering', () => {
+	it('updates translateY when getVirtualItems returns new start values', () => {
+		const {container, rerender} = render(
+			<TagList
+				virtualizer={stub([
+					{index: 0, size: 37, start: 0},
+					{index: 1, size: 37, start: 37},
+					{index: 2, size: 37, start: 74},
+					{index: 3, size: 37, start: 111},
+				])}
+			/>
+		);
+
+		expect(transforms(container)).toEqual([
+			'translateY(0px)',
+			'translateY(37px)',
+			'translateY(74px)',
+			'translateY(111px)',
+		]);
+
+		rerender(
+			<TagList
+				virtualizer={stub([
+					{index: 0, size: 74, start: 0},
+					{index: 1, size: 74, start: 74},
+					{index: 2, size: 32, start: 148},
+					{index: 3, size: 32, start: 180},
+				])}
+			/>
+		);
+
+		expect(transforms(container)).toEqual([
+			'translateY(0px)',
+			'translateY(74px)',
+			'translateY(148px)',
+			'translateY(180px)',
+		]);
+	});
+});

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/useCollection.tsx
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-core/src/collection/useCollection.tsx
@@ -381,13 +381,7 @@ export function useCollection<
 				}
 			);
 		},
-		[
-			performItemRender,
-			publicApi,
-			virtualizerItems?.length,
-			visibleKeys,
-			itemIdKey,
-		]
+		[performItemRender, publicApi, virtualizerItems, visibleKeys, itemIdKey]
 	);
 
 	const getItem = useCallback((key: React.Key) => {

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-multi-select/src/__tests__/__snapshots__/IncrementalInteractions.tsx.snap
@@ -42,7 +42,7 @@ exports[`MultiSelect incremental interactions renders a custom item 1`] = `
   <li
     data-index="1"
     role="presentation"
-    style="left: 0px; position: absolute; top: 0px; transform: translateY(37px); width: 100%;"
+    style="left: 0px; position: absolute; top: 0px; transform: translateY(0px); width: 100%;"
   >
     <button
       aria-selected="true"


### PR DESCRIPTION
# What is this trying to solve?
Ticket: https://liferay.atlassian.net/browse/LPD-87534.

When opening a virtualized Clay dropdown (e.g. the Tags field on a Web Content) for the first time, items with multi-line labels overlap because they render at the virtualizer's `estimateSize` (`37px`) fallback positions instead of their real measured heights. Closing and reopening the dropdown renders it correctly, so the bug is only on the first open.  

# How am I fixing it?
In `useCollection.tsx`, the dep array on `performCollectionRender` tracked `virtualizerItems?.length`. Remeasuring rows changes start/size, not length, so the cached render was reused and `translateY` stayed at the `37px` estimate.                                                                                              
                                                                                                                                                                                                                                                                                                                              
Changed the dep to `virtualizerItems`. Its identity changes whenever any item's position or size changes, which is the signal needed to re-render.     

# How can you verify that it works?
Run the included automated tests.