### PR TITLE
LPD-92485 Restore string quoting for the legacy collection filter type

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -120,16 +120,16 @@ function getOdataString({
 
 	const quotedSelectedItems = selectedItems.map((item) => {
 		if (
-			entityFieldType === EEntityFieldType.INTEGER ||
-			entityFieldType === EEntityFieldType.COLLECTION_INTEGER
+			entityFieldType === EEntityFieldType.COLLECTION_INTEGER ||
+			entityFieldType === EEntityFieldType.INTEGER
 		) {
 			return item.value;
 		}
 
 		if (
-			entityFieldType === EEntityFieldType.STRING ||
 			entityFieldType === EEntityFieldType.COLLECTION ||
-			entityFieldType === EEntityFieldType.COLLECTION_STRING
+			entityFieldType === EEntityFieldType.COLLECTION_STRING ||
+			entityFieldType === EEntityFieldType.STRING
 		) {
 			return `'${item.value}'`;
 		}
@@ -150,9 +150,9 @@ function getOdataString({
 	});
 
 	if (
-		entityFieldType === EEntityFieldType.COLLECTION_STRING ||
+		entityFieldType === EEntityFieldType.COLLECTION ||
 		entityFieldType === EEntityFieldType.COLLECTION_INTEGER ||
-		entityFieldType === EEntityFieldType.COLLECTION
+		entityFieldType === EEntityFieldType.COLLECTION_STRING
 	) {
 		return `${id}/any(x:${quotedSelectedItems
 			.map((value) => `(x ${exclude ? 'ne' : 'eq'} ${value})`)

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -128,6 +128,7 @@ function getOdataString({
 
 		if (
 			entityFieldType === EEntityFieldType.STRING ||
+			entityFieldType === EEntityFieldType.COLLECTION ||
 			entityFieldType === EEntityFieldType.COLLECTION_STRING
 		) {
 			return `'${item.value}'`;

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -330,4 +330,164 @@ describe('SelectionFilter.getOdataString', () => {
 			);
 		});
 	});
+
+	describe('with entityFieldType="collection-string"', () => {
+		it('generates an "any" filter with "eq" and quotes for a single item', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_STRING,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: '123'}],
+				},
+			} as any);
+
+			expect(result).toBe("testField/any(x:(x eq '123'))");
+		});
+
+		it('generates an "any" filter with "eq" and quotes for a single item with a number value', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_STRING,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: 123}],
+				},
+			} as any);
+
+			expect(result).toBe("testField/any(x:(x eq '123'))");
+		});
+
+		it('generates an "any" filter with "or" for multiple items', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_STRING,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: false,
+					selectedItems: [
+						{label: 'Item 1', value: '123'},
+						{label: 'Item 2', value: '456'},
+					],
+				},
+			} as any);
+
+			expect(result).toBe(
+				"testField/any(x:(x eq '123') or (x eq '456'))"
+			);
+		});
+
+		it('generates an "any" filter with "ne" for a single excluded item', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_STRING,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: true,
+					selectedItems: [{label: 'Item 1', value: '123'}],
+				},
+			} as any);
+
+			expect(result).toBe("testField/any(x:(x ne '123'))");
+		});
+
+		it('generates an "any" filter with "and" for multiple excluded items', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_STRING,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: true,
+					selectedItems: [
+						{label: 'Item 1', value: '123'},
+						{label: 'Item 2', value: '456'},
+					],
+				},
+			} as any);
+
+			expect(result).toBe(
+				"testField/any(x:(x ne '123') and (x ne '456'))"
+			);
+		});
+	});
+
+	describe('with entityFieldType="collection-integer"', () => {
+		it('generates an "any" filter without quotes for a single item', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: 123}],
+				},
+			} as any);
+
+			expect(result).toBe('testField/any(x:(x eq 123))');
+		});
+
+		it('generates an "any" filter without quotes for a single item with a string value', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: '123'}],
+				},
+			} as any);
+
+			expect(result).toBe('testField/any(x:(x eq 123))');
+		});
+
+		it('generates an "any" filter with "or" for multiple items', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: false,
+					selectedItems: [
+						{label: 'Item 1', value: 123},
+						{label: 'Item 2', value: 456},
+					],
+				},
+			} as any);
+
+			expect(result).toBe('testField/any(x:(x eq 123) or (x eq 456))');
+		});
+
+		it('generates an "any" filter with "ne" for a single excluded item', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: true,
+					selectedItems: [{label: 'Item 1', value: 123}],
+				},
+			} as any);
+
+			expect(result).toBe('testField/any(x:(x ne 123))');
+		});
+
+		it('generates an "any" filter with "and" for multiple excluded items', () => {
+			const result = getOdataString({
+				entityFieldType: EEntityFieldType.COLLECTION_INTEGER,
+				id: 'testField',
+				multiple: true,
+				selectedData: {
+					exclude: true,
+					selectedItems: [
+						{label: 'Item 1', value: 123},
+						{label: 'Item 2', value: 456},
+					],
+				},
+			} as any);
+
+			expect(result).toBe('testField/any(x:(x ne 123) and (x ne 456))');
+		});
+	});
 });

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -264,7 +264,7 @@ describe('SelectionFilter.getOdataString', () => {
 			expect(result).toBe("testField/any(x:(x eq '123'))");
 		});
 
-		it('generates an "any" filter with "eq" without quotes for a single item with a number value', () => {
+		it('generates an "any" filter with "eq" with quotes for a single item with a number value', () => {
 			const result = getOdataString({
 				entityFieldType: EEntityFieldType.COLLECTION,
 				id: 'testField',
@@ -275,7 +275,7 @@ describe('SelectionFilter.getOdataString', () => {
 				},
 			} as any);
 
-			expect(result).toBe('testField/any(x:(x eq 123))');
+			expect(result).toBe("testField/any(x:(x eq '123'))");
 		});
 
 		it('generates an "any" filter with "or" for multiple items', () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92485

## What is being fixed

`SelectionFilter.getOdataString` stopped quoting string values for the legacy `EEntityFieldType.COLLECTION` type, producing OData expressions like `testField/any(x:(x eq 123))` instead of `(x eq '123')`. Filters whose item values are strings under the legacy collection type were emitting raw, unquoted values.

## How it is being fixed

Commit 0e2625bee62e2 (LPD-56706) introduced `COLLECTION_STRING` and `COLLECTION_INTEGER` variants and changed the value-quoting fallback from "always quote" to "raw value", silently dropping quoting for the still-supported `COLLECTION` legacy type. This adds `EEntityFieldType.COLLECTION` to the string-quoting branch alongside `STRING` and `COLLECTION_STRING`, restoring the pre-regression behavior. The companion test update aligns the affected fixtures and adds coverage for `COLLECTION_STRING` (quoted) and `COLLECTION_INTEGER` (unquoted), which were not previously exercised.