### PR TITLE
LPD-88075 Update TranslationAdminSelector snapshots after Clay bump

### DIFF
--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/__snapshots__/TranslationAdminSelector.js.snap
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/__snapshots__/TranslationAdminSelector.js.snap
@@ -21,6 +21,7 @@ exports[`TranslationAdminSelector is used as a controlled component 1`] = `
         id="en_US"
         role="option"
         tabindex="-1"
+        type="button"
       >
         <span
           class="dropdown-item-indicator-start"
@@ -93,6 +94,7 @@ exports[`TranslationAdminSelector is used as a controlled component 1`] = `
         id="ar_SA"
         role="option"
         tabindex="-1"
+        type="button"
       >
         <span
           class="autofit-row"
@@ -153,6 +155,7 @@ exports[`TranslationAdminSelector is used as a controlled component 1`] = `
         id="nl_NL"
         role="option"
         tabindex="-1"
+        type="button"
       >
         <span
           class="autofit-row"
@@ -277,6 +280,7 @@ exports[`TranslationAdminSelector renders an open dropdown with the list of acti
         id="en_US"
         role="option"
         tabindex="-1"
+        type="button"
       >
         <span
           class="dropdown-item-indicator-start"
@@ -349,6 +353,7 @@ exports[`TranslationAdminSelector renders an open dropdown with the list of acti
         id="ca_ES"
         role="option"
         tabindex="-1"
+        type="button"
       >
         <span
           class="autofit-row"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88075

## What is being fixed

Two snapshot assertions in `TranslationAdminSelector.js` started failing after recent Clay package upgrades. The rendered DOM for Clay dropdown items now includes a `type="button"` attribute that the stored snapshots do not record, so `toMatchSnapshot()` reports drift on every run.

## How it is being fixed

Regenerated the affected snapshots with `yarn test -u`. The new output matches Clay's current render and brings the test suite back to green (97 passed, 2 skipped, 0 failed).

## Why are there no tests?

The change updates only an existing Jest snapshot file (`.snap`) to track an upstream Clay rendering update. There is no production-code change to cover.