### PR TITLE
LPD-89211 Exclude .ck from being affected by .cadmin CSS

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_reboot.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_reboot.scss
@@ -77,7 +77,9 @@ html#{$cadmin-selector} {
 		tr,
 		ul,
 		var {
-			@extend %cadmin-reset !optional;
+			&:where(:not(.ck, .ck *)) {
+				@extend %cadmin-reset !optional;
+			}
 		}
 
 		// Shim for "new" HTML5 structural elements to display correctly (IE11)

--- a/modules/apps/frontend-js/frontend-js-clay-web/test.properties
+++ b/modules/apps/frontend-js/frontend-js-clay-web/test.properties
@@ -1,0 +1,11 @@
+modified.files.includes[relevant][frontend-js-clay-web-playwright-rule]=**
+
+playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][frontend-js-clay-web-playwright-rule]=\
+    frontend-js-clay-web.main
+
+relevant.rule.names=frontend-js-clay-web-playwright-rule
+
+test.batch.names[relevant][frontend-js-clay-web-playwright-rule]=\
+    playwright-js-tomcat101-postgresql163
+
+testray.main.component.name=Liferay Themes

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -85,6 +85,7 @@ import {config as frontendEditorAlloyEditorWebConfig} from './tests/frontend-edi
 import {config as frontendEditorCKEditorWebConfig} from './tests/frontend-editor-ckeditor-web/main/config';
 import {config as frontendJsAuiWebConfig} from './tests/frontend-js-aui-web/main/config';
 import {config as frontendJsBootstrapSupportWebConfig} from './tests/frontend-js-bootstrap-support-web/main/config';
+import {config as frontendJsClayWebConfig} from './tests/frontend-js-clay-web/main/config';
 import {config as frontendJsComponentsWebConfig} from './tests/frontend-js-components-web/main/config';
 import {config as frontendJsItemSelectorWebConfig} from './tests/frontend-js-item-selector-web/main/config';
 import {config as frontendJsSpaWebConfig} from './tests/frontend-js-spa-web/main/config';
@@ -308,6 +309,7 @@ export default defineConfig({
 		frontendEditorCKEditorWebConfig,
 		frontendJsAuiWebConfig,
 		frontendJsBootstrapSupportWebConfig,
+		frontendJsClayWebConfig,
 		frontendJsComponentsWebConfig,
 		frontendJsItemSelectorWebConfig,
 		frontendJsSpaWebConfig,

--- a/modules/test/playwright/tests/frontend-js-clay-web/main/clayCss.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-clay-web/main/clayCss.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../../utils/getRandomString';
+import getPageDefinition from '../../layout-content-page-editor-web/main/utils/getPageDefinition';
+import getWidgetDefinition from '../../layout-content-page-editor-web/main/utils/getWidgetDefinition';
+
+const test = mergeTests(
+	apiHelpersTest,
+	isolatedSiteTest,
+	pageEditorPagesTest,
+	featureFlagsTest({
+		'LPS-178052': {enabled: true},
+	}),
+	loginTest()
+);
+
+test(
+	'CKEditor 5 displays correctly in modal with cadmin',
+	{tag: '@LPD-89211'},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		const widgetId = getRandomString();
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				getWidgetDefinition({
+					id: widgetId,
+					widgetName:
+						'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+				}),
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToWidgetConfiguration(widgetId);
+
+		const configurationIframe = page.frameLocator(
+			'iframe[title*="Configuration"]'
+		);
+
+		await configurationIframe
+			.getByText('Subscriptions', {exact: true})
+			.first()
+			.click();
+
+		const toolbarButton = configurationIframe
+			.locator('.cadmin .ck.ck-toolbar .ck-button')
+			.first();
+
+		await expect(toolbarButton).toBeVisible();
+
+		const padding = await toolbarButton.evaluate(
+			(element) => getComputedStyle(element).padding
+		);
+
+		expect(padding).not.toBe('0px');
+
+		const minWidth = await toolbarButton.evaluate(
+			(element) => getComputedStyle(element).minWidth
+		);
+
+		expect(minWidth).not.toBe('0px');
+		expect(parseFloat(minWidth)).toBeGreaterThan(0);
+
+		const borderWidth = await toolbarButton.evaluate(
+			(element) => getComputedStyle(element).borderWidth
+		);
+
+		expect(borderWidth).not.toBe('0px');
+	}
+);

--- a/modules/test/playwright/tests/frontend-js-clay-web/main/config.ts
+++ b/modules/test/playwright/tests/frontend-js-clay-web/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'frontend-js-clay-web.main',
+	testDir: 'tests/frontend-js-clay-web/main',
+};

--- a/modules/test/playwright/tests/frontend-js-clay-web/main/test.properties
+++ b/modules/test/playwright/tests/frontend-js-clay-web/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Liferay Themes


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89211
https://liferay.atlassian.net/browse/LPP-63967

Inside a modal with .cadmin, CKEditor 5 toolbar would get `html:not(#__):not(#___) .cadmin div` CSS applied which would result in the toolbar to display incorrectly.

Adjusting the CSS to exclude .ck would prevent this CSS and make the toolbar display correctly.

Please let me know if there are any questions or comments about this.
Thank you!