### PR TITLE
LPD-92819 Fix snapshot sharing interpreter test on a clean database

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-test/src/testIntegration/java/com/liferay/frontend/data/set/internal/sharing/test/DataSetSnapshotSharingEntryInterpreterTest.java
@@ -6,6 +6,7 @@
 package com.liferay.frontend.data.set.internal.sharing.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.frontend.data.set.test.util.FrontendDataSetTestUtil;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -46,7 +48,9 @@ import org.junit.runner.RunWith;
 /**
  * @author Juanjo Fernandez
  */
-@FeatureFlag("LPD-17564")
+@FeatureFlags(
+	featureFlags = {@FeatureFlag("LPD-34594"), @FeatureFlag("LPS-164563")}
+)
 @RunWith(Arquillian.class)
 public class DataSetSnapshotSharingEntryInterpreterTest {
 
@@ -59,6 +63,9 @@ public class DataSetSnapshotSharingEntryInterpreterTest {
 
 	@Before
 	public void setUp() throws Exception {
+		FrontendDataSetTestUtil.initialize(
+			DataSetSnapshotSharingEntryInterpreterTest.class);
+
 		_objectDefinition =
 			_objectDefinitionLocalService.
 				fetchObjectDefinitionByExternalReferenceCode(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92812

## What Is Being Fixed

The integration test `DataSetSnapshotSharingEntryInterpreterTest` fails on
Testray's clean-database builds with an `AssertionError` in `setUp`: the
`L_DATA_SET_SNAPSHOT` system object definition it fetches comes back null.

That object definition is seeded only by the `01-object-definition`
batch-engine file, whose import is gated on the `LPS-164563` feature flag. The
test instead enabled the unrelated `LPD-17564` CMS flag, so the seed never ran
and the object definition was never created. It passed only on long-lived dev
bundles where `LPS-164563` had been enabled during earlier work, leaving the
definition persisted — a false positive.

## How It Is Being Fixed

Enable the flag that actually gates the seed, `LPS-164563`, together with its
declared dependency `LPD-34594`, and call `FrontendDataSetTestUtil.initialize`
at the start of `setUp` so the object definitions are seeded synchronously
before the test reads them. This mirrors the existing, working setup in
`DataSetShowSearchUpgradeProcessTest`, which depends on the same definitions.

## Why Are There No Tests?

The change is confined to test code and fixes an existing integration test so
it runs deterministically on a clean database. No production code changed, so
no additional coverage is warranted.