### PR TITLE
LPD-91993 Increase button constrast in CKEditor5

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/css/ckeditor5/editor.scss
@@ -33,6 +33,8 @@
 		}
 
 		&.ck-button {
+			color: $secondary;
+
 			&:active,
 			&.ck-on:focus,
 			&.ck-disabled:active {
@@ -52,10 +54,14 @@
 				box-shadow: $btn-focus-box-shadow;
 			}
 
-			&.ck-on,
-			&.ck-on:not(.ck-disabled):hover,
 			&:not(.ck-disabled):hover {
 				background: $gray-100;
+				color: $gray-900;
+			}
+
+			&.ck-on,
+			&.ck-on:not(.ck-disabled):hover {
+				background: $gray-200;
 				color: $gray-900;
 			}
 		}


### PR DESCRIPTION
Based on [this](https://liferay.atlassian.net/browse/LPP-64150?focusedCommentId=5091102), we are modifying CKEditor button colors to match Clay and improve accessibility, specially regarding contrast color.

**Before**
<img width="722" height="237" alt="image" src="https://github.com/user-attachments/assets/b55d2300-ee96-40d3-aa90-bb09e622b718" />

**After**
<img width="603" height="267" alt="image" src="https://github.com/user-attachments/assets/993ed50e-248e-41ed-8917-3b01edc4185d" />
