### PR TITLE
LPD-92129 This rule should apply only to Safari and be avoided in any other browser

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_reboot.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/cadmin/components/_reboot.scss
@@ -241,7 +241,9 @@ html#{$cadmin-selector} {
 
 			// Remove the margin in Safari
 
-			margin: 0;
+			@supports (-webkit-hyphens: none) {
+				margin: 0;
+			}
 		}
 
 		button,


### PR DESCRIPTION
# The issue
When we have CKEditor5 on an iframe, table generator is not working as expected. Instead of showing a 10x10 grid, it is showing a 9x11 plus one single square in the last row. Due to that weird grid-box, it is not indicating correctly the amount of columns/rows when hovering over the grid. This is only happening when CKEditor is on an iframe with cadmin, and not on a maximized non-cadmin window.

# The root cause
On a non-cadmin context, CKEditor 5 "Insert Table" dropdown is just a flex container with `flex-wrap: wrap` and a fixed pixel width, in such a way, the inner content area is exactly 140px, and each cell takes exactly 14px (12px min-width with `box-sizing: border-box` + 1px margin on each side). That's how 10 square fit per row.

However, on a cadmin context, we are applying that `margin: 0` to any browser (not only to Safari) which makes one extra cell per row to fit in, creating that weird grid-box and affecting the hovering functionality. As you can imagine, this bug is not reproducible on Safari, but it is on Chrome or Firefox.

# The solution
In general, rules applied for one specific browser are harmless for the others, however, that's not the case here and this specific Safari-rule is causing an issue on other browsers. Even though Chrome or Firefox can use `-webkit-hyphens:none`, they don't expose this prefixed version to `@supports`, while Safari actually does it, and that's the reason why we are using it to apply only to that browser.