### PR TITLE
LPD-90770 Fix selection filter state not reset after removing filter chip

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/FiltersDropdown.tsx
@@ -23,7 +23,7 @@ const FiltersDropdown = () => {
 		useContext(ViewsContext);
 
 	const [active, setActive] = useState(false);
-	const [activeFilter, setActiveFilter] = useState<IFilter | null>(null);
+	const [activeFilterId, setActiveFilterId] = useState<string | null>(null);
 
 	const validFilters = useMemo(
 		() =>
@@ -39,6 +39,12 @@ const FiltersDropdown = () => {
 			}),
 		[globalFDSState.filters]
 	);
+
+	const activeFilter = activeFilterId
+		? (validFilters.find(
+				(filter) => filter.id === activeFilterId
+			) as unknown as IFilter) ?? null
+		: null;
 
 	const renderableGroupedFilters = useMemo(() => {
 		return groupedFilters
@@ -99,7 +105,7 @@ const FiltersDropdown = () => {
 							className="btn-filter-navigation"
 							displayType="unstyled"
 							onClick={() => {
-								setActiveFilter(null);
+								setActiveFilterId(null);
 							}}
 							size="sm"
 							symbol="angle-left"
@@ -134,7 +140,9 @@ const FiltersDropdown = () => {
 												<ClayDropDown.Item
 													key={filter.id}
 													onClick={() =>
-														setActiveFilter(filter)
+														setActiveFilterId(
+															filter.id
+														)
 													}
 												>
 													{filter.label}
@@ -146,7 +154,7 @@ const FiltersDropdown = () => {
 										<ClayDropDown.Item
 											key={filter.id}
 											onClick={() =>
-												setActiveFilter(filter)
+												setActiveFilterId(filter.id)
 											}
 										>
 											{filter.label}

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/filters.spec.ts
@@ -647,3 +647,60 @@ test(
 		});
 	}
 );
+
+test(
+	'Selection filter state resets after removing filter chip',
+	{
+		tag: ['@LPD-90770'],
+	},
+	async ({fdsSamplePage, page}) => {
+		await test.step('Remove the preloaded Color filter chip', async () => {
+			await page.getByRole('button', {name: 'Remove Filter'}).click();
+
+			await page
+				.getByText('This is a description for sample 1.')
+				.waitFor();
+		});
+
+		await test.step('Open filter dropdown and navigate to Color', async () => {
+			await fdsSamplePage.managementToolbar.filterButton.click();
+
+			await fdsSamplePage.filterMenu
+				.getByRole('menuitem', {name: 'Color'})
+				.click();
+		});
+
+		await test.step('Select only "Red" and add filter', async () => {
+			await fdsSamplePage.filterDropdownMenu
+				.getByRole('checkbox', {name: 'Red'})
+				.check();
+
+			await fdsSamplePage.filterShowResultsOrAddButton.click();
+
+			await page
+				.getByText('This is a description for sample')
+				.first()
+				.waitFor();
+		});
+
+		await test.step('Remove the Color: Red filter chip', async () => {
+			await page.getByRole('button', {name: 'Remove Filter'}).click();
+
+			await page
+				.getByText('This is a description for sample 1.')
+				.waitFor();
+		});
+
+		await test.step('Reopen filter dropdown — Color panel shows directly', async () => {
+			await fdsSamplePage.managementToolbar.filterButton.click();
+		});
+
+		await test.step('Assert Red is no longer checked', async () => {
+			await expect(
+				fdsSamplePage.filterDropdownMenu.getByRole('checkbox', {
+					name: 'Red',
+				})
+			).not.toBeChecked();
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90770

## What is being fixed

When a selection filter (e.g., Color) was opened, applied, and then
removed via the chip's X button, reopening the filter dropdown showed
the previously selected items still checked. The filter appeared
pre-populated even though it had been cleared.

The root cause was in FiltersDropdown: it stored the active filter as a
full object snapshot in useState. SelectionFilter is never unmounted
(ClayDropDown hides children via CSS, not unmounting). Its useEffect
sync only fires when the selectedData prop changes reference, but the
stored snapshot always held selectedData = undefined after deactivation
— so the prop never changed and SelectionFilter's local checked state
was never reset.

## How it is being fixed

Only the active filter's ID is stored in state. The activeFilter object
is derived on each render by looking it up live from validFilters
(sourced from globalFDSState.filters). When deactivateFilter clears
selectedData in the global state, the derived activeFilter reflects the
updated value, and SelectionFilter's useEffect sees the prop change and
resets its local selections.

A Playwright test covering this regression is added alongside the fix.