### PR TITLE
LPD-89810 Preserve actions on items after FDS refresh

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -72,6 +72,7 @@ import {loadData} from './utils/loadData';
 
 import {logError} from './utils/logError';
 import {transformAdditionalAPIURLParameters} from './utils/transformAdditionalAPIURLParameters';
+import transformDataSetItems from './utils/transformDataSetItems';
 import {
 	EConfigInURLBehavior,
 	EConfigInURLKeys,
@@ -801,27 +802,16 @@ const FrontendDataSetContent = ({
 
 	const updateDataSetItems = useCallback(
 		(dataSetData: IDataSetData) => {
-			const remappedItems = dataSetData.items.map((item) => {
-				if (item.embedded && item.embedded.actions) {
-					return {
-						...item,
-						actions: item.embedded.actions,
-					};
-				}
+			const transformedItems = transformDataSetItems(dataSetData.items);
 
-				return {
-					...item,
-				};
-			});
-
-			setItems(remappedItems);
+			setItems(transformedItems);
 			setTotal(dataSetData.totalCount);
 
 			if (!dataSetData.items.length && dataSetData.totalCount > 0) {
 				viewsDispatch(updatePageNumber(dataSetData.lastPage));
 			}
 
-			return remappedItems;
+			return transformedItems;
 		},
 		[updatePageNumber, viewsDispatch]
 	);

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -803,13 +803,9 @@ const FrontendDataSetContent = ({
 		(dataSetData: IDataSetData) => {
 			const remappedItems = dataSetData.items.map((item) => {
 				if (item.embedded && item.embedded.actions) {
-					const actions = item.embedded.actions;
-
-					delete item.embedded.actions;
-
 					return {
 						...item,
-						actions,
+						actions: item.embedded.actions,
 					};
 				}
 
@@ -824,6 +820,8 @@ const FrontendDataSetContent = ({
 			if (!dataSetData.items.length && dataSetData.totalCount > 0) {
 				viewsDispatch(updatePageNumber(dataSetData.lastPage));
 			}
+
+			return remappedItems;
 		},
 		[updatePageNumber, viewsDispatch]
 	);
@@ -1303,10 +1301,10 @@ const FrontendDataSetContent = ({
 					}
 
 					if (isMounted()) {
-						updateDataSetItems(data);
+						const updatedItems = updateDataSetItems(data);
 
 						setSelectedItems(
-							data.items.filter(
+							updatedItems.filter(
 								(item: ISelectionFilterStateItem) => {
 									const itemValue = getObjectValueFromPath({
 										object: item,

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/transformDataSetItems.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/utils/transformDataSetItems.ts
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IItemsActions} from './types';
+
+type ItemActionsMap = Record<string, IItemsActions>;
+
+export default function transformDataSetItems<
+	T extends {
+		embedded?: {actions?: ItemActionsMap} & Record<string, unknown>;
+	},
+>(items: T[]): Array<T & {actions?: ItemActionsMap}> {
+	return items.map((item) => {
+		if (item.embedded && item.embedded.actions) {
+			return {
+				...item,
+				actions: item.embedded.actions,
+			};
+		}
+
+		return {...item};
+	});
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/transformDataSetItems.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/utils/transformDataSetItems.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import transformDataSetItems from '../../src/main/resources/META-INF/resources/utils/transformDataSetItems';
+
+describe('transformDataSetItems utility', () => {
+	it('copies embedded.actions to a top-level actions property', () => {
+		const actions = {
+			delete: {href: '/o/delete', method: 'DELETE'},
+			versions: {href: '/o/versions', method: 'GET'},
+		};
+
+		const [item] = transformDataSetItems([
+			{embedded: {actions, id: 1}, score: 1},
+		]);
+
+		expect(item.actions).toBe(actions);
+	});
+
+	it('leaves items without embedded.actions unchanged in shape', () => {
+		const [item] = transformDataSetItems([{embedded: {id: 1}, score: 1}]);
+
+		expect(item).toEqual({embedded: {id: 1}, score: 1});
+		expect(item).not.toHaveProperty('actions');
+	});
+
+	it('does not mutate the original items or their embedded objects', () => {
+		const actions = {
+			versions: {href: '/o/versions', method: 'GET'},
+		};
+		const original = {embedded: {actions, id: 1}, score: 1};
+
+		transformDataSetItems([original]);
+
+		expect(original.embedded.actions).toBe(actions);
+		expect(original).not.toHaveProperty('actions');
+	});
+
+	it('is idempotent: running twice produces the same shape', () => {
+		const actions = {
+			versions: {href: '/o/versions', method: 'GET'},
+		};
+		const input = [{embedded: {actions, id: 1}, score: 1}];
+
+		const once = transformDataSetItems(input);
+		const twice = transformDataSetItems(input);
+
+		expect(once).toEqual(twice);
+		expect(once[0].actions).toBe(actions);
+		expect(twice[0].actions).toBe(actions);
+	});
+});

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/versions.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/info-panel/versions.spec.ts
@@ -191,6 +191,7 @@ test(
 					'Version 1 of the content has been successfully restored.'
 				);
 
+				await expect(infoPanelPage.selectTab('More')).toBeVisible();
 				await expect(page.getByRole('tabpanel')).toContainText(
 					'Version 3'
 				);
@@ -206,7 +207,7 @@ test(
 				);
 
 				await expect(page.getByRole('tabpanel')).toContainText(
-					'expired'
+					'Expire'
 				);
 
 				await infoPanelPage.dropdownVersionAction('Version 1').click();
@@ -368,6 +369,7 @@ test(
 					'Version 1 of the content has been successfully restored.'
 				);
 
+				await expect(infoPanelPage.selectTab('More')).toBeVisible();
 				await expect(page.getByRole('tabpanel')).toContainText(
 					'Version 3'
 				);
@@ -383,7 +385,7 @@ test(
 				);
 
 				await expect(page.getByRole('tabpanel')).toContainText(
-					'expired'
+					'Expire'
 				);
 
 				await infoPanelPage.dropdownVersionAction('Version 1').click();

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/recycleBin.spec.ts
@@ -12,6 +12,7 @@ import {addCMSAdministrator} from '../../../utils/addCMSAdministrator';
 import {checkAccessibility} from '../../../utils/checkAccessibility';
 import getRandomString from '../../../utils/getRandomString';
 import performLoginViaApi, {
+	performUserSwitch,
 	performUserSwitchViaApi,
 	userData,
 } from '../../../utils/performLogin';


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89810

## What is being fixed

After clicking Restore Version on a version in the Info Panel's Versions tab, the panel re-rendered with a different tab layout: the More dropdown disappeared, the Comments tab slid into the main row, and the previously-active tab index silently pointed at Comments instead of Versions. The Versions tab was unreachable until the page was reloaded. The symptom of LPD-89810 was a CMS Info Panel artifact, but the underlying defect was broader: any fds-update-display event stripped the actions map from selected items, so any FDS consumer that derived its tab structure from item.actions collapsed.

## How it is being fixed

The lift of embedded.actions to top-level actions in FrontendDataSet.tsx mutated the raw response items by deleting embedded.actions from the original, and refreshData then filtered selectedItems from those mutated raw items rather than the lifted copies. The fix lifts without mutating and filters selectedItems from the lifted copies. The lift logic is extracted into a transformDataSetItems utility with Jest coverage for the no-mutation and idempotency invariants. The Playwright spec was strengthened with an explicit assertion that the More tab survives Restore Version, so a future regression of the same symptom is caught directly.

_AI-assisted with Claude Code._