### PR TITLE
LPD-92807 Quote selection filter values when entity field type is unset

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -146,7 +146,7 @@ function getOdataString({
 			return parsedValue.toLocaleLowerCase();
 		}
 
-		return item.value;
+		return typeof item.value === 'string' ? `'${item.value}'` : item.value;
 	});
 
 	if (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -146,7 +146,9 @@ function getOdataString({
 			return parsedValue.toLocaleLowerCase();
 		}
 
-		return typeof item.value === 'string' ? `'${item.value}'` : item.value;
+		return typeof item.value === 'string'
+			? `'${item.value.replace(/'/g, "''")}'`
+			: item.value;
 	});
 
 	if (

--- a/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/test/management_bar/controls/filters/implementation/SelectionFilter.tsx
@@ -490,4 +490,45 @@ describe('SelectionFilter.getOdataString', () => {
 			expect(result).toBe('testField/any(x:(x ne 123) and (x ne 456))');
 		});
 	});
+
+	describe('without entityFieldType', () => {
+		it('generates a "eq" filter with quotes for a single item', () => {
+			const result = getOdataString({
+				id: 'testField',
+				multiple: false,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: '123'}],
+				},
+			} as any);
+
+			expect(result).toBe("testField eq '123'");
+		});
+
+		it('generates a "eq" filter without quotes for a single item with a number value', () => {
+			const result = getOdataString({
+				id: 'testField',
+				multiple: false,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: 123}],
+				},
+			} as any);
+
+			expect(result).toBe('testField eq 123');
+		});
+
+		it('escapes single quotes in a string value', () => {
+			const result = getOdataString({
+				id: 'testField',
+				multiple: false,
+				selectedData: {
+					exclude: false,
+					selectedItems: [{label: 'Item 1', value: "O'Connor"}],
+				},
+			} as any);
+
+			expect(result).toBe("testField eq 'O''Connor'");
+		});
+	});
 });


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92807

## Failing Test

`LocalFile.FilterSortAndSearchTheListOfAPIApplications#CanFilterAPIsByExcludeStatus`

`modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationsInTheAPIBuilder/FilterSortAndSearchTheListOfAPIApplications.testcase`

```
java.lang.Exception: Element is present at "//div[contains(@class,'table-list-title') and contains(.,'test1')]/../..//td[contains(.,'Published')]"
```

## Root Cause

Commit `0e2625b` ("LPD-56706 added collection-type for entityFieldType") changed the default branch of `getOdataString` in the data set `SelectionFilter` from returning a quoted value to returning the raw value. A selection filter that does not declare an `entityFieldType` — such as the API Builder status filter, defined in `fdsFilters.ts` without one — then emits unquoted OData like `applicationStatus ne published`, which the backend rejects, so the exclude filter silently stops filtering and the published row stays visible.

## Fix

Restore the quoting fallback for string values in the default branch of `getOdataString`, so a value whose `entityFieldType` is unset is quoted again, while keeping the explicit integer and boolean handling the regressing commit added. Verified by a red→green local Poshi run of the failing test.

- `modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/filters/implementation/SelectionFilter.tsx`

## Why Are There No Tests?

The behavior is already covered by the existing Poshi functional test `FilterSortAndSearchTheListOfAPIApplications#CanFilterAPIsByExcludeStatus`, which fails before this change and passes after. The fix restores the contract that test already asserts, so no new test is warranted.
