### PR TITLE
LPD-88400 Enable CKEditor 4 (LPD-11235 feature flag) for all poshi tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -13555,6 +13555,14 @@ feature.flag.LPD-11342=true</echo>
 			</then>
 		</if>
 
+		<if>
+			<equals arg1="${functional.test.type}" arg2="poshi" />
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+feature.flag.LPD-11235=true</echo>
+			</then>
+		</if>
+
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 analytics.cloud.domain.allowed=*</echo>
 


### PR DESCRIPTION
This is an alternative implementation of https://github.com/brianchandotcom/liferay-portal/pull/175511. (comes from https://github.com/izaera/liferay-portal/pull/193)

Since we already made sure that turning on the FF fixes the broken tests, as confirmed by a comparison test run from @nikki-pru and the two affected teams in slack conversations, this should fix the issues too.

However since @kenjiheigel hasn't tested it (https://github.com/izaera/liferay-portal/pull/193#issue-4551684535) I'm sending this to be tested at CI again just in case.

I will notify BPM and content management teams about this PR so that they can run the failing test suites and check if this fixes the problems too. If everything is OK we will then forward it for merging.