### PR TITLE
LPD-89089 Fix broken test.

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/search.spec.ts
@@ -282,6 +282,7 @@ test('Search Bar is shown/hidden according to FDS configuration', async ({
 				restEndpoint: '/',
 				restSchema: 'FDSSample',
 				showSearch: false,
+				snapshotsEnabled: true,
 			});
 		}
 	});


### PR DESCRIPTION
[frontend-data-set-web/main/tests/advanced/userViews.spec.ts > Create, edit and delete user views](https://github.com/liferay/liferay-portal/blob/master/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/userViews.spec.ts#L34) got broken in the moment we include this test.

In this test, in search.spec.ts, in case there is no existing copy of Advanced Sample Data Set we create one via API, but we don't specify any value for "snapshotsEnabled" property, so the record persisting this Data Set in database is created with `snapshotsEnabled=false`, even though the default value for that property when creating the Data Set through the user interface is `true`.

In the end, when running our test routine, User View tests run after this one, and they expect User Views to be enabled, so I'm updating the properties when we creat it to fix other tests.