### PR TITLE
LPD-89120 Fix race condition by clearing the interval when an SPA navigation fires

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/session.ts
@@ -292,6 +292,11 @@ export class Session {
 				}
 			}
 		}, 1000);
+
+		const handle = Liferay.on('beforeNavigate', () => {
+			clearInterval(this._intervalId);
+			handle.detach();
+		});
 	}
 
 	private _removeAlert() {


### PR DESCRIPTION
I’ve managed to reproduce the error in master but it appears randomly. I believe it’s a race condition between SPA navigations and the session timer. If the order of events is this that would explain it:

1. session module is instantiated and stores the page title
2. session timer from 1 triggers and changes the title
3. SPA navigation happens and resets the title
4. session timer from 1 triggers again and changes the title
5. a new session module is instantiated and stores the page title (with the previous warning from 4)

(See https://liferay.atlassian.net/browse/LPP-63943?focusedCommentId=5063704)

Clearing the interval before SPA navigation makes this race condition impossible.

Unfortunately we cannot create a test to simulate the race condition because since it is time dependent the test would be flaky by definition.