### PR TITLE
LPD-89781 Use FDS pretty URL format in CMS Home search bar

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/home/SearchBar.tsx
@@ -5,6 +5,7 @@
 
 import {ClayButtonWithIcon} from '@clayui/button';
 import {ClayInput} from '@clayui/form';
+import {serializeFDSConfig} from '@liferay/frontend-data-set-web';
 import React, {ChangeEvent, useState} from 'react';
 
 import '../../../css/home/SearchBar.scss';
@@ -25,12 +26,10 @@ export default function SearchBar({
 	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
-		const encodedState = encodeURIComponent(JSON.stringify({q: term}));
-
 		window.location.href =
 			searchResultsURL +
 			'?com.liferay.site.cms.site.initializer-allSection_fdsConfig=' +
-			encodedState;
+			serializeFDSConfig({q: term});
 	};
 
 	return (

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/home.spec.ts
@@ -893,7 +893,7 @@ test(
 
 test(
 	'Can use Search Bar to search for content',
-	{tag: '@LPD-61220'},
+	{tag: ['@LPD-61220', '@LPD-89781']},
 	async ({apiHelpers, assetsPage, homePage, page}) => {
 		const applicationName = 'cms/basic-web-contents';
 		const spaceName = 'Default';
@@ -929,9 +929,15 @@ test(
 
 			await searchInput.press('Enter');
 
+			await test.step('Verify URL uses the FDS pretty format', async () => {
+				await expect(page).toHaveURL(/_fdsConfig=\(q:title\)(?:&|$)/);
+			});
+
 			const row = assetsPage.table.bodyRows.filter({hasText: file1Title});
 
-			await expect(row.getByText(file1Title)).toBeVisible();
+			await expect(
+				row.getByRole('link', {name: file1Title})
+			).toBeVisible();
 
 			await test.step('Verify search input contains the search value', async () => {
 				const searchInput = page.getByPlaceholder('Search');


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89781

## What is being fixed

The CMS Home page (`/web/cms/home`) has a search bar. When a term is submitted, the page redirects to `/web/cms/all` passing the term through the `_fdsConfig` URL parameter. The search bar was still encoding that value with `JSON.stringify(...)` (URL-encoded JSON like `%7B%22q%22%3A%22image%22%7D`), the deprecated format from before LPD-72405 introduced the FDS "pretty URL" form.

## How it is being fixed

`SearchBar.tsx` now calls the shared `serializeFDSConfig` helper from `@liferay/frontend-data-set-web` (already a dependency of this module) instead of `JSON.stringify`. The helper is the same one every other FDS caller uses, so the redirect URL now reads `?...=(q:image)` and matches the rest of FDS end-to-end.

A second commit adds a new step to the existing `Can use Search Bar to search for content` Playwright spec asserting the redirect URL contains the pretty `=(q:title)` segment. The same commit replaces a `getByText(file1Title)` locator with `getByRole('link', {name: file1Title})` to disambiguate from a sibling `.sr-only` Actions span on the row — without that, the test would hit a strict-mode violation independent of LPD-89781 but it blocked a clean run of the new assertion.