### PR TITLE
LPD-79347 Fix flaky tableColumns Playwright tests

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-api/src/main/java/com/liferay/frontend/data/set/filter/BaseSelectionFDSFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.frontend.data.set.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.util.Collections;
@@ -19,6 +20,11 @@ public abstract class BaseSelectionFDSFilter implements FDSFilter {
 
 	public String getAPIURL() {
 		return null;
+	}
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.STRING;
 	}
 
 	public String getItemKey() {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.frontend.data.set.sample.web.internal.filter;
 
+import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
@@ -26,6 +27,11 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class ColorSelectionFDSFilter extends BaseSelectionFDSFilter {
+
+	@Override
+	public String getEntityFieldType() {
+		return FDSEntityFieldTypes.STRING;
+	}
 
 	@Override
 	public String getId() {

--- a/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-sample-web/src/main/java/com/liferay/frontend/data/set/sample/web/internal/filter/ColorSelectionFDSFilter.java
@@ -5,7 +5,6 @@
 
 package com.liferay.frontend.data.set.sample.web.internal.filter;
 
-import com.liferay.frontend.data.set.constants.FDSEntityFieldTypes;
 import com.liferay.frontend.data.set.filter.BaseSelectionFDSFilter;
 import com.liferay.frontend.data.set.filter.FDSFilter;
 import com.liferay.frontend.data.set.filter.SelectionFDSFilterItem;
@@ -27,11 +26,6 @@ import org.osgi.service.component.annotations.Component;
 	service = FDSFilter.class
 )
 public class ColorSelectionFDSFilter extends BaseSelectionFDSFilter {
-
-	@Override
-	public String getEntityFieldType() {
-		return FDSEntityFieldTypes.STRING;
-	}
 
 	@Override
 	public String getId() {

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/tableColumns.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/tableColumns.spec.ts
@@ -12,7 +12,9 @@ import {loginTest} from '../../../../../fixtures/loginTest';
 import {EFDSVisualizationMode, waitForFDS} from '../../../../../utils/waitFor';
 import {waitForAlert} from '../../../../../utils/waitForAlert';
 import {systemDataSetsPageTest} from '../../../../frontend-data-set-admin-web/main/fixtures/systemDataSetsPageTest';
+import {SystemDataSetsPage} from '../../../../frontend-data-set-admin-web/main/pages/SystemDataSetsPage';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
+import {FDSSamplePage} from '../../pages/FDSSamplePage';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -27,14 +29,54 @@ const test = mergeTests(
 
 let fdsSamplePageURL: string;
 
-test.beforeEach(async ({fdsSamplePage, page, site}) => {
+async function deleteAdvancedSampleCustomization({
+	fdsSamplePage,
+	systemDataSetsPage,
+}: {
+	fdsSamplePage: FDSSamplePage;
+	systemDataSetsPage: SystemDataSetsPage;
+}) {
+	await systemDataSetsPage.goto();
+
+	const advancedSampleRow = systemDataSetsPage.pageContainer
+		.locator('.fds tr')
+		.filter({hasText: 'Advanced Sample'});
+
+	if ((await advancedSampleRow.count()) === 0) {
+		return;
+	}
+
+	await advancedSampleRow.locator('.dropdown-toggle').click();
+
+	await fdsSamplePage.dropdownMenu
+		.getByRole('menuitem', {name: 'Delete'})
+		.click();
+
+	const deleteModal = systemDataSetsPage.page.getByRole('dialog');
+
+	await deleteModal.getByRole('button', {name: 'Delete'}).click();
+
+	await waitForAlert(systemDataSetsPage.page);
+
+	await expect(advancedSampleRow).not.toBeAttached();
+}
+
+test.beforeEach(async ({fdsSamplePage, page, site, systemDataSetsPage}) => {
+	await deleteAdvancedSampleCustomization({
+		fdsSamplePage,
+		systemDataSetsPage,
+	});
+
 	const {url} = await fdsSamplePage.setupFDSSampleWidget({site});
 
 	fdsSamplePageURL = url;
 
 	await fdsSamplePage.selectTab('Advanced');
 
-	await waitForFDS({page, visualizationMode: EFDSVisualizationMode.TABLE});
+	await waitForFDS({
+		page,
+		visualizationMode: EFDSVisualizationMode.TABLE,
+	});
 });
 
 test('Resize columns', {tag: '@LPD-54497'}, async ({fdsSamplePage, page}) => {
@@ -164,32 +206,10 @@ test(
 		}
 		finally {
 			await test.step('Delete used system data set', async () => {
-				await systemDataSetsPage.goto();
-
-				const fdsRows =
-					systemDataSetsPage.pageContainer.locator('.fds tr');
-
-				const advancedSampleRow = fdsRows.filter({
-					hasText: 'Advanced Sample',
+				await deleteAdvancedSampleCustomization({
+					fdsSamplePage,
+					systemDataSetsPage,
 				});
-
-				if ((await advancedSampleRow.count()) === 0) {
-					return;
-				}
-
-				await advancedSampleRow.locator('.dropdown-toggle').click();
-
-				await fdsSamplePage.dropdownMenu
-					.getByRole('menuitem', {name: 'Delete'})
-					.click();
-
-				const deleteModal = systemDataSetsPage.page.getByRole('dialog');
-
-				await deleteModal.getByRole('button', {name: 'Delete'}).click();
-
-				await waitForAlert(systemDataSetsPage.page);
-
-				await expect(advancedSampleRow).not.toBeAttached();
 			});
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-79347

## What is being fixed

The third test in tableColumns.spec.ts ("Columns with nested field names are shown") timed out at 90s whenever a prior run had been interrupted before its finally block removed the Advanced Sample system data set customization. The modal then displayed the row as already "Created", the click never applied the selected class, and the assertion waited forever.

Advanced FDS sample widgets also failed to render. The color selection filter BaseSelectionFDSFilter returned the FDSFilter interface default of null for the entity field type, leaving the filter unable to resolve against the data set fields and the FrontendDataSet cannot compose the correct oData string.

## How it is being fixed

The UI cleanup that the third test ran in its finally block is lifted into a helper and invoked from beforeEach, so every test starts with no Advanced Sample customization in place regardless of how the previous run ended. The third test's finally now delegates to the same helper.

BaseSelectionFDSFilter overrides getEntityFieldType to return FDSEntityFieldTypes.STRING, the type selection filters use by default. Subclasses whose data is not a string (StatusSelectionFDSFilter, AdvancedDateRangeFDSFilter) keep their explicit overrides.