### PR TITLE
LPD-92057 Fix visualizationModes.spec.ts > Assert the CellRenderer is displayed

### DIFF
--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/components/FieldSelectModalPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/pages/components/FieldSelectModalPage.ts
@@ -46,7 +46,7 @@ export class FieldSelectModalPage {
 	}) {
 		const treeItem = dataId
 			? this.fieldSelectModalContainer.locator(
-					`.treeview-link[data-id="${dataId}"]`
+					`.treeview-link[data-id$=",${dataId}"]`
 				)
 			: this.fieldSelectModalContainer.getByRole('treeitem', {
 					exact: true,


### PR DESCRIPTION
Issue: https://liferay.atlassian.net/browse/LPD-92056

<h1>Fix treeview-link locator to use suffix match for ClayUI data-id format</h1>

ClayUI's TreeView renders data-id as "string,<key>" or "number,<key>", not as the bare key. Commit a2085ed (LPD-56706) changed the checkField locator from the suffix match operator ($=) to an exact match operator (=), so selectors like data-id="removedBy.*" never match the actual data-id="string,removedBy.*" attribute and the click times out.