### PR TITLE
LPD-91696 Remove filter params from URL when clearing FDS filters

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/FrontendDataSet.tsx
@@ -748,8 +748,14 @@ const FrontendDataSetContent = ({
 		const globalFDSStateSearchQuery = globalFDSState.search.query;
 		const urlSearchQuery = configInURL?.q;
 
-		const shouldUpdateFilters = globalFDSState.filters.some(
-			(filter: IBaseFilterState) => {
+		const hasActiveFilterInURL = Boolean(configInURL?.filters?.length);
+		const hasActiveFilterInState = globalFDSState.filters.some(
+			(filter: IBaseFilterState) => filter.active
+		);
+
+		const shouldUpdateFilters =
+			(hasActiveFilterInURL && !hasActiveFilterInState) ||
+			globalFDSState.filters.some((filter: IBaseFilterState) => {
 				if (filter.preloadedData || filter.selectedData) {
 					const preloadedData = JSON.stringify(filter.preloadedData);
 					const selectedData = JSON.stringify(filter.selectedData);
@@ -760,8 +766,7 @@ const FrontendDataSetContent = ({
 				}
 
 				return false;
-			}
-		);
+			});
 
 		const shouldUpdateSearch =
 			(urlSearchQuery ?? '') !== (globalFDSStateSearchQuery ?? '') &&

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/configInURL.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/configInURL.spec.ts
@@ -708,6 +708,24 @@ for (const spaConfiguration of spaConfigurations) {
 					await removeFilter('Status: Approved, Draft', page);
 					await assertNoActiveFiltersInURL('advanced', page);
 				});
+
+				await test.step('Clear all filters in the UI', async () => {
+					await activateFilter(
+						['Yellow', 'Green'],
+						'Color',
+						fdsSamplePage,
+						page
+					);
+					await checkFilter(
+						true,
+						'color',
+						'Color: Yellow, Green',
+						true
+					);
+
+					await fdsSamplePage.activeFiltersToolbar.clearButton.click();
+					await assertNoActiveFiltersInURL('advanced', page);
+				});
 			}
 		);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91696

## What is being fixed

Clicking the "Clear" button (or the X on a filter chip) in the FrontendDataSet results bar removed the active filter from component state and from the visible filter chips, but the `_fdsConfig` query parameter on the page URL still carried the filter data. Reloading the page or sharing the URL re-applied the stale filter.

## How it is being fixed

The state-to-URL `useEffect` in `FrontendDataSet.tsx` gated its filter sync on `filter.preloadedData || filter.selectedData`. After `deactivateFilter()` both are `undefined`, so the predicate could not see that the URL still held filters and never called `updateConfigInURL`. The fix detects the mismatch between "URL has filters" and "state has any active filter" explicitly so the deactivation is written through.

The filter `configWriter` now returns `undefined` when every filter is inactive instead of `[]`, letting the existing "key is undefined → delete from current config" branch in `writeConfigInURL` remove the filter entry entirely. `writeConfigInURL` also drops the `_fdsConfig` query parameter (and the trailing `?` on the path) when the merged config has no remaining keys, so Clear leaves the URL completely free of FDS state rather than a residual `_fdsConfig=(filters:())`.

The branch also cherry-picks `LPD-44313 Stop spreading messages prop into nested DropDown JSX` from brianchandotcom to unblock the pre-existing TypeScript error in `clay-drop-down/src/DropDownWithItems.tsx` that prevented Source Format from passing.

## Why are there no tests?

The state-to-URL sync `useEffect` and `writeConfigInURL` are tightly coupled to React component lifecycle, `window.history`, and `Liferay.SPA.app.updateHistory_`. Exercising them at the unit level would require mocking the entire SPA navigation harness and component tree. The fix was verified end-to-end in the browser against `/web/cms/contents`: apply Status filter → URL gains `_fdsConfig=(filters:(...))`; click Clear → URL becomes `/web/cms/contents` with no FDS params; click chip X → same clean URL.