### PR TITLE
LPD-89765 Prevent race condition between data set deletion and snapshot verification

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/CustomDataSetsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/CustomDataSetsPage.ts
@@ -212,7 +212,14 @@ export class CustomDataSetsPage {
 
 		const deleteModal = this.page.getByRole('dialog');
 
-		await deleteModal.getByRole('button', {name: 'Delete'}).click();
+		await Promise.all([
+			deleteModal.getByRole('button', {name: 'Delete'}).click(),
+			this.page.waitForResponse(
+				(response) =>
+					response.status() === 200 &&
+					response.url().includes('delete_custom_data_set')
+			),
+		]);
 	}
 
 	async sortBy(columnName: string) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89765

## What is being fixed

The test "Custom Views are deleted after deleting Data Set" was flaky
due to a race condition. After clicking Delete in the confirmation
dialog, the test immediately queried the API to verify that snapshots
were deleted. The `deleteDataSet()` method returned as soon as the
button was clicked, without waiting for the server to finish.

## How it is being fixed

`deleteDataSet()` now wraps the confirmation click in `Promise.all`
alongside a `waitForResponse` that resolves when the portlet resource
request to `delete_custom_data_set` returns 200. This ensures the
server has completed the deletion — including cascade removal of
associated snapshots — before the test checks the snapshot count.
The approach follows the existing `sortBy()` pattern in the same file.