### PR TITLE
LPD-87016 FDS User Views permissions

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -531,7 +531,7 @@ const SnapshotsControls = () => {
 					}
 				>
 					<ClayDropDown.ItemList>
-						{activeSnapshotERC && (
+						{activeSnapshotERC && isActiveSnapshotOwned && (
 							<ClayDropDown.Item
 								onClick={() => {
 									saveSnapshot({
@@ -553,7 +553,7 @@ const SnapshotsControls = () => {
 							{Liferay.Language.get('save-view-as')}
 						</ClayDropDown.Item>
 
-						{activeSnapshotERC && (
+						{activeSnapshotERC && isActiveSnapshotOwned && (
 							<>
 								<ClayDropDown.Item
 									onClick={openRenameSnapshotModal}
@@ -562,7 +562,7 @@ const SnapshotsControls = () => {
 									{Liferay.Language.get('rename-view')}
 								</ClayDropDown.Item>
 
-								{isActiveSnapshotOwned && activeSnapshot.id ? (
+								{activeSnapshot.id ? (
 									<ClayDropDown.Item
 										onClick={() => {
 											shareSnapshotAction({

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {render, screen} from '@testing-library/react';
+import React from 'react';
+
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import FrontendDataSetContext from '../../../../src/main/resources/META-INF/resources/FrontendDataSetContext';
+import SnapshotsControls from '../../../../src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls';
+import ViewsContext from '../../../../src/main/resources/META-INF/resources/views/ViewsContext';
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/management_bar/controls/snapshots/shareSnapshotAction',
+	() => jest.fn()
+);
+
+global.Liferay = {
+	Language: {
+		get: (key: string) => key,
+	},
+} as any;
+
+const mockFDSContext = {
+	globalFDSState: {filters: []},
+	id: 'testFDS',
+	namespace: 'testNamespace_',
+	onSnapshotChange: jest.fn(),
+	portletId: 'testPortlet',
+};
+
+const ownedSnapshot = {erc: 'owned-erc', id: 1, label: 'Owned View'};
+const sharedSnapshot = {erc: 'shared-erc', id: 2, label: 'Shared View'};
+
+const renderSnapshotsControls = (viewsState: any) =>
+	render(
+		<FrontendDataSetContext.Provider value={mockFDSContext as any}>
+			<ViewsContext.Provider value={[viewsState, jest.fn()] as any}>
+				<SnapshotsControls />
+			</ViewsContext.Provider>
+		</FrontendDataSetContext.Provider>
+	);
+
+const openActionsDropdown = async () => {
+	await userEvent.click(
+		screen.getByRole('button', {name: 'show-view-actions'})
+	);
+};
+
+describe('SnapshotsControls action gating', () => {
+	describe('when the active snapshot is owned by the current user', () => {
+		beforeEach(() => {
+			renderSnapshotsControls({
+				activeSnapshotERC: ownedSnapshot.erc,
+				activeView: null,
+				defaultSnapshot: {},
+				paginationDelta: null,
+				snapshotUpdated: false,
+				snapshots: [{headerVisible: false, items: [ownedSnapshot]}],
+				sorts: [],
+				visibleFieldNames: {},
+			});
+		});
+
+		it('shows every owner action plus "Save View As"', async () => {
+			await openActionsDropdown();
+
+			expect(await screen.findByText('save-view')).toBeInTheDocument();
+			expect(screen.getByText('save-view-as')).toBeInTheDocument();
+			expect(screen.getByText('rename-view')).toBeInTheDocument();
+			expect(screen.getByText('share-view')).toBeInTheDocument();
+			expect(screen.getByText('delete-view')).toBeInTheDocument();
+		});
+	});
+
+	describe('when the active snapshot is shared with the current user', () => {
+		beforeEach(() => {
+			renderSnapshotsControls({
+				activeSnapshotERC: sharedSnapshot.erc,
+				activeView: null,
+				defaultSnapshot: {},
+				paginationDelta: null,
+				snapshotUpdated: false,
+				snapshots: [
+					{headerVisible: false, items: []},
+					{
+						headerVisible: true,
+						items: [sharedSnapshot],
+						label: 'shared-with-me',
+					},
+				],
+				sorts: [],
+				visibleFieldNames: {},
+			});
+		});
+
+		it('only offers "Save View As" and hides every owner action', async () => {
+			await openActionsDropdown();
+
+			expect(await screen.findByText('save-view-as')).toBeInTheDocument();
+			expect(screen.queryByText('save-view')).not.toBeInTheDocument();
+			expect(screen.queryByText('rename-view')).not.toBeInTheDocument();
+			expect(screen.queryByText('share-view')).not.toBeInTheDocument();
+			expect(screen.queryByText('delete-view')).not.toBeInTheDocument();
+		});
+	});
+});

--- a/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-fragment-web/main/userViews.spec.ts
@@ -654,8 +654,8 @@ test(
 );
 
 test(
-	'User views shared with the current user appear under "Shared with Me"',
-	{tag: '@LPD-78095'},
+	'Shared user views appear under "Shared with Me" and are read-only for the recipient',
+	{tag: ['@LPD-78095', '@LPD-87016']},
 	async ({
 		apiHelpers,
 		dataSetFragmentPage,
@@ -747,6 +747,61 @@ test(
 					name: sharedSnapshotName,
 				})
 			).toBeVisible();
+		});
+
+		await test.step('Selecting the shared view makes it the active view', async () => {
+			await page.getByRole('option', {name: sharedSnapshotName}).click();
+
+			await expect(
+				dataSetFragmentPage.userViewsSelectorButton
+			).toHaveText(sharedSnapshotName);
+		});
+
+		await test.step('The shared view offers only "Save View As", not save, rename, share, or delete', async () => {
+			await dataSetFragmentPage.userViewsActionsButton.click();
+
+			const userViewsActionsDropdownId =
+				await dataSetFragmentPage.userViewsActionsButton.getAttribute(
+					'aria-controls'
+				);
+			const userViewsActionsDropdown = page.locator(
+				`#${userViewsActionsDropdownId}`
+			);
+
+			await userViewsActionsDropdown
+				.filter({has: page.getByRole('menu')})
+				.waitFor();
+
+			await expect(
+				userViewsActionsDropdown.getByRole('menuitem', {
+					name: 'Save View As...',
+				})
+			).toBeVisible();
+
+			await expect(
+				userViewsActionsDropdown.getByRole('menuitem', {
+					exact: true,
+					name: 'Save View',
+				})
+			).toHaveCount(0);
+
+			await expect(
+				userViewsActionsDropdown.getByRole('menuitem', {
+					name: 'Rename View',
+				})
+			).toHaveCount(0);
+
+			await expect(
+				userViewsActionsDropdown.getByRole('menuitem', {
+					name: 'Share View',
+				})
+			).toHaveCount(0);
+
+			await expect(
+				userViewsActionsDropdown.getByRole('menuitem', {
+					name: 'Delete View',
+				})
+			).toHaveCount(0);
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87016

## Goal

Recipients of a shared Frontend Data Set User View saw the same actions menu as the owner — Save View, Rename View, and Delete View all appeared, even though the snapshots endpoints reject those writes for anyone but the owner. The dropdown offered actions that were doomed to fail, which contradicts the acceptance criteria: a recipient must not be able to edit or delete a view they do not own.

## Technical details

The ownership signal already existed in SnapshotsControls.tsx — isActiveSnapshotOwned, derived from the serializer's owned vs "Shared with Me" grouping — and only the Share action consumed it. The same check now gates Save View, Rename View, and Delete View, while Save View As stays unconditional so a recipient can still make a personal copy. For a recipient on a shared view, the actions menu is limited to Save View As.

A Jest test covers the owned-vs-shared dropdown contents, and the existing "Shared with Me" Playwright test is extended so the recipient selects the shared view and asserts only Save View As is offered.

## UI

https://github.com/user-attachments/assets/dc7c098a-11a0-4554-9c95-659e71e3cb00

