### PR TITLE
LPD-91078 CSP is skipping "excluded paths" configuration when the request is forwarded

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -9,6 +9,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -119,7 +120,12 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration,
 		HttpServletRequest httpServletRequest) {
 
-		String requestURI = httpServletRequest.getRequestURI();
+		String requestURI = (String)httpServletRequest.getAttribute(
+			JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI);
+
+		if (requestURI == null) {
+			requestURI = httpServletRequest.getRequestURI();
+		}
 
 		if (Validator.isNull(requestURI)) {
 			return false;

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -123,7 +123,7 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		String requestURI = (String)httpServletRequest.getAttribute(
 			JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI);
 
-		if (requestURI == null) {
+		if (Validator.isNull(requestURI)) {
 			requestURI = httpServletRequest.getRequestURI();
 		}
 

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.content.security.policy.internal.servlet.filter;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+public class ContentSecurityPolicyFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_contentSecurityPolicyConfiguration = Mockito.mock(
+			ContentSecurityPolicyConfiguration.class);
+
+		Mockito.when(
+			_contentSecurityPolicyConfiguration.excludedPaths()
+		).thenReturn(
+			new String[] {"/group"}
+		);
+
+		_contentSecurityPolicyFilter = new ContentSecurityPolicyFilter();
+	}
+
+	@Test
+	public void testExcludedPathMatchesOriginalForwardedURI() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(
+				JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI)
+		).thenReturn(
+			"/group/guest/home"
+		);
+		Mockito.when(
+			httpServletRequest.getRequestURI()
+		).thenReturn(
+			"/c/portal/layout"
+		);
+
+		Assert.assertTrue(_isExcludedURIPath(httpServletRequest));
+	}
+
+	@Test
+	public void testExcludedPathMatchesRequestURIWhenNoForward() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(
+				JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI)
+		).thenReturn(
+			null
+		);
+		Mockito.when(
+			httpServletRequest.getRequestURI()
+		).thenReturn(
+			"/group/guest/home"
+		);
+
+		Assert.assertTrue(_isExcludedURIPath(httpServletRequest));
+	}
+
+	@Test
+	public void testNonExcludedPathDoesNotMatch() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(
+				JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI)
+		).thenReturn(
+			null
+		);
+		Mockito.when(
+			httpServletRequest.getRequestURI()
+		).thenReturn(
+			"/c/portal/layout"
+		);
+
+		Assert.assertFalse(_isExcludedURIPath(httpServletRequest));
+	}
+
+	private boolean _isExcludedURIPath(
+		HttpServletRequest httpServletRequest) {
+
+		return ReflectionTestUtil.invoke(
+			_contentSecurityPolicyFilter, "_isExcludedURIPath",
+			new Class<?>[] {
+				ContentSecurityPolicyConfiguration.class,
+				HttpServletRequest.class
+			},
+			_contentSecurityPolicyConfiguration, httpServletRequest);
+	}
+
+	private ContentSecurityPolicyConfiguration
+		_contentSecurityPolicyConfiguration;
+	private ContentSecurityPolicyFilter _contentSecurityPolicyFilter;
+
+}

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -20,6 +20,9 @@ import org.junit.Test;
 
 import org.mockito.Mockito;
 
+/**
+ * @author Antonio Ortega
+ */
 public class ContentSecurityPolicyFilterTest {
 
 	@ClassRule
@@ -52,6 +55,7 @@ public class ContentSecurityPolicyFilterTest {
 		).thenReturn(
 			"/group/guest/home"
 		);
+
 		Mockito.when(
 			httpServletRequest.getRequestURI()
 		).thenReturn(
@@ -72,6 +76,7 @@ public class ContentSecurityPolicyFilterTest {
 		).thenReturn(
 			null
 		);
+
 		Mockito.when(
 			httpServletRequest.getRequestURI()
 		).thenReturn(
@@ -82,7 +87,7 @@ public class ContentSecurityPolicyFilterTest {
 	}
 
 	@Test
-	public void testNonExcludedPathDoesNotMatch() {
+	public void testNonexcludedPathDoesNotMatch() {
 		HttpServletRequest httpServletRequest = Mockito.mock(
 			HttpServletRequest.class);
 
@@ -92,6 +97,7 @@ public class ContentSecurityPolicyFilterTest {
 		).thenReturn(
 			null
 		);
+
 		Mockito.when(
 			httpServletRequest.getRequestURI()
 		).thenReturn(
@@ -101,9 +107,7 @@ public class ContentSecurityPolicyFilterTest {
 		Assert.assertFalse(_isExcludedURIPath(httpServletRequest));
 	}
 
-	private boolean _isExcludedURIPath(
-		HttpServletRequest httpServletRequest) {
-
+	private boolean _isExcludedURIPath(HttpServletRequest httpServletRequest) {
 		return ReflectionTestUtil.invoke(
 			_contentSecurityPolicyFilter, "_isExcludedURIPath",
 			new Class<?>[] {


### PR DESCRIPTION
Hey,

This is coming from [LPD-91078 - CSP Headers are included for internally excluded paths](https://liferay.atlassian.net/browse/LPD-91078).

Our CSP configuration should be skipping by default to add CSP headers to any URL matching our [_INTERNALLY_EXCLUDED_PATHS](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java#L152-L154):
```
	private static final String[] _INTERNALLY_EXCLUDED_PATHS = {
		"/group/", "/user/", "/web/"
	};
```

However, CSP headers are being added because when we are accessing to Site Admin, or just any page starting by `/group/`, our [FriendlyURLServlet](https://github.com/liferay/liferay-portal/blob/master/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java) forwards the request to an internal page. 

Adding some DEBUG logs in that servlet is an easy way to see it:

`2026-05-19 14:16:49.272 DEBUG [http-nio-8080-exec-21][FriendlyURLServlet:746] Forward from /group/control_panel/manage to /c/portal/layout?p_l_id=1&p_v_l_s_g_id=0`

So later on, in CSP when we are checking whether it is a excluded path, we check the forwarded URI (`/c/portal/layout?p_l_id=1&p_v_l_s_g_id=0`) and not the original one (`/group/control_panel/manage`). 

This PR is just checking firstly the original URI.

Thanks.

Regards.